### PR TITLE
feat(web+core): update banner + version detection (SSE open + version event)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
 import { subscribeToSse } from '../lib/sse'
+import useUpdateAvailable from '../hooks/useUpdateAvailable'
 import { fetchVersion } from '../lib/api'
 import type { VersionResponse } from '../lib/api'
 
@@ -15,6 +16,7 @@ export function AppLayout() {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const animationDurationMs = 1400
   const [version, setVersion] = useState<VersionResponse | null>(null)
+  const update = useUpdateAvailable()
 
   useEffect(() => {
     const unsubscribe = subscribeToSse(() => {
@@ -86,6 +88,34 @@ export function AppLayout() {
           {/* Dev-only Demo+ button removed */}
         </nav>
       </header>
+      {update.visible && (
+        <div className="alert alert-warning rounded-none sticky top-[64px] z-40 shadow-md">
+          <div className="flex flex-1 flex-wrap items-center gap-3">
+            <span className="font-semibold">有新版本可用：</span>
+            <span className="kbd kbd-sm">{version?.version ?? '当前'}</span>
+            <span>→</span>
+            <span className="kbd kbd-sm">{update.availableVersion}</span>
+            <div className="flex gap-4 ml-auto items-center">
+              <button
+                type="button"
+                className="link link-primary cursor-pointer"
+                style={{ cursor: 'pointer' }}
+                onClick={update.reload}
+              >
+                立即刷新
+              </button>
+              <button
+                type="button"
+                className="link cursor-pointer"
+                style={{ cursor: 'pointer' }}
+                onClick={update.dismiss}
+              >
+                稍后
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <main className="px-4 py-6 pb-16">
         <Outlet />
       </main>

--- a/web/src/hooks/useUpdateAvailable.ts
+++ b/web/src/hooks/useUpdateAvailable.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { fetchVersion } from '../lib/api'
+import { subscribeToSseOpen } from '../lib/sse'
+
+const DISMISS_KEY = 'update-dismissed-version'
+
+export function useUpdateAvailable() {
+  const [currentVersion, setCurrentVersion] = useState<string | null>(null)
+  const [availableVersion, setAvailableVersion] = useState<string | null>(null)
+  const [visible, setVisible] = useState(false)
+  const initialVersionRef = useRef<string | null>(null)
+
+  const dismissed = useMemo(() => {
+    try {
+      return localStorage.getItem(DISMISS_KEY)
+    } catch {
+      return null
+    }
+  }, [])
+
+  const loadVersion = useCallback(async () => {
+    try {
+      const v = await fetchVersion()
+      return v.version
+    } catch {
+      return null
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const v = await loadVersion()
+      if (cancelled) return
+      setCurrentVersion(v)
+      initialVersionRef.current = v
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [loadVersion])
+
+  useEffect(() => {
+    const unsubscribe = subscribeToSseOpen(async () => {
+      const next = await loadVersion()
+      if (!next) return
+      const initial = initialVersionRef.current
+      if (!initial) {
+        initialVersionRef.current = next
+        setCurrentVersion(next)
+        return
+      }
+      if (next !== initial && next !== dismissed) {
+        setAvailableVersion(next)
+        setVisible(true)
+      }
+    })
+    return unsubscribe
+  }, [dismissed, loadVersion])
+
+  const dismiss = useCallback(() => {
+    if (availableVersion) {
+      try {
+        localStorage.setItem(DISMISS_KEY, availableVersion)
+      } catch {
+        /* noop */
+      }
+    }
+    setVisible(false)
+  }, [availableVersion])
+
+  const reload = useCallback(() => {
+    window.location.reload()
+  }, [])
+
+  // Dev-only helper
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+    ;(window as unknown as { __DEV_FORCE_UPDATE_BANNER__?: () => void }).__DEV_FORCE_UPDATE_BANNER__ = () => {
+      setAvailableVersion((v) => v ?? (currentVersion ? `${currentVersion}-dev` : 'dev-next'))
+      setVisible(true)
+    }
+  }, [currentVersion])
+
+  return { currentVersion, availableVersion, visible, dismiss, reload }
+}
+
+export default useUpdateAvailable

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -97,6 +97,10 @@ export type BroadcastPayload =
       type: 'quota'
       snapshot: QuotaSnapshot
     }
+  | {
+      type: 'version'
+      version: string
+    }
 
 export async function fetchInvocations(limit: number, params?: { model?: string; status?: string }) {
   const search = new URLSearchParams()
@@ -111,12 +115,11 @@ export async function fetchStats() {
   return fetchJson<StatsResponse>('/api/stats')
 }
 
-export interface VersionResponse {
-  version: string
-}
-
-export async function fetchVersion() {
-  return fetchJson<VersionResponse>('/api/version')
+interface VersionApi { backend: string; frontend: string }
+export interface VersionResponse { version: string }
+export async function fetchVersion(): Promise<VersionResponse> {
+  const v = await fetchJson<VersionApi>('/api/version')
+  return { version: v.backend }
 }
 
 export async function fetchSummary(window: string, options?: { limit?: number }) {


### PR DESCRIPTION
Implements persistent update notification UI and robust version detection.

UI
- Sticky `alert-warning` banner under the header (high contrast).
- Shows `current → available` with actions: Refresh (reload) and Later (dismiss and remember per-version in localStorage).
- Buttons render with pointer cursor for clear affordance.

Version detection
- On SSE connection open (including reconnect), fetch `/api/version` and compare to initial version.
- Backend now emits an initial SSE payload `{ type: 'version', version: <backend> }` to immediately inform clients upon connect without an extra request.
- Note: EventSource cannot read response headers in browsers; the SSE event solves discovery-on-reconnect reliably.

Files
- web/src/hooks/useUpdateAvailable.ts (new): handles detection via SSE-open & version events; dev helper `__DEV_FORCE_UPDATE_BANNER__()`.
- web/src/components/AppLayout.tsx: renders banner and actions.
- web/src/lib/sse.ts: adds subscribeToSseOpen and keeps dev heartbeat.
- web/src/lib/api.ts: adds `BroadcastPayload['version']`, maps `/api/version` {backend,frontend} → {version}.
- src/main.rs: adds `BroadcastPayload::Version` and seeds one event at the start of each SSE stream.

Verification
- Backend: `XY_HTTP_BIND=127.0.0.1:18082 cargo run`
- Frontend: `VITE_BACKEND_PROXY=http://127.0.0.1:18082 npm run dev -- --host 127.0.0.1 --port 60182`
- Visit `http://127.0.0.1:60182/#/dashboard`, trigger `__DEV_FORCE_UPDATE_BANNER__()` in console to see the banner. Refresh/Later behave as expected.
