### PR TITLE
fix(proxy): recover startup backfills for relative raw payload paths

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,10 +6,10 @@
 
 ## Index
 
-| ID    | Title                                                               | Status | Spec                                         | Last       | Notes                |
-| ----- | ------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
-| 5932d | SSE 驱动的请求记录与统计实时更新                                    | 已完成 | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |
-| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                       | 已完成 | `jpg66-settings-shadcn-refresh/SPEC.md`      | 2026-02-25 | 已完成并通过视觉确认 |
-| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略               | 已完成 | `q86c7-setup-uipro-codex/SPEC.md`            | 2026-02-24 | PR #50               |
-| gwpsb | 线上失败请求分类治理与可观测性增强                                  | 已完成 | `gwpsb-proxy-failure-hardening/SPEC.md`      | 2026-02-24 | PR #51               |
-| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Session ID） | 已完成 | `z9h7v-invocation-log-observability/SPEC.md` | 2026-02-25 | local                |
+| ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
+| ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
+| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成 | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |
+| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成 | `jpg66-settings-shadcn-refresh/SPEC.md`      | 2026-02-25 | 已完成并通过视觉确认 |
+| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成 | `q86c7-setup-uipro-codex/SPEC.md`            | 2026-02-24 | PR #50               |
+| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成 | `gwpsb-proxy-failure-hardening/SPEC.md`      | 2026-02-24 | PR #51               |
+| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成 | `z9h7v-invocation-log-observability/SPEC.md` | 2026-02-25 | PR #57               |

--- a/docs/specs/z9h7v-invocation-log-observability/SPEC.md
+++ b/docs/specs/z9h7v-invocation-log-observability/SPEC.md
@@ -130,3 +130,4 @@
 - 2026-02-25: 完成后端字段采集、`/api/invocations` 投影扩展与前端表格升级，并通过 `cargo test`、`cargo check`、`web npm run build` 验证。
 - 2026-02-25: 修复 SSE `records` 广播回查 SQL 投影不全问题，确保 `endpoint/requesterIp/promptCacheKey/failureKind` 与 `/api/invocations` 一致，并补充回归测试。
 - 2026-02-25: 将对外字段从 `codexSessionId` 切换为 `promptCacheKey`，新增启动期历史数据全量回填与旧键清理，并补充回填幂等/异常分支测试。
+- 2026-02-25: 修复启动回填对历史相对路径 raw 文件的兼容性（新增 `database_path` 父目录兜底），避免因工作目录变化导致 `skipped_missing_file` 异常偏高。


### PR DESCRIPTION
## Why
Historical records still showed `Prompt Cache Key = —` even after field migration because startup backfill could not read many raw files when `request_raw_path` / `response_raw_path` were stored as relative paths.

## What changed
- add `read_proxy_raw_bytes(path, fallback_root)` to support reading relative paths via fallback root
- derive fallback root from `database_path.parent()` during startup
- thread fallback root through usage/prompt-cache-key backfill flows
- add regression tests for both prompt-cache-key and usage backfills with relative paths
- sync spec changelog entries for this fix

## Verification
- `cargo test` (97 passed)
