### PR TITLE
fix(forward-proxy): extend subscription validation timeout to 60s

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,19 +6,20 @@
 
 ## Index
 
-| ID    | Title                                                                     | Status          | Spec                                         | Last       | Notes                |
-| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------- | ---------- | -------------------- |
-| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`         | 2026-03-01 | hotfix               |
-| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`         | 2026-03-01 | fast-track / hotfix  |
-| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`    | 2026-03-01 | PR #66 / fast-track  |
-| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`         | 2026-03-01 | PR #65 / fast-track  |
-| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`       | 2026-02-28 | fast-track           |
-| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`   | 2026-02-27 | PR #61               |
-| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`    | 2026-02-27 | 补按钮交互回归断言   |
-| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`    | 2026-02-26 | PR #56 / fast-track  |
-| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`  | 2026-02-26 | PR #58               |
-| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`          | 2026-02-25 | PR #52               |
-| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`      | 2026-02-25 | 已完成并通过视觉确认 |
-| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`            | 2026-02-24 | PR #50               |
-| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`      | 2026-02-24 | PR #51               |
-| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md` | 2026-02-25 | PR #57               |
+| ID    | Title                                                                     | Status          | Spec                                               | Last       | Notes                |
+| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------- | ---------- | -------------------- |
+| c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md` | 2026-03-01 | fast-track           |
+| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`               | 2026-03-01 | hotfix               |
+| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`               | 2026-03-01 | fast-track / hotfix  |
+| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`          | 2026-03-01 | PR #66 / fast-track  |
+| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`               | 2026-03-01 | PR #65 / fast-track  |
+| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`             | 2026-02-28 | fast-track           |
+| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`         | 2026-02-27 | PR #61               |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`          | 2026-02-27 | 补按钮交互回归断言   |
+| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`          | 2026-02-26 | PR #56 / fast-track  |
+| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`        | 2026-02-26 | PR #58               |
+| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`                | 2026-02-25 | PR #52               |
+| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`            | 2026-02-25 | 已完成并通过视觉确认 |
+| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`                  | 2026-02-24 | PR #50               |
+| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`            | 2026-02-24 | PR #51               |
+| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md`       | 2026-02-25 | PR #57               |

--- a/docs/specs/c5yag-subscription-validation-timeout-60/SPEC.md
+++ b/docs/specs/c5yag-subscription-validation-timeout-60/SPEC.md
@@ -1,0 +1,59 @@
+# Extend subscription validation timeout to 60s (keep single-proxy at 5s)（#c5yag）
+
+## 状态
+
+- Status: 已完成（3/3）
+- Created: 2026-03-01
+- Last: 2026-03-01
+
+## 背景 / 问题陈述
+
+- 设置页“添加订阅链接”在慢链路场景中频繁出现 `validation request timed out after 5s`。
+- 现状是前后端都使用 5 秒超时，订阅验证流程容易误判失败。
+- 订阅验证链路包含：拉取订阅、解析节点、代理探测上游，时延显著高于单条节点验证。
+
+## 目标 / 非目标
+
+### Goals
+
+- 将“订阅 URL 验证”超时改为 60 秒，降低误超时。
+- 保持“单条代理 URL 验证”超时为 5 秒，维持快速反馈。
+- 前后端超时行为与错误文案秒数保持一致。
+
+### Non-goals
+
+- 不新增环境变量或配置项（本次采用硬编码常量）。
+- 不修改 API 路径、请求/响应字段。
+- 不修改订阅解析策略、可达性判定规则（2xx/401/403）。
+
+## 范围（Scope）
+
+### In scope
+
+- `src/main.rs`: 订阅/单条验证超时分流（60s vs 5s）。
+- `web/src/lib/api.ts`: 按 `kind` 分流 `AbortController` 超时（60_000ms vs 5_000ms）。
+- 补充后端与前端测试，覆盖超时分流与超时消息秒数。
+
+### Out of scope
+
+- 设置页视觉与交互流程改版。
+- 订阅探测节点数量、xray 运行机制变更。
+
+## 接口契约（Interfaces & Contracts）
+
+- 保持 `POST /api/settings/forward-proxy/validate` 不变：
+  - request: `{ kind: 'proxyUrl' | 'subscriptionUrl', value: string }`
+  - response: `{ ok, message, normalizedValue, discoveredNodes, latencyMs }`
+
+## 验收标准（Acceptance Criteria）
+
+- 订阅验证在 5~60 秒内完成时，不再出现 `...timed out after 5s`。
+- 订阅验证超过 60 秒时，报错秒数应为 60。
+- 单条代理验证超过 5 秒时，仍报 `...timed out after 5s`。
+- 相关 Rust/Web 测试通过，且前端 build 通过。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 后端超时策略按验证类型分流（订阅 60s、单条 5s）
+- [x] M2: 前端超时策略按 `kind` 分流并保持报错秒数一致
+- [x] M3: 补齐测试并完成本地验证

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { validateForwardProxyCandidate } from './api'
+
+function abortError(): Error {
+  const error = new Error('aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+function createAbortAwareFetch() {
+  return vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return
+      if (signal.aborted) {
+        reject(abortError())
+        return
+      }
+      signal.addEventListener(
+        'abort',
+        () => {
+          reject(abortError())
+        },
+        { once: true },
+      )
+    })
+  })
+}
+
+describe('validateForwardProxyCandidate timeout split', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses 60s timeout for subscription validation', async () => {
+    vi.useFakeTimers()
+    const fetchMock = createAbortAwareFetch()
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+
+    const pending = validateForwardProxyCandidate({
+      kind: 'subscriptionUrl',
+      value: 'https://example.com/subscription',
+    })
+
+    const assertion = expect(pending).rejects.toThrow('validation request timed out after 60s')
+    await vi.advanceTimersByTimeAsync(60_000)
+    await assertion
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps 5s timeout for single proxy validation', async () => {
+    vi.useFakeTimers()
+    const fetchMock = createAbortAwareFetch()
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+
+    const pending = validateForwardProxyCandidate({
+      kind: 'proxyUrl',
+      value: 'socks5://127.0.0.1:1080',
+    })
+
+    const assertion = expect(pending).rejects.toThrow('validation request timed out after 5s')
+    await vi.advanceTimersByTimeAsync(5_000)
+    await assertion
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What
- split validation timeout by kind for forward proxy candidate checks
- keep single proxy URL validation at `5s`
- increase subscription URL validation to `60s` on both backend and frontend
- add regression tests for timeout split behavior
- add spec entry `c5yag` under `docs/specs/`

## Why
Subscription validation currently times out too aggressively (`5s`) in slow-link scenarios, causing false negatives while single-node validation still needs fast feedback.

## Validation
- `cargo test`
- `cd web && npm run test`
- `cd web && npm run build`