### PR TITLE
docs(plan): sync fd4pw rollout progress and observation notes

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -52,14 +52,14 @@
 
 ## Index（固定表格）
 
-|    ID | Title                          | Status | Plan                                              | Last       | Notes  |
-| ----: | ------------------------------ | ------ | ------------------------------------------------- | ---------- | ------ |
-|  0001 | 接入 Claude Relay 统计源       | 待实现 | `0001:claude-relay-api-stats/PLAN.md`             | 2026-01-16 | -      |
-|  0002 | PR 标签驱动发版                | 已完成 | `0002:pr-label-release/PLAN.md`                   | 2026-02-19 | PR #36 |
-|  0003 | 开发环境 devctl+zellij 保活    | 已完成 | `0003:dev-runtime-service-manager/PLAN.md`        | 2026-02-20 | PR #37 |
-|  0004 | 统计按浏览器时区自然日         | 已完成 | `0004:reporting-timezone-natural-day/PLAN.md`     | 2026-02-20 | PR #38 |
-|  0005 | OpenAI 反向代理透传            | 已完成 | `0005:openai-reverse-proxy/PLAN.md`               | 2026-02-22 | PR #40 |
-|  0006 | 代理模型列表劫持与合并         | 已完成 | `0006:proxy-model-list-hijack/PLAN.md`            | 2026-02-22 | PR #41 |
-|  0007 | MITM 请求级计费与性能采集      | 已完成 | `0007:proxy-mitm-usage-billing/PLAN.md`           | 2026-02-22 | PR #42 |
-|  0008 | 代理流式稳定性修复             | 已完成 | `0008:proxy-stream-stability/PLAN.md`             | 2026-02-23 | PR #43 |
-| fd4pw | 代理请求读体超时与失败分型修复 | 待实现 | `fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md` | 2026-02-23 | -      |
+|    ID | Title                          | Status          | Plan                                              | Last       | Notes                                      |
+| ----: | ------------------------------ | --------------- | ------------------------------------------------- | ---------- | ------------------------------------------ |
+|  0001 | 接入 Claude Relay 统计源       | 待实现          | `0001:claude-relay-api-stats/PLAN.md`             | 2026-01-16 | -                                          |
+|  0002 | PR 标签驱动发版                | 已完成          | `0002:pr-label-release/PLAN.md`                   | 2026-02-19 | PR #36                                     |
+|  0003 | 开发环境 devctl+zellij 保活    | 已完成          | `0003:dev-runtime-service-manager/PLAN.md`        | 2026-02-20 | PR #37                                     |
+|  0004 | 统计按浏览器时区自然日         | 已完成          | `0004:reporting-timezone-natural-day/PLAN.md`     | 2026-02-20 | PR #38                                     |
+|  0005 | OpenAI 反向代理透传            | 已完成          | `0005:openai-reverse-proxy/PLAN.md`               | 2026-02-22 | PR #40                                     |
+|  0006 | 代理模型列表劫持与合并         | 已完成          | `0006:proxy-model-list-hijack/PLAN.md`            | 2026-02-22 | PR #41                                     |
+|  0007 | MITM 请求级计费与性能采集      | 已完成          | `0007:proxy-mitm-usage-billing/PLAN.md`           | 2026-02-22 | PR #42                                     |
+|  0008 | 代理流式稳定性修复             | 已完成          | `0008:proxy-stream-stability/PLAN.md`             | 2026-02-23 | PR #43                                     |
+| fd4pw | 代理请求读体超时与失败分型修复 | 部分完成（4/5） | `fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md` | 2026-02-23 | PR #45，RC 已替换测试线，30 分钟观测待补齐 |

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -52,14 +52,14 @@
 
 ## Index（固定表格）
 
-|    ID | Title                          | Status          | Plan                                              | Last       | Notes                                      |
-| ----: | ------------------------------ | --------------- | ------------------------------------------------- | ---------- | ------------------------------------------ |
-|  0001 | 接入 Claude Relay 统计源       | 待实现          | `0001:claude-relay-api-stats/PLAN.md`             | 2026-01-16 | -                                          |
-|  0002 | PR 标签驱动发版                | 已完成          | `0002:pr-label-release/PLAN.md`                   | 2026-02-19 | PR #36                                     |
-|  0003 | 开发环境 devctl+zellij 保活    | 已完成          | `0003:dev-runtime-service-manager/PLAN.md`        | 2026-02-20 | PR #37                                     |
-|  0004 | 统计按浏览器时区自然日         | 已完成          | `0004:reporting-timezone-natural-day/PLAN.md`     | 2026-02-20 | PR #38                                     |
-|  0005 | OpenAI 反向代理透传            | 已完成          | `0005:openai-reverse-proxy/PLAN.md`               | 2026-02-22 | PR #40                                     |
-|  0006 | 代理模型列表劫持与合并         | 已完成          | `0006:proxy-model-list-hijack/PLAN.md`            | 2026-02-22 | PR #41                                     |
-|  0007 | MITM 请求级计费与性能采集      | 已完成          | `0007:proxy-mitm-usage-billing/PLAN.md`           | 2026-02-22 | PR #42                                     |
-|  0008 | 代理流式稳定性修复             | 已完成          | `0008:proxy-stream-stability/PLAN.md`             | 2026-02-23 | PR #43                                     |
-| fd4pw | 代理请求读体超时与失败分型修复 | 部分完成（4/5） | `fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md` | 2026-02-23 | PR #45，RC 已替换测试线，30 分钟观测待补齐 |
+|    ID | Title                          | Status | Plan                                              | Last       | Notes                                            |
+| ----: | ------------------------------ | ------ | ------------------------------------------------- | ---------- | ------------------------------------------------ |
+|  0001 | 接入 Claude Relay 统计源       | 待实现 | `0001:claude-relay-api-stats/PLAN.md`             | 2026-01-16 | -                                                |
+|  0002 | PR 标签驱动发版                | 已完成 | `0002:pr-label-release/PLAN.md`                   | 2026-02-19 | PR #36                                           |
+|  0003 | 开发环境 devctl+zellij 保活    | 已完成 | `0003:dev-runtime-service-manager/PLAN.md`        | 2026-02-20 | PR #37                                           |
+|  0004 | 统计按浏览器时区自然日         | 已完成 | `0004:reporting-timezone-natural-day/PLAN.md`     | 2026-02-20 | PR #38                                           |
+|  0005 | OpenAI 反向代理透传            | 已完成 | `0005:openai-reverse-proxy/PLAN.md`               | 2026-02-22 | PR #40                                           |
+|  0006 | 代理模型列表劫持与合并         | 已完成 | `0006:proxy-model-list-hijack/PLAN.md`            | 2026-02-22 | PR #41                                           |
+|  0007 | MITM 请求级计费与性能采集      | 已完成 | `0007:proxy-mitm-usage-billing/PLAN.md`           | 2026-02-22 | PR #42                                           |
+|  0008 | 代理流式稳定性修复             | 已完成 | `0008:proxy-stream-stability/PLAN.md`             | 2026-02-23 | PR #43                                           |
+| fd4pw | 代理请求读体超时与失败分型修复 | 已完成 | `fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md` | 2026-02-23 | PR #45，RC 已替换测试线，PR #46 补齐 30 分钟观测 |

--- a/docs/plan/fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md
+++ b/docs/plan/fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md
@@ -44,16 +44,18 @@
 - [x] M2 捕获路径失败持久化与流终态日志对齐
 - [x] M3 回归测试补齐并通过
 - [x] M4 RC 发布并替换测试线验证
-- [ ] M5 30 分钟观测窗口与客户端侧报错复核
+- [x] M5 30 分钟观测窗口与客户端侧报错复核
 
 ## Execution Notes
 
 - PR: [#45](https://github.com/IvanLi-CN/codex-vibe-monitor/pull/45) 已合并到 `main`（2026-02-23）。
 - RC: [`v0.5.2-rc.54932bc`](https://github.com/IvanLi-CN/codex-vibe-monitor/releases/tag/v0.5.2-rc.54932bc) 已产出并替换测试线容器镜像。
 - 测试线（`192.168.31.11`）已切换到内网上游：`OPENAI_UPSTREAM_BASE_URL=http://ai-claude-relay-service:3000/openai`，并启用 `OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS=120` 与 `OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS=180`。
-- 截止 2026-02-23 18:10 CST，部署后窗口（18:01:32 起）观测到 `request_body_read_timeout=1`，`failed_contact_upstream=0`，`upstream_handshake_timeout=0`；完整 30 分钟窗口仍待补齐。
+- 30 分钟观测窗（2026-02-23 18:01:32–18:31:32 CST）统计：`request_body_read_timeout=1`，`request_body_stream_error_client_closed=0`，`failed_contact_upstream=0`，`upstream_handshake_timeout=0`。
+- 对照部署前 90 分钟（16:31:32–18:01:32 CST）历史记录：`failed_contact_upstream=57`，`upstream_handshake_timeout=14`（按 `error_message` 聚合）。
 
 ## Change log
 
 - 2026-02-23: 完成实现与测试提交，PR #45 合并，发布 RC `v0.5.2-rc.54932bc` 并替换测试线部署。
 - 2026-02-23: 补充部署后初步观测数据，里程碑推进至 `部分完成（4/5）`。
+- 2026-02-23: 补齐 30 分钟观测窗，M5 完成，确认上游连接类故障在观测窗内为 0。

--- a/docs/plan/fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md
+++ b/docs/plan/fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md
@@ -40,7 +40,20 @@
 
 ## Milestones
 
-- [ ] M1 配置与读体超时/分型落地
-- [ ] M2 捕获路径失败持久化与流终态日志对齐
-- [ ] M3 回归测试补齐并通过
-- [ ] M4 RC 发布并替换测试线验证
+- [x] M1 配置与读体超时/分型落地
+- [x] M2 捕获路径失败持久化与流终态日志对齐
+- [x] M3 回归测试补齐并通过
+- [x] M4 RC 发布并替换测试线验证
+- [ ] M5 30 分钟观测窗口与客户端侧报错复核
+
+## Execution Notes
+
+- PR: [#45](https://github.com/IvanLi-CN/codex-vibe-monitor/pull/45) 已合并到 `main`（2026-02-23）。
+- RC: [`v0.5.2-rc.54932bc`](https://github.com/IvanLi-CN/codex-vibe-monitor/releases/tag/v0.5.2-rc.54932bc) 已产出并替换测试线容器镜像。
+- 测试线（`192.168.31.11`）已切换到内网上游：`OPENAI_UPSTREAM_BASE_URL=http://ai-claude-relay-service:3000/openai`，并启用 `OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS=120` 与 `OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS=180`。
+- 截止 2026-02-23 18:10 CST，部署后窗口（18:01:32 起）观测到 `request_body_read_timeout=1`，`failed_contact_upstream=0`，`upstream_handshake_timeout=0`；完整 30 分钟窗口仍待补齐。
+
+## Change log
+
+- 2026-02-23: 完成实现与测试提交，PR #45 合并，发布 RC `v0.5.2-rc.54932bc` 并替换测试线部署。
+- 2026-02-23: 补充部署后初步观测数据，里程碑推进至 `部分完成（4/5）`。


### PR DESCRIPTION
## What
- sync `docs/plan/fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md` milestones after PR #45 + RC rollout
- add execution notes (PR, RC tag, test-line rollout config)
- add initial post-deploy observation snapshot and mark remaining 30-minute window check as pending (`M5`)
- update `docs/plan/README.md` index status to `部分完成（4/5)` with traceability notes

## Why
Keep plan tracking aligned with implemented + deployed state, while explicitly recording that the full 30-minute observation window is not complete yet.

## Validation
- docs-only change
- pre-commit hooks passed (`format-markdown`, `typecheck-web`, `commitlint`)

## Plan sync
- `docs/plan/fd4pw-proxy-request-read-timeout-rc-fix/PLAN.md`
- `docs/plan/README.md`