### PR TITLE
fix: unblock subscription validation when xray runtime dir is missing

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 | ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
 | wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix  |
-| m96jw | 修复订阅验证路径下 xray 运行目录缺失导致添加失败                          | 进行中（2/3）   | `m96jw-subscription-validation-xray-runtime-dir/SPEC.md` | 2026-03-01 | fast-track / bugfix  |
+| m96jw | 修复订阅验证路径下 xray 运行目录缺失导致添加失败                          | 已完成（3/3）   | `m96jw-subscription-validation-xray-runtime-dir/SPEC.md` | 2026-03-01 | PR #71 / fast-track  |
 | c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md`       | 2026-03-01 | fast-track           |
 | 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`                     | 2026-03-01 | hotfix               |
 | vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`                     | 2026-03-01 | fast-track / hotfix  |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,21 +6,22 @@
 
 ## Index
 
-| ID    | Title                                                                     | Status          | Spec                                               | Last       | Notes                |
-| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------- | ---------- | -------------------- |
-| wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`    | 2026-03-01 | fast-track / hotfix  |
-| c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md` | 2026-03-01 | fast-track           |
-| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`               | 2026-03-01 | hotfix               |
-| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`               | 2026-03-01 | fast-track / hotfix  |
-| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`          | 2026-03-01 | PR #66 / fast-track  |
-| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`               | 2026-03-01 | PR #65 / fast-track  |
-| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`             | 2026-02-28 | fast-track           |
-| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`         | 2026-02-27 | PR #61               |
-| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`          | 2026-02-27 | 补按钮交互回归断言   |
-| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`          | 2026-02-26 | PR #56 / fast-track  |
-| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`        | 2026-02-26 | PR #58               |
-| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`                | 2026-02-25 | PR #52               |
-| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`            | 2026-02-25 | 已完成并通过视觉确认 |
-| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`                  | 2026-02-24 | PR #50               |
-| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`            | 2026-02-24 | PR #51               |
-| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md`       | 2026-02-25 | PR #57               |
+| ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                |
+| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
+| wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix  |
+| m96jw | 修复订阅验证路径下 xray 运行目录缺失导致添加失败                          | 进行中（2/3）   | `m96jw-subscription-validation-xray-runtime-dir/SPEC.md` | 2026-03-01 | fast-track / bugfix  |
+| c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md`       | 2026-03-01 | fast-track           |
+| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`                     | 2026-03-01 | hotfix               |
+| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`                     | 2026-03-01 | fast-track / hotfix  |
+| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`                | 2026-03-01 | PR #66 / fast-track  |
+| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`                     | 2026-03-01 | PR #65 / fast-track  |
+| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`                   | 2026-02-28 | fast-track           |
+| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`               | 2026-02-27 | PR #61               |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`                | 2026-02-27 | 补按钮交互回归断言   |
+| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`                | 2026-02-26 | PR #56 / fast-track  |
+| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`              | 2026-02-26 | PR #58               |
+| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`                      | 2026-02-25 | PR #52               |
+| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`                  | 2026-02-25 | 已完成并通过视觉确认 |
+| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`                        | 2026-02-24 | PR #50               |
+| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`                  | 2026-02-24 | PR #51               |
+| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md`             | 2026-02-25 | PR #57               |

--- a/docs/specs/m96jw-subscription-validation-xray-runtime-dir/SPEC.md
+++ b/docs/specs/m96jw-subscription-validation-xray-runtime-dir/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 进行中（2/3）
+- Status: 已完成（3/3）
 - Created: 2026-03-01
 - Last: 2026-03-01
 
@@ -47,4 +47,4 @@
 
 - [x] M1: 复现失败并定位到 `spawn_instance` 写配置前未创建目录
 - [x] M2: 修复目录创建逻辑 + 新增回归测试
-- [ ] M3: fast-flow 下完成 PR + checks + review-loop 收敛
+- [x] M3: fast-flow 下完成 PR + checks + review-loop 收敛

--- a/docs/specs/m96jw-subscription-validation-xray-runtime-dir/SPEC.md
+++ b/docs/specs/m96jw-subscription-validation-xray-runtime-dir/SPEC.md
@@ -1,0 +1,50 @@
+# 修复订阅验证路径下 xray 运行目录缺失导致添加失败（#m96jw）
+
+## 状态
+
+- Status: 进行中（2/3）
+- Created: 2026-03-01
+- Last: 2026-03-01
+
+## 背景 / 问题陈述
+
+- 设置页“添加订阅链接”在订阅包含 `vless/vmess/trojan/ss` share link 时，点击“验证可用性”后快速失败，无法添加订阅。
+- 后端报错为：`failed to write xray config: .codex/xray-forward/...json`。
+- 根因是候选项验证路径会直接走 `XraySupervisor::spawn_instance`，而该路径未保证 `xray_runtime_dir` 已存在。
+
+## 目标 / 非目标
+
+### Goals
+
+- 修复订阅候选校验路径，确保写 xray 配置前一定创建运行目录。
+- 添加回归测试，防止未来回归到“目录不存在导致写配置失败”。
+- 保持既有 API 与校验语义不变。
+
+### Non-goals
+
+- 不修改前端弹窗交互与按钮状态机。
+- 不修改订阅解析、节点探测策略与超时策略。
+
+## 范围（Scope）
+
+### In scope
+
+- `src/main.rs`：`XraySupervisor::spawn_instance` 在写配置前创建 `runtime_dir`。
+- `src/main.rs` tests：新增针对验证路径目录创建的回归测试。
+
+### Out of scope
+
+- Docker 镜像内 xray 二进制安装策略。
+- 代理探测目标与探测轮次策略。
+
+## 验收标准（Acceptance Criteria）
+
+- 订阅校验路径不再出现 `failed to write xray config: .codex/xray-forward/...` 类错误。
+- 新增回归测试可稳定通过，且断言不会回归到“写配置失败”。
+- 相关 Rust 测试通过。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 复现失败并定位到 `spawn_instance` 写配置前未创建目录
+- [x] M2: 修复目录创建逻辑 + 新增回归测试
+- [ ] M3: fast-flow 下完成 PR + checks + review-loop 收敛

--- a/src/main.rs
+++ b/src/main.rs
@@ -9098,6 +9098,12 @@ impl XraySupervisor {
     ) -> Result<Url> {
         let outbound = build_xray_outbound_for_endpoint(endpoint)?;
         let local_port = pick_unused_local_port().context("failed to allocate xray local port")?;
+        fs::create_dir_all(&self.runtime_dir).with_context(|| {
+            format!(
+                "failed to create xray runtime directory: {}",
+                self.runtime_dir.display()
+            )
+        })?;
         let config_path = self.runtime_dir.join(format!(
             "forward-proxy-{:016x}.json",
             stable_hash_u64(&endpoint.key)
@@ -11367,6 +11373,47 @@ mod tests {
         assert_eq!(timeout_seconds_for_message(Duration::from_millis(1)), 1);
         assert_eq!(timeout_seconds_for_message(Duration::from_secs(5)), 5);
         assert_eq!(timeout_seconds_for_message(Duration::from_millis(5500)), 6);
+    }
+
+    #[tokio::test]
+    async fn xray_supervisor_ensure_instance_creates_runtime_dir_for_validation_path() {
+        let temp_root = make_temp_test_dir("xray-runtime-create");
+        let runtime_dir = temp_root.join("nested/runtime");
+        let mut supervisor = XraySupervisor::new(
+            "/path/to/non-existent-xray".to_string(),
+            runtime_dir.clone(),
+        );
+        let endpoint = ForwardProxyEndpoint {
+            key: "xray-validation-test".to_string(),
+            source: FORWARD_PROXY_SOURCE_SUBSCRIPTION.to_string(),
+            display_name: "xray-validation-test".to_string(),
+            protocol: ForwardProxyProtocol::Vless,
+            endpoint_url: None,
+            raw_url: Some(
+                "vless://11111111-1111-1111-1111-111111111111@127.0.0.1:443?encryption=none"
+                    .to_string(),
+            ),
+        };
+
+        let err = supervisor
+            .ensure_instance_with_ready_timeout(&endpoint, Duration::from_millis(50))
+            .await
+            .expect_err("non-existent xray binary should fail to start");
+        let message = format!("{err:#}");
+        assert!(
+            runtime_dir.is_dir(),
+            "runtime dir should be created before writing xray config"
+        );
+        assert!(
+            message.contains("failed to start xray binary"),
+            "expected startup failure after config write path is available, got: {message}"
+        );
+        assert!(
+            !message.contains("failed to write xray config"),
+            "runtime dir creation regression: {message}"
+        );
+
+        let _ = fs::remove_dir_all(&temp_root);
     }
 
     #[test]


### PR DESCRIPTION
## What
- ensure `XraySupervisor::spawn_instance` creates `xray_runtime_dir` before writing config files
- add a regression test that exercises the validation spawn path and asserts we no longer fail on `failed to write xray config`
- add/track spec `m96jw-subscription-validation-xray-runtime-dir`

## Why
Adding subscription URLs could fail immediately in validation because the xray runtime directory was not guaranteed to exist on the validation path.

## Verification
- `cargo test xray_supervisor_ensure_instance_creates_runtime_dir_for_validation_path -- --nocapture`
- `cargo test forward_proxy_validation_timeout_is_split_by_kind -- --nocapture`
