### PR TITLE
fix(web): prevent 1mo stats freeze + adaptive chart animations; perf(backend): add SQLite indexes

### DIFF
--- a/web/src/components/SuccessFailureChart.tsx
+++ b/web/src/components/SuccessFailureChart.tsx
@@ -38,19 +38,20 @@ export function SuccessFailureChart({ points, isLoading, bucketSeconds }: Succes
     success: p.successCount,
     failure: p.failureCount,
   }))
+  const animate = chartData.length <= 800
 
   return (
     <div className="h-96 w-full">
       <ResponsiveContainer>
         <BarChart data={chartData} margin={{ top: 16, right: 32, left: 0, bottom: 8 }}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="label" minTickGap={32} angle={-15} dy={8} height={60} />
+          <XAxis dataKey="label" minTickGap={32} angle={-15} dy={8} height={60} interval="preserveStartEnd" />
           <YAxis tickFormatter={(v) => numberFormatter.format(v as number)} />
           <Tooltip formatter={(v, k) => [numberFormatter.format(v as number), legendName(k as string, t)]} />
           <Legend />
           {/* Success at bottom, Failure stacked above */}
-          <Bar dataKey="success" name={t('stats.cards.success')} stackId="count" fill="#22c55e" radius={[4, 4, 0, 0]} />
-          <Bar dataKey="failure" name={t('stats.cards.failures')} stackId="count" fill="#ef4444" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="success" name={t('stats.cards.success')} stackId="count" fill="#22c55e" radius={[4, 4, 0, 0]} isAnimationActive={animate} />
+          <Bar dataKey="failure" name={t('stats.cards.failures')} stackId="count" fill="#ef4444" radius={[4, 4, 0, 0]} isAnimationActive={animate} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/web/src/components/TimeseriesChart.tsx
+++ b/web/src/components/TimeseriesChart.tsx
@@ -61,6 +61,9 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds, showDate = t
     }
   })
 
+  // Keep animations for normal point counts; auto-disable only for extreme cases to avoid UI lockups
+  const animate = chartData.length <= 800
+
   const seriesNames = {
     totalTokens: t('chart.totalTokens'),
     totalCost: t('chart.totalCost'),
@@ -82,7 +85,7 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds, showDate = t
         {useLine ? (
           <AreaChart data={chartData} margin={{ top: 16, right: 32, left: 0, bottom: 8 }}>
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="label" minTickGap={32} angle={-15} dy={8} height={60} />
+            <XAxis dataKey="label" minTickGap={32} angle={-15} dy={8} height={60} interval="preserveStartEnd" />
             <YAxis
               yAxisId="tokens"
               orientation="left"
@@ -108,6 +111,7 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds, showDate = t
               fill="#a78bfa"
               fillOpacity={0.2}
               strokeWidth={2}
+              isAnimationActive={animate}
             />
             <Area
               type="monotone"
@@ -118,6 +122,7 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds, showDate = t
               fill="#3b82f6"
               fillOpacity={0.2}
               strokeWidth={2}
+              isAnimationActive={animate}
             />
             <Area
               type="monotone"
@@ -128,12 +133,13 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds, showDate = t
               fill="#fb923c"
               fillOpacity={0.2}
               strokeWidth={2}
+              isAnimationActive={animate}
             />
           </AreaChart>
         ) : (
           <ComposedChart data={chartData} margin={{ top: 16, right: 32, left: 0, bottom: 8 }}>
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="label" minTickGap={32} angle={-15} dy={8} height={60} />
+            <XAxis dataKey="label" minTickGap={32} angle={-15} dy={8} height={60} interval="preserveStartEnd" />
             <YAxis
               yAxisId="tokens"
               orientation="left"
@@ -150,9 +156,9 @@ export function TimeseriesChart({ points, isLoading, bucketSeconds, showDate = t
               formatter={(value, key) => [formatValue(value as number, key as keyof typeof seriesNames), seriesNames[key as keyof typeof seriesNames]]}
             />
             <Legend />
-            <Bar yAxisId="tokens" dataKey="totalTokens" name={seriesNames.totalTokens} fill="#a78bfa" radius={[4, 4, 0, 0]} />
-            <Bar yAxisId="count" dataKey="totalCount" name={seriesNames.totalCount} fill="#3b82f6" radius={[4, 4, 0, 0]} />
-            <Bar yAxisId="cost" dataKey="totalCost" name={seriesNames.totalCost} fill="#fb923c" radius={[4, 4, 0, 0]} />
+            <Bar yAxisId="tokens" dataKey="totalTokens" name={seriesNames.totalTokens} fill="#a78bfa" radius={[4, 4, 0, 0]} isAnimationActive={animate} />
+            <Bar yAxisId="count" dataKey="totalCount" name={seriesNames.totalCount} fill="#3b82f6" radius={[4, 4, 0, 0]} isAnimationActive={animate} />
+            <Bar yAxisId="cost" dataKey="totalCost" name={seriesNames.totalCost} fill="#fb923c" radius={[4, 4, 0, 0]} isAnimationActive={animate} />
           </ComposedChart>
         )}
       </ResponsiveContainer>


### PR DESCRIPTION
Summary
- Fix front-end freeze when switching to Stats → last month (1mo).
- Preserve chart animations under normal loads; auto-disable only for extreme point counts to avoid UI lockups.
- Add SQLite indexes to accelerate time-range queries and latest snapshot fetch.

Changes
- web/src/pages/Stats.tsx
  - Enforce valid aggregation bucket for selected range via `effectiveBucket`.
  - Keep select state and API params in sync across range changes.
- web/src/components/TimeseriesChart.tsx
  - Keep animations by default; auto-disable when `chartData.length > 800`.
  - Reduce X-axis tick density with `interval="preserveStartEnd"`.
- web/src/components/SuccessFailureChart.tsx
  - Same adaptive animation toggle and X-axis optimization.
- src/main.rs
  - Create indexes:
    - `idx_codex_invocations_occurred_at`
    - `idx_codex_invocations_occurred_at_status`
    - `idx_quota_snapshots_captured_at`

Why
- Front-end was issuing 1mo range with a previous (invalid) bucket like 15m, yielding thousands of points; Recharts axis/animations caused the page to become unresponsive. Enforcing a valid bucket and adaptive animations fixes the UX without sacrificing effects.
- Indexes reduce DB scan/sort time for monthly queries, further improving responsiveness.

Verification
1. Start backend: `./scripts/start-backend.sh` (wait for /health ok)
2. Start frontend: `./scripts/start-frontend.sh` (open http://127.0.0.1:60080)
3. Navigate to Stats → switch ranges:
   - 1d with 15m/30m/1h buckets
   - 1mo with 6h/12h/1d buckets
   - Page stays responsive, animations present under normal data sizes.
4. (Optional) Direct API:
   - `/api/stats/timeseries?range=1mo&bucket=6h`
   - `/api/stats/summary?window=1mo`

Notes
- Index creation is idempotent and performed during `ensure_schema`; no manual migration needed.
- No changes to API schemas; UI/UX improved for long ranges.
