### PR TITLE
fix(web): improve update banner readability and opacity safety

### DIFF
--- a/docs/specs/67acu-update-banner-readability/SPEC.md
+++ b/docs/specs/67acu-update-banner-readability/SPEC.md
@@ -4,7 +4,7 @@
 
 - Status: 已完成
 - Created: 2026-02-26
-- Last: 2026-02-26
+- Last: 2026-02-27
 
 ## 背景 / 问题陈述
 
@@ -68,3 +68,4 @@
 - 已修复同类透明度写法：`alert.tsx` warning/error 分别统一为 `/15`，`TodayStatsOverview` 主卡渐变 `from-primary/15`。
 - 已通过 `npm run lint`、`npm run test`、`npm run build`、`cargo fmt --all -- --check`。
 - 已完成 Playwright 视觉核验：桌面浅色中文、桌面深色中文、桌面浅色英文、移动端浅色中文，横幅文本与操作按钮均可读可点。
+- 已补充更新横幅按钮交互回归断言（`onReload` / `onDismiss`），覆盖“立即刷新 / 稍后”回调绑定。

--- a/docs/specs/67acu-update-banner-readability/SPEC.md
+++ b/docs/specs/67acu-update-banner-readability/SPEC.md
@@ -1,0 +1,70 @@
+# 修复更新提示可读性（#67acu）
+
+## 状态
+
+- Status: 已完成
+- Created: 2026-02-26
+- Last: 2026-02-26
+
+## 背景 / 问题陈述
+
+- Dashboard 顶部“有新版本可用”提示条在浅色主题下文本对比度不足，用户难以辨识版本号与提示内容。
+- `AppLayout` 使用 `bg-info/12` 这类非标准透明度 class，Tailwind 不生成该样式，导致背景退化为透明，进一步放大可读性问题。
+- 仓库内还存在同类透明度写法（`/12`、`/14`），存在重复回归风险。
+
+## 目标 / 非目标
+
+### Goals
+
+- 修复更新提示条在浅/深色主题下的可读性并补足基础可访问性语义。
+- 将更新提示条抽离为独立组件，降低 `AppLayout` 复杂度并增加回归测试覆盖。
+- 修复同类非标准透明度写法：`Alert` warning/error 和今日统计卡片渐变。
+- 新增组件级测试，防止回退到不可读样式。
+
+### Non-goals
+
+- 不改动后端 API、SSE 协议、数据库结构或版本检测逻辑。
+- 不改动更新提示条出现/消失时机（`useUpdateAvailable` 行为保持不变）。
+- 不调整页面其它区域布局与交互。
+
+## 范围（Scope）
+
+### In scope
+
+- `web/src/components/UpdateAvailableBanner.tsx`（新增）
+- `web/src/components/AppLayout.tsx`（替换内联更新提示条）
+- `web/src/components/ui/alert.tsx`（修正 warning/error 透明度类）
+- `web/src/components/TodayStatsOverview.tsx`（修正渐变透明度类）
+- `web/src/components/UpdateAvailableBanner.test.tsx`（新增）
+- `web/src/components/ui/alert.test.tsx`（新增）
+- `docs/specs/README.md`（索引登记）
+
+### Out of scope
+
+- `src/` 下 Rust 后端代码。
+- 其它页面配色体系重构。
+
+## 验收标准（Acceptance Criteria）
+
+- Given 浅色主题 + 中文界面，When 出现更新提示，Then “有新版本可用：0.10.2 → 0.10.4”可清晰识别，按钮可点击。
+- Given 深色主题 + 中文界面，When 出现更新提示，Then 文本对比度与按钮层次清晰。
+- Given 英文界面，When 出现更新提示，Then 文案不溢出且布局正常。
+- Given 移动端宽度（375）与桌面宽度（1536），When 出现更新提示，Then 不遮挡关键操作且不横向溢出。
+- Given 运行前端测试，When 执行 `npm run test`，Then 覆盖更新提示组件及 alert 透明度回归断言。
+- Given SSE 离线提示存在，When 更新提示出现，Then 互不影响，离线提示行为不回归。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 建立 Spec 并登记到 `docs/specs/README.md`。
+- [x] M2: 新增 `UpdateAvailableBanner` 组件并接入 `AppLayout`。
+- [x] M3: 修复 `alert.tsx` 与 `TodayStatsOverview.tsx` 的非标准透明度类。
+- [x] M4: 新增 `UpdateAvailableBanner.test.tsx` 与 `alert.test.tsx`。
+- [x] M5: 完成 lint/test/build + `cargo fmt --check` 验证。
+- [x] M6: 完成浅/深色 + 中/英 + 移动/桌面视觉验证并记录结果。
+
+## 进度备注
+
+- 已完成更新横幅抽离与可读性修复：容器改为 `bg-info/15 + text-base-content`，版本号高亮 `text-info`，并增加 `role="status" aria-live="polite"`。
+- 已修复同类透明度写法：`alert.tsx` warning/error 分别统一为 `/15`，`TodayStatsOverview` 主卡渐变 `from-primary/15`。
+- 已通过 `npm run lint`、`npm run test`、`npm run build`、`cargo fmt --all -- --check`。
+- 已完成 Playwright 视觉核验：桌面浅色中文、桌面深色中文、桌面浅色英文、移动端浅色中文，横幅文本与操作按钮均可读可点。

--- a/docs/specs/67acu-update-banner-readability/SPEC.md
+++ b/docs/specs/67acu-update-banner-readability/SPEC.md
@@ -64,7 +64,7 @@
 
 ## 进度备注
 
-- 已完成更新横幅抽离与可读性修复：容器改为 `bg-info/15 + text-base-content`，版本号高亮 `text-info`，并增加 `role="status" aria-live="polite"`。
+- 已完成更新横幅抽离与可读性修复：容器改为 `bg-primary/10 + text-base-content`，版本号高亮 `text-primary`，并增加 `role="status" aria-live="polite"`。
 - 已修复同类透明度写法：`alert.tsx` warning/error 分别统一为 `/15`，`TodayStatsOverview` 主卡渐变 `from-primary/15`。
 - 已通过 `npm run lint`、`npm run test`、`npm run build`、`cargo fmt --all -- --check`。
 - 已完成 Playwright 视觉核验：桌面浅色中文、桌面深色中文、桌面浅色英文、移动端浅色中文，横幅文本与操作按钮均可读可点。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-26 | 横幅可读性收敛       |
 | 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成 | `26knq-invocation-table-overflow/SPEC.md`    | 2026-02-26 | PR #56 / fast-track  |
 | s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成 | `s8d2w-dashboard-today-stats-bento/SPEC.md`  | 2026-02-26 | PR #58               |
 | 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成 | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 
 | ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
-| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-26 | 横幅可读性收敛       |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |
 | 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成 | `26knq-invocation-table-overflow/SPEC.md`    | 2026-02-26 | PR #56 / fast-track  |
 | s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成 | `s8d2w-dashboard-today-stats-bento/SPEC.md`  | 2026-02-26 | PR #58               |
 | 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成 | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from '../i18n'
 import { supportedLocales, type Locale } from '../i18n'
 import { useTheme } from '../theme'
 import { Button } from './ui/button'
+import { UpdateAvailableBanner } from './UpdateAvailableBanner'
 import { cn } from '../lib/utils'
 
 const navItems = [
@@ -317,21 +318,18 @@ export function AppLayout() {
           </div>
         </div>
       )}
-      {update.visible && (
-        <div className="sticky top-[70px] z-40 mx-auto mt-2 flex w-[calc(100%-2rem)] max-w-[1200px] items-start gap-2 rounded-xl border border-info/40 bg-info/12 px-4 py-3 text-info shadow">
-          <div className="flex flex-1 flex-wrap items-center gap-3 text-info-content">
-            <span>
-              {t('app.update.available')}{' '}
-              <span className="font-mono">{versionInfo?.backend ?? t('app.update.current')}</span>
-              {' → '}
-              <span className="font-mono">{update.availableVersion}</span>
-            </span>
-            <div className="ml-auto flex gap-2">
-              <Button size="sm" onClick={update.reload}>{t('app.update.refresh')}</Button>
-              <Button size="sm" variant="secondary" onClick={update.dismiss}>{t('app.update.later')}</Button>
-            </div>
-          </div>
-        </div>
+      {update.visible && update.availableVersion && (
+        <UpdateAvailableBanner
+          currentVersion={versionInfo?.backend ?? t('app.update.current')}
+          availableVersion={update.availableVersion}
+          onReload={update.reload}
+          onDismiss={update.dismiss}
+          labels={{
+            available: t('app.update.available'),
+            refresh: t('app.update.refresh'),
+            later: t('app.update.later'),
+          }}
+        />
       )}
       <main className="mx-auto w-full max-w-[1200px] px-4 py-6 pb-8">
         <Outlet />

--- a/web/src/components/TodayStatsOverview.tsx
+++ b/web/src/components/TodayStatsOverview.tsx
@@ -26,7 +26,7 @@ function MetricTile({ label, value, loading, prominent, toneClass }: MetricTileP
     <div
       className={cn(
         'rounded-xl border bg-base-200/60 p-4',
-        prominent && 'sm:col-span-2 border-primary/35 bg-gradient-to-br from-primary/12 via-base-100/55 to-secondary/10',
+        prominent && 'sm:col-span-2 border-primary/35 bg-gradient-to-br from-primary/15 via-base-100/55 to-secondary/10',
         !prominent && 'border-base-300/75',
       )}
     >

--- a/web/src/components/UpdateAvailableBanner.test.tsx
+++ b/web/src/components/UpdateAvailableBanner.test.tsx
@@ -1,6 +1,30 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import { Button } from './ui/button'
 import { UpdateAvailableBanner } from './UpdateAvailableBanner'
+
+type ButtonElement = ReactElement<{
+  children?: ReactNode
+  onClick?: () => void
+  disabled?: boolean
+}>
+
+function collectButtons(node: ReactNode, buttons: ButtonElement[] = []): ButtonElement[] {
+  if (!isValidElement<{ children?: ReactNode }>(node)) {
+    return buttons
+  }
+
+  if (node.type === Button) {
+    buttons.push(node as ButtonElement)
+  }
+
+  Children.forEach(node.props.children, child => {
+    collectButtons(child, buttons)
+  })
+
+  return buttons
+}
 
 describe('UpdateAvailableBanner', () => {
   it('renders update text, versions, and action labels', () => {
@@ -64,5 +88,34 @@ describe('UpdateAvailableBanner', () => {
     expect(html).toContain('border-primary/35')
     expect(html).toContain('text-base-content')
     expect(html).not.toContain('text-info-content')
+  })
+
+  it('binds refresh and dismiss buttons to provided callbacks', () => {
+    const onReload = vi.fn()
+    const onDismiss = vi.fn()
+
+    const tree = UpdateAvailableBanner({
+      currentVersion: '0.10.2',
+      availableVersion: '0.10.4',
+      onReload,
+      onDismiss,
+      labels: {
+        available: '有新版本可用：',
+        refresh: '立即刷新',
+        later: '稍后',
+      },
+    })
+
+    const buttons = collectButtons(tree)
+    const refreshButton = buttons.find(button => button.props.children === '立即刷新')
+    const laterButton = buttons.find(button => button.props.children === '稍后')
+
+    expect(refreshButton).toBeDefined()
+    expect(laterButton).toBeDefined()
+
+    expect(refreshButton?.props.onClick).toBe(onReload)
+    expect(laterButton?.props.onClick).toBe(onDismiss)
+    expect(refreshButton?.props.disabled).not.toBe(true)
+    expect(laterButton?.props.disabled).not.toBe(true)
   })
 })

--- a/web/src/components/UpdateAvailableBanner.test.tsx
+++ b/web/src/components/UpdateAvailableBanner.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { UpdateAvailableBanner } from './UpdateAvailableBanner'
+
+describe('UpdateAvailableBanner', () => {
+  it('renders update text, versions, and action labels', () => {
+    const html = renderToStaticMarkup(
+      <UpdateAvailableBanner
+        currentVersion="0.10.2"
+        availableVersion="0.10.4"
+        onReload={vi.fn()}
+        onDismiss={vi.fn()}
+        labels={{
+          available: '有新版本可用：',
+          refresh: '立即刷新',
+          later: '稍后',
+        }}
+      />,
+    )
+
+    expect(html).toContain('有新版本可用：')
+    expect(html).toContain('0.10.2')
+    expect(html).toContain('0.10.4')
+    expect(html).toContain('→')
+    expect(html).toContain('立即刷新')
+    expect(html).toContain('稍后')
+  })
+
+  it('includes a11y status attributes', () => {
+    const html = renderToStaticMarkup(
+      <UpdateAvailableBanner
+        currentVersion="0.10.2"
+        availableVersion="0.10.4"
+        onReload={vi.fn()}
+        onDismiss={vi.fn()}
+        labels={{
+          available: 'A new version is available:',
+          refresh: 'Refresh now',
+          later: 'Later',
+        }}
+      />,
+    )
+
+    expect(html).toContain('role="status"')
+    expect(html).toContain('aria-live="polite"')
+  })
+
+  it('uses readable info styles and avoids info-content text token', () => {
+    const html = renderToStaticMarkup(
+      <UpdateAvailableBanner
+        currentVersion="0.10.2"
+        availableVersion="0.10.4"
+        onReload={vi.fn()}
+        onDismiss={vi.fn()}
+        labels={{
+          available: 'A new version is available:',
+          refresh: 'Refresh now',
+          later: 'Later',
+        }}
+      />,
+    )
+
+    expect(html).toContain('bg-info/15')
+    expect(html).toContain('border-info/45')
+    expect(html).toContain('text-base-content')
+    expect(html).not.toContain('text-info-content')
+  })
+})

--- a/web/src/components/UpdateAvailableBanner.test.tsx
+++ b/web/src/components/UpdateAvailableBanner.test.tsx
@@ -45,7 +45,7 @@ describe('UpdateAvailableBanner', () => {
     expect(html).toContain('aria-live="polite"')
   })
 
-  it('uses readable info styles and avoids info-content text token', () => {
+  it('uses readable primary styles and avoids low-contrast info-content token', () => {
     const html = renderToStaticMarkup(
       <UpdateAvailableBanner
         currentVersion="0.10.2"
@@ -60,8 +60,8 @@ describe('UpdateAvailableBanner', () => {
       />,
     )
 
-    expect(html).toContain('bg-info/15')
-    expect(html).toContain('border-info/45')
+    expect(html).toContain('bg-primary/10')
+    expect(html).toContain('border-primary/35')
     expect(html).toContain('text-base-content')
     expect(html).not.toContain('text-info-content')
   })

--- a/web/src/components/UpdateAvailableBanner.tsx
+++ b/web/src/components/UpdateAvailableBanner.tsx
@@ -1,0 +1,44 @@
+import { Button } from './ui/button'
+
+export interface UpdateAvailableBannerProps {
+  currentVersion: string
+  availableVersion: string
+  onReload: () => void
+  onDismiss: () => void
+  labels: {
+    available: string
+    refresh: string
+    later: string
+  }
+}
+
+export function UpdateAvailableBanner({
+  currentVersion,
+  availableVersion,
+  onReload,
+  onDismiss,
+  labels,
+}: UpdateAvailableBannerProps) {
+  return (
+    <div
+      className="sticky top-[70px] z-40 mx-auto mt-2 flex w-[calc(100%-2rem)] max-w-[1200px] items-start gap-2 rounded-xl border border-info/45 bg-info/15 px-4 py-3 text-base-content shadow"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex flex-1 flex-wrap items-center gap-3">
+        <span>
+          {labels.available}{' '}
+          <span className="font-mono font-semibold text-info">{currentVersion}</span>
+          {' → '}
+          <span className="font-mono font-semibold text-info">{availableVersion}</span>
+        </span>
+        <div className="ml-auto flex gap-2">
+          <Button size="sm" onClick={onReload}>{labels.refresh}</Button>
+          <Button size="sm" variant="secondary" onClick={onDismiss}>{labels.later}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default UpdateAvailableBanner

--- a/web/src/components/UpdateAvailableBanner.tsx
+++ b/web/src/components/UpdateAvailableBanner.tsx
@@ -21,16 +21,16 @@ export function UpdateAvailableBanner({
 }: UpdateAvailableBannerProps) {
   return (
     <div
-      className="sticky top-[70px] z-40 mx-auto mt-2 flex w-[calc(100%-2rem)] max-w-[1200px] items-start gap-2 rounded-xl border border-info/45 bg-info/15 px-4 py-3 text-base-content shadow"
+      className="sticky top-[70px] z-40 mx-auto mt-2 flex w-[calc(100%-2rem)] max-w-[1200px] items-start gap-2 rounded-xl border border-primary/35 bg-primary/10 px-4 py-3 text-base-content"
       role="status"
       aria-live="polite"
     >
       <div className="flex flex-1 flex-wrap items-center gap-3">
         <span>
           {labels.available}{' '}
-          <span className="font-mono font-semibold text-info">{currentVersion}</span>
+          <span className="font-mono font-semibold text-primary">{currentVersion}</span>
           {' → '}
-          <span className="font-mono font-semibold text-info">{availableVersion}</span>
+          <span className="font-mono font-semibold text-primary">{availableVersion}</span>
         </span>
         <div className="ml-auto flex gap-2">
           <Button size="sm" onClick={onReload}>{labels.refresh}</Button>

--- a/web/src/components/ui/alert.test.tsx
+++ b/web/src/components/ui/alert.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { Alert } from './alert'
+
+describe('Alert variants', () => {
+  it('keeps warning variant on supported opacity token', () => {
+    const html = renderToStaticMarkup(<Alert variant="warning">warning</Alert>)
+
+    expect(html).toContain('bg-warning/15')
+    expect(html).not.toContain('bg-warning/14')
+  })
+
+  it('keeps error variant on supported opacity token', () => {
+    const html = renderToStaticMarkup(<Alert variant="error">error</Alert>)
+
+    expect(html).toContain('bg-error/15')
+    expect(html).not.toContain('bg-error/12')
+  })
+})

--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -8,8 +8,8 @@ const alertVariants = cva('flex items-start gap-2 rounded-xl border px-4 py-3 te
       default: 'border-base-300/75 bg-base-200/55 text-base-content',
       info: 'border-info/45 bg-info/10 text-info',
       success: 'border-success/45 bg-success/10 text-success',
-      warning: 'border-warning/45 bg-warning/14 text-warning',
-      error: 'border-error/45 bg-error/12 text-error',
+      warning: 'border-warning/45 bg-warning/15 text-warning',
+      error: 'border-error/45 bg-error/15 text-error',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary
- extract update notice into `UpdateAvailableBanner` to simplify `AppLayout` and improve testability
- improve banner readability in light/dark themes with primary palette tokens (`border-primary/35`, `bg-primary/10`, `text-base-content`) and highlighted versions (`text-primary`)
- keep accessibility semantics on banner (`role="status"`, `aria-live="polite"`)
- normalize unsupported opacity tokens in related components (`bg-warning/15`, `bg-error/15`, `from-primary/15`)
- add regression tests for banner rendering/a11y/style tokens, banner action callback binding, and alert opacity variants
- sync spec records for `67acu-update-banner-readability`

## Validation
- `cd web && npm run lint`
- `cd web && npm run test`
- `cd web && npm run build`
- `cargo fmt --all -- --check`
- `codex review --base main` (latest round: P0/P1/P2 = 0)
- Playwright visual checks:
  - desktop zh light
  - desktop zh dark
  - desktop en light
  - mobile zh light

## Notes
- release intent for this PR: `type:patch` + `channel:stable`