### PR TITLE
feat(web): add rich tooltips for heatmaps

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -130,6 +130,7 @@ const baseTranslations = {
     'chart.totalTokens': 'Total tokens',
     'chart.totalCost': 'Cost (USD)',
     'chart.totalCount': 'Calls',
+    'unit.calls': 'calls',
     'quota.status.expired.badge': 'Expired',
   },
   zh: {
@@ -258,6 +259,7 @@ const baseTranslations = {
     'chart.totalTokens': '总 Tokens',
     'chart.totalCost': '成本（美元）',
     'chart.totalCount': '次数',
+    'unit.calls': '次',
     'quota.status.expired.badge': '已到期',
   },
 } as const

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -14,3 +14,13 @@ body {
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum" 1;
 }
+
+/* Utility to hide scrollbars while preserving scroll behavior */
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}

--- a/web/src/lib/numberFormatters.ts
+++ b/web/src/lib/numberFormatters.ts
@@ -1,0 +1,24 @@
+export function formatTokensShort(value: number, localeTag: string): string {
+  const abs = Math.abs(value)
+  const sign = value < 0 ? '-' : ''
+
+  const format = (n: number) =>
+    new Intl.NumberFormat(localeTag, {
+      maximumFractionDigits: n >= 10 ? 0 : 1,
+      minimumFractionDigits: 0,
+    }).format(n)
+
+  if (abs >= 1_000_000_000) {
+    return `${sign}${format(abs / 1_000_000_000)}B`
+  }
+  if (abs >= 1_000_000) {
+    return `${sign}${format(abs / 1_000_000)}M`
+  }
+  if (abs >= 1_000) {
+    return `${sign}${format(abs / 1_000)}K`
+  }
+
+  // For smaller values, keep full precision but with locale-aware grouping
+  return new Intl.NumberFormat(localeTag, { maximumFractionDigits: 0 }).format(value)
+}
+

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -45,7 +45,7 @@ export default function DashboardPage() {
 
       <WeeklyHourlyHeatmap />
 
-      <section className="card bg-base-100 shadow-sm">
+      <section className="card bg-base-100 shadow-sm overflow-visible">
         <div className="card-body gap-6">
           <div className="flex items-center justify-between gap-3">
             <h2 className="card-title">{t('dashboard.section.summaryTitle')}</h2>


### PR DESCRIPTION
Add rich tooltips to all heatmaps (weekly, 24h, usage calendar) with token scaling, localized units and improved hover UX.

Changes
- WeeklyHourlyHeatmap: add two-line HTML tooltip (datetime + value), scale tokens with K/M/B using formatTokensShort, localize counts with "次"/"calls", and avoid clipping on bottom rows.
- Last24hTenMinuteHeatmap: same tooltip pattern for 10-minute grid, using bottom/top placement to avoid card border clipping.
- UsageCalendar: custom tooltip overlay above react-activity-calendar with consistent styling, edge clamping to keep bubbles inside the card, and shared token/count formatting.
- Add web/src/lib/numberFormatters.ts and unit.calls translation key; add .no-scrollbar utility to hide inner scrollbars without changing layout.

Verification
- Ran `npm run lint` and `npm run build` in `web` (via lefthook pre-commit hooks).
- Visually verified in browser:
  - All three heatmaps show tooltips on hover for all metrics.
  - Tokens display as 20M/100K style values; counts show localized unit.
  - Tooltips are not clipped on left/right edges or bottom rows and do not introduce extra scrollbars in cards.

Signed-off-by: Ivan Li <ivanli2048@gmail.com>