### PR TITLE
fix(proxy): project payload detail fields into SSE broadcast records

### DIFF
--- a/docs/specs/z9h7v-invocation-log-observability/SPEC.md
+++ b/docs/specs/z9h7v-invocation-log-observability/SPEC.md
@@ -123,3 +123,4 @@
 
 - 2026-02-25: 初始化规格，冻结实现边界与验收口径。
 - 2026-02-25: 完成后端字段采集、`/api/invocations` 投影扩展与前端表格升级，并通过 `cargo test`、`cargo check`、`web npm run build` 验证。
+- 2026-02-25: 修复 SSE `records` 广播回查 SQL 投影不全问题，确保 `endpoint/requesterIp/codexSessionId/failureKind` 与 `/api/invocations` 一致，并补充回归测试。


### PR DESCRIPTION
## Summary
- fix proxy capture post-insert lookup so SSE `records` payload projects the same detail fields as `GET /api/invocations`
- include payload-derived `endpoint`, `requesterIp`, `codexSessionId`, and payload-first `failureKind` fallback in the broadcast record query
- extend regression coverage to assert those detail fields are present in broadcasted records
- sync spec change log with this consistency fix

## Context / Repro Evidence
- observed mismatch on production dashboard: expanded row for `invokeId=proxy-1822-1772028165671` showed `endpoint=—`
- same `invokeId` from `/api/invocations` returned `endpoint=/v1/responses` and `requesterIp=192.168.31.1`
- root cause: `persist_proxy_capture_record` post-insert select did not project payload detail fields, and `#[sqlx(default)]` silently produced `None`

## Spec
- Spec: `docs/specs/z9h7v-invocation-log-observability/SPEC.md`
- Spec Status: 已完成

## Test Plan
- `cargo test proxy_capture_persist_and_broadcast_emits_records_summary_and_quota -- --nocapture`
- `cargo test`