### PR TITLE
fix(ci): force rebuild of real binary after docker dummy compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN mkdir -p src \
 # Copy app sources and build the real binary.
 COPY src ./src
 ENV APP_EFFECTIVE_VERSION=${APP_EFFECTIVE_VERSION}
-RUN rm -f target/release/codex-vibe-monitor \
+RUN find src -type f -name '*.rs' -exec touch {} + \
+    && rm -f target/release/codex-vibe-monitor \
     && cargo build --release --locked
 
 # Stage 3: fetch Xray-core (xray) for forward-proxy subscription validation


### PR DESCRIPTION
## What
- force-refresh Rust source mtimes before final release build in Docker
- keep dependency warmup layer, but prevent Cargo from reusing dummy `main.rs` build output

## Why
Release smoke jobs still failed on both amd64/arm64 because container default command exited immediately (`Exited (0)`), which indicates the runtime image still had dummy binary output.

## Verification
- CI should pass smoke gate on both `linux/amd64` and `linux/arm64`
- `Release Publish` should run and produce a new stable tag/release
