### PR TITLE
chore(dev): align dev server runtime to devctl + zellij

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /web/node_modules
 /web/dist
 /web/.vite
+.codex/
 logs/
 .serena

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,43 +21,42 @@
 
 This workflow avoids blocking the shell and strictly prohibits using `alarm` for long‑running services. The only acceptable use of short timeouts is for one‑off, non‑service commands (e.g., a build), never for dev servers.
 
-- Always start local dev servers via the wrapper scripts under `scripts/`:
-  - `./scripts/start-backend.sh` for the Rust API (port 8080).
-  - `./scripts/start-frontend.sh` for the Vite SPA (port 60080).
-- Do **not** launch these services by hand with ad-hoc `nohup`/`cargo run`/`npm run dev` commands; the wrappers enforce PID tracking and strict port usage. If a port is in use the script exits and you must resolve the conflict manually instead of allowing automatic port changes.
+- Always run long-lived dev services via `devctl` (Zellij background sessions), either directly or through `scripts/` wrappers:
+  - Backend start: `./scripts/start-backend.sh`
+  - Frontend start: `./scripts/start-frontend.sh`
+  - Status: `./scripts/dev-status.sh`
+  - Stop: `./scripts/stop-backend.sh` / `./scripts/stop-frontend.sh`
 
-- NEVER wrap long‑running dev services (backend, Vite) with `alarm` or any hard kill timeout.
-- Run services in background with `nohup` + PID files; detach stdin to prevent TTY hangs.
-- Use bounded readiness probes (curl loops with a hard max wait) instead of waiting on processes.
-- If readiness fails, fail fast and print the last log lines; do not keep waiting.
+- Do **not** launch these services by hand with ad-hoc `nohup`/`cargo run`/`npm run dev` commands.
+- Do **not** use `alarm` for any long-running service (backend, Vite); it is only allowed for one-off commands that might hang.
 
 Service management (recommended patterns)
 
 - Backend (Rust, port `8080`):
-  - Start (detached):
-    - `mkdir -p logs && nohup env RUST_LOG=info cargo run </dev/null >> logs/backend.dev.log 2>&1 & echo $! > logs/backend.pid`
+  - Start (detached via zellij):
+    - `~/.codex/bin/devctl --root $(pwd) up backend -- env RUST_LOG=info cargo run`
   - Readiness (max 60s):
-    - `SECS=0; until curl -sS -m 1 http://127.0.0.1:8080/health | grep -q ok; do sleep 1; SECS=$((SECS+1)); if [ $SECS -ge 60 ]; then echo 'backend not ready'; tail -n 200 logs/backend.dev.log; exit 1; fi; done`
+    - `SECS=0; until curl -sS -m 1 http://127.0.0.1:8080/health | grep -q ok; do sleep 1; SECS=$((SECS+1)); if [ $SECS -ge 60 ]; then echo 'backend not ready'; ~/.codex/bin/devctl --root $(pwd) logs backend -n 200; exit 1; fi; done`
+  - Logs:
+    - `~/.codex/bin/devctl --root $(pwd) logs backend -n 200`
   - Stop:
-    - `kill $(lsof -ti tcp:8080 -sTCP:LISTEN) 2>/dev/null || kill $(cat logs/backend.pid) 2>/dev/null || true`
+    - `~/.codex/bin/devctl --root $(pwd) down backend`
 
-- Front‑end (Vite, port `60080`):
-  - Start (detached):
-    - `mkdir -p logs && nohup bash -lc 'cd web && npm run dev -- --host 127.0.0.1 --port 60080' </dev/null >> logs/web.dev.log 2>&1 & echo $! > logs/web.pid`
+- Front-end (Vite, port `60080`):
+  - Start (detached via zellij):
+    - `~/.codex/bin/devctl --root $(pwd) up frontend -- bash -lc 'cd web && npm run dev -- --host 127.0.0.1 --port 60080 --strictPort true'`
   - Readiness (max 90s):
-    - `SECS=0; until curl -sS -m 1 http://127.0.0.1:60080/ >/dev/null; do sleep 1; SECS=$((SECS+1)); if [ $SECS -ge 90 ]; then echo 'frontend not ready'; tail -n 200 logs/web.dev.log; exit 1; fi; done`
+    - `SECS=0; until curl -sS -m 1 http://127.0.0.1:60080/ >/dev/null; do sleep 1; SECS=$((SECS+1)); if [ $SECS -ge 90 ]; then echo 'frontend not ready'; ~/.codex/bin/devctl --root $(pwd) logs frontend -n 200; exit 1; fi; done`
+  - Logs:
+    - `~/.codex/bin/devctl --root $(pwd) logs frontend -n 200`
   - Stop:
-    - `kill $(lsof -ti tcp:60080 -sTCP:LISTEN) 2>/dev/null || kill $(cat logs/web.pid) 2>/dev/null || true`
-
-- Avoid overlapping instances:
-  - Prefer kill‑by‑port before restart (see Stop commands above).
-  - Always write `logs/*.pid`; do not commit log/PID files.
+    - `~/.codex/bin/devctl --root $(pwd) down frontend`
 
 Operational notes
 
-- `alarm` must NOT be used for any background service. It is permitted only for ad‑hoc commands that could hang (e.g., migrations) and must never be combined with `nohup`.
-- Always run readiness checks with finite timeouts and exit non‑zero on failure to avoid indefinite blocking.
-- Keep services’ stdout/err in `logs/*.log` and rely on `tail -n` on failures instead of `tail -f` to avoid blocking the shell.
+- One service per zellij session; stopping is always `devctl down <service>` (focus-independent).
+- Logs are written to `.codex/logs/<service>.log` so viewing does not depend on focused panes.
+- If a port is in use, the wrapper scripts will refuse to start and you must resolve the conflict manually.
 - Vite dev server proxies to the backend as configured in `web/vite.config.ts`.
 
 ## Coding Style & Naming Conventions

--- a/README.md
+++ b/README.md
@@ -58,6 +58,34 @@ npm run dev -- --host 127.0.0.1 --port 60080
 
 开发服务器默认代理到 `http://127.0.0.1:8080`，也可用 `VITE_BACKEND_PROXY` 覆盖。
 
+### Codex（devctl + zellij）推荐启动方式
+
+在 Codex 环境中，长驻开发服务建议使用 `devctl`（Zellij 后台 session），以便服务在 turn 边界后仍持续运行，并提供统一的 `status/logs/down` 管理入口。
+
+一键方式（推荐）：
+
+```bash
+./scripts/start-backend.sh
+./scripts/start-frontend.sh
+./scripts/dev-status.sh
+
+# stop
+./scripts/stop-backend.sh
+./scripts/stop-frontend.sh
+```
+
+日志默认落在：
+
+- `.codex/logs/backend.log`
+- `.codex/logs/frontend.log`
+
+也可以使用 `devctl` 直接查看：
+
+```bash
+~/.codex/bin/devctl --root "$(pwd)" logs backend -n 200
+~/.codex/bin/devctl --root "$(pwd)" logs frontend -n 200
+```
+
 ## 配置
 
 在仓库根目录创建 `.env.local`（已忽略提交），常用变量如下（括号内为默认值）：

--- a/docs/plan/0003:dev-runtime-service-manager/PLAN.md
+++ b/docs/plan/0003:dev-runtime-service-manager/PLAN.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 部分完成（2/3）
+- Status: 已完成
 - Created: 2026-02-20
 - Last: 2026-02-20
 
@@ -70,8 +70,12 @@
 
 - [x] M1: `scripts/` 启动/停止脚本迁移为 `devctl`（No fallback）
 - [x] M2: 文档口径对齐（AGENTS.md + README.md + .gitignore）
-- [ ] M3: 最小验证与 PR 交付（PR + checks 结果明确）
+- [x] M3: 最小验证与 PR 交付（PR + checks 结果明确）
 
 ## 风险与开放问题（Risks / Open questions）
 
 - 本仓库脚本强依赖 `zellij` + `~/.codex/bin/devctl`；若不满足则启动失败（符合 No fallback 的预期）。
+
+## 变更记录（Change log）
+
+- 2026-02-20: 对齐开发环境长驻服务到 devctl+zellij（脚本、文档、忽略规则）。PR #37。

--- a/docs/plan/0003:dev-runtime-service-manager/PLAN.md
+++ b/docs/plan/0003:dev-runtime-service-manager/PLAN.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 待实现
+- Status: 部分完成（2/3）
 - Created: 2026-02-20
 - Last: 2026-02-20
 
@@ -68,8 +68,8 @@
 
 ## 里程碑（Milestones）
 
-- [ ] M1: `scripts/` 启动/停止脚本迁移为 `devctl`（No fallback）
-- [ ] M2: 文档口径对齐（AGENTS.md + README.md + .gitignore）
+- [x] M1: `scripts/` 启动/停止脚本迁移为 `devctl`（No fallback）
+- [x] M2: 文档口径对齐（AGENTS.md + README.md + .gitignore）
 - [ ] M3: 最小验证与 PR 交付（PR + checks 结果明确）
 
 ## 风险与开放问题（Risks / Open questions）

--- a/docs/plan/0003:dev-runtime-service-manager/PLAN.md
+++ b/docs/plan/0003:dev-runtime-service-manager/PLAN.md
@@ -1,0 +1,77 @@
+# 开发环境 devctl+zellij 保活（#0003）
+
+## 状态
+
+- Status: 待实现
+- Created: 2026-02-20
+- Last: 2026-02-20
+
+## 问题陈述
+
+当前仓库的长驻开发服务（backend / frontend）主要通过 `nohup + logs/*.pid` 启动与管理：
+
+- PID 文件可能漂移/陈旧（尤其当服务被其它方式启动或重启后），导致 stop/status 难以可信。
+- 日志、状态、停止方式缺少统一入口，不符合 Codex 环境的最新长驻服务方案。
+
+需要对齐到 `devctl + zellij`：一个 service 一个 zellij session，日志落到 `.codex/logs/*.log`，并通过 `devctl status/logs/down` 统一管理。
+
+## 目标 / 非目标
+
+### Goals
+
+- 以 `~/.codex/bin/devctl` + zellij 作为唯一的长驻开发服务启动方式（No fallback）。
+- 统一启动/停止/日志/状态命令与脚本入口。
+- 文档口径对齐：`AGENTS.md` 为强约束，`README.md` 提供推荐方式并保留通用 quickstart。
+
+### Non-goals
+
+- 不改变运行端口与参数：backend `127.0.0.1:8080`，frontend `127.0.0.1:60080`。
+- 不引入 pm2/systemd 等其它进程管理器。
+- 不清理历史日志文件。
+
+## 范围（Scope）
+
+### In scope
+
+- `scripts/` 中的 dev server 启动脚本迁移为 `devctl`。
+- 新增 stop/status 辅助脚本。
+- `.gitignore` 忽略 `.codex/` 目录。
+- 更新 `AGENTS.md` 与 `README.md` 的开发运行口径。
+
+### Out of scope
+
+- 后端/前端业务逻辑修改。
+- CI、Docker、发布流程修改。
+
+## 验收标准（Acceptance Criteria）
+
+- Given 在仓库根目录
+  When 执行 `./scripts/start-backend.sh`
+  Then `~/.codex/bin/devctl --root <repo> status backend` 为 running，且 `curl http://127.0.0.1:8080/health` 返回 `ok`。
+- Given 在仓库根目录
+  When 执行 `./scripts/start-frontend.sh`
+  Then `~/.codex/bin/devctl --root <repo> status frontend` 为 running，且 `curl http://127.0.0.1:60080/` 可达。
+- Given backend/frontend 已 running
+  When 再次执行 `./scripts/start-*.sh`
+  Then 脚本返回 0 并提示已在运行（不应因端口占用报错）。
+- When 执行 `./scripts/stop-backend.sh` 与 `./scripts/stop-frontend.sh`
+  Then 对应 `devctl status` 变为 stopped，端口不再监听。
+- `.codex/` 不应出现在 `git status` 未跟踪文件中（已被 `.gitignore` 忽略）。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+- 本地至少执行 1 条与改动相关的自动化验证：
+  - `bash -n scripts/start-backend.sh`
+  - `bash -n scripts/start-frontend.sh`
+  - `bash -n scripts/stop-backend.sh`
+  - `bash -n scripts/stop-frontend.sh`
+
+## 里程碑（Milestones）
+
+- [ ] M1: `scripts/` 启动/停止脚本迁移为 `devctl`（No fallback）
+- [ ] M2: 文档口径对齐（AGENTS.md + README.md + .gitignore）
+- [ ] M3: 最小验证与 PR 交付（PR + checks 结果明确）
+
+## 风险与开放问题（Risks / Open questions）
+
+- 本仓库脚本强依赖 `zellij` + `~/.codex/bin/devctl`；若不满足则启动失败（符合 No fallback 的预期）。

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -52,7 +52,8 @@
 
 ## Index（固定表格）
 
-|   ID | Title                    | Status | Plan                                  | Last       | Notes  |
-| ---: | ------------------------ | ------ | ------------------------------------- | ---------- | ------ |
-| 0001 | 接入 Claude Relay 统计源 | 待实现 | `0001:claude-relay-api-stats/PLAN.md` | 2026-01-16 | -      |
-| 0002 | PR 标签驱动发版          | 已完成 | `0002:pr-label-release/PLAN.md`       | 2026-02-19 | PR #36 |
+|   ID | Title                       | Status | Plan                                       | Last       | Notes  |
+| ---: | --------------------------- | ------ | ------------------------------------------ | ---------- | ------ |
+| 0001 | 接入 Claude Relay 统计源    | 待实现 | `0001:claude-relay-api-stats/PLAN.md`      | 2026-01-16 | -      |
+| 0002 | PR 标签驱动发版             | 已完成 | `0002:pr-label-release/PLAN.md`            | 2026-02-19 | PR #36 |
+| 0003 | 开发环境 devctl+zellij 保活 | 待实现 | `0003:dev-runtime-service-manager/PLAN.md` | 2026-02-20 | -      |

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -52,8 +52,8 @@
 
 ## Index（固定表格）
 
-|   ID | Title                       | Status          | Plan                                       | Last       | Notes  |
-| ---: | --------------------------- | --------------- | ------------------------------------------ | ---------- | ------ |
-| 0001 | 接入 Claude Relay 统计源    | 待实现          | `0001:claude-relay-api-stats/PLAN.md`      | 2026-01-16 | -      |
-| 0002 | PR 标签驱动发版             | 已完成          | `0002:pr-label-release/PLAN.md`            | 2026-02-19 | PR #36 |
-| 0003 | 开发环境 devctl+zellij 保活 | 部分完成（2/3） | `0003:dev-runtime-service-manager/PLAN.md` | 2026-02-20 | -      |
+|   ID | Title                       | Status | Plan                                       | Last       | Notes  |
+| ---: | --------------------------- | ------ | ------------------------------------------ | ---------- | ------ |
+| 0001 | 接入 Claude Relay 统计源    | 待实现 | `0001:claude-relay-api-stats/PLAN.md`      | 2026-01-16 | -      |
+| 0002 | PR 标签驱动发版             | 已完成 | `0002:pr-label-release/PLAN.md`            | 2026-02-19 | PR #36 |
+| 0003 | 开发环境 devctl+zellij 保活 | 已完成 | `0003:dev-runtime-service-manager/PLAN.md` | 2026-02-20 | PR #37 |

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -52,8 +52,8 @@
 
 ## Index（固定表格）
 
-|   ID | Title                       | Status | Plan                                       | Last       | Notes  |
-| ---: | --------------------------- | ------ | ------------------------------------------ | ---------- | ------ |
-| 0001 | 接入 Claude Relay 统计源    | 待实现 | `0001:claude-relay-api-stats/PLAN.md`      | 2026-01-16 | -      |
-| 0002 | PR 标签驱动发版             | 已完成 | `0002:pr-label-release/PLAN.md`            | 2026-02-19 | PR #36 |
-| 0003 | 开发环境 devctl+zellij 保活 | 待实现 | `0003:dev-runtime-service-manager/PLAN.md` | 2026-02-20 | -      |
+|   ID | Title                       | Status          | Plan                                       | Last       | Notes  |
+| ---: | --------------------------- | --------------- | ------------------------------------------ | ---------- | ------ |
+| 0001 | 接入 Claude Relay 统计源    | 待实现          | `0001:claude-relay-api-stats/PLAN.md`      | 2026-01-16 | -      |
+| 0002 | PR 标签驱动发版             | 已完成          | `0002:pr-label-release/PLAN.md`            | 2026-02-19 | PR #36 |
+| 0003 | 开发环境 devctl+zellij 保活 | 部分完成（2/3） | `0003:dev-runtime-service-manager/PLAN.md` | 2026-02-20 | -      |

--- a/scripts/dev-status.sh
+++ b/scripts/dev-status.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+DEVCTL="${HOME}/.codex/bin/devctl"
+
+if [[ ! -x "$DEVCTL" ]]; then
+  echo "[dev] devctl not found or not executable: $DEVCTL" >&2
+  exit 1
+fi
+
+set +e
+"$DEVCTL" --root "$ROOT_DIR" status backend
+"$DEVCTL" --root "$ROOT_DIR" status frontend
+exit 0

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -4,18 +4,31 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-LOG_DIR="$ROOT_DIR/logs"
-PID_FILE="$LOG_DIR/backend.pid"
+DEVCTL="${HOME}/.codex/bin/devctl"
+SERVICE="backend"
 PORT=8080
 
-mkdir -p "$LOG_DIR"
-
-# stop existing process if requested
-if lsof -ti tcp:$PORT -sTCP:LISTEN >/dev/null 2>&1; then
-  echo "[backend] port $PORT already in use; refusing to auto-restart" >&2
+if [[ ! -x "$DEVCTL" ]]; then
+  echo "[backend] devctl not found or not executable: $DEVCTL" >&2
+  echo "[backend] this repo uses devctl+zellij for long-lived dev services (no fallback)" >&2
   exit 1
 fi
 
-nohup env RUST_LOG=info cargo run </dev/null >> "$LOG_DIR/backend.dev.log" 2>&1 &
-echo $! > "$PID_FILE"
-echo "[backend] started pid $(cat "$PID_FILE")"
+if ! command -v zellij >/dev/null 2>&1; then
+  echo "[backend] zellij not found in PATH" >&2
+  exit 1
+fi
+
+# If already running via devctl, do not fail on the port check (port is expected to be in use).
+if "$DEVCTL" --root "$ROOT_DIR" status "$SERVICE" >/dev/null 2>&1; then
+  echo "[backend] already running (devctl session exists)"
+  exit 0
+fi
+
+if lsof -ti tcp:$PORT -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "[backend] port $PORT already in use; stop the existing process first" >&2
+  exit 1
+fi
+
+"$DEVCTL" --root "$ROOT_DIR" up "$SERVICE" -- env RUST_LOG=info cargo run
+echo "[backend] started via devctl (logs: $ROOT_DIR/.codex/logs/$SERVICE.log)"

--- a/scripts/stop-backend.sh
+++ b/scripts/stop-backend.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+DEVCTL="${HOME}/.codex/bin/devctl"
+SERVICE="backend"
+
+if [[ ! -x "$DEVCTL" ]]; then
+  echo "[backend] devctl not found or not executable: $DEVCTL" >&2
+  exit 1
+fi
+
+"$DEVCTL" --root "$ROOT_DIR" down "$SERVICE"

--- a/scripts/stop-frontend.sh
+++ b/scripts/stop-frontend.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+DEVCTL="${HOME}/.codex/bin/devctl"
+SERVICE="frontend"
+
+if [[ ! -x "$DEVCTL" ]]; then
+  echo "[frontend] devctl not found or not executable: $DEVCTL" >&2
+  exit 1
+fi
+
+"$DEVCTL" --root "$ROOT_DIR" down "$SERVICE"


### PR DESCRIPTION
Plan: docs/plan/0003:dev-runtime-service-manager/PLAN.md
Plan Status: 已完成

Summary:
- Switch long-lived dev server management from nohup+PID to devctl (zellij sessions)
- Add start/stop/status scripts and ignore .codex runtime directory
- Update AGENTS.md + README.md runtime guidance

Test Plan:
- bash -n scripts/start-backend.sh scripts/start-frontend.sh scripts/stop-backend.sh scripts/stop-frontend.sh scripts/dev-status.sh
- lefthook pre-commit hook ran: typecheck-web

Notes:
- No fallback: scripts require zellij and ~/.codex/bin/devctl
