### PR TITLE
docs(specs): mark vdukd spec as completed

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,16 +6,16 @@
 
 ## Index
 
-| ID    | Title                                                                     | Status          | Spec                                         | Last       | Notes                |
-| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------- | ---------- | -------------------- |
-| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 部分完成（2/3） | `vdukd-ghcr-glibc-drift-fix/SPEC.md`         | 2026-03-01 | fast-track / hotfix  |
-| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
-| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
-| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |
-| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`    | 2026-02-26 | PR #56 / fast-track  |
-| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`  | 2026-02-26 | PR #58               |
-| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |
-| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`      | 2026-02-25 | 已完成并通过视觉确认 |
-| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`            | 2026-02-24 | PR #50               |
-| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`      | 2026-02-24 | PR #51               |
-| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md` | 2026-02-25 | PR #57               |
+| ID    | Title                                                                     | Status        | Spec                                         | Last       | Notes                |
+| ----- | ------------------------------------------------------------------------- | ------------- | -------------------------------------------- | ---------- | -------------------- |
+| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3） | `vdukd-ghcr-glibc-drift-fix/SPEC.md`         | 2026-03-01 | fast-track / hotfix  |
+| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成        | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
+| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成        | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成        | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |
+| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成        | `26knq-invocation-table-overflow/SPEC.md`    | 2026-02-26 | PR #56 / fast-track  |
+| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成        | `s8d2w-dashboard-today-stats-bento/SPEC.md`  | 2026-02-26 | PR #58               |
+| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成        | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |
+| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成        | `jpg66-settings-shadcn-refresh/SPEC.md`      | 2026-02-25 | 已完成并通过视觉确认 |
+| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成        | `q86c7-setup-uipro-codex/SPEC.md`            | 2026-02-24 | PR #50               |
+| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成        | `gwpsb-proxy-failure-hardening/SPEC.md`      | 2026-02-24 | PR #51               |
+| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成        | `z9h7v-invocation-log-observability/SPEC.md` | 2026-02-25 | PR #57               |

--- a/docs/specs/vdukd-ghcr-glibc-drift-fix/SPEC.md
+++ b/docs/specs/vdukd-ghcr-glibc-drift-fix/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 部分完成（2/3）
+- Status: 已完成（3/3）
 - Created: 2026-03-01
 - Last: 2026-03-01
 
@@ -100,7 +100,9 @@ None
 
 - [x] M1: Pin Rust build stage to Debian bookworm（避免 glibc 漂移）
 - [x] M2: Add CI smoke gate before pushing image tags
-- [ ] M3: Release stable patch and verify `:latest` is usable
+- [x] M3: Release stable patch and verify `:latest` is usable
+  - Released: `v0.11.1`
+  - Good image digest (`v0.11.1` / `latest`): `sha256:8e4a351d68f809bfde1dcb42b27eecb078124af71850137b4bd42893d456c92a`
 
 ## 方案概述（Approach, high-level）
 
@@ -114,5 +116,6 @@ None
 
 ## 参考（References）
 
-- GitHub Release: v0.11.0
+- PR: #64
+- GitHub Release: `v0.11.1`
 - Bad image digest: `ghcr.io/ivanli-cn/codex-vibe-monitor@sha256:4f8cf36367d6e7a5cba7496cee119bc205b06a118df54171c51a6dfa162ac327`


### PR DESCRIPTION
- Mark vdukd (GHCR GLIBC drift hotfix) spec as completed after v0.11.1 release verification.
- Docs-only change; no runtime / CI behavior changes.