### PR TITLE
fix(web): center usage calendar and align month labels

### DIFF
--- a/web/src/components/UsageCalendar.tsx
+++ b/web/src/components/UsageCalendar.tsx
@@ -184,17 +184,17 @@ export function UsageCalendar() {
   // Measure tabs width (kept for possible future responsive tweaks)
   // no-op: tab width no longer influences calendar sizing
 
-  // Measure svg margin-left (weekday label offset) and track changes
+  // Measure left offset from container to SVG (includes weekday label margin + centering gap)
   // Avoid periodic polling that could cause layout thrashing/jitter.
   useLayoutEffect(() => {
     const contEl = containerRef.current
     if (!contEl) return
     const queryAndSet = () => {
-      const svg = contEl.querySelector('svg') as SVGElement | null
+      const svg = contEl.querySelector('article svg') as SVGElement | null
       if (!svg) return
-      const ml = parseFloat(getComputedStyle(svg).marginLeft || '0')
-      if (!Number.isFinite(ml)) return
-      const next = Math.max(0, Math.round(ml))
+      const svgRect = svg.getBoundingClientRect()
+      const contRect = contEl.getBoundingClientRect()
+      const next = Math.max(0, Math.round(svgRect.left - contRect.left))
       setLeftOffset((prev) => (prev !== next ? next : prev))
     }
     // initial read and re-read once after paint

--- a/web/src/components/UsageCalendar.tsx
+++ b/web/src/components/UsageCalendar.tsx
@@ -268,7 +268,7 @@ export function UsageCalendar() {
             <div className="min-w-0">
               <div
                 ref={containerRef}
-                className="relative block w-full overflow-hidden pt-4 [&>svg]:h-auto [&>svg]:w-full"
+                className="relative flex w-full justify-center overflow-hidden pt-4 [&>svg]:h-auto"
                 style={minContainerWidth ? { minWidth: `${minContainerWidth}px` } : undefined}
                 data-testid="usage-calendar-wrapper"
               >

--- a/web/tests/e2e/usage-calendar.spec.ts
+++ b/web/tests/e2e/usage-calendar.spec.ts
@@ -76,4 +76,25 @@ test.describe('UsageCalendar responsive layout', () => {
     test.info().annotations.push({ type: 'width-samples', description: JSON.stringify(samples) })
     expect(max - min).toBeLessThanOrEqual(2)
   })
+
+  test('centers calendar when stacked at 768px', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 900 })
+    await page.goto('/dashboard')
+    const wrapper = page.getByTestId('usage-calendar-wrapper')
+    await wrapper.waitFor({ state: 'visible' })
+    await page.waitForTimeout(300)
+    const gaps = await wrapper.evaluate((el) => {
+      const rect = (el as HTMLElement).getBoundingClientRect()
+      const article = (el as HTMLElement).querySelector('article') as HTMLElement | null
+      if (!article) {
+        return { leftGap: 0, rightGap: 0, width: rect.width, articleWidth: rect.width }
+      }
+      const a = article.getBoundingClientRect()
+      const leftGap = Math.round(a.left - rect.left)
+      const rightGap = Math.round(rect.right - a.right)
+      return { leftGap, rightGap, width: Math.round(rect.width), articleWidth: Math.round(a.width) }
+    })
+    test.info().annotations.push({ type: 'center-gaps', description: JSON.stringify(gaps) })
+    expect(Math.abs(gaps.leftGap - gaps.rightGap)).toBeLessThanOrEqual(16)
+  })
 })


### PR DESCRIPTION
Summary
- Stabilize usage calendar sizing; remove jitter on large viewports
- Center calendar when stacked on small screens
- Align month labels with centered grid (use container→SVG offset)
- Keep adaptive min-width so blocks retain healthy height

Verification
- E2E tests: 6 passing (incl. 1873px anti-jitter, 768px centering)
- Manual checks via Playwright screenshots

Notes
- No backend changes. Front-end only in UsageCalendar + e2e.
- No config/schema changes.
