### PR TITLE
fix(proxy): harden upstream streaming stability for Codex traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +795,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1504,6 +1524,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 chrono-tz = "0.10"
 dotenvy = "0.15"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "http2"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "macros"] }

--- a/docs/plan/0008:proxy-stream-stability/PLAN.md
+++ b/docs/plan/0008:proxy-stream-stability/PLAN.md
@@ -1,0 +1,45 @@
+# 代理流式稳定性修复（Codex 断流问题）
+
+## Goal
+
+修复 `/v1/*` 反向代理在流式转发阶段的误导性日志与断流处理，降低 Codex 侧出现 `stream disconnected before completion` / `error decoding response body` 的概率，并提升问题可观测性。
+
+## In / Out
+
+### In
+
+- 调整代理日志语义：区分“响应头就绪”与“流式完成”。
+- 在首包前上游流失败时直接返回 `502`，避免先返回 `200` 后中断。
+- 优化代理 HTTP 传输配置（启用 HTTP/2 keepalive）。
+- 增加对应回归测试（首包前失败、首包后失败）。
+- 使用 Codex 客户端走代理链路做稳定性联调。
+
+### Out
+
+- 不改动前端页面逻辑。
+- 不重构整体代理架构与存储模型。
+- 不引入额外中间件或新外部依赖服务。
+
+## Acceptance Criteria
+
+1. Given 上游在首个响应块前失败，When 代理处理该请求，Then 返回 `502` 且错误语义明确。
+2. Given 上游在首包后中断，When 代理转发流，Then 下游可感知流错误且日志可定位到同次代理请求。
+3. Given 正常流式响应，When 请求完成，Then 仅记录“headers ready”与“stream completed”两类语义明确日志，不再用“response finished”误导完整性。
+4. Given Codex 通过代理调用 `/v1/responses`，When 连续多次执行，Then 无 `stream disconnected before completion` 与 `error decoding response body` 签名。
+
+## Testing
+
+- 自动化测试：`cargo fmt`、`cargo test`（含新增回归用例）。
+- 最终联调：`codex exec` 通过 `http://127.0.0.1:8080/v1` 连续执行稳定性验证并统计结果。
+
+## Risks
+
+- 上游服务限流/鉴权策略可能干扰稳定性判断。
+- 日志增强会增加少量日志量；需关注生产日志采集成本。
+
+## Milestones
+
+- [ ] M1 日志语义修正与首包失败处理
+- [ ] M2 HTTP 传输配置优化（HTTP/2 keepalive）
+- [ ] M3 回归测试补齐并通过
+- [ ] M4 Codex 端到端联调完成并留存结果

--- a/docs/plan/0008:proxy-stream-stability/PLAN.md
+++ b/docs/plan/0008:proxy-stream-stability/PLAN.md
@@ -39,7 +39,13 @@
 
 ## Milestones
 
-- [ ] M1 日志语义修正与首包失败处理
-- [ ] M2 HTTP 传输配置优化（HTTP/2 keepalive）
-- [ ] M3 回归测试补齐并通过
-- [ ] M4 Codex 端到端联调完成并留存结果
+- [x] M1 日志语义修正与首包失败处理
+- [x] M2 HTTP 传输配置优化（HTTP/2 keepalive）
+- [x] M3 回归测试补齐并通过
+- [x] M4 Codex 端到端联调完成并留存结果
+
+## Execution Notes
+
+- PR: #43
+- Automated: `cargo fmt`, `cargo test`（55 passed, 0 failed）
+- Codex 联调：`codex exec` 走 `http://127.0.0.1:8080/v1`，连续 5 次稳定性验证通过（`pass=5, mismatch=0, fail=0`）

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -61,4 +61,4 @@
 | 0005 | OpenAI 反向代理透传         | 已完成 | `0005:openai-reverse-proxy/PLAN.md`           | 2026-02-22 | PR #40 |
 | 0006 | 代理模型列表劫持与合并      | 已完成 | `0006:proxy-model-list-hijack/PLAN.md`        | 2026-02-22 | PR #41 |
 | 0007 | MITM 请求级计费与性能采集   | 已完成 | `0007:proxy-mitm-usage-billing/PLAN.md`       | 2026-02-22 | PR #42 |
-| 0008 | 代理流式稳定性修复          | 待实现 | `0008:proxy-stream-stability/PLAN.md`         | 2026-02-23 | -      |
+| 0008 | 代理流式稳定性修复          | 已完成 | `0008:proxy-stream-stability/PLAN.md`         | 2026-02-23 | PR #43 |

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -61,3 +61,4 @@
 | 0005 | OpenAI 反向代理透传         | 已完成 | `0005:openai-reverse-proxy/PLAN.md`           | 2026-02-22 | PR #40 |
 | 0006 | 代理模型列表劫持与合并      | 已完成 | `0006:proxy-model-list-hijack/PLAN.md`        | 2026-02-22 | PR #41 |
 | 0007 | MITM 请求级计费与性能采集   | 已完成 | `0007:proxy-mitm-usage-billing/PLAN.md`       | 2026-02-22 | PR #42 |
+| 0008 | 代理流式稳定性修复          | 待实现 | `0008:proxy-stream-stability/PLAN.md`         | 2026-02-23 | -      |


### PR DESCRIPTION
## Summary

This PR fixes the in-project `/v1/*` reverse-proxy streaming path to avoid misleading success logs and improve robustness for Codex client traffic.

## Frozen Scope

Plan: `docs/plan/0008:proxy-stream-stability/PLAN.md`

- Split logging semantics between `response headers ready` and actual stream lifecycle.
- Return explicit `502` when upstream stream fails **before first chunk**.
- Preserve downstream stream behavior for mid-stream upstream failures, with better diagnostics.
- Enable `reqwest` HTTP/2 support and keepalive tuning for proxy clients.
- Add regression tests for first-chunk and mid-stream failure paths.
- Validate with real Codex client calls through proxy (`codex exec` against `http://127.0.0.1:8080/v1`).

## Key Changes

- `Cargo.toml`
  - Enable `reqwest` feature: `http2`.
- `src/main.rs`
  - Rename misleading log from `openai proxy response finished` to `openai proxy response headers ready`.
  - Introduce first-chunk gate:
    - first chunk error => immediate `502`.
    - empty body => build empty response cleanly.
  - Stream forwarding moved into task with explicit diagnostics for:
    - downstream early-close,
    - upstream mid-stream error,
    - upstream stream completed.
  - Add HTTP/2 keepalive settings on shared/proxy HTTP clients.
  - Add upstream test endpoints for stream-first-error / stream-mid-error.
  - Add regression tests:
    - `proxy_openai_v1_returns_bad_gateway_when_first_stream_chunk_fails`
    - `proxy_openai_v1_propagates_stream_error_after_first_chunk`

## Test Plan

### Automated

- `cargo fmt`
- `cargo test`

Result: `55 passed, 0 failed`.

### Codex end-to-end via proxy (required final integration)

Proxy target for Codex provider:

- `model_providers.nsngc.base_url = "http://127.0.0.1:8080/v1"`

Stability run (5 consecutive `codex exec` calls):

- `total=5, pass=5, fail=0`
- proxy logs: `openai proxy request started=7`, `openai proxy response headers ready=7`
- error signatures found: `0`
  - no `stream disconnected before completion`
  - no `error decoding response body`
  - no `openai proxy upstream response stream error`

## Risk / Notes

- Upstream auth/rate-limit behavior can still influence perceived reliability, but this PR removes proxy-side false-positive success logging and handles pre-first-chunk failures explicitly.
