### PR TITLE
fix(ci): publish smoke-verified multi-arch release manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # NOTE: The release smoke gate relies on buildx `load: true` (single platform only).
-  PLATFORMS: linux/amd64
+  PLATFORM_AMD64: linux/amd64
+  PLATFORM_ARM64: linux/arm64
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   lint:
@@ -270,10 +271,11 @@ jobs:
           set -euo pipefail
           image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}"
           if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
+            # Keep version tag first to avoid "latest updated but version missing" partial state.
             {
               echo "tags<<EOF"
-              echo "${image}:latest"
               echo "${image}:v${APP_EFFECTIVE_VERSION}"
+              echo "${image}:latest"
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           else
@@ -301,52 +303,147 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # buildx `load` only supports a single-platform result.
-          if [[ "${PLATFORMS}" == *","* || "${PLATFORMS}" == *" "* ]]; then
-            echo "Smoke requires a single platform when using buildx load (PLATFORMS=${PLATFORMS})" >&2
-            exit 1
-          fi
+          required_platforms=("${PLATFORM_AMD64}" "${PLATFORM_ARM64}")
+          normalized=",${PLATFORMS// /},"
+          for platform in "${required_platforms[@]}"; do
+            if [[ "${normalized}" != *",${platform},"* ]]; then
+              echo "Missing required platform in PLATFORMS=${PLATFORMS}: ${platform}" >&2
+              exit 1
+            fi
+          done
 
-      - name: Build Docker image (load)
+      - name: Build smoke image (linux/amd64, load)
         if: steps.intent.outputs.release_enabled == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ env.PLATFORM_AMD64 }}
           push: false
           load: true
-          tags: ${{ steps.image-tags.outputs.tags }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:smoke-${{ github.run_id }}-${{ github.run_attempt }}-amd64
+            ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:candidate-${{ github.run_id }}-${{ github.run_attempt }}-amd64
           build-args: |
             APP_EFFECTIVE_VERSION=${{ env.APP_EFFECTIVE_VERSION }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache,mode=max
 
-      - name: Smoke test Docker image (startup + /health)
+      - name: Smoke test image (linux/amd64)
         if: steps.intent.outputs.release_enabled == 'true'
         shell: bash
         env:
-          SMOKE_TAG: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:v${{ env.APP_EFFECTIVE_VERSION }}
-          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-${{ github.run_id }}-${{ github.run_attempt }}
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:smoke-${{ github.run_id }}-${{ github.run_attempt }}-amd64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-amd64-${{ github.run_id }}-${{ github.run_attempt }}
+          SMOKE_PLATFORM: ${{ env.PLATFORM_AMD64 }}
         run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
 
-      - name: Push Docker image tags (after smoke)
+      - name: Build smoke image (linux/arm64, load)
+        if: steps.intent.outputs.release_enabled == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORM_ARM64 }}
+          push: false
+          load: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:smoke-${{ github.run_id }}-${{ github.run_attempt }}-arm64
+            ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:candidate-${{ github.run_id }}-${{ github.run_attempt }}-arm64
+          build-args: |
+            APP_EFFECTIVE_VERSION=${{ env.APP_EFFECTIVE_VERSION }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:buildcache,mode=max
+
+      - name: Smoke test image (linux/arm64)
         if: steps.intent.outputs.release_enabled == 'true'
         shell: bash
         env:
-          SMOKE_TAG: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:v${{ env.APP_EFFECTIVE_VERSION }}
-          TAGS: ${{ steps.image-tags.outputs.tags }}
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}:smoke-${{ github.run_id }}-${{ github.run_attempt }}-arm64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          SMOKE_PLATFORM: ${{ env.PLATFORM_ARM64 }}
+          SMOKE_TIMEOUT_SECS: "120"
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push smoke-verified platform images
+        if: steps.intent.outputs.release_enabled == 'true'
+        id: staged-images
+        shell: bash
         run: |
           set -euo pipefail
-          echo "[push] ${SMOKE_TAG}"
-          docker push "${SMOKE_TAG}"
+          image="${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}"
+          suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          candidate_amd64="${image}:candidate-${suffix}-amd64"
+          candidate_arm64="${image}:candidate-${suffix}-arm64"
+          echo "[push] ${candidate_amd64}"
+          docker push "${candidate_amd64}"
+          echo "[push] ${candidate_arm64}"
+          docker push "${candidate_arm64}"
+          echo "candidate_amd64=${candidate_amd64}" >> "$GITHUB_OUTPUT"
+          echo "candidate_arm64=${candidate_arm64}" >> "$GITHUB_OUTPUT"
 
+      - name: Create release manifest tags from smoke-verified images
+        if: steps.intent.outputs.release_enabled == 'true'
+        shell: bash
+        env:
+          TAGS: ${{ steps.image-tags.outputs.tags }}
+          CANDIDATE_AMD64: ${{ steps.staged-images.outputs.candidate_amd64 }}
+          CANDIDATE_ARM64: ${{ steps.staged-images.outputs.candidate_arm64 }}
+        run: |
+          set -euo pipefail
           mapfile -t tags <<< "${TAGS}"
           for tag in "${tags[@]}"; do
             [[ -z "${tag}" ]] && continue
-            [[ "${tag}" == "${SMOKE_TAG}" ]] && continue
-            echo "[push] ${tag}"
-            docker push "${tag}"
+            echo "[manifest] ${tag} <= ${CANDIDATE_AMD64}, ${CANDIDATE_ARM64}"
+            for attempt in 1 2 3 4 5; do
+              if docker buildx imagetools create --tag "${tag}" "${CANDIDATE_AMD64}" "${CANDIDATE_ARM64}" 2>"/tmp/imagetools-create-${attempt}.err"; then
+                break
+              fi
+              if [[ "${attempt}" == "5" ]]; then
+                echo "[manifest] failed after ${attempt} attempts for ${tag}" >&2
+                if [[ -s "/tmp/imagetools-create-${attempt}.err" ]]; then
+                  cat "/tmp/imagetools-create-${attempt}.err" >&2
+                fi
+                exit 1
+              fi
+              sleep_secs=$((attempt * 3))
+              echo "[manifest] retry in ${sleep_secs}s (${attempt}/5): ${tag}" >&2
+              sleep "${sleep_secs}"
+            done
+          done
+
+      - name: Verify pushed manifest platforms
+        if: steps.intent.outputs.release_enabled == 'true'
+        shell: bash
+        env:
+          TAGS: ${{ steps.image-tags.outputs.tags }}
+          REQUIRED_PLATFORMS: ${{ env.PLATFORMS }}
+        run: |
+          set -euo pipefail
+          mapfile -t tags <<< "${TAGS}"
+          for tag in "${tags[@]}"; do
+            [[ -z "${tag}" ]] && continue
+            echo "[verify] ${tag}"
+            for attempt in 1 2 3 4 5; do
+              if raw_json="$(docker buildx imagetools inspect "${tag}" --raw 2>"/tmp/imagetools-${attempt}.err")"; then
+                if RAW_JSON="${raw_json}" python3 -c "import json, os, sys; tag = sys.argv[1]; manifest = json.loads(os.environ['RAW_JSON']); required = {p.strip() for p in os.environ.get('REQUIRED_PLATFORMS', '').split(',') if p.strip()}; platforms = {f\"{p.get('os')}/{p.get('architecture')}\" for p in [(item.get('platform') or {}) for item in manifest.get('manifests', [])] if p.get('os') and p.get('architecture')}; missing = sorted(required - platforms); missing and (_ for _ in ()).throw(SystemExit(f'missing required platforms for {tag}: {\", \".join(missing)} (detected: {sorted(platforms)})')); print(f'[verify] {tag}: detected {sorted(platforms)}')" "${tag}"
+                then
+                  break
+                fi
+              fi
+
+              if [[ "${attempt}" == "5" ]]; then
+                echo "[verify] failed after ${attempt} attempts for ${tag}" >&2
+                if [[ -s "/tmp/imagetools-${attempt}.err" ]]; then
+                  cat "/tmp/imagetools-${attempt}.err" >&2
+                fi
+                exit 1
+              fi
+
+              sleep_secs=$((attempt * 3))
+              echo "[verify] retry in ${sleep_secs}s (${attempt}/5): ${tag}" >&2
+              sleep "${sleep_secs}"
+            done
           done
 
       - name: Create and push git tag

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ docker run --rm \
 
 容器内默认：`XY_DATABASE_PATH=/srv/app/data/codex_vibe_monitor.db`，`XY_HTTP_BIND=0.0.0.0:8080`，`XY_STATIC_DIR=/srv/app/web`。
 
+GHCR 发布镜像默认提供多架构 manifest（`linux/amd64` + `linux/arm64`），`stable` 会同步更新 `${image}:latest`。
+
 ## 验证与排查
 
 - SQLite 检查：
@@ -219,6 +221,8 @@ docker run --rm \
 - 镜像：推送至 GHCR `ghcr.io/ivanli-cn/codex-vibe-monitor`
   - stable：`${image}:vX.Y.Z` 与 `${image}:latest`
   - rc：`${image}:vX.Y.Z-rc.<sha7>`（仅该 tag）
+  - 发布前会分别对 `linux/amd64` 与 `linux/arm64` 做容器 smoke（`--help`、`xray version`、`/health`）；通过后再推送多架构 manifest
+  - 推送后会校验版本 tag 的 manifest 必须同时包含 `linux/amd64` 与 `linux/arm64`
   - 同步创建 GitHub Release（stable 为非 prerelease，rc 为 prerelease）
 
 ## 许可证

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                     | Status          | Spec                                               | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------- | ---------- | -------------------- |
+| wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`    | 2026-03-01 | fast-track / hotfix  |
 | c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md` | 2026-03-01 | fast-track           |
 | 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`               | 2026-03-01 | hotfix               |
 | vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`               | 2026-03-01 | fast-track / hotfix  |

--- a/docs/specs/wtwsn-ghcr-multiarch-release-manifest/SPEC.md
+++ b/docs/specs/wtwsn-ghcr-multiarch-release-manifest/SPEC.md
@@ -1,0 +1,70 @@
+# GHCR 发布切换多架构 manifest（amd64 + arm64）（#wtwsn）
+
+## 状态
+
+- Status: 已完成（5/5）
+- Created: 2026-03-01
+- Last: 2026-03-01
+
+## 背景 / 问题陈述
+
+- 线上发布的 `stable/latest` 标签此前是单架构 manifest（`linux/amd64`），部分平台展示为 `arch 未知`。
+- 当前 release job 采用单次 `buildx load` + `docker push`，无法生成包含多平台条目的 manifest list。
+- 需要在不改变业务代码的前提下，将发布产物升级为可识别的双架构镜像，并保留发布前 smoke 门禁。
+
+## 目标 / 非目标
+
+### Goals
+
+- 让 `stable` 发布同时产出 `linux/amd64` 与 `linux/arm64` 的 manifest list。
+- 发布前分别对 amd64/arm64 进行完整 smoke（`--help`、`xray version`、`/health`）。
+- 推送后强制校验标签 manifest 必须同时包含上述两个平台，缺失即阻断后续 tag/release。
+
+### Non-goals
+
+- 不变更 Rust/前端业务逻辑、HTTP API 或数据库 schema。
+- 不新增 `arm/v7`、`s390x` 等额外平台。
+- 不调整现有 release intent（`type:*` + `channel:*`）规则。
+
+## 范围（Scope）
+
+### In scope
+
+- `.github/workflows/ci.yml`：release job 多架构构建、分平台 smoke、推送后 manifest 校验。
+- `.github/scripts/smoke-test-image.sh`：新增 `SMOKE_PLATFORM` 支持，在指定平台执行 smoke。
+- `README.md`：补充 GHCR 多架构发布与校验行为说明。
+
+### Out of scope
+
+- 部署编排（Compose/K8s）改造。
+- 运行时参数或环境变量语义变更。
+
+## 接口契约（Interfaces & Contracts）
+
+- `smoke-test-image.sh`：
+  - 入参保持不变：`smoke-test-image.sh <image-tag>`。
+  - 新增可选环境变量：`SMOKE_PLATFORM`（例如 `linux/arm64`），用于 `docker run --platform`。
+- Release workflow：
+  - `PLATFORMS` 固定为 `linux/amd64,linux/arm64`。
+  - 镜像推送改为 `buildx build --platform <multi> --push`，产物为 manifest list。
+
+## 验收标准（Acceptance Criteria）
+
+- Given `release_enabled=true`，When release job 运行，Then amd64 与 arm64 smoke 都通过后才允许推送正式 tags。
+- Given 多架构推送完成，When 校验版本 tag manifest，Then 必须同时检测到 `linux/amd64` 与 `linux/arm64`。
+- Given 任一 smoke 或 manifest 校验失败，When workflow 执行，Then job fail 且不执行 git tag/GitHub Release。
+- Given `type:docs`/`type:skip`，When workflow 触发，Then release 路径仍保持跳过。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 建立 specs 文档并登记索引
+- [x] M2: smoke 脚本支持 `SMOKE_PLATFORM`
+- [x] M3: release job 拆分 amd64/arm64 smoke gate
+- [x] M4: release job 改为多架构 push，并新增 manifest 平台校验
+- [x] M5: README 更新多架构发布说明并完成本地校验
+
+## 风险 / 备注
+
+- arm64 smoke 依赖 QEMU，执行时间可能波动，默认将 arm64 smoke timeout 提升到 120 秒。
+- manifest 展示在部分平台可能存在缓存延迟；以 registry 实际 manifest 校验结果为准。
+- 发布流程会写入 run 级 `candidate-*` 中间标签用于组装最终 manifest；当前未内建自动回收，后续可按仓库保留策略补充清理。


### PR DESCRIPTION
## What changed
- add a new spec for GHCR multi-arch release manifest rollout: `docs/specs/wtwsn-ghcr-multiarch-release-manifest/SPEC.md`
- update release workflow to:
  - build and smoke-test `linux/amd64` and `linux/arm64` images separately
  - push smoke-verified candidate images
  - create release tags (`vX.Y.Z` then `latest` for stable) as multi-arch manifests from candidate images
  - retry `imagetools create` and manifest verification to reduce GHCR propagation flakiness
- extend smoke script with optional `SMOKE_PLATFORM` so smoke checks can run under explicit target architecture
- document multi-arch release behavior in README and specs index

## Why
The previous release path produced single-arch manifests and could show `arch unknown` on some platforms. This change ensures release tags are explicit multi-arch manifests and that published artifacts come from smoke-verified images.

## Verification
- `bash -n .github/scripts/smoke-test-image.sh`
- YAML parse check for `.github/workflows/ci.yml` via `python3` + `yaml.safe_load`
- `cargo test --locked --all-features`
- `codex review --base origin/main` loop (5 rounds) with fixes applied for blocking findings
