### PR TITLE
feat(web): hide Invoke ID across UI

### DIFF
--- a/web/src/components/InvocationTable.tsx
+++ b/web/src/components/InvocationTable.tsx
@@ -42,7 +42,6 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
         <thead>
           <tr>
             <th>Time</th>
-            <th>Invoke ID</th>
             <th>Model</th>
             <th>Status</th>
             <th>Input</th>
@@ -58,7 +57,6 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
             return (
               <tr key={`${record.invokeId}-${record.occurredAt}`}>
                 <td>{isNaN(occurred.getTime()) ? record.occurredAt : dateFormatter.format(occurred)}</td>
-                <td className="font-mono text-xs">{record.invokeId}</td>
                 <td>{record.model ?? '—'}</td>
                 <td>
                   <span


### PR DESCRIPTION
Summary
- Remove Invoke ID column from InvocationTable header and row cells so it is no longer displayed anywhere in the UI.

Scope
- Front-end (React/Vite): web/src/components/InvocationTable.tsx
- No backend schema or API changes.

Verification
- Local build succeeded: `cd web && npm run build`.
- Manual verification via dev server confirmed no "Invoke ID" text remains; table aligns correctly.

Notes
- `invokeId` remains in internal data for keys/merging, but is no longer rendered.
- No tests affected; project currently has no front-end test files.
