### PR TITLE
feat(web): add footer repo and version links

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@iconify/react": "^6.0.2",
         "react": "^19.1.1",
         "react-activity-calendar": "^2.7.15",
         "react-dom": "^19.1.1",
@@ -1005,6 +1006,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iconify/react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-6.0.2.tgz",
+      "integrity": "sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@iconify/react": "^6.0.2",
     "react": "^19.1.1",
     "react-activity-calendar": "^2.7.15",
     "react-dom": "^19.1.1",

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Icon } from '@iconify/react'
 import { NavLink, Outlet } from 'react-router-dom'
 import { subscribeToSse } from '../lib/sse'
 import useUpdateAvailable from '../hooks/useUpdateAvailable'
@@ -11,12 +12,15 @@ const navItems = [
   { to: '/live', label: '实况' },
 ]
 
+const repositoryUrl = 'https://github.com/IvanLi-CN/codex-vibe-monitor'
+
 export function AppLayout() {
   const [pulse, setPulse] = useState(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const animationDurationMs = 1400
   const [version, setVersion] = useState<VersionResponse | null>(null)
   const update = useUpdateAvailable()
+  const tagVersion = version?.version.startsWith('v') ? version.version : (version ? `v${version.version}` : null)
 
   useEffect(() => {
     const unsubscribe = subscribeToSse(() => {
@@ -109,13 +113,32 @@ export function AppLayout() {
       </main>
       <footer className="bt border-base-300 bg-base-100 text-sm text-base-content/70 w-full py-2 px-4 fixed bottom-0 left-0 flex items-center justify-between">
         <span>© Codex Vibe Monitor</span>
-        <span>
-          {version ? (
-            <>Version v{version.version}</>
-          ) : (
-            'Loading version…'
-          )}
-        </span>
+        <div className="flex items-center gap-4">
+          <a
+            className="link flex items-center gap-1"
+            href={repositoryUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="打开 GitHub 仓库"
+          >
+            <Icon icon="mdi:github" className="h-4 w-4" aria-hidden />
+            <span>GitHub</span>
+          </a>
+          <span>
+            {version && tagVersion ? (
+              <a
+                className="link font-mono"
+                href={`${repositoryUrl}/releases/tag/${tagVersion}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Version {tagVersion}
+              </a>
+            ) : (
+              'Loading version…'
+            )}
+          </span>
+        </div>
       </footer>
     </div>
   )


### PR DESCRIPTION
## Summary
- add Iconify dependency and surface a GitHub icon link in the footer
- turn the displayed version into a link that targets the matching release tag

## Testing
- npm run lint
- npm run dev