### PR TITLE
feat(web): enforce tabular numerals globally

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -10,4 +10,7 @@ body,
 
 body {
   @apply bg-base-200 text-base-content antialiased;
+  /* Ensure all numeric glyphs render with equal width across the app */
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
 }


### PR DESCRIPTION
- Apply tabular-nums via global CSS in `web/src/index.css`
- Ensures all digits render with equal width across the SPA
- Verified on dev server (60180/18080) with Playwright: computed `fontVariantNumeric = tabular-nums` on numeric nodes.

Verification steps
- Start backend: `XY_HTTP_BIND=127.0.0.1:18080 cargo run`
- Start web: `VITE_BACKEND_PROXY=http://127.0.0.1:18080 npm run dev -- --host 127.0.0.1 --port 60180`
- Visit `http://127.0.0.1:60180/#/dashboard`, ensure numbers align with fixed-width glyphs.
