### PR TITLE
fix(web): harden SSE reconnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /web/dist
 /web/.vite
 logs/
+.serena

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -7,6 +7,15 @@ let eventSource: EventSource | null = null
 const listeners = new Set<SseListener>()
 const openListeners = new Set<() => void>()
 let lastEventAt = Date.now()
+let reconnectTimer: number | null = null
+let connectionWatchdog: number | null = null
+let reconnectAttempts = 0
+let connectingSince: number | null = null
+
+const BASE_RECONNECT_DELAY_MS = 2000
+const MAX_RECONNECT_DELAY_MS = 30000
+const CONNECTING_TIMEOUT_MS = 45000
+const WATCHDOG_INTERVAL_MS = 5000
 
 // Dev-only heartbeat simulator: when SSE is silent for a while, periodically
 // synthesize a small summary update to drive UI animations.
@@ -112,10 +121,17 @@ function handleMessage(event: MessageEvent<string>) {
 
 function handleError(event: Event) {
   console.warn('SSE connection error', event)
+  if (listeners.size === 0) return
+  const source = event.currentTarget as EventSource | null
+  const immediate = source?.readyState === EventSource.CLOSED
+  scheduleReconnect({ immediate })
 }
 
 function handleOpen() {
   lastEventAt = Date.now()
+  reconnectAttempts = 0
+  connectingSince = null
+  clearReconnectTimer()
   openListeners.forEach((cb) => {
     try {
       cb()
@@ -127,25 +143,92 @@ function handleOpen() {
 
 function ensureEventSource() {
   if (eventSource) return eventSource
+  connectingSince = Date.now()
   eventSource = createEventSource('/events')
   eventSource.addEventListener('message', handleMessage as EventListener)
   eventSource.addEventListener('error', handleError)
   eventSource.addEventListener('open', handleOpen)
   ensureDevSimulator()
+  startConnectionWatchdog()
   return eventSource
 }
 
+function destroyEventSource() {
+  if (!eventSource) return
+  eventSource.removeEventListener('message', handleMessage as EventListener)
+  eventSource.removeEventListener('error', handleError)
+  eventSource.removeEventListener('open', handleOpen)
+  eventSource.close()
+  eventSource = null
+}
+
 function cleanupEventSource() {
-  if (eventSource && listeners.size === 0) {
-    eventSource.removeEventListener('message', handleMessage as EventListener)
-    eventSource.removeEventListener('error', handleError)
-    eventSource.removeEventListener('open', handleOpen)
-    eventSource.close()
-    eventSource = null
-  }
   if (listeners.size === 0) {
+    destroyEventSource()
     stopDevSimulator()
+    stopConnectionWatchdog()
+    clearReconnectTimer()
+    reconnectAttempts = 0
   }
+}
+
+function clearReconnectTimer() {
+  if (reconnectTimer != null) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+}
+
+function scheduleReconnect(options: { immediate?: boolean } = {}) {
+  if (listeners.size === 0) return
+  const { immediate = false } = options
+  if (!immediate && reconnectTimer != null) return
+
+  clearReconnectTimer()
+  destroyEventSource()
+
+  const delay = immediate
+    ? 0
+    : Math.min(BASE_RECONNECT_DELAY_MS * 2 ** reconnectAttempts, MAX_RECONNECT_DELAY_MS)
+  const nextAttempts = Math.min(reconnectAttempts + 1, 10)
+
+  reconnectTimer = window.setTimeout(() => {
+    reconnectTimer = null
+    reconnectAttempts = nextAttempts
+    ensureEventSource()
+  }, delay)
+}
+
+function startConnectionWatchdog() {
+  if (connectionWatchdog != null) return
+  connectionWatchdog = window.setInterval(() => {
+    if (!eventSource) return
+    if (eventSource.readyState === EventSource.OPEN) {
+      connectingSince = null
+      return
+    }
+    if (eventSource.readyState === EventSource.CLOSED) {
+      scheduleReconnect({ immediate: true })
+      return
+    }
+    if (eventSource.readyState === EventSource.CONNECTING) {
+      if (connectingSince == null) {
+        connectingSince = Date.now()
+      }
+      if (connectingSince != null && Date.now() - connectingSince > CONNECTING_TIMEOUT_MS) {
+        console.warn('SSE stuck in CONNECTING state, forcing reconnect')
+        scheduleReconnect({ immediate: true })
+      }
+    }
+  }, WATCHDOG_INTERVAL_MS)
+}
+
+function stopConnectionWatchdog() {
+  if (connectionWatchdog != null) {
+    clearInterval(connectionWatchdog)
+    connectionWatchdog = null
+  }
+  connectingSince = null
 }
 
 export function subscribeToSse(listener: SseListener) {


### PR DESCRIPTION
## Summary
- add explicit reconnection/backoff logic to the web SSE client so transient 5xx errors recover automatically
- introduce a watchdog to detect long CONNECTING periods and force a reconnect
- ignore the local `.serena` directory

## Testing
- `npm run lint`
- `tsc`
- manual SSE reconnection test (observe `/events` reconnects within 45s after injected 502)
