### PR TITLE
fix(web): sticky footer layout on short pages

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 
 | ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
-| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 待实现 | `zrxcd-sticky-footer-layout/SPEC.md`         | 2026-03-01 | fast-track           |
+| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成 | `zrxcd-sticky-footer-layout/SPEC.md`         | 2026-03-01 | PR #65 / fast-track  |
 | ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成 | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
 | 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成 | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
 | 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
+| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 待实现 | `zrxcd-sticky-footer-layout/SPEC.md`         | 2026-03-01 | fast-track           |
 | ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成 | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
 | 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成 | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
 | 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |

--- a/docs/specs/zrxcd-sticky-footer-layout/SPEC.md
+++ b/docs/specs/zrxcd-sticky-footer-layout/SPEC.md
@@ -1,0 +1,63 @@
+# Sticky Footer 修复：页脚在短页面贴底（#zrxcd）
+
+## 状态
+
+- Status: 待实现
+- Created: 2026-03-01
+- Last: 2026-03-01
+
+## 背景 / 问题陈述
+
+- 当页面内容高度不足一屏时，页脚会跟随内容结束位置停在页面中部，导致页脚下方出现大块空白区域，视觉上不稳定。
+- 期望行为：短页面时页脚贴在视口底部；长页面时页脚位于内容之后（需要滚动到底部才出现），不覆盖内容。
+
+## 目标 / 非目标
+
+### Goals
+
+- 将 `AppLayout` 调整为标准的 sticky footer 布局：
+  - 内容不足一屏：footer 贴底。
+  - 内容超出一屏：footer 在视口外，滚动到底部才出现。
+- 不影响现有 `header` 的 `sticky` 行为与更新横幅的 `sticky` 行为。
+
+### Non-goals
+
+- 不将 footer 改为 `fixed`（避免覆盖内容）。
+- 不做 UI 视觉风格重构，不调整页面信息架构。
+- 不改动 Rust 后端、SSE 协议、数据库或 API。
+
+## 范围（Scope）
+
+### In scope
+
+- `/Users/ivan/.codex/worktrees/75ff/codex-vibe-monitor/web/src/components/AppLayout.tsx`
+  - 外层容器改为纵向 flex，`main` 使用 `flex-1` 撑满剩余高度。
+- （可选）新增轻量 Playwright E2E 回归：`web/tests/e2e/sticky-footer.spec.ts`
+
+### Out of scope
+
+- 其它页面布局重构或组件重排。
+- 任何后端接口变更。
+
+## 验收标准（Acceptance Criteria）
+
+- Given 内容高度不足一屏（拉高浏览器窗口即可复现）
+  When 打开任意主页面（`#/dashboard`、`#/stats`、`#/live`、`#/settings`）
+  Then footer 应贴到视口底部（footer 下方不应再出现明显空白）。
+- Given 内容高度超过视口（缩小窗口高度即可复现）
+  When 页面可滚动
+  Then footer 位于内容之后，初始不在视口内；滚动到底部才出现（不覆盖内容）。
+- Given header 为 `sticky` 且更新横幅为 `sticky`
+  When 页面滚动/窗口 resize
+  Then 二者行为不回归。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 新增本 Spec 并登记到 `docs/specs/README.md`。
+- [ ] M2: 完成 `AppLayout` sticky footer 布局修复。
+- [ ] M3: 通过 `web` 的 lint + build（必要时补充 E2E 回归）。
+- [ ] M4: PR ready（checks 状态明确），并在 Index Notes 记录 PR 号。
+
+## 进度备注
+
+- 2026-03-01: 创建 Spec 并登记 Index，待实现。

--- a/docs/specs/zrxcd-sticky-footer-layout/SPEC.md
+++ b/docs/specs/zrxcd-sticky-footer-layout/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 待实现
+- Status: 已完成
 - Created: 2026-03-01
 - Last: 2026-03-01
 
@@ -30,7 +30,7 @@
 
 ### In scope
 
-- `/Users/ivan/.codex/worktrees/75ff/codex-vibe-monitor/web/src/components/AppLayout.tsx`
+- `web/src/components/AppLayout.tsx`
   - 外层容器改为纵向 flex，`main` 使用 `flex-1` 撑满剩余高度。
 - （可选）新增轻量 Playwright E2E 回归：`web/tests/e2e/sticky-footer.spec.ts`
 
@@ -54,10 +54,13 @@
 ## 实现里程碑（Milestones / Delivery checklist）
 
 - [x] M1: 新增本 Spec 并登记到 `docs/specs/README.md`。
-- [ ] M2: 完成 `AppLayout` sticky footer 布局修复。
-- [ ] M3: 通过 `web` 的 lint + build（必要时补充 E2E 回归）。
-- [ ] M4: PR ready（checks 状态明确），并在 Index Notes 记录 PR 号。
+- [x] M2: 完成 `AppLayout` sticky footer 布局修复。
+- [x] M3: 通过 `web` 的 lint + build（必要时补充 E2E 回归）。
+- [x] M4: PR ready（checks 状态明确），并在 Index Notes 记录 PR 号。
 
 ## 进度备注
 
-- 2026-03-01: 创建 Spec 并登记 Index，待实现。
+- 2026-03-01: 完成 sticky footer 布局修复（`web/src/components/AppLayout.tsx`）：`app-shell` 增加 `flex flex-col`，`main` 增加 `flex-1 min-h-0`。
+- 2026-03-01: 新增 Playwright E2E 回归：`web/tests/e2e/sticky-footer.spec.ts`（短页贴底 + 长页滚动到底部才出现）。
+- 2026-03-01: 验证通过：`cd web && npm run lint -- --max-warnings=0`、`cd web && npx tsc -b`、`cd web && npm run build`。
+- 2026-03-01: PR #65，CI Pipeline 与 Label Gate 均为 success。

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -25,3 +25,7 @@ dist-ssr
 
 *storybook.log
 storybook-static
+
+# Playwright artifacts
+test-results
+playwright-report

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -177,7 +177,7 @@ export function AppLayout() {
   const themeSwitcherLabel = t(isDarkTheme ? 'app.theme.switchToLight' : 'app.theme.switchToDark')
 
   return (
-    <div className="app-shell min-h-screen text-base-content">
+    <div className="app-shell min-h-screen flex flex-col text-base-content">
       <header className="sticky top-0 z-50 border-b border-base-300/75 bg-base-100/80 backdrop-blur-md">
         <div className="mx-auto flex w-full max-w-[1200px] items-center gap-2 px-4 py-2">
           <div className="flex min-w-0 flex-1 items-center gap-3">
@@ -331,7 +331,7 @@ export function AppLayout() {
           }}
         />
       )}
-      <main className="mx-auto w-full max-w-[1200px] px-4 py-6 pb-8">
+      <main className="mx-auto w-full max-w-[1200px] flex-1 min-h-0 px-4 py-6 pb-8">
         <Outlet />
       </main>
       <footer className="border-t border-base-300/75 bg-base-100/80 text-sm text-base-content/70 backdrop-blur">

--- a/web/src/components/AppLayout.tsx
+++ b/web/src/components/AppLayout.tsx
@@ -334,7 +334,10 @@ export function AppLayout() {
       <main className="mx-auto w-full max-w-[1200px] flex-1 min-h-0 px-4 py-6 pb-8">
         <Outlet />
       </main>
-      <footer className="border-t border-base-300/75 bg-base-100/80 text-sm text-base-content/70 backdrop-blur">
+      <footer
+        className="border-t border-base-300/75 bg-base-100/80 text-sm text-base-content/70 backdrop-blur"
+        data-testid="app-footer"
+      >
         <div className="mx-auto flex w-full max-w-[1200px] flex-wrap items-center justify-between gap-3 px-4 py-3">
           <span>{t('app.footer.copyright')}</span>
           <div className="flex flex-wrap items-center gap-4">

--- a/web/tests/e2e/sticky-footer.spec.ts
+++ b/web/tests/e2e/sticky-footer.spec.ts
@@ -5,8 +5,8 @@ test.describe('Sticky footer layout', () => {
     await page.setViewportSize({ width: 1280, height: 900 })
     await page.goto('/#/stats')
 
-    const footer = page.locator('footer')
-    await expect(footer).toBeVisible()
+    const footer = page.locator('.app-shell > footer')
+    await expect(footer).toBeAttached()
 
     // Force the "short content" scenario without depending on backend data volume.
     await page.addStyleTag({
@@ -16,20 +16,48 @@ test.describe('Sticky footer layout', () => {
       `,
     })
 
-    await page.waitForTimeout(50)
+    await expect(footer).toBeVisible()
 
-    const metrics = await page.evaluate(() => {
-      const node = document.querySelector('footer') as HTMLElement | null
-      if (!node) return null
-      const rect = node.getBoundingClientRect()
-      return {
-        footerBottom: rect.bottom,
-        viewportHeight: window.innerHeight,
-      }
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          const node = document.querySelector('.app-shell > footer') as HTMLElement | null
+          if (!node) return Number.POSITIVE_INFINITY
+          const rect = node.getBoundingClientRect()
+          return Math.abs(window.innerHeight - rect.bottom)
+        })
+      })
+      .toBeLessThanOrEqual(2)
+  })
+
+  test('keeps footer off-viewport on long pages until scrolled to bottom', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.goto('/#/stats')
+
+    const footer = page.locator('.app-shell > footer')
+    await expect(footer).toBeAttached()
+
+    // Make the page tall using CSS (avoids mutating the React-managed DOM).
+    await page.addStyleTag({
+      content: `
+        main::after { content: ''; display: block; height: 200vh; }
+      `,
     })
 
-    expect(metrics).not.toBeNull()
-    expect(Math.abs((metrics?.viewportHeight ?? 0) - (metrics?.footerBottom ?? 0))).toBeLessThanOrEqual(2)
+    await expect(footer).not.toBeInViewport()
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+
+    await expect(footer).toBeInViewport()
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          const node = document.querySelector('.app-shell > footer') as HTMLElement | null
+          if (!node) return Number.POSITIVE_INFINITY
+          const rect = node.getBoundingClientRect()
+          return Math.abs(window.innerHeight - rect.bottom)
+        })
+      })
+      .toBeLessThanOrEqual(2)
   })
 })
-

--- a/web/tests/e2e/sticky-footer.spec.ts
+++ b/web/tests/e2e/sticky-footer.spec.ts
@@ -20,10 +20,8 @@ test.describe('Sticky footer layout', () => {
 
     await expect
       .poll(async () => {
-        return page.evaluate(() => {
-          const node = document.querySelector('[data-testid="app-footer"]') as HTMLElement | null
-          if (!node) return Number.POSITIVE_INFINITY
-          const rect = node.getBoundingClientRect()
+        return footer.evaluate((node) => {
+          const rect = (node as HTMLElement).getBoundingClientRect()
           return Math.abs(window.innerHeight - rect.bottom)
         })
       })
@@ -54,10 +52,8 @@ test.describe('Sticky footer layout', () => {
     await expect(footer).toBeInViewport()
     await expect
       .poll(async () => {
-        return page.evaluate(() => {
-          const node = document.querySelector('[data-testid="app-footer"]') as HTMLElement | null
-          if (!node) return Number.POSITIVE_INFINITY
-          const rect = node.getBoundingClientRect()
+        return footer.evaluate((node) => {
+          const rect = (node as HTMLElement).getBoundingClientRect()
           return Math.abs(window.innerHeight - rect.bottom)
         })
       })

--- a/web/tests/e2e/sticky-footer.spec.ts
+++ b/web/tests/e2e/sticky-footer.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Sticky footer layout', () => {
+  test('keeps footer pinned to viewport bottom when main content is short', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.goto('/#/stats')
+
+    const footer = page.locator('footer')
+    await expect(footer).toBeVisible()
+
+    // Force the "short content" scenario without depending on backend data volume.
+    await page.addStyleTag({
+      content: `
+        main > * { display: none !important; }
+        main { padding: 0 !important; }
+      `,
+    })
+
+    await page.waitForTimeout(50)
+
+    const metrics = await page.evaluate(() => {
+      const node = document.querySelector('footer') as HTMLElement | null
+      if (!node) return null
+      const rect = node.getBoundingClientRect()
+      return {
+        footerBottom: rect.bottom,
+        viewportHeight: window.innerHeight,
+      }
+    })
+
+    expect(metrics).not.toBeNull()
+    expect(Math.abs((metrics?.viewportHeight ?? 0) - (metrics?.footerBottom ?? 0))).toBeLessThanOrEqual(2)
+  })
+})
+

--- a/web/tests/e2e/sticky-footer.spec.ts
+++ b/web/tests/e2e/sticky-footer.spec.ts
@@ -5,14 +5,14 @@ test.describe('Sticky footer layout', () => {
     await page.setViewportSize({ width: 1280, height: 900 })
     await page.goto('/#/stats')
 
-    const footer = page.locator('.app-shell > footer')
+    const footer = page.getByTestId('app-footer')
     await expect(footer).toBeAttached()
 
     // Force the "short content" scenario without depending on backend data volume.
     await page.addStyleTag({
       content: `
-        main > * { display: none !important; }
-        main { padding: 0 !important; }
+        .app-shell > main > * { display: none !important; }
+        .app-shell > main { padding: 0 !important; }
       `,
     })
 
@@ -21,7 +21,7 @@ test.describe('Sticky footer layout', () => {
     await expect
       .poll(async () => {
         return page.evaluate(() => {
-          const node = document.querySelector('.app-shell > footer') as HTMLElement | null
+          const node = document.querySelector('[data-testid="app-footer"]') as HTMLElement | null
           if (!node) return Number.POSITIVE_INFINITY
           const rect = node.getBoundingClientRect()
           return Math.abs(window.innerHeight - rect.bottom)
@@ -34,25 +34,28 @@ test.describe('Sticky footer layout', () => {
     await page.setViewportSize({ width: 1280, height: 900 })
     await page.goto('/#/stats')
 
-    const footer = page.locator('.app-shell > footer')
+    const footer = page.getByTestId('app-footer')
     await expect(footer).toBeAttached()
 
     // Make the page tall using CSS (avoids mutating the React-managed DOM).
     await page.addStyleTag({
       content: `
-        main::after { content: ''; display: block; height: 200vh; }
+        .app-shell > main::after { content: ''; display: block; height: 200vh; }
       `,
     })
 
     await expect(footer).not.toBeInViewport()
 
-    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.evaluate(() => {
+      const scrollingElement = document.scrollingElement ?? document.documentElement
+      window.scrollTo(0, scrollingElement.scrollHeight)
+    })
 
     await expect(footer).toBeInViewport()
     await expect
       .poll(async () => {
         return page.evaluate(() => {
-          const node = document.querySelector('.app-shell > footer') as HTMLElement | null
+          const node = document.querySelector('[data-testid="app-footer"]') as HTMLElement | null
           if (!node) return Number.POSITIVE_INFINITY
           const rect = node.getBoundingClientRect()
           return Math.abs(window.innerHeight - rect.bottom)


### PR DESCRIPTION
## What
- Make `AppLayout` a column flex container and let `main` grow (`flex-1`) so the footer stays at the viewport bottom when content is short.
- Add a lightweight Playwright regression test to validate the sticky footer behavior.

## Why
When page content is shorter than one viewport, the footer currently sits mid-page and leaves a large blank area below it.

## Spec
- `docs/specs/zrxcd-sticky-footer-layout/SPEC.md`

## Verification
- `cd web && npm ci`
- `cd web && npm run lint`
- `cd web && npm run build`

(Playwright E2E requires a running frontend at the configured baseURL; see `web/playwright.config.ts`.)