### PR TITLE
feat(web): footer shows grey struck old → new tag

### DIFF
--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -136,41 +136,21 @@ export function AppLayout() {
     !!normalizedBackendVersion && normalizedBackendVersion === normalizedFrontendVersion
 
   function renderDiffVersion(oldV: string, newV: string) {
-    // Compute visual diff on full normalized version (including suffix),
-    // and strike only the changed part from the old version.
-    const oldRaw = oldV.replace(/^v/, '')
-    const newRaw = newV.replace(/^v/, '')
-    const minLen = Math.min(oldRaw.length, newRaw.length)
-    // Longest common prefix
-    let p = 0
-    while (p < minLen && oldRaw[p] === newRaw[p]) p++
-    // Longest common suffix, avoid overlapping prefix
-    let s = 0
-    while (s < minLen - p && oldRaw[oldRaw.length - 1 - s] === newRaw[newRaw.length - 1 - s]) {
-      s++
-    }
-    const prefix = newRaw.slice(0, p)
-    const oldMid = oldRaw.slice(p, oldRaw.length - s)
-    const newMid = newRaw.slice(p, newRaw.length - s)
-    const suffix = newRaw.slice(newRaw.length - s)
+    // Simple, clear style: strike the whole old version (grey), arrow, then new version.
     return (
       <>
         <span>{t('app.footer.newVersionAvailable')}{' '}</span>
+        <span className="font-mono text-base-content/60">
+          <del style={{ textDecorationColor: 'currentColor' }}>{oldV}</del>
+        </span>
+        <span aria-hidden>{' '}										{' 		'}→{' '}</span>
         <a
           className="link font-mono"
           href={releaseLink ?? undefined}
           target="_blank"
           rel="noreferrer"
         >
-          {'v'}
-          {prefix}
-          {oldMid ? (
-            <del className="text-error" style={{ textDecorationColor: 'currentColor' }}>
-              {oldMid}
-            </del>
-          ) : null}
-          <span className="text-success">{newMid}</span>
-          {suffix}
+          {newV}
         </a>
       </>
     )

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -136,11 +136,10 @@ export function AppLayout() {
     !!normalizedBackendVersion && normalizedBackendVersion === normalizedFrontendVersion
 
   function renderDiffVersion(oldV: string, newV: string) {
-    // For display, strip prerelease/build suffixes like -dev/-rc/+meta, to match
-    // the requested visual style (e.g., show v0.2.~3~5 instead of including -dev).
-    const stripSuffix = (v: string) => v.replace(/^v/, '').split(/[+-]/, 1)[0]
-    const oldRaw = stripSuffix(oldV)
-    const newRaw = stripSuffix(newV)
+    // Compute visual diff on full normalized version (including suffix),
+    // and strike only the changed part from the old version.
+    const oldRaw = oldV.replace(/^v/, '')
+    const newRaw = newV.replace(/^v/, '')
     const minLen = Math.min(oldRaw.length, newRaw.length)
     // Longest common prefix
     let p = 0
@@ -165,8 +164,12 @@ export function AppLayout() {
         >
           {'v'}
           {prefix}
-          {oldMid ? <del>{oldMid}</del> : null}
-          {newMid}
+          {oldMid ? (
+            <del className="text-error" style={{ textDecorationColor: 'currentColor' }}>
+              {oldMid}
+            </del>
+          ) : null}
+          <span className="text-success">{newMid}</span>
           {suffix}
         </a>
       </>


### PR DESCRIPTION
Final design per request:
- Only show version banner when front-end and back-end differ.
- Display: "页面有新版本" + grey, struck-through old version, arrow, then link to new tag.
- Example: 页面有新版本 v0.2.3 → v0.2.5-dev (old fully struck via <del>, grey text; new is a link to the tag).
- No other colors, no scope labels when equal.

Changes
- web/src/components/AppLayout.tsx: simplify banner rendering to old (grey, del) → new (linked tag).
- i18n keys already present (app.footer.newVersionAvailable).

Verification
- Local dev with backend v0.2.5-dev and frontend v0.2.3 renders banner.
- Equal versions render only single vX linked to tag (no banner).

Notes
- Replaces prior diff-highlighting approach with the requested clear, minimal style.
