### PR TITLE
feat(web): add count to Stats and align chart colors; fix Dashboard 1h bucket

### DIFF
--- a/web/src/components/InvocationChart.tsx
+++ b/web/src/components/InvocationChart.tsx
@@ -99,8 +99,8 @@ export function InvocationChart({ records, isLoading }: InvocationChartProps) {
             dataKey="totalTokens"
             name="Total Tokens"
             yAxisId="tokens"
-            stroke="#2563eb"
-            fill="#3b82f6"
+            stroke="#8b5cf6"
+            fill="#a78bfa"
             fillOpacity={0.25}
             strokeWidth={2}
             isAnimationActive={false}

--- a/web/src/components/TimeseriesChart.tsx
+++ b/web/src/components/TimeseriesChart.tsx
@@ -54,6 +54,8 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds }: Timeseries
               orientation="left"
               tickFormatter={(value) => numberFormatter.format(value as number)}
             />
+            {/* Hidden Y axis for count to maintain independent scaling without clutter */}
+            <YAxis yAxisId="count" hide />
             <YAxis
               yAxisId="cost"
               orientation="right"
@@ -73,6 +75,16 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds }: Timeseries
               dataKey="totalTokens"
               name="Total Tokens"
               yAxisId="tokens"
+              stroke="#8b5cf6"
+              fill="#a78bfa"
+              fillOpacity={0.2}
+              strokeWidth={2}
+            />
+            <Area
+              type="monotone"
+              dataKey="totalCount"
+              name="次数"
+              yAxisId="count"
               stroke="#2563eb"
               fill="#3b82f6"
               fillOpacity={0.2}
@@ -98,6 +110,8 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds }: Timeseries
               orientation="left"
               tickFormatter={(value) => numberFormatter.format(value as number)}
             />
+            {/* Hidden Y axis for count to maintain independent scaling without clutter */}
+            <YAxis yAxisId="count" hide />
             <YAxis
               yAxisId="cost"
               orientation="right"
@@ -116,6 +130,14 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds }: Timeseries
               yAxisId="tokens"
               dataKey="totalTokens"
               name="Total Tokens"
+              fill="#a78bfa"
+              radius={[4, 4, 0, 0]}
+            />
+            {/* Show count as a separate bar */}
+            <Bar
+              yAxisId="count"
+              dataKey="totalCount"
+              name="次数"
               fill="#3b82f6"
               radius={[4, 4, 0, 0]}
             />

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -26,7 +26,7 @@ export default function DashboardPage() {
     data: timeseries,
     isLoading: timeseriesLoading,
     error: timeseriesError,
-  } = useTimeseries('1d', { bucket: '30m' })
+  } = useTimeseries('1d', { bucket: '1h' })
   const {
     records,
     isLoading: tableLoading,


### PR DESCRIPTION
Summary
- Add count series (totalCount) to Stats timeseries chart with an independent hidden Y-axis; render as area in line mode and bar in composed mode.
- Align chart colors with UsageCalendar palette: count=blue, cost=orange, tokens=purple. Applied to TimeseriesChart and Live InvocationChart.
- Improve Dashboard readability by changing default aggregation to 1h (from 30m).

Affected Areas
- Front-end (web): charts and Dashboard.

Verification
- Ran local dev env (backend 127.0.0.1:8080, web 127.0.0.1:60080) and verified:
  - Stats page shows three series (次数 blue, Cost orange, Tokens purple).
  - Live page token series uses purple; cost remains orange.
  - Dashboard trend uses 1h buckets and reads clearer with sparse data.

Notes
- No backend change required.
- Commit messages follow Conventional Commits.
