### PR TITLE
ci: gate release image push with docker smoke test

### DIFF
--- a/.github/scripts/smoke-test-image.sh
+++ b/.github/scripts/smoke-test-image.sh
@@ -37,7 +37,7 @@ while (( SECONDS < deadline )); do
     exit 1
   fi
 
-  if curl -m 1 -fsS "http://${host}:${port}/health" | grep -q "ok"; then
+  if curl -m 1 -fsS "http://${host}:${port}/health" | grep -qx "ok"; then
     echo "[smoke] /health ok"
     exit 0
   fi

--- a/.github/scripts/smoke-test-image.sh
+++ b/.github/scripts/smoke-test-image.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+if [[ -z "$tag" ]]; then
+  echo "usage: $0 <image-tag>" >&2
+  exit 2
+fi
+
+host="${SMOKE_HOST:-127.0.0.1}"
+port="${SMOKE_PORT:-18080}"
+timeout_secs="${SMOKE_TIMEOUT_SECS:-60}"
+name="${SMOKE_CONTAINER_NAME:-smoke-codex-vibe-monitor}"
+
+docker rm -f "$name" >/dev/null 2>&1 || true
+
+echo "[smoke] starting container: ${tag}"
+docker run -d --name "$name" -p "${host}:${port}:8080" "$tag" >/dev/null
+
+deadline=$((SECONDS + timeout_secs))
+while (( SECONDS < deadline )); do
+  if curl -fsS "http://${host}:${port}/health" | grep -q "ok"; then
+    echo "[smoke] /health ok"
+    docker rm -f "$name" >/dev/null
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "[smoke] timed out waiting for /health (timeout=${timeout_secs}s)" >&2
+docker ps -a >&2 || true
+docker logs "$name" >&2 || true
+docker rm -f "$name" >/dev/null 2>&1 || true
+exit 1
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # NOTE: The release smoke gate relies on buildx `load: true` (single platform only).
   PLATFORMS: linux/amd64
 
 jobs:
@@ -320,10 +321,16 @@ jobs:
       - name: Push Docker image tags (after smoke)
         if: steps.intent.outputs.release_enabled == 'true'
         shell: bash
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:v${{ env.APP_EFFECTIVE_VERSION }}
         run: |
           set -euo pipefail
+          echo "[push] $SMOKE_TAG"
+          docker push "$SMOKE_TAG"
+
           echo "${{ steps.image-tags.outputs.tags }}" | while IFS= read -r tag; do
             [[ -z "$tag" ]] && continue
+            [[ "$tag" == "$SMOKE_TAG" ]] && continue
             echo "[push] $tag"
             docker push "$tag"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,19 +295,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build Docker image (load locally)
         if: steps.intent.outputs.release_enabled == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: ${{ env.PLATFORMS }}
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.image-tags.outputs.tags }}
           build-args: |
             APP_EFFECTIVE_VERSION=${{ env.APP_EFFECTIVE_VERSION }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache,mode=max
+
+      - name: Smoke test image (/health)
+        if: steps.intent.outputs.release_enabled == 'true'
+        shell: bash
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:v${{ env.APP_EFFECTIVE_VERSION }}
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push Docker image tags (after smoke)
+        if: steps.intent.outputs.release_enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "${{ steps.image-tags.outputs.tags }}" | while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            echo "[push] $tag"
+            docker push "$tag"
+          done
 
       - name: Create and push git tag
         if: steps.intent.outputs.release_enabled == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Validate platforms for smoke gate
+        if: steps.intent.outputs.release_enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${PLATFORMS}" == *","* ]]; then
+            echo "PLATFORMS must be single-platform when using load: true (smoke gate)." >&2
+            exit 1
+          fi
+
       - name: Build Docker image (load locally)
         if: steps.intent.outputs.release_enabled == 'true'
         uses: docker/build-push-action@v6
@@ -316,6 +326,7 @@ jobs:
         shell: bash
         env:
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:v${{ env.APP_EFFECTIVE_VERSION }}
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-${{ github.run_id }}-${{ github.run_attempt }}
         run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
 
       - name: Push Docker image tags (after smoke)
@@ -328,12 +339,12 @@ jobs:
           echo "[push] $SMOKE_TAG"
           docker push "$SMOKE_TAG"
 
-          echo "${{ steps.image-tags.outputs.tags }}" | while IFS= read -r tag; do
+          while IFS= read -r tag; do
             [[ -z "$tag" ]] && continue
             [[ "$tag" == "$SMOKE_TAG" ]] && continue
             echo "[push] $tag"
             docker push "$tag"
-          done
+          done <<< "${{ steps.image-tags.outputs.tags }}"
 
       - name: Create and push git tag
         if: steps.intent.outputs.release_enabled == 'true'

--- a/docs/specs/9mbsz-release-docker-smoke-gate/SPEC.md
+++ b/docs/specs/9mbsz-release-docker-smoke-gate/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 待实现
+- Status: 已完成
 - Created: 2026-03-01
 - Last: 2026-03-01
 
@@ -77,9 +77,13 @@ None
 
 ## 实现里程碑（Milestones / Delivery checklist）
 
-- [ ] M1: Add spec + index row
-- [ ] M2: Add smoke script
-- [ ] M3: Wire release job to gate push on smoke success
+- [x] M1: Add spec + index row
+- [x] M2: Add smoke script
+- [x] M3: Wire release job to gate push on smoke success
+
+## 进度备注
+
+- release job 现在会在 push 镜像 tags 前执行 `docker run` + `/health` smoke test；失败会中断后续发布步骤。
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 

--- a/docs/specs/9mbsz-release-docker-smoke-gate/SPEC.md
+++ b/docs/specs/9mbsz-release-docker-smoke-gate/SPEC.md
@@ -87,7 +87,7 @@ None
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 
-- 风险：runner 端口冲突导致 false negative（默认使用 18080；可用环境变量覆盖）。
+- 风险：容器启动慢或 runner 资源抖动导致 smoke 超时；默认使用随机 host 端口发布（可用 `SMOKE_PORT` 固定端口）。
 - 假设：`ubuntu-latest` runner 具备 `docker` 与 `curl`。
 
 ## 参考（References）

--- a/docs/specs/9mbsz-release-docker-smoke-gate/SPEC.md
+++ b/docs/specs/9mbsz-release-docker-smoke-gate/SPEC.md
@@ -1,0 +1,92 @@
+# Release 前 Docker Smoke Gate（#9mbsz）
+
+## 状态
+
+- Status: 待实现
+- Created: 2026-03-01
+- Last: 2026-03-01
+
+## 背景 / 问题陈述
+
+- 当前 CI 在 `main` push 时会构建并推送 GHCR 镜像、打 git tag、创建 GitHub Release，但不验证镜像是否能启动以及服务是否可用。
+- 这会把“镜像可构建但不可运行”的问题延后到发版后才暴露，排查与回滚成本更高。
+
+## 目标 / 非目标
+
+### Goals
+
+- 在 release_enabled=true 的发版路径中，把镜像 tag push 之前增加运行态 smoke gate：
+  - 先 build 到 runner 本地（`load`）
+  - `docker run` 启动容器
+  - `GET /health` 返回 `ok`
+- smoke 未通过时：阻断后续镜像 tag push、git tag 与 GitHub Release。
+
+### Non-goals
+
+- 不做 post-release 的“拉取已推送镜像再验证”的二次工作流。
+- 不在 PR 阶段运行 docker smoke gate（如需可另开 spec）。
+- 不扩展更严格的运行态验证范围（本次仅 `/health`）。
+
+## 范围（Scope）
+
+### In scope
+
+- 修改 `.github/workflows/ci.yml` 的 release job 步骤：build(load) -> smoke -> push tags -> tag -> release。
+- 新增 `.github/scripts/smoke-test-image.sh` 脚本（只做 `/health` 校验）。
+
+### Out of scope
+
+- 应用代码、HTTP API、Dockerfile 与部署文档内容变更。
+
+## 需求（Requirements）
+
+### MUST
+
+- `release_enabled=true` 时，smoke 失败必须使 job 失败，并且不 push 镜像 tags、不打 tag、不建 Release。
+- smoke 通过后，push 镜像 tags + git tag + GitHub Release 与原行为一致。
+
+### SHOULD
+
+- smoke 失败输出包含容器日志（便于定位启动失败原因）。
+
+### COULD
+
+- 后续扩展 smoke 覆盖 `/api/version` 或首页 200（本次不做）。
+
+## 接口契约（Interfaces & Contracts）
+
+None
+
+## 验收标准（Acceptance Criteria）
+
+- Given `release_enabled=true`
+  When smoke test 超时或 `/health` 非 `ok`
+  Then workflow 失败，且不会执行镜像 tag push / git tag / GitHub Release。
+- Given `release_enabled=true`
+  When smoke test 通过
+  Then 镜像 tags 推送成功，且后续 git tag 与 GitHub Release 步骤执行成功。
+- Given `release_enabled=false`（`type:docs` 或 `type:skip`）
+  When workflow 在 `main` push 触发
+  Then build/smoke/push/tag/release 相关步骤不会执行（与现有行为一致）。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Quality checks
+
+- `bash -n .github/scripts/smoke-test-image.sh` 通过。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [ ] M1: Add spec + index row
+- [ ] M2: Add smoke script
+- [ ] M3: Wire release job to gate push on smoke success
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：runner 端口冲突导致 false negative（默认使用 18080；可用环境变量覆盖）。
+- 假设：`ubuntu-latest` runner 具备 `docker` 与 `curl`。
+
+## 参考（References）
+
+- `.github/workflows/ci.yml`（docker job）
+- `src/main.rs`：`GET /health` 返回 `ok`

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
+| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 待实现 | `9mbsz-release-docker-smoke-gate/SPEC.md`    | 2026-03-01 | fast-track           |
 | ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成 | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
 | 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成 | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
 | 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 
 | ID    | Title                                                                     | Status | Spec                                         | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | ------ | -------------------------------------------- | ---------- | -------------------- |
-| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 待实现 | `9mbsz-release-docker-smoke-gate/SPEC.md`    | 2026-03-01 | fast-track           |
+| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成 | `9mbsz-release-docker-smoke-gate/SPEC.md`    | 2026-03-01 | PR #66 / fast-track  |
 | ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成 | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
 | 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成 | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
 | 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成 | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |


### PR DESCRIPTION
This adds a release-time Docker smoke gate so we only push GHCR image tags after the container boots and `GET /health` returns `ok`.

Changes:
- Add `.github/scripts/smoke-test-image.sh` (docker run + /health polling)
- Reorder the release job to: build (load locally) -> smoke -> push tags -> git tag -> GitHub Release
- Keep registry buildcache enabled

Verification:
- `bash -n .github/scripts/smoke-test-image.sh`

Note:
- The release job still runs only on `push` to `main`; the smoke gate will be exercised on the next release-enabled merge.