### PR TITLE
fix(web): remove dev-only Demo+ button

### DIFF
--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -83,19 +83,7 @@ export function AppLayout() {
               </li>
             ))}
           </ul>
-          {import.meta.env.DEV && (
-            <button
-              type="button"
-              className="btn btn-xs btn-primary"
-              title="触发一次演示更新 (dev only)"
-              onClick={() => {
-                const anyWin = window as unknown as { __DEV_SUMMARY_TICK__?: () => void }
-                anyWin.__DEV_SUMMARY_TICK__?.()
-              }}
-            >
-              Demo+
-            </button>
-          )}
+          {/* Dev-only Demo+ button removed */}
         </nav>
       </header>
       <main className="px-4 py-6 pb-16">


### PR DESCRIPTION
Remove the Demo+ header button that was only intended for local dev demos. The dev console hook `window.__DEV_SUMMARY_TICK__()` remains available in development mode for manual triggering.

- Remove UI trigger from `web/src/components/AppLayout.tsx`
- No functional changes to production; button was gated behind `import.meta.env.DEV`
- Pre-commit hooks pass (lint/typecheck)

Verification
- Run frontend in dev and confirm the header no longer shows Demo+.
- In dev console, `__DEV_SUMMARY_TICK__?.()` still triggers demo updates if needed.
