### PR TITLE
fix(web): center quota donut and right-size usage tile

### DIFF
--- a/web/src/components/QuotaOverview.tsx
+++ b/web/src/components/QuotaOverview.tsx
@@ -54,8 +54,9 @@ export function QuotaOverview({ snapshot, isLoading, error }: QuotaOverviewProps
 
   const radialProgressStyle: RadialProgressStyle = {
     '--value': usagePercent,
-    '--size': '4rem',
-    '--thickness': '0.5rem',
+    // Smaller size per feedback
+    '--size': '5.4rem',
+    '--thickness': '0.45rem',
   }
 
   return (
@@ -79,8 +80,9 @@ export function QuotaOverview({ snapshot, isLoading, error }: QuotaOverviewProps
         </div>
 
         <div className="grid gap-3 grid-cols-2 items-stretch">
-          <OverviewTile label={t('quota.labels.usageRate')} compact>
-            <div className="flex items-center gap-3">
+          <OverviewTile label={t('quota.labels.usageRate')} compact padClass="px-4 py-2" overlayLabel>
+            {/* Center the radial progress; minimize vertical gap to ~py-2 via tile padding */}
+            <div className="flex items-center justify-center h-full">
               <div className="radial-progress text-primary" style={radialProgressStyle}>
                 {isLoading ? '…' : <AnimatedDigits value={`${Math.round(usagePercent)}%`} />}
               </div>
@@ -111,15 +113,21 @@ interface OverviewTileProps {
   loading?: boolean
   compact?: boolean
   children?: React.ReactNode
+  padClass?: string
+  overlayLabel?: boolean
 }
 
-function OverviewTile({ label, value, caption, loading, compact, children }: OverviewTileProps) {
+function OverviewTile({ label, value, caption, loading, compact, children, padClass, overlayLabel }: OverviewTileProps) {
   const valueClass = compact
     ? 'text-xl font-semibold whitespace-nowrap overflow-hidden text-ellipsis'
     : 'text-2xl font-semibold whitespace-nowrap overflow-hidden text-ellipsis'
   return (
-    <div className="rounded-box border border-base-300 bg-base-200/60 p-4">
-      <div className="text-sm text-base-content/60">{label}</div>
+    <div className={`rounded-box border border-base-300 bg-base-200/60 ${overlayLabel ? 'relative' : ''} ${padClass ?? 'p-4'}`}>
+      {overlayLabel ? (
+        <div className="absolute top-2 left-2 text-sm text-base-content/60">{label}</div>
+      ) : (
+        <div className="text-sm text-base-content/60">{label}</div>
+      )}
       <div className={valueClass}>{loading ? <span className="loading loading-dots loading-md" /> : (children ?? value)}</div>
       {caption ? <div className="text-xs text-base-content/50">{caption}</div> : null}
     </div>


### PR DESCRIPTION
Summary
- Center the quota usage donut within the tile (both axes)
- Reduce vertical padding to approximately py-2; overlay the label to free vertical space
- Set donut size to ~86px with balanced ring thickness for readability

UI Notes
- Verified in dev using Playwright: donut size ~86px; top/bottom gaps ~9px each (≈ py-2)
- Works with DaisyUI radial-progress

Verification
1) Backend: `env RUST_LOG=info cargo run` (reads .env.local)
2) Frontend: `cd web && npm run dev -- --host 127.0.0.1 --port 60080`
3) Open `http://127.0.0.1:60080/#/dashboard` and inspect the quota overview tile.

Scope
- Frontend only: `web/src/components/QuotaOverview.tsx`

No schema or env changes.