### PR TITLE
fix(docker): prevent GLIBC drift in release image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,16 +318,30 @@ jobs:
           image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}"
           version_tag="${image}:v${APP_EFFECTIVE_VERSION}"
 
+          # buildx `load` only supports a single-platform result.
+          if [[ "${PLATFORMS}" == *","* || "${PLATFORMS}" == *" "* ]]; then
+            echo "Smoke requires a single platform when using buildx load (PLATFORMS=${PLATFORMS})" >&2
+            exit 1
+          fi
+
           echo "Smoke: ${version_tag} -> codex-vibe-monitor --help"
           docker run --rm "${version_tag}" codex-vibe-monitor --help
 
           echo "Smoke: ${version_tag} -> start container and probe /health"
-          cid="$(docker run -d -p 18080:8080 "${version_tag}")"
-          cleanup() { docker rm -f "${cid}" >/dev/null 2>&1 || true; }
+          cid="$(docker run -d -p 127.0.0.1::8080 "${version_tag}")"
+          cleanup() { docker rm -f -v "${cid}" >/dev/null 2>&1 || true; }
           trap cleanup EXIT
 
+          host_port="$(docker inspect -f '{{ (index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort }}' "${cid}")"
+          if [[ -z "${host_port}" ]]; then
+            echo "Smoke failed: unable to resolve published host port for container ${cid}" >&2
+            docker ps -a || true
+            docker logs "${cid}" || true
+            exit 1
+          fi
+
           for _ in $(seq 1 30); do
-            if curl -fsS "http://127.0.0.1:18080/health" | grep -q '^ok$'; then
+            if curl -fsS "http://127.0.0.1:${host_port}/health" | grep -q '^ok$'; then
               echo "Smoke: /health ok"
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,19 +295,63 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build Docker image (load)
         if: steps.intent.outputs.release_enabled == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: ${{ env.PLATFORMS }}
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.image-tags.outputs.tags }}
           build-args: |
             APP_EFFECTIVE_VERSION=${{ env.APP_EFFECTIVE_VERSION }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache,mode=max
+
+      - name: Smoke test Docker image (startup + /health)
+        if: steps.intent.outputs.release_enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}"
+          version_tag="${image}:v${APP_EFFECTIVE_VERSION}"
+
+          echo "Smoke: ${version_tag} -> codex-vibe-monitor --help"
+          docker run --rm "${version_tag}" codex-vibe-monitor --help
+
+          echo "Smoke: ${version_tag} -> start container and probe /health"
+          cid="$(docker run -d -p 18080:8080 "${version_tag}")"
+          cleanup() { docker rm -f "${cid}" >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 30); do
+            if curl -fsS "http://127.0.0.1:18080/health" | grep -q '^ok$'; then
+              echo "Smoke: /health ok"
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Smoke failed: /health not ready in 30s" >&2
+          docker ps -a || true
+          docker logs "${cid}" || true
+          exit 1
+
+      - name: Push Docker image tags
+        if: steps.intent.outputs.release_enabled == 'true'
+        shell: bash
+        env:
+          TAGS: ${{ steps.image-tags.outputs.tags }}
+        run: |
+          set -euo pipefail
+          mapfile -t tags <<< "${TAGS}"
+          for tag in "${tags[@]}"; do
+            [[ -z "${tag}" ]] && continue
+            echo "Pushing ${tag}"
+            docker push "${tag}"
+          done
 
       - name: Create and push git tag
         if: steps.intent.outputs.release_enabled == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
           fi
 
           for _ in $(seq 1 30); do
-            if curl -fsS "http://127.0.0.1:${host_port}/health" | grep -q '^ok$'; then
+            if curl -fsS -m 1 "http://127.0.0.1:${host_port}/health" | grep -q '^ok$'; then
               echo "Smoke: /health ok"
               exit 0
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ ENV VITE_APP_VERSION=${APP_EFFECTIVE_VERSION}
 RUN npm run build
 
 # Stage 2: build the Rust binary
-FROM rust:1.91 AS rust-builder
+# IMPORTANT: runtime image is Debian bookworm (glibc 2.36). Pin the Rust build stage to bookworm too,
+# otherwise the rust:<version> default base may drift and produce a binary requiring newer GLIBC.
+FROM rust:1.91.0-bookworm AS rust-builder
 ARG APP_EFFECTIVE_VERSION
 WORKDIR /app
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
+| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 待实现 | `vdukd-ghcr-glibc-drift-fix/SPEC.md`         | 2026-03-01 | fast-track / hotfix  |
 | ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成 | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
 | 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成 | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
 | 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,16 +6,16 @@
 
 ## Index
 
-| ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
-| ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
-| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 待实现 | `vdukd-ghcr-glibc-drift-fix/SPEC.md`         | 2026-03-01 | fast-track / hotfix  |
-| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成 | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
-| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成 | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
-| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |
-| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成 | `26knq-invocation-table-overflow/SPEC.md`    | 2026-02-26 | PR #56 / fast-track  |
-| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成 | `s8d2w-dashboard-today-stats-bento/SPEC.md`  | 2026-02-26 | PR #58               |
-| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成 | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |
-| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成 | `jpg66-settings-shadcn-refresh/SPEC.md`      | 2026-02-25 | 已完成并通过视觉确认 |
-| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成 | `q86c7-setup-uipro-codex/SPEC.md`            | 2026-02-24 | PR #50               |
-| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成 | `gwpsb-proxy-failure-hardening/SPEC.md`      | 2026-02-24 | PR #51               |
-| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成 | `z9h7v-invocation-log-observability/SPEC.md` | 2026-02-25 | PR #57               |
+| ID    | Title                                                                     | Status          | Spec                                         | Last       | Notes                |
+| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------- | ---------- | -------------------- |
+| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 部分完成（2/3） | `vdukd-ghcr-glibc-drift-fix/SPEC.md`         | 2026-03-01 | fast-track / hotfix  |
+| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
+| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |
+| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`    | 2026-02-26 | PR #56 / fast-track  |
+| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`  | 2026-02-26 | PR #58               |
+| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |
+| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`      | 2026-02-25 | 已完成并通过视觉确认 |
+| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`            | 2026-02-24 | PR #50               |
+| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`      | 2026-02-24 | PR #51               |
+| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md` | 2026-02-25 | PR #57               |

--- a/docs/specs/vdukd-ghcr-glibc-drift-fix/SPEC.md
+++ b/docs/specs/vdukd-ghcr-glibc-drift-fix/SPEC.md
@@ -1,0 +1,118 @@
+# Fix GHCR image GLIBC drift (Debian bookworm runtime)（#vdukd）
+
+## 状态
+
+- Status: 待实现
+- Created: 2026-03-01
+- Last: 2026-03-01
+
+## 背景 / 问题陈述
+
+- `v0.11.0` 发布的镜像在 Debian 12 (bookworm, glibc 2.36) 运行时启动即退出：
+  - `/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.39' not found (required by codex-vibe-monitor)`
+- 该现象表明：Rust 二进制在 glibc >= 2.39 的环境中构建/动态链接后，被拷入 bookworm 运行时镜像。
+- 影响：服务容器起不来，Traefik 未加载 router，外部访问表现为 404。
+
+## 目标 / 非目标
+
+### Goals
+
+- 让发布镜像可在 Debian 12 bookworm（glibc 2.36）正常运行（不再出现 `GLIBC_2.39 not found`）。
+- 固定 build stage 与 runtime base 的 OS variant，避免 glibc 漂移。
+- 在 CI release 流程加入镜像启动烟测门禁：smoke 失败则不 push 镜像 tags、不打 git tag、不创建 GitHub Release。
+- 发布一个 stable patch（预期 `v0.11.1`）修复 `latest`。
+
+### Non-goals
+
+- 切换到 musl 静态编译（`x86_64-unknown-linux-musl`）。
+- 升级/更换 runtime base（例如改为更新的 Debian/Ubuntu）。
+- 调整 Traefik/部署配置。
+
+## 范围（Scope）
+
+### In scope
+
+- `/Dockerfile`：将 Rust build stage pin 到 bookworm（与 runtime 对齐）。
+- `/.github/workflows/ci.yml`：release job 改为 `build(load) -> smoke -> push`。
+
+### Out of scope
+
+- 任何后端 API / SSE / 前端逻辑变更。
+
+## 需求（Requirements）
+
+### MUST
+
+- Docker build stage 使用 `rust:1.91.0-bookworm`（若 CI 验证不存在，再回退 `rust:1.91-bookworm`）。
+- CI 在 push 前对 `:v${APP_EFFECTIVE_VERSION}` 做 smoke：
+  - `docker run --rm <image>:v... codex-vibe-monitor --help`
+  - 启动容器并探活 `GET /health` 返回 `ok`
+- smoke 失败时：
+  - `docker push` 不应执行
+  - “Create and push git tag / Create GitHub Release” 不应执行
+
+### SHOULD
+
+- smoke 失败时输出可诊断信息：`docker ps` + `docker logs`。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- Release pipeline（stable）：
+  - Build 镜像到本地 Docker daemon（`load: true`），打上 `:vX.Y.Z`（以及 `:latest`）。
+  - 运行 smoke（`--help` + `/health`）。
+  - 仅当 smoke 通过时 push tags。
+
+### Edge cases / errors
+
+- 若 `rust:1.91.0-bookworm` tag 不存在，改用 `rust:1.91-bookworm` 并在 PR 中说明原因。
+
+## 接口契约（Interfaces & Contracts）
+
+None
+
+## 验收标准（Acceptance Criteria）
+
+- 新发布镜像执行 `codex-vibe-monitor --help` 正常返回（exit code = 0），无 `GLIBC_2.39 not found`。
+- 新发布镜像启动后 30s 内 `GET /health` 返回 `ok`。
+- CI release job 的 smoke step 失败时，不会 push 镜像 tags，也不会创建 git tag / GitHub Release。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- Unit tests: `cargo test --locked --all-features`
+
+### Quality checks
+
+- Formatting: `cargo fmt --all -- --check`
+
+## 文档更新（Docs to Update）
+
+- None（本修复不改变使用方式；仅修复镜像构建与发布门禁）
+
+## 资产晋升（Asset promotion）
+
+None
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [ ] M1: Pin Rust build stage to Debian bookworm（避免 glibc 漂移）
+- [ ] M2: Add CI smoke gate before pushing image tags
+- [ ] M3: Release stable patch and verify `:latest` is usable
+
+## 方案概述（Approach, high-level）
+
+- 通过固定 Rust builder 镜像的 OS variant（bookworm）让编译/链接环境与 runtime 对齐。
+- 通过 CI “build -> smoke -> push” 把坏镜像阻断在发布前，而不是让 `latest` 漂到线上。
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：`docker/build-push-action` 的 `load: true` 与 cache 配置在 release job 上可能需要微调（以 CI 结果为准）。
+- 假设：服务在 `XY_LEGACY_POLL_ENABLED=false` 下无需外部环境变量即可启动并响应 `/health`。
+
+## 参考（References）
+
+- GitHub Release: v0.11.0
+- Bad image digest: `ghcr.io/ivanli-cn/codex-vibe-monitor@sha256:4f8cf36367d6e7a5cba7496cee119bc205b06a118df54171c51a6dfa162ac327`

--- a/docs/specs/vdukd-ghcr-glibc-drift-fix/SPEC.md
+++ b/docs/specs/vdukd-ghcr-glibc-drift-fix/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 待实现
+- Status: 部分完成（2/3）
 - Created: 2026-03-01
 - Last: 2026-03-01
 
@@ -98,8 +98,8 @@ None
 
 ## 实现里程碑（Milestones / Delivery checklist）
 
-- [ ] M1: Pin Rust build stage to Debian bookworm（避免 glibc 漂移）
-- [ ] M2: Add CI smoke gate before pushing image tags
+- [x] M1: Pin Rust build stage to Debian bookworm（避免 glibc 漂移）
+- [x] M2: Add CI smoke gate before pushing image tags
 - [ ] M3: Release stable patch and verify `:latest` is usable
 
 ## 方案概述（Approach, high-level）


### PR DESCRIPTION
Context
- v0.11.0 image fails on Debian bookworm runtime: `GLIBC_2.39 not found` (binary built/linked against newer glibc than runtime).

Changes
- Pin Rust build stage to `rust:1.91.0-bookworm` to match runtime (`debian:bookworm-slim`).
- Release workflow (push to main): build (load) -> smoke test (`--help` + `/health`) -> push tags. Smoke failure blocks pushing tags and prevents git tag / GitHub Release.
  - Smoke uses random host port mapping, cleans up container + anonymous volumes, and adds a curl timeout to avoid hangs.
- Add hotfix spec: `docs/specs/vdukd-ghcr-glibc-drift-fix/SPEC.md` (now marked in-progress).

Verification (local)
- `cargo fmt --all -- --check`
- `cargo test --locked --all-features`
- `cd web && npm run lint -- --max-warnings=0`

Expected release
- With labels `type:patch` + `channel:stable`, merge should publish `v0.11.1` and update `:latest`.