### PR TITLE
feat(api,web): iso8601 utc + local-time UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +319,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "chrono-tz",
  "clap",
  "dotenvy",
  "futures-util",
@@ -1230,6 +1241,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1731,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono-tz = "0.10"
 dotenvy = "0.15"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/web/src/components/InvocationChart.tsx
+++ b/web/src/components/InvocationChart.tsx
@@ -23,8 +23,8 @@ const numberFormatter = new Intl.NumberFormat('en-US', {
 export function InvocationChart({ records, isLoading }: InvocationChartProps) {
   const data = useMemo(() => {
     const chronological = [...records].sort((a, b) => {
-      const aEpoch = parseNaiveDateTime(a.occurredAt)
-      const bEpoch = parseNaiveDateTime(b.occurredAt)
+      const aEpoch = parseIsoEpoch(a.occurredAt)
+      const bEpoch = parseIsoEpoch(b.occurredAt)
       if (aEpoch == null && bEpoch == null) return 0
       if (aEpoch == null) return -1
       if (bEpoch == null) return 1
@@ -32,7 +32,7 @@ export function InvocationChart({ records, isLoading }: InvocationChartProps) {
     })
 
     return chronological.map((record, index) => {
-      const occurredEpoch = parseNaiveDateTime(record.occurredAt)
+      const occurredEpoch = parseIsoEpoch(record.occurredAt)
       const occurred = occurredEpoch != null ? new Date(occurredEpoch * 1000) : null
       const timeLabel = occurred
         ? occurred.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
@@ -122,18 +122,9 @@ export function InvocationChart({ records, isLoading }: InvocationChartProps) {
   )
 }
 
-function parseNaiveDateTime(value: string) {
-  const [datePart, timePart] = value?.split(' ') ?? []
-  if (!datePart || !timePart) {
-    return null
-  }
-
-  const [year, month, day] = datePart.split('-').map(Number)
-  const [hour, minute, second] = timePart.split(':').map(Number)
-  if ([year, month, day, hour, minute, second].some((segment) => !Number.isFinite(segment))) {
-    return null
-  }
-
-  const epochMilliseconds = Date.UTC(year, (month ?? 1) - 1, day ?? 1, hour ?? 0, minute ?? 0, second ?? 0)
-  return Math.floor(epochMilliseconds / 1000)
+function parseIsoEpoch(value?: string | null) {
+  if (!value) return null
+  const t = Date.parse(value)
+  if (Number.isNaN(t)) return null
+  return Math.floor(t / 1000)
 }

--- a/web/src/components/WeeklyHourlyHeatmap.tsx
+++ b/web/src/components/WeeklyHourlyHeatmap.tsx
@@ -32,8 +32,12 @@ const ACCENT_BY_METRIC: Record<MetricKey, string> = {
   totalTokens: '#8B5CF6',
 }
 
-function parseDateTimeParts(naive: string) {
-  const [datePart, timePart] = naive.split(' ')
+function parseDateTimeParts(value: string) {
+  if (value.includes('T')) {
+    const d = new Date(value)
+    return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate(), hour: d.getHours() }
+  }
+  const [datePart, timePart] = value.split(' ')
   const [year, month, day] = (datePart ?? '').split('-').map(Number)
   const [hour] = (timePart ?? '').split(':').map(Number)
   return { year, month, day, hour: Number.isFinite(hour) ? hour : 0 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -60,6 +60,7 @@ export default function DashboardPage() {
               points={timeseries?.points ?? []}
               isLoading={timeseriesLoading}
               bucketSeconds={timeseries?.bucketSeconds}
+              showDate={false}
             />
           )}
         </div>


### PR DESCRIPTION
Summary
- Backend
  - Timeseries and snapshot APIs return ISO 8601 UTC (Z).
  - Aggregate historical naive local timestamps as Asia/Shanghai -> UTC for correct bucketing.
  - Graceful /api/quota/latest when no snapshots (avoid 500).
- Frontend
  - Parse ISO strings and render in browser timezone.
  - Dashboard 24h chart shows only time (HH or HH:mm).
  - Auto-retry for timeseries and invocations on transient errors.

Motivation
- Fixes missing hours after 10:00 due to timezone misinterpretation.
- Eliminates transient 500s during dev by making quota endpoint robust; adds client retries.
- Improves readability by localizing times and simplifying 24h labels.

Verification
- Ran backend locally against provided DB copy; APIs 200 for stats/summary/timeseries/quota.
- Vite dev served SPA; Playwright navigated to /#/dashboard and asserted no "Request failed: 500".
- Charts reflect local timezone; Dashboard 24h axis shows HH or HH:mm only.

Notes
- In dev, avoid killing backend with very short alarm; run without alarm or increase to 1800/3600.
- No schema changes; serialization is backward-compatible.
