### PR TITLE
feat(web): enable SSE for dashboard recent records

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -30,7 +30,7 @@ export default function DashboardPage() {
     records,
     isLoading: tableLoading,
     error: tableError,
-  } = useInvocationStream(RECENT_LIMIT, undefined, undefined, { enableStream: false })
+  } = useInvocationStream(RECENT_LIMIT, undefined, undefined, { enableStream: true })
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">


### PR DESCRIPTION
### Summary

Enable SSE streaming for the dashboard "recent 20 live records" table so that it updates in real time as new invocation records arrive.

### Changes

- Frontend (web):
  - `web/src/pages/Dashboard.tsx`
    - Switch `useInvocationStream` for the recent records table from `enableStream: false` to `enableStream: true`.
    - This makes the "Latest 20 live records" section use the shared SSE stream (via `useInvocationStream` and `/events`) instead of only fetching once on page load.

### Verification

- Local dev:
  - Start backend: `./scripts/start-backend.sh`
  - Start frontend: `./scripts/start-frontend.sh`
  - Open `http://127.0.0.1:60080/dashboard`
  - Observe that the "最近 20 条实况 / Latest 20 live records" table now updates automatically when new Codex invocations are ingested (no manual refresh required).

No backend/API surface changes; this PR only toggles the existing SSE-enabled hook on the dashboard page.