### PR TITLE
style(web): unify card typography

### DIFF
--- a/web/src/components/Last24hTenMinuteHeatmap.tsx
+++ b/web/src/components/Last24hTenMinuteHeatmap.tsx
@@ -154,7 +154,9 @@ export function Last24hTenMinuteHeatmap({ metric: controlledMetric, onChangeMetr
       <div className="gap-4">
         {showHeader && (
           <div className="flex items-center justify-between gap-3">
-            <h3 className="card-title">{t('heatmap24h.title')}</h3>
+            <div className="card-heading">
+              <h3 className="card-title">{t('heatmap24h.title')}</h3>
+            </div>
             <div className="tabs tabs-sm tabs-border" role="tablist" aria-label={t('heatmap.metricsToggleAria')}>
               {metricOptions.map((o) => {
                 const active = o.key === metric

--- a/web/src/components/QuotaOverview.tsx
+++ b/web/src/components/QuotaOverview.tsx
@@ -62,10 +62,10 @@ export function QuotaOverview({ snapshot, isLoading, error }: QuotaOverviewProps
   return (
     <div className="card h-full bg-base-100 shadow-sm">
       <div className="card-body gap-6">
-        <div className="flex flex-wrap items-center justify-between">
-          <div>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="card-heading">
             <h2 className="card-title">{t('quota.title')}</h2>
-            <p className="text-sm text-base-content/60 flex items-center gap-2">
+            <p className="card-description flex items-center gap-2">
               <span>{t('quota.subscription', { name: snapshot?.subTypeName ?? '—' })}</span>
               <CountdownUntil expireISO={snapshot?.expireTime} />
             </p>

--- a/web/src/components/UsageCalendar.tsx
+++ b/web/src/components/UsageCalendar.tsx
@@ -252,13 +252,15 @@ export function UsageCalendar() {
       className="card h-full w-full max-w-full overflow-visible bg-base-100 shadow-sm lg:w-fit"
       data-testid="usage-calendar-card"
     >
-      <div className="card-body gap-4 lg:w-auto">
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="card-title">{t('calendar.title')}</h2>
-            <div
-              className="tabs tabs-sm tabs-border"
-              role="tablist"
+        <div className="card-body gap-4 lg:w-auto">
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="card-heading">
+                <h2 className="card-title">{t('calendar.title')}</h2>
+              </div>
+              <div
+                className="tabs tabs-sm tabs-border"
+                role="tablist"
               aria-label={t('calendar.metricsToggleAria')}
             >
               {metricOptions.map((option) => {

--- a/web/src/components/WeeklyHourlyHeatmap.tsx
+++ b/web/src/components/WeeklyHourlyHeatmap.tsx
@@ -127,7 +127,9 @@ export function WeeklyHourlyHeatmap() {
     <section className="card bg-base-100 shadow-sm overflow-visible" data-testid="weekly-hourly-heatmap">
       <div className="card-body gap-4">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="card-title">{t('heatmap.title')}</h2>
+          <div className="card-heading">
+            <h2 className="card-title">{t('heatmap.title')}</h2>
+          </div>
           <div className="tabs tabs-sm tabs-border" role="tablist" aria-label={t('heatmap.metricsToggleAria')}>
             {metricOptions.map((o) => {
               const active = o.key === metric

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -15,6 +15,30 @@ body {
   font-feature-settings: "tnum" 1;
 }
 
+/* Unified card typography */
+.card-heading {
+  @apply flex flex-col gap-1;
+}
+
+.card-title {
+  @apply text-lg sm:text-xl font-semibold leading-tight tracking-tight text-base-content;
+}
+
+.card-subtitle,
+.card-eyebrow {
+  @apply text-xs font-semibold uppercase text-base-content opacity-60;
+  letter-spacing: 0.12em;
+}
+
+.card-description {
+  @apply text-sm leading-relaxed text-base-content opacity-70;
+}
+
+/* Align stat tiles with the card heading tone */
+.stats .stat-title {
+  @apply text-xs font-semibold uppercase text-base-content opacity-70 tracking-[0.14em];
+}
+
 /* Utility to hide scrollbars while preserving scroll behavior */
 .no-scrollbar {
   -ms-overflow-style: none; /* IE and Edge */

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -47,8 +47,10 @@ export default function DashboardPage() {
 
       <section className="card bg-base-100 shadow-sm overflow-visible">
         <div className="card-body gap-6">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="card-title">{t('dashboard.section.summaryTitle')}</h2>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="card-heading">
+              <h2 className="card-title">{t('dashboard.section.summaryTitle')}</h2>
+            </div>
             <div className="tabs tabs-sm tabs-border" role="tablist" aria-label={t('heatmap.metricsToggleAria')}>
               {[
                 { key: 'totalCount', label: t('metric.totalCount') },
@@ -83,7 +85,9 @@ export default function DashboardPage() {
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-4">
           <div className="flex items-center justify-between">
-            <h2 className="card-title">{t('dashboard.section.recentLiveTitle', { count: RECENT_LIMIT })}</h2>
+            <div className="card-heading">
+              <h2 className="card-title">{t('dashboard.section.recentLiveTitle', { count: RECENT_LIMIT })}</h2>
+            </div>
           </div>
           <InvocationTable records={records} isLoading={tableLoading} error={tableError} />
         </div>

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -46,8 +46,10 @@ export default function LivePage() {
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 className="card-title">{t('live.summary.title')}</h2>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="card-heading">
+              <h2 className="card-title">{t('live.summary.title')}</h2>
+            </div>
             <div className="join">
               {summaryWindows.map((option) => (
                 <input
@@ -69,8 +71,10 @@ export default function LivePage() {
 
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-6">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 className="card-title">{t('live.chart.title')}</h2>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="card-heading">
+              <h2 className="card-title">{t('live.chart.title')}</h2>
+            </div>
             <label className="form-control w-36">
               <div className="label py-0">
                 <span className="label-text text-xs uppercase tracking-wide">{t('live.window.label')}</span>
@@ -94,7 +98,9 @@ export default function LivePage() {
 
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-4">
-          <h2 className="card-title">{t('live.latest.title')}</h2>
+          <div className="card-heading">
+            <h2 className="card-title">{t('live.latest.title')}</h2>
+          </div>
           <InvocationTable records={records} isLoading={isLoading} error={error} />
         </div>
       </section>

--- a/web/src/pages/Stats.tsx
+++ b/web/src/pages/Stats.tsx
@@ -124,10 +124,10 @@ export default function StatsPage() {
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="card-heading">
               <h2 className="card-title">{t('stats.title')}</h2>
-              <p className="text-sm text-base-content/60">{t('stats.subtitle')}</p>
+              <p className="card-description">{t('stats.subtitle')}</p>
             </div>
             <div className="flex flex-wrap items-center gap-3">
               <select
@@ -176,7 +176,9 @@ export default function StatsPage() {
 
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-4">
-          <h3 className="card-title">{t('stats.trendTitle')}</h3>
+          <div className="card-heading">
+            <h3 className="card-title">{t('stats.trendTitle')}</h3>
+          </div>
           {timeseriesError ? (
             <div className="alert alert-error">{timeseriesError}</div>
           ) : (
@@ -191,7 +193,9 @@ export default function StatsPage() {
 
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-4">
-          <h3 className="card-title">{t('stats.successFailureTitle')}</h3>
+          <div className="card-heading">
+            <h3 className="card-title">{t('stats.successFailureTitle')}</h3>
+          </div>
           {timeseriesError ? (
             <div className="alert alert-error">{timeseriesError}</div>
           ) : (
@@ -206,7 +210,9 @@ export default function StatsPage() {
 
       <section className="card bg-base-100 shadow-sm">
         <div className="card-body gap-4">
-          <h3 className="card-title">{t('stats.errors.title')}</h3>
+          <div className="card-heading">
+            <h3 className="card-title">{t('stats.errors.title')}</h3>
+          </div>
           {errorsError ? (
             <div className="alert alert-error">{errorsError}</div>
           ) : (


### PR DESCRIPTION
## Summary
- unify card title/subtitle/description typography with shared classes
- align card headers and controls across dashboard/stats/live views
- restyle stat titles to match the updated heading tone

## Testing
- eslint web
- typecheck web
