### PR TITLE
fix(ci): force real binary rebuild for release smoke jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN mkdir -p src \
 # Copy app sources and build the real binary.
 COPY src ./src
 ENV APP_EFFECTIVE_VERSION=${APP_EFFECTIVE_VERSION}
-RUN cargo build --release --locked
+RUN rm -f target/release/codex-vibe-monitor \
+    && cargo build --release --locked
 
 # Stage 3: fetch Xray-core (xray) for forward-proxy subscription validation
 # The app defaults to `XY_XRAY_BINARY=xray` (PATH lookup). If the runtime image doesn't bundle


### PR DESCRIPTION
## Summary
- force a real binary rebuild after replacing dummy `src/main.rs` in Docker dependency warmup flow
- prevent release smoke jobs from accidentally running a stale warmup binary that exits immediately

## Why
The release run on `main` failed in both `linux/amd64` and `linux/arm64` smoke jobs because container process exited immediately (no published host port), which indicates the runtime binary did not stay alive as expected.

## Verification
- release smoke jobs (`--help`, `xray version`, `/health`) will validate with rebuilt runtime binary in next `main` push run
