### PR TITLE
fix(web): make invocation records responsive layout

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -10,6 +10,7 @@
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
 | c58kc | 实况页新增“代理”统计表与 24h 成败示意图                                   | 已完成（5/5）   | `c58kc-live-forward-proxy-table/SPEC.md`                 | 2026-03-02 | fast-track / PR #77  |
 | wv3m7 | Forward Proxy 新增后异步首轮探测补齐                                      | 已完成（3/3）   | `wv3m7-forward-proxy-bootstrap-probe/SPEC.md`            | 2026-03-02 | fast-track           |
+| r8m3k | InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化               | 进行中（1/5）   | `r8m3k-invocation-table-responsive-no-overflow/SPEC.md`  | 2026-03-02 | fast-track           |
 | k52tw | Forward proxy 验证放宽：404 视为可达（proxyUrl + subscriptionUrl）        | 已完成（3/3）   | `k52tw-forward-proxy-validation-allow-404/SPEC.md`       | 2026-03-01 | fast-track / hotfix  |
 | zanzr | Release 构建加速：arm64 迁移到 GitHub-hosted ARM runner                   | 部分完成（3/4） | `zanzr-release-arm64-native-runner/SPEC.md`              | 2026-03-01 | fast-track           |
 | wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix  |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -10,7 +10,7 @@
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
 | c58kc | 实况页新增“代理”统计表与 24h 成败示意图                                   | 已完成（5/5）   | `c58kc-live-forward-proxy-table/SPEC.md`                 | 2026-03-02 | fast-track / PR #77  |
 | wv3m7 | Forward Proxy 新增后异步首轮探测补齐                                      | 已完成（3/3）   | `wv3m7-forward-proxy-bootstrap-probe/SPEC.md`            | 2026-03-02 | fast-track           |
-| r8m3k | InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化               | 进行中（1/5）   | `r8m3k-invocation-table-responsive-no-overflow/SPEC.md`  | 2026-03-02 | fast-track           |
+| r8m3k | InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化               | 已完成（5/5）   | `r8m3k-invocation-table-responsive-no-overflow/SPEC.md`  | 2026-03-02 | fast-track / PR #79  |
 | k52tw | Forward proxy 验证放宽：404 视为可达（proxyUrl + subscriptionUrl）        | 已完成（3/3）   | `k52tw-forward-proxy-validation-allow-404/SPEC.md`       | 2026-03-01 | fast-track / hotfix  |
 | zanzr | Release 构建加速：arm64 迁移到 GitHub-hosted ARM runner                   | 部分完成（3/4） | `zanzr-release-arm64-native-runner/SPEC.md`              | 2026-03-01 | fast-track           |
 | wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix  |

--- a/docs/specs/r8m3k-invocation-table-responsive-no-overflow/SPEC.md
+++ b/docs/specs/r8m3k-invocation-table-responsive-no-overflow/SPEC.md
@@ -84,3 +84,4 @@
 - 2026-03-02: E2E 扩展为 Dashboard/Live × `375/768/1024/1280/1440/1873` 全矩阵，校验视图形态、溢出约束与详情交互。
 - 2026-03-02: 本地验证通过：`npm run test`、`npm run build`、`E2E_BASE_URL=http://127.0.0.1:4173 npm run test:e2e -- tests/e2e/invocation-table-layout.spec.ts`。
 - 2026-03-02: 快车道交付 PR [#79](https://github.com/IvanLi-CN/codex-vibe-monitor/pull/79)，标签 `type:patch` + `channel:stable`。
+- 2026-03-02: 修复 `768px` 展开后右侧留白：按 `xl` 可见列动态设置 `colSpan`，并重配 `md/xl` 列宽预算；E2E 新增“首行右侧空隙 <= 1px”断言。

--- a/docs/specs/r8m3k-invocation-table-responsive-no-overflow/SPEC.md
+++ b/docs/specs/r8m3k-invocation-table-responsive-no-overflow/SPEC.md
@@ -1,0 +1,81 @@
+# InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化（#r8m3k）
+
+## 状态
+
+- Status: 进行中
+- Created: 2026-03-02
+- Last: 2026-03-02
+
+## 背景 / 问题陈述
+
+- 当前请求记录表在部分桌面视口会出现不合理横向滚动，导致首屏信息可见性下降。
+- 移动端沿用表格结构可读性较差，且容易引入页面级横向溢出。
+
+## 目标 / 非目标
+
+### Goals
+
+- 在 `lg` 及以上视口彻底消除 InvocationTable 横向滚动条。
+- 在 `sm` 及以下（本次实现为 `<768px`）切换为列表卡片视图，保留同等信息密度与详情展开能力。
+- 为 Dashboard 与 Live 两页补齐跨视口 E2E 回归。
+
+### Non-goals
+
+- 不修改后端 API / SSE / SQLite。
+- 不改造 InvocationTable 之外的其它业务表格组件。
+
+## 范围（Scope）
+
+### In scope
+
+- `web/src/components/InvocationTable.tsx`
+- `web/tests/e2e/invocation-table-layout.spec.ts`
+- `docs/specs/README.md`
+
+### Out of scope
+
+- `src/**` Rust 后端
+- 非 InvocationTable 的页面布局
+
+## 需求（Requirements）
+
+### MUST
+
+- `>=1024px`：`scrollWidth - clientWidth <= 1`，不可出现横向滚动。
+- `<768px`：仅显示列表视图；页面级 `documentElement.scrollWidth - clientWidth <= 1`。
+- Dashboard / Live 两页均满足上述约束。
+- 列表与表格均支持展开详情，且详情字段一致。
+
+### SHOULD
+
+- 仅改样式与前端展示，不引入 API/type 破坏性变更。
+- 现有加载态、空态、错误态行为不回退。
+
+## 验收标准（Acceptance Criteria）
+
+- Given `375 / 768 / 1024 / 1280 / 1440 / 1873` 视口、Dashboard 与 Live 两页，When 渲染 InvocationTable，Then 布局与溢出断言全部通过。
+- Given 移动端列表首项，When 点击展开按钮，Then 详情可正常展开并可读。
+- Given 桌面端表格首项，When 点击展开按钮，Then 详情可正常展开并且按钮默认可见。
+
+## 质量门槛（Quality Gates）
+
+- `cd web && npm run build`
+- `cd web && npm run test`
+- `cd web && npm run test:e2e -- tests/e2e/invocation-table-layout.spec.ts`
+
+## 里程碑（Milestones）
+
+- [x] M1: 新建规格并锁定断点契约与验收矩阵。
+- [ ] M2: 完成 InvocationTable 响应式双视图改造与桌面防溢出。
+- [ ] M3: 扩展 E2E 回归并通过本地验证。
+- [ ] M4: 快车道收敛（push + PR + checks + review-loop）。
+- [ ] M5: 回写规格状态与变更记录。
+
+## 风险 / 假设
+
+- 假设：`md (768~1023)` 采用表格视图。
+- 风险：超长无空格文本可能触发单元格挤压，需通过截断策略兜底。
+
+## 变更记录（Change log）
+
+- 2026-03-02: 创建规格，进入实现阶段。

--- a/docs/specs/r8m3k-invocation-table-responsive-no-overflow/SPEC.md
+++ b/docs/specs/r8m3k-invocation-table-responsive-no-overflow/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 进行中
+- Status: 已完成（5/5）
 - Created: 2026-03-02
 - Last: 2026-03-02
 
@@ -66,10 +66,10 @@
 ## 里程碑（Milestones）
 
 - [x] M1: 新建规格并锁定断点契约与验收矩阵。
-- [ ] M2: 完成 InvocationTable 响应式双视图改造与桌面防溢出。
-- [ ] M3: 扩展 E2E 回归并通过本地验证。
-- [ ] M4: 快车道收敛（push + PR + checks + review-loop）。
-- [ ] M5: 回写规格状态与变更记录。
+- [x] M2: 完成 InvocationTable 响应式双视图改造与桌面防溢出。
+- [x] M3: 扩展 E2E 回归并通过本地验证。
+- [x] M4: 快车道收敛（push + PR + checks + review-loop）。
+- [x] M5: 回写规格状态与变更记录。
 
 ## 风险 / 假设
 
@@ -79,3 +79,8 @@
 ## 变更记录（Change log）
 
 - 2026-03-02: 创建规格，进入实现阶段。
+- 2026-03-02: `InvocationTable` 完成双视图改造（`<768` 列表卡片、`>=768` 表格），并统一展开详情行为。
+- 2026-03-02: 表格视图收敛列宽预算与长文本截断策略，覆盖长 endpoint / 长错误串场景，`lg+` 无横向滚动。
+- 2026-03-02: E2E 扩展为 Dashboard/Live × `375/768/1024/1280/1440/1873` 全矩阵，校验视图形态、溢出约束与详情交互。
+- 2026-03-02: 本地验证通过：`npm run test`、`npm run build`、`E2E_BASE_URL=http://127.0.0.1:4173 npm run test:e2e -- tests/e2e/invocation-table-layout.spec.ts`。
+- 2026-03-02: 快车道交付 PR [#79](https://github.com/IvanLi-CN/codex-vibe-monitor/pull/79)，标签 `type:patch` + `channel:stable`。

--- a/web/src/components/InvocationTable.tsx
+++ b/web/src/components/InvocationTable.tsx
@@ -74,6 +74,10 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
   const { t, locale } = useTranslation()
   const localeTag = locale === 'zh' ? 'zh-CN' : 'en-US'
   const [expandedId, setExpandedId] = useState<number | null>(null)
+  const [isXlUp, setIsXlUp] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia('(min-width: 1280px)').matches
+  })
 
   const toggleLabels = useMemo(() => {
     if (locale === 'zh') {
@@ -100,6 +104,27 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
       return records.some((record) => record.id === current) ? current : null
     })
   }, [records])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mediaQuery = window.matchMedia('(min-width: 1280px)')
+    const sync = () => {
+      setIsXlUp(mediaQuery.matches)
+    }
+
+    sync()
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', sync)
+      return () => {
+        mediaQuery.removeEventListener('change', sync)
+      }
+    }
+
+    mediaQuery.addListener(sync)
+    return () => {
+      mediaQuery.removeListener(sync)
+    }
+  }, [])
 
   const dateFormatter = useMemo(
     () =>
@@ -341,8 +366,8 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
           <table className="w-full table-fixed border-separate border-spacing-0 text-sm">
             <thead className="bg-base-200/65 text-[11px] uppercase tracking-[0.08em] text-base-content/70">
               <tr>
-                <th className="w-[10%] px-2 py-2.5 text-left font-semibold whitespace-nowrap xl:px-3">{t('table.column.time')}</th>
-                <th className="w-[15%] px-2 py-2.5 text-center font-semibold whitespace-nowrap xl:px-3">
+                <th className="w-[12%] px-2 py-2.5 text-left font-semibold whitespace-nowrap xl:w-[10%] xl:px-3">{t('table.column.time')}</th>
+                <th className="w-[18%] px-2 py-2.5 text-center font-semibold whitespace-nowrap xl:w-[15%] xl:px-3">
                   <div className="flex flex-col leading-tight">
                     <span>{t('table.column.proxy')}</span>
                     <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
@@ -350,7 +375,7 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
                     </span>
                   </div>
                 </th>
-                <th className="w-[16%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">
+                <th className="w-[19%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:w-[16%] xl:px-3">
                   <div className="flex flex-col leading-tight">
                     <span>{t('table.column.model')}</span>
                     <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
@@ -358,7 +383,7 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
                     </span>
                   </div>
                 </th>
-                <th className="w-[15%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">
+                <th className="w-[18%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:w-[15%] xl:px-3">
                   <div className="flex flex-col leading-tight">
                     <span>{t('table.column.inputTokens')}</span>
                     <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
@@ -366,8 +391,8 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
                     </span>
                   </div>
                 </th>
-                <th className="w-[9%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">{t('table.column.outputTokens')}</th>
-                <th className="w-[10%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">{t('table.column.totalTokens')}</th>
+                <th className="w-[10%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:w-[9%] xl:px-3">{t('table.column.outputTokens')}</th>
+                <th className="w-[13%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:w-[10%] xl:px-3">{t('table.column.totalTokens')}</th>
                 <th className="hidden w-[18%] px-2 py-2.5 text-left font-semibold xl:table-cell xl:px-3">
                   <div className="flex flex-col leading-tight">
                     <span>{t('table.column.error')}</span>
@@ -376,7 +401,7 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
                     </span>
                   </div>
                 </th>
-                <th className="w-[7%] px-2 py-2.5 text-right xl:px-3">
+                <th className="w-[10%] px-2 py-2.5 text-right xl:w-[7%] xl:px-3">
                   <span className="sr-only">{toggleLabels.header}</span>
                 </th>
               </tr>
@@ -470,7 +495,7 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
                     </tr>
                     {isExpanded && (
                       <tr className="bg-base-200/68">
-                        <td colSpan={8} className="border-t border-base-300/65 px-2 py-2.5 xl:px-3">
+                        <td colSpan={isXlUp ? 8 : 7} className="border-t border-base-300/65 px-2 py-2.5 xl:px-3">
                           {renderExpandedContent(tableDetailId, row.detailPairs, row.timingPairs, row.errorMessage, 'default')}
                         </td>
                       </tr>

--- a/web/src/components/InvocationTable.tsx
+++ b/web/src/components/InvocationTable.tsx
@@ -442,8 +442,12 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
                       </td>
                       <td className="hidden min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle xl:table-cell xl:px-3">
                         <div className="flex min-w-0 flex-col justify-center gap-1 leading-tight">
-                          <span className="truncate whitespace-nowrap text-base-content/70" title={row.endpointValue}>{row.endpointValue}</span>
-                          <span className="truncate whitespace-nowrap" title={row.errorMessage || undefined}>{row.errorMessage || FALLBACK_CELL}</span>
+                          <span className="block truncate whitespace-nowrap text-base-content/70" title={row.endpointValue}>
+                            {row.endpointValue}
+                          </span>
+                          <span className="block truncate whitespace-nowrap" title={row.errorMessage || undefined}>
+                            {row.errorMessage || FALLBACK_CELL}
+                          </span>
                         </div>
                       </td>
                       <td className="border-t border-base-300/65 px-2 py-2.5 align-middle text-right xl:px-3">

--- a/web/src/components/InvocationTable.tsx
+++ b/web/src/components/InvocationTable.tsx
@@ -46,7 +46,28 @@ function resolveProxyDisplayName(record: ApiInvocation) {
   if (payloadProxyName) return payloadProxyName
   const sourceValue = record.source?.trim()
   if (sourceValue && sourceValue.toLowerCase() !== 'proxy') return sourceValue
-  return null
+  return FALLBACK_CELL
+}
+
+interface InvocationRowViewModel {
+  record: ApiInvocation
+  recordId: number
+  meta: { variant: 'default' | 'secondary' | 'success' | 'warning' | 'error'; key: TranslationKey }
+  occurredTime: string
+  occurredDate: string
+  proxyDisplayName: string
+  modelValue: string
+  costValue: string
+  inputTokensValue: string
+  cacheInputTokensValue: string
+  outputTokensValue: string
+  totalTokensValue: string
+  endpointValue: string
+  errorMessage: string
+  latencySummary: string
+  latencyCompactSummary: string
+  detailPairs: Array<{ label: TranslationKey; value: string }>
+  timingPairs: Array<{ label: TranslationKey; value: string }>
 }
 
 export function InvocationTable({ records, isLoading, error }: InvocationTableProps) {
@@ -110,6 +131,108 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
     [localeTag],
   )
 
+  const rows = useMemo<InvocationRowViewModel[]>(
+    () =>
+      records.map((record) => {
+        const occurred = new Date(record.occurredAt)
+        const normalizedStatus = (record.status ?? 'unknown').toLowerCase()
+        const meta = STATUS_META[normalizedStatus] ?? FALLBACK_STATUS_META
+        const recordId = record.id
+        const errorMessage = record.errorMessage?.trim() ?? ''
+        const endpointValue = record.endpoint?.trim() || FALLBACK_CELL
+        const proxyDisplayName = resolveProxyDisplayName(record)
+        const latencySummary = `${formatMilliseconds(record.tUpstreamTtfbMs)} / ${formatMilliseconds(record.tTotalMs)}`
+        const latencyCompactSummary = `${formatMillisecondsCompact(record.tUpstreamTtfbMs)}/${formatMillisecondsCompact(record.tTotalMs)}`
+        const occurredValid = !Number.isNaN(occurred.getTime())
+        const occurredTime = occurredValid ? timeFormatter.format(occurred) : record.occurredAt
+        const occurredDate = occurredValid ? dateFormatter.format(occurred) : FALLBACK_CELL
+
+        const detailPairs: Array<{ label: TranslationKey; value: string }> = [
+          { label: 'table.details.invokeId', value: record.invokeId || FALLBACK_CELL },
+          { label: 'table.details.source', value: record.source || FALLBACK_CELL },
+          { label: 'table.details.endpoint', value: record.endpoint || FALLBACK_CELL },
+          { label: 'table.details.requesterIp', value: record.requesterIp || FALLBACK_CELL },
+          { label: 'table.details.promptCacheKey', value: record.promptCacheKey || FALLBACK_CELL },
+          { label: 'table.details.failureKind', value: record.failureKind || FALLBACK_CELL },
+        ]
+        const timingPairs: Array<{ label: TranslationKey; value: string }> = [
+          { label: 'table.details.stage.requestRead', value: formatMilliseconds(record.tReqReadMs) },
+          { label: 'table.details.stage.requestParse', value: formatMilliseconds(record.tReqParseMs) },
+          { label: 'table.details.stage.upstreamConnect', value: formatMilliseconds(record.tUpstreamConnectMs) },
+          { label: 'table.details.stage.upstreamFirstByte', value: formatMilliseconds(record.tUpstreamTtfbMs) },
+          { label: 'table.details.stage.upstreamStream', value: formatMilliseconds(record.tUpstreamStreamMs) },
+          { label: 'table.details.stage.responseParse', value: formatMilliseconds(record.tRespParseMs) },
+          { label: 'table.details.stage.persistence', value: formatMilliseconds(record.tPersistMs) },
+          { label: 'table.details.stage.total', value: formatMilliseconds(record.tTotalMs) },
+        ]
+
+        return {
+          record,
+          recordId,
+          meta,
+          occurredTime,
+          occurredDate,
+          proxyDisplayName,
+          modelValue: record.model ?? FALLBACK_CELL,
+          costValue: typeof record.cost === 'number' ? currencyFormatter.format(record.cost) : FALLBACK_CELL,
+          inputTokensValue: formatOptionalNumber(record.inputTokens, numberFormatter),
+          cacheInputTokensValue: formatOptionalNumber(record.cacheInputTokens, numberFormatter),
+          outputTokensValue: formatOptionalNumber(record.outputTokens, numberFormatter),
+          totalTokensValue: formatOptionalNumber(record.totalTokens, numberFormatter),
+          endpointValue,
+          errorMessage,
+          latencySummary,
+          latencyCompactSummary,
+          detailPairs,
+          timingPairs,
+        }
+      }),
+    [records, currencyFormatter, dateFormatter, numberFormatter, timeFormatter],
+  )
+
+  const renderExpandedContent = (
+    detailId: string,
+    detailPairs: Array<{ label: TranslationKey; value: string }>,
+    timingPairs: Array<{ label: TranslationKey; value: string }>,
+    errorMessage: string,
+    size: 'compact' | 'default',
+  ) => (
+    <div id={detailId} className={`flex flex-col gap-4 ${size === 'compact' ? 'p-3' : 'p-4'}`}>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">{t('table.detailsTitle')}</span>
+        <div className="grid gap-2 md:grid-cols-2">
+          {detailPairs.map((entry) => (
+            <div key={entry.label} className="flex items-start gap-2">
+              <span className="min-w-28 text-xs uppercase tracking-wide text-base-content/60 md:min-w-36">{t(entry.label)}</span>
+              <span className="break-all font-mono text-sm">{entry.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">
+          {t('table.details.timingsTitle')}
+        </span>
+        <div className="grid gap-2 md:grid-cols-2">
+          {timingPairs.map((entry) => (
+            <div key={entry.label} className="flex items-start gap-2">
+              <span className="min-w-28 text-xs uppercase tracking-wide text-base-content/60 md:min-w-36">{t(entry.label)}</span>
+              <span className="font-mono text-sm">{entry.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {errorMessage && (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">{t('table.errorDetailsTitle')}</span>
+          <pre className="whitespace-pre-wrap break-words font-mono text-sm">{errorMessage}</pre>
+        </div>
+      )}
+    </div>
+  )
+
   if (error) {
     return (
       <Alert variant="error">
@@ -131,229 +254,230 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
   }
 
   return (
-    <div
-      className="overflow-x-auto rounded-xl border border-base-300/70 bg-base-100/52 backdrop-blur"
-      data-testid="invocation-table-scroll"
-    >
-      <table className="w-full min-w-full border-separate border-spacing-0 text-sm">
-        <thead className="bg-base-200/65 text-[11px] uppercase tracking-[0.08em] text-base-content/70">
-          <tr>
-            <th className="w-28 px-3 py-2.5 text-left font-semibold whitespace-nowrap">{t('table.column.time')}</th>
-            <th className="w-28 px-3 py-2.5 text-center font-semibold whitespace-nowrap">
-              <div className="flex flex-col leading-tight">
-                <span>{t('table.column.proxy')}</span>
-                <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
-                  {t('table.column.latency')}
-                </span>
-              </div>
-            </th>
-            <th className="w-36 px-3 py-2.5 text-right font-semibold whitespace-nowrap">
-              <div className="flex flex-col leading-tight">
-                <span>{t('table.column.model')}</span>
-                <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
-                  {t('table.column.costUsd')}
-                </span>
-              </div>
-            </th>
-            <th className="w-32 px-3 py-2.5 text-right font-semibold whitespace-nowrap">
-              <div className="flex flex-col leading-tight">
-                <span>{t('table.column.inputTokens')}</span>
-                <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
-                  {t('table.column.cacheInputTokens')}
-                </span>
-              </div>
-            </th>
-            <th className="w-24 px-3 py-2.5 text-right font-semibold whitespace-nowrap">{t('table.column.outputTokens')}</th>
-            <th className="w-24 px-3 py-2.5 text-right font-semibold whitespace-nowrap">{t('table.column.totalTokens')}</th>
-            <th className="hidden min-w-64 px-3 py-2.5 text-left font-semibold xl:table-cell">
-              <div className="flex flex-col leading-tight">
-                <span>{t('table.column.error')}</span>
-                <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
-                  {t('table.details.endpoint')}
-                </span>
-              </div>
-            </th>
-            <th className="w-12 px-3 py-2.5 text-right">
-              <span className="sr-only">{toggleLabels.header}</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-base-300/65">
-          {records.map((record, rowIndex) => {
-            const occurred = new Date(record.occurredAt)
-            const normalizedStatus = (record.status ?? 'unknown').toLowerCase()
-            const meta = STATUS_META[normalizedStatus] ?? FALLBACK_STATUS_META
-            const recordId = record.id
-            const detailId = `invocation-details-${recordId}`
-            const isExpanded = expandedId === recordId
-            const errorMessage = record.errorMessage?.trim() ?? ''
-            const endpointValue = record.endpoint?.trim() || FALLBACK_CELL
-            const proxyDisplayName = resolveProxyDisplayName(record)
-            const statusLabel = t(meta.key)
-            const proxyBadgeLabel = proxyDisplayName ?? statusLabel
-            const latencySummary = `${formatMilliseconds(record.tUpstreamTtfbMs)} / ${formatMilliseconds(record.tTotalMs)}`
-            const latencyCompactSummary = `${formatMillisecondsCompact(record.tUpstreamTtfbMs)}/${formatMillisecondsCompact(record.tTotalMs)}`
-            const occurredValid = !Number.isNaN(occurred.getTime())
-            const occurredTime = occurredValid ? timeFormatter.format(occurred) : record.occurredAt
-            const occurredDate = occurredValid ? dateFormatter.format(occurred) : FALLBACK_CELL
+    <div className="space-y-3">
+      <div className="space-y-3 md:hidden" data-testid="invocation-list">
+        {rows.map((row, rowIndex) => {
+          const listDetailId = `invocation-list-details-${row.recordId}`
+          const isExpanded = expandedId === row.recordId
+          const handleToggle = () => {
+            setExpandedId((current) => (current === row.recordId ? null : row.recordId))
+          }
 
-            const detailPairs: Array<{ label: TranslationKey; value: string }> = [
-              { label: 'table.details.invokeId', value: record.invokeId || FALLBACK_CELL },
-              { label: 'table.details.source', value: record.source || FALLBACK_CELL },
-              { label: 'table.details.endpoint', value: record.endpoint || FALLBACK_CELL },
-              { label: 'table.details.requesterIp', value: record.requesterIp || FALLBACK_CELL },
-              { label: 'table.details.promptCacheKey', value: record.promptCacheKey || FALLBACK_CELL },
-              { label: 'table.details.failureKind', value: record.failureKind || FALLBACK_CELL },
-            ]
-            const timingPairs: Array<{ label: TranslationKey; value: string }> = [
-              { label: 'table.details.stage.requestRead', value: formatMilliseconds(record.tReqReadMs) },
-              { label: 'table.details.stage.requestParse', value: formatMilliseconds(record.tReqParseMs) },
-              { label: 'table.details.stage.upstreamConnect', value: formatMilliseconds(record.tUpstreamConnectMs) },
-              { label: 'table.details.stage.upstreamFirstByte', value: formatMilliseconds(record.tUpstreamTtfbMs) },
-              { label: 'table.details.stage.upstreamStream', value: formatMilliseconds(record.tUpstreamStreamMs) },
-              { label: 'table.details.stage.responseParse', value: formatMilliseconds(record.tRespParseMs) },
-              { label: 'table.details.stage.persistence', value: formatMilliseconds(record.tPersistMs) },
-              { label: 'table.details.stage.total', value: formatMilliseconds(record.tTotalMs) },
-            ]
+          return (
+            <article
+              key={`mobile-${row.recordId}`}
+              data-testid="invocation-list-item"
+              className={`rounded-xl border border-base-300/70 px-3 py-3 ${rowIndex % 2 === 0 ? 'bg-base-100/40' : 'bg-base-200/24'}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-semibold">{row.occurredTime}</div>
+                  <div className="truncate text-xs text-base-content/65">{row.occurredDate}</div>
+                </div>
+                <button
+                  type="button"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-base-content/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  onClick={handleToggle}
+                  aria-expanded={isExpanded}
+                  aria-controls={listDetailId}
+                  aria-label={isExpanded ? toggleLabels.hide : toggleLabels.show}
+                >
+                  <Icon
+                    icon={isExpanded ? 'mdi:chevron-down' : 'mdi:chevron-right'}
+                    className="h-5 w-5"
+                    aria-hidden
+                  />
+                  <span className="sr-only">{isExpanded ? toggleLabels.expanded : toggleLabels.collapsed}</span>
+                </button>
+              </div>
 
-            const handleToggle = () => {
-              setExpandedId((current) => (current === recordId ? null : recordId))
-            }
+              <div className="mt-2 flex min-w-0 items-center gap-2">
+                <Badge variant={row.meta.variant}>{t(row.meta.key)}</Badge>
+                <span className="min-w-0 truncate text-xs text-base-content/75" title={row.proxyDisplayName}>
+                  {row.proxyDisplayName}
+                </span>
+              </div>
 
-            return (
-              <Fragment key={recordId}>
-                <tr className={`${rowIndex % 2 === 0 ? 'bg-base-100/38' : 'bg-base-200/22'} hover:bg-primary/6`}>
-                  <td className="border-t border-base-300/65 px-3 py-2.5 align-middle">
-                    <div className="flex flex-col justify-center gap-1 leading-tight">
-                      <span className="block truncate whitespace-nowrap font-medium">{occurredTime}</span>
-                      <span className="block truncate whitespace-nowrap text-base-content/70">{occurredDate}</span>
-                    </div>
-                  </td>
-                  <td className="border-t border-base-300/65 px-3 py-2.5 align-middle text-center">
-                    <div className="flex w-full min-w-0 flex-col items-center justify-center gap-1 leading-tight">
-                      <Badge variant={meta.variant} className="max-w-[7rem] justify-center overflow-hidden sm:max-w-[8rem]">
-                        <span className="block max-w-[7rem] truncate whitespace-nowrap text-center sm:max-w-[8rem]" title={proxyBadgeLabel}>
-                          {proxyBadgeLabel}
-                        </span>
-                      </Badge>
-                      {proxyDisplayName ? (
-                        <span className="text-xs text-base-content/70">{statusLabel}</span>
-                      ) : null}
-                      <span className="block whitespace-nowrap font-mono text-xs text-base-content/70 sm:hidden" title={latencySummary}>
-                        {latencyCompactSummary}
-                      </span>
-                      <span className="hidden whitespace-nowrap font-mono text-xs text-base-content/70 sm:block" title={latencySummary}>
-                        {latencySummary}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="border-t border-base-300/65 px-3 py-2.5 align-middle">
-                    <div className="flex flex-col items-end justify-center gap-1 leading-tight text-right">
-                      <span className="block truncate whitespace-nowrap text-base-content/85" title={record.model ?? FALLBACK_CELL}>
-                        {record.model ?? FALLBACK_CELL}
-                      </span>
-                      <span className="block truncate whitespace-nowrap font-mono tabular-nums text-base-content/70">
-                        {typeof record.cost === 'number' ? currencyFormatter.format(record.cost) : FALLBACK_CELL}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="border-t border-base-300/65 px-3 py-2.5 align-middle">
-                    <div className="flex flex-col items-end justify-center gap-1 leading-tight text-right">
-                      <span className="block truncate whitespace-nowrap font-mono tabular-nums">
-                        {formatOptionalNumber(record.inputTokens, numberFormatter)}
-                      </span>
-                      <span className="block truncate whitespace-nowrap font-mono tabular-nums text-base-content/70">
-                        {formatOptionalNumber(record.cacheInputTokens, numberFormatter)}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="border-t border-base-300/65 px-3 py-2.5 align-middle text-right font-mono tabular-nums">
-                    <span className="block truncate whitespace-nowrap">
-                      {formatOptionalNumber(record.outputTokens, numberFormatter)}
+              <div className="mt-2 text-xs font-mono text-base-content/70" title={row.latencySummary}>
+                {row.latencySummary}
+              </div>
+
+              <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                <dt className="text-base-content/65">{t('table.column.model')}</dt>
+                <dd className="truncate text-right" title={row.modelValue}>{row.modelValue}</dd>
+                <dt className="text-base-content/65">{t('table.column.costUsd')}</dt>
+                <dd className="truncate text-right font-mono">{row.costValue}</dd>
+                <dt className="text-base-content/65">{t('table.column.inputTokens')}</dt>
+                <dd className="truncate text-right font-mono">{row.inputTokensValue}</dd>
+                <dt className="text-base-content/65">{t('table.column.cacheInputTokens')}</dt>
+                <dd className="truncate text-right font-mono">{row.cacheInputTokensValue}</dd>
+                <dt className="text-base-content/65">{t('table.column.outputTokens')}</dt>
+                <dd className="truncate text-right font-mono">{row.outputTokensValue}</dd>
+                <dt className="text-base-content/65">{t('table.column.totalTokens')}</dt>
+                <dd className="truncate text-right font-mono">{row.totalTokensValue}</dd>
+              </dl>
+
+              <div className="mt-3 space-y-1 border-t border-base-300/65 pt-2">
+                <div className="text-[10px] uppercase tracking-[0.08em] text-base-content/60">{t('table.details.endpoint')}</div>
+                <div className="truncate text-xs text-base-content/75" title={row.endpointValue}>{row.endpointValue}</div>
+                <div className="truncate text-xs" title={row.errorMessage || undefined}>{row.errorMessage || FALLBACK_CELL}</div>
+              </div>
+
+              {isExpanded && (
+                <div className="mt-3 rounded-lg border border-base-300/70 bg-base-200/58">
+                  {renderExpandedContent(listDetailId, row.detailPairs, row.timingPairs, row.errorMessage, 'compact')}
+                </div>
+              )}
+            </article>
+          )
+        })}
+      </div>
+
+      <div className="hidden md:block">
+        <div
+          className="overflow-x-hidden rounded-xl border border-base-300/70 bg-base-100/52 backdrop-blur"
+          data-testid="invocation-table-scroll"
+        >
+          <table className="w-full table-fixed border-separate border-spacing-0 text-sm">
+            <thead className="bg-base-200/65 text-[11px] uppercase tracking-[0.08em] text-base-content/70">
+              <tr>
+                <th className="w-[10%] px-2 py-2.5 text-left font-semibold whitespace-nowrap xl:px-3">{t('table.column.time')}</th>
+                <th className="w-[15%] px-2 py-2.5 text-center font-semibold whitespace-nowrap xl:px-3">
+                  <div className="flex flex-col leading-tight">
+                    <span>{t('table.column.proxy')}</span>
+                    <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
+                      {t('table.column.latency')}
                     </span>
-                  </td>
-                  <td className="border-t border-base-300/65 px-3 py-2.5 align-middle text-right font-mono tabular-nums">
-                    <span className="block truncate whitespace-nowrap">
-                      {formatOptionalNumber(record.totalTokens, numberFormatter)}
+                  </div>
+                </th>
+                <th className="w-[16%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">
+                  <div className="flex flex-col leading-tight">
+                    <span>{t('table.column.model')}</span>
+                    <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
+                      {t('table.column.costUsd')}
                     </span>
-                  </td>
-                  <td className="hidden border-t border-base-300/65 px-3 py-2.5 align-middle xl:table-cell">
-                    <div className="flex flex-col justify-center gap-1 leading-tight">
-                      <span className="block truncate whitespace-nowrap text-base-content/70" title={endpointValue}>
-                        {endpointValue}
-                      </span>
-                      <span className="block truncate whitespace-nowrap" title={errorMessage || undefined}>
-                        {errorMessage || FALLBACK_CELL}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="border-t border-base-300/65 px-3 py-2.5 align-middle text-right">
-                    <button
-                      type="button"
-                      className="inline-flex items-center justify-end gap-1 text-lg leading-none text-base-content/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                      onClick={handleToggle}
-                      aria-expanded={isExpanded}
-                      aria-controls={detailId}
-                      aria-label={isExpanded ? toggleLabels.hide : toggleLabels.show}
-                    >
-                      <Icon
-                        icon={isExpanded ? 'mdi:chevron-down' : 'mdi:chevron-right'}
-                        className="h-4 w-4"
-                        aria-hidden
-                      />
-                      <span className="sr-only">{isExpanded ? toggleLabels.expanded : toggleLabels.collapsed}</span>
-                    </button>
-                  </td>
-                </tr>
-                {isExpanded && (
-                  <tr className="bg-base-200/68">
-                    <td colSpan={8} className="border-t border-base-300/65 px-3 py-2.5">
-                      <div id={detailId} className="flex flex-col gap-4 p-4">
-                        <div className="flex flex-col gap-2">
-                          <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">
-                            {t('table.detailsTitle')}
-                          </span>
-                          <div className="grid gap-2 md:grid-cols-2">
-                            {detailPairs.map((entry) => (
-                              <div key={entry.label} className="flex items-start gap-2">
-                                <span className="min-w-36 text-xs uppercase tracking-wide text-base-content/60">{t(entry.label)}</span>
-                                <span className="break-all font-mono text-sm">{entry.value}</span>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
+                  </div>
+                </th>
+                <th className="w-[15%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">
+                  <div className="flex flex-col leading-tight">
+                    <span>{t('table.column.inputTokens')}</span>
+                    <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
+                      {t('table.column.cacheInputTokens')}
+                    </span>
+                  </div>
+                </th>
+                <th className="w-[9%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">{t('table.column.outputTokens')}</th>
+                <th className="w-[10%] px-2 py-2.5 text-right font-semibold whitespace-nowrap xl:px-3">{t('table.column.totalTokens')}</th>
+                <th className="hidden w-[18%] px-2 py-2.5 text-left font-semibold xl:table-cell xl:px-3">
+                  <div className="flex flex-col leading-tight">
+                    <span>{t('table.column.error')}</span>
+                    <span className="text-[10px] font-medium normal-case tracking-normal text-base-content/60">
+                      {t('table.details.endpoint')}
+                    </span>
+                  </div>
+                </th>
+                <th className="w-[7%] px-2 py-2.5 text-right xl:px-3">
+                  <span className="sr-only">{toggleLabels.header}</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-base-300/65">
+              {rows.map((row, rowIndex) => {
+                const tableDetailId = `invocation-table-details-${row.recordId}`
+                const isExpanded = expandedId === row.recordId
+                const handleToggle = () => {
+                  setExpandedId((current) => (current === row.recordId ? null : row.recordId))
+                }
 
-                        <div className="flex flex-col gap-2">
-                          <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">
-                            {t('table.details.timingsTitle')}
-                          </span>
-                          <div className="grid gap-2 md:grid-cols-2">
-                            {timingPairs.map((entry) => (
-                              <div key={entry.label} className="flex items-start gap-2">
-                                <span className="min-w-36 text-xs uppercase tracking-wide text-base-content/60">{t(entry.label)}</span>
-                                <span className="font-mono text-sm">{entry.value}</span>
-                              </div>
-                            ))}
-                          </div>
+                return (
+                  <Fragment key={row.recordId}>
+                    <tr className={`${rowIndex % 2 === 0 ? 'bg-base-100/38' : 'bg-base-200/22'} hover:bg-primary/6`}>
+                      <td className="min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle xl:px-3">
+                        <div className="flex min-w-0 flex-col justify-center gap-1 leading-tight">
+                          <span className="truncate whitespace-nowrap font-medium">{row.occurredTime}</span>
+                          <span className="truncate whitespace-nowrap text-base-content/70">{row.occurredDate}</span>
                         </div>
-
-                        {errorMessage && (
-                          <div className="flex flex-col gap-2">
-                            <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">
-                              {t('table.errorDetailsTitle')}
+                      </td>
+                      <td className="min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle text-center xl:px-3">
+                        <div className="flex min-w-0 flex-col items-center justify-center gap-1 leading-tight">
+                          <Badge variant={row.meta.variant} className="max-w-full justify-center overflow-hidden">
+                            <span className="block max-w-full truncate whitespace-nowrap text-center" title={row.proxyDisplayName}>
+                              {row.proxyDisplayName}
                             </span>
-                            <pre className="whitespace-pre-wrap break-words font-mono text-sm">{errorMessage}</pre>
-                          </div>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                )}
-              </Fragment>
-            )
-          })}
-        </tbody>
-      </table>
+                            <span className="sr-only">{t(row.meta.key)}</span>
+                          </Badge>
+                          <span className="hidden whitespace-nowrap font-mono text-[11px] text-base-content/70 lg:block" title={row.latencySummary}>
+                            {row.latencySummary}
+                          </span>
+                          <span className="whitespace-nowrap font-mono text-[11px] text-base-content/70 lg:hidden" title={row.latencySummary}>
+                            {row.latencyCompactSummary}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle xl:px-3">
+                        <div className="flex min-w-0 flex-col items-end justify-center gap-1 leading-tight text-right">
+                          <span className="w-full truncate whitespace-nowrap text-base-content/85" title={row.modelValue}>
+                            {row.modelValue}
+                          </span>
+                          <span className="w-full truncate whitespace-nowrap font-mono tabular-nums text-base-content/70">
+                            {row.costValue}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle xl:px-3">
+                        <div className="flex min-w-0 flex-col items-end justify-center gap-1 leading-tight text-right">
+                          <span className="w-full truncate whitespace-nowrap font-mono tabular-nums">
+                            {row.inputTokensValue}
+                          </span>
+                          <span className="w-full truncate whitespace-nowrap font-mono tabular-nums text-base-content/70">
+                            {row.cacheInputTokensValue}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle text-right font-mono tabular-nums xl:px-3">
+                        <span className="block truncate whitespace-nowrap">{row.outputTokensValue}</span>
+                      </td>
+                      <td className="min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle text-right font-mono tabular-nums xl:px-3">
+                        <span className="block truncate whitespace-nowrap">{row.totalTokensValue}</span>
+                      </td>
+                      <td className="hidden min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle xl:table-cell xl:px-3">
+                        <div className="flex min-w-0 flex-col justify-center gap-1 leading-tight">
+                          <span className="truncate whitespace-nowrap text-base-content/70" title={row.endpointValue}>{row.endpointValue}</span>
+                          <span className="truncate whitespace-nowrap" title={row.errorMessage || undefined}>{row.errorMessage || FALLBACK_CELL}</span>
+                        </div>
+                      </td>
+                      <td className="border-t border-base-300/65 px-2 py-2.5 align-middle text-right xl:px-3">
+                        <button
+                          type="button"
+                          className="inline-flex items-center justify-end gap-1 text-lg leading-none text-base-content/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                          onClick={handleToggle}
+                          aria-expanded={isExpanded}
+                          aria-controls={tableDetailId}
+                          aria-label={isExpanded ? toggleLabels.hide : toggleLabels.show}
+                        >
+                          <Icon
+                            icon={isExpanded ? 'mdi:chevron-down' : 'mdi:chevron-right'}
+                            className="h-4 w-4"
+                            aria-hidden
+                          />
+                          <span className="sr-only">{isExpanded ? toggleLabels.expanded : toggleLabels.collapsed}</span>
+                        </button>
+                      </td>
+                    </tr>
+                    {isExpanded && (
+                      <tr className="bg-base-200/68">
+                        <td colSpan={8} className="border-t border-base-300/65 px-2 py-2.5 xl:px-3">
+                          {renderExpandedContent(tableDetailId, row.detailPairs, row.timingPairs, row.errorMessage, 'default')}
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   )
 }

--- a/web/tests/e2e/invocation-table-layout.spec.ts
+++ b/web/tests/e2e/invocation-table-layout.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test, type Page } from '@playwright/test'
 
 const VIEWPORTS = [
+  { width: 375, height: 900 },
+  { width: 768, height: 900 },
+  { width: 1024, height: 900 },
   { width: 1280, height: 900 },
   { width: 1440, height: 900 },
   { width: 1873, height: 900 },
@@ -19,6 +22,7 @@ const INVOCATION_FIXTURE = {
       occurredAt: '2026-02-26T02:35:52Z',
       createdAt: '2026-02-26T02:35:52Z',
       source: 'proxy',
+      proxyDisplayName: 'sg-relay-edge-01',
       endpoint: '/v1/responses',
       model: 'gpt-5.3-codex',
       status: 'success',
@@ -36,9 +40,10 @@ const INVOCATION_FIXTURE = {
       occurredAt: '2026-02-26T02:34:52Z',
       createdAt: '2026-02-26T02:34:52Z',
       source: 'proxy',
-      endpoint: '/v1/responses',
+      proxyDisplayName: 'tokyo-super-long-relay-name-for-overflow-regression-verify',
+      endpoint: '/v1/responses/' + 'very-long-segment-'.repeat(12),
       model: 'gpt-5.3-codex',
-      status: 'success',
+      status: 'failed',
       inputTokens: 95250,
       outputTokens: 69,
       cacheInputTokens: 99072,
@@ -46,6 +51,9 @@ const INVOCATION_FIXTURE = {
       cost: 0.0186,
       tUpstreamTtfbMs: 102.2,
       tTotalMs: 7348.7,
+      errorMessage:
+        '[downstream_closed] ' +
+        'x'.repeat(260),
     },
   ],
 }
@@ -58,12 +66,113 @@ interface TableMetrics {
 }
 
 async function mockInvocations(page: Page) {
-  await page.route('**/api/invocations?**', async (route) => {
+  await page.route('**/events', async (route) => {
     await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(INVOCATION_FIXTURE),
+      status: 204,
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+      },
+      body: '',
     })
+  })
+
+  await page.route('**/api/**', async (route) => {
+    const requestUrl = new URL(route.request().url())
+    const pathname = requestUrl.pathname
+
+    if (pathname === '/api/invocations') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(INVOCATION_FIXTURE),
+      })
+      return
+    }
+
+    if (pathname === '/api/stats' || pathname === '/api/stats/summary') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          totalCount: INVOCATION_FIXTURE.records.length,
+          successCount: 1,
+          failureCount: 1,
+          totalCost: 0.0467,
+          totalTokens: 212768,
+        }),
+      })
+      return
+    }
+
+    if (pathname === '/api/stats/timeseries') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rangeStart: '2026-03-02T00:00:00Z',
+          rangeEnd: '2026-03-02T12:00:00Z',
+          bucketSeconds: 600,
+          points: [],
+        }),
+      })
+      return
+    }
+
+    if (pathname === '/api/stats/errors') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rangeStart: '2026-03-02T00:00:00Z',
+          rangeEnd: '2026-03-02T12:00:00Z',
+          items: [],
+        }),
+      })
+      return
+    }
+
+    if (pathname === '/api/stats/failures/summary') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rangeStart: '2026-03-02T00:00:00Z',
+          rangeEnd: '2026-03-02T12:00:00Z',
+          totalFailures: 1,
+          serviceFailureCount: 1,
+          clientFailureCount: 0,
+          clientAbortCount: 0,
+          actionableFailureCount: 1,
+          actionableFailureRate: 1,
+        }),
+      })
+      return
+    }
+
+    if (pathname === '/api/stats/perf') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rangeStart: '2026-03-02T00:00:00Z',
+          rangeEnd: '2026-03-02T12:00:00Z',
+          items: [],
+        }),
+      })
+      return
+    }
+
+    if (pathname === '/api/version') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ backend: '0.2.0', frontend: '0.2.0' }),
+      })
+      return
+    }
+
+    throw new Error(`Unexpected API request in invocation-table-layout spec: ${pathname}`)
   })
 }
 
@@ -90,10 +199,17 @@ async function readTableMetrics(page: Page): Promise<TableMetrics> {
   })
 }
 
+async function readViewportOverflow(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const root = document.documentElement
+    return root.scrollWidth - root.clientWidth
+  })
+}
+
 test.describe('InvocationTable layout regression', () => {
   for (const viewport of VIEWPORTS) {
     for (const target of TARGET_PAGES) {
-      test(`keeps expand toggle visible without artificial horizontal overflow at ${target.label} ${viewport.width}px`, async ({
+      test(`keeps responsive layout stable at ${target.label} ${viewport.width}px`, async ({
         page,
       }) => {
         await page.setViewportSize(viewport)
@@ -101,14 +217,38 @@ test.describe('InvocationTable layout regression', () => {
         await page.goto(target.path)
         await expect(page).toHaveURL(new RegExp(`${target.hashPath}$`))
 
-        const metrics = await readTableMetrics(page)
-        test.info().annotations.push({
-          type: 'invocation-table-layout',
-          description: JSON.stringify({ target: target.label, viewport, metrics }),
-        })
+        if (viewport.width < 768) {
+          const mobileList = page.getByTestId('invocation-list')
+          await expect(mobileList).toBeVisible()
+          await expect(page.getByTestId('invocation-list-item')).toHaveCount(INVOCATION_FIXTURE.records.length)
+          await expect(page.getByTestId('invocation-table-scroll')).toBeHidden()
 
-        expect(metrics.overflowDelta).toBeLessThanOrEqual(2)
-        expect(metrics.firstToggleHiddenRightPx).toBeLessThanOrEqual(0)
+          const listToggle = mobileList.locator('button[aria-expanded]').first()
+          await expect(listToggle).toBeVisible()
+          await listToggle.click()
+          await expect(listToggle).toHaveAttribute('aria-expanded', 'true')
+
+          const viewportOverflow = await readViewportOverflow(page)
+          test.info().annotations.push({
+            type: 'invocation-mobile-layout',
+            description: JSON.stringify({ target: target.label, viewport, viewportOverflow }),
+          })
+          expect(viewportOverflow).toBeLessThanOrEqual(1)
+        } else {
+          await expect(page.getByTestId('invocation-list')).toBeHidden()
+          const metrics = await readTableMetrics(page)
+          const firstToggle = page.getByTestId('invocation-table-scroll').locator('tbody tr button').first()
+          await firstToggle.click()
+          await expect(firstToggle).toHaveAttribute('aria-expanded', 'true')
+
+          test.info().annotations.push({
+            type: 'invocation-table-layout',
+            description: JSON.stringify({ target: target.label, viewport, metrics }),
+          })
+          const maxOverflow = viewport.width >= 1024 ? 1 : 2
+          expect(metrics.overflowDelta).toBeLessThanOrEqual(maxOverflow)
+          expect(metrics.firstToggleHiddenRightPx).toBeLessThanOrEqual(0)
+        }
       })
     }
   }

--- a/web/tests/e2e/invocation-table-layout.spec.ts
+++ b/web/tests/e2e/invocation-table-layout.spec.ts
@@ -163,6 +163,19 @@ async function mockInvocations(page: Page) {
       return
     }
 
+    if (pathname === '/api/stats/forward-proxy') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rangeStart: '2026-03-02T00:00:00Z',
+          rangeEnd: '2026-03-02T12:00:00Z',
+          items: [],
+        }),
+      })
+      return
+    }
+
     if (pathname === '/api/version') {
       await route.fulfill({
         status: 200,
@@ -245,8 +258,7 @@ test.describe('InvocationTable layout regression', () => {
             type: 'invocation-table-layout',
             description: JSON.stringify({ target: target.label, viewport, metrics }),
           })
-          const maxOverflow = viewport.width >= 1024 ? 1 : 2
-          expect(metrics.overflowDelta).toBeLessThanOrEqual(maxOverflow)
+          expect(metrics.overflowDelta).toBeLessThanOrEqual(1)
           expect(metrics.firstToggleHiddenRightPx).toBeLessThanOrEqual(0)
         }
       })

--- a/web/tests/e2e/invocation-table-layout.spec.ts
+++ b/web/tests/e2e/invocation-table-layout.spec.ts
@@ -63,6 +63,7 @@ interface TableMetrics {
   scrollWidth: number
   overflowDelta: number
   firstToggleHiddenRightPx: number
+  firstRowTrailingGapPx: number
 }
 
 async function mockInvocations(page: Page) {
@@ -197,9 +198,13 @@ async function readTableMetrics(page: Page): Promise<TableMetrics> {
 
   return tableScroll.evaluate((node) => {
     const container = node as HTMLElement
-    const firstToggle = container.querySelector('tbody tr button') as HTMLElement | null
+    const firstDataRow = container.querySelector('tbody tr')
+    const firstToggle = firstDataRow?.querySelector('button') as HTMLElement | null
+    const firstDataCells = firstDataRow ? Array.from(firstDataRow.querySelectorAll('td')) : []
+    const lastDataCell = firstDataCells.length > 0 ? (firstDataCells[firstDataCells.length - 1] as HTMLElement) : null
     const containerRect = container.getBoundingClientRect()
     const toggleRect = firstToggle?.getBoundingClientRect()
+    const lastDataCellRect = lastDataCell?.getBoundingClientRect()
 
     return {
       clientWidth: container.clientWidth,
@@ -207,6 +212,9 @@ async function readTableMetrics(page: Page): Promise<TableMetrics> {
       overflowDelta: container.scrollWidth - container.clientWidth,
       firstToggleHiddenRightPx: toggleRect
         ? Math.max(0, toggleRect.right - containerRect.right)
+        : Number.POSITIVE_INFINITY,
+      firstRowTrailingGapPx: lastDataCellRect
+        ? Math.max(0, containerRect.right - lastDataCellRect.right)
         : Number.POSITIVE_INFINITY,
     }
   })
@@ -249,17 +257,27 @@ test.describe('InvocationTable layout regression', () => {
           expect(viewportOverflow).toBeLessThanOrEqual(1)
         } else {
           await expect(page.getByTestId('invocation-list')).toBeHidden()
-          const metrics = await readTableMetrics(page)
+          const metricsBeforeExpand = await readTableMetrics(page)
           const firstToggle = page.getByTestId('invocation-table-scroll').locator('tbody tr button').first()
           await firstToggle.click()
           await expect(firstToggle).toHaveAttribute('aria-expanded', 'true')
+          const metricsAfterExpand = await readTableMetrics(page)
 
           test.info().annotations.push({
             type: 'invocation-table-layout',
-            description: JSON.stringify({ target: target.label, viewport, metrics }),
+            description: JSON.stringify({
+              target: target.label,
+              viewport,
+              metricsBeforeExpand,
+              metricsAfterExpand,
+            }),
           })
-          expect(metrics.overflowDelta).toBeLessThanOrEqual(1)
-          expect(metrics.firstToggleHiddenRightPx).toBeLessThanOrEqual(0)
+          expect(metricsBeforeExpand.overflowDelta).toBeLessThanOrEqual(1)
+          expect(metricsAfterExpand.overflowDelta).toBeLessThanOrEqual(1)
+          expect(metricsBeforeExpand.firstToggleHiddenRightPx).toBeLessThanOrEqual(0)
+          expect(metricsAfterExpand.firstToggleHiddenRightPx).toBeLessThanOrEqual(0)
+          expect(metricsBeforeExpand.firstRowTrailingGapPx).toBeLessThanOrEqual(1)
+          expect(metricsAfterExpand.firstRowTrailingGapPx).toBeLessThanOrEqual(1)
         }
       })
     }


### PR DESCRIPTION
## Summary
- switch `InvocationTable` to responsive dual view: list cards below `md`, table at `md+`
- remove desktop/table horizontal overflow via `table-fixed`, tighter column budgeting, and stronger truncation guards
- preserve expandable detail behavior on both views and keep mobile/detail field parity (including cached input tokens)
- expand E2E layout regression to Dashboard + Live across `375 / 768 / 1024 / 1280 / 1440 / 1873`
- add strict API/SSE mocking in the layout spec to avoid hidden regressions

## Validation
- `cd web && npm run test`
- `cd web && npm run build`
- `cd web && npm run test:e2e -- tests/e2e/invocation-table-layout.spec.ts`
- `cd web && npm run lint -- src/components/InvocationTable.tsx tests/e2e/invocation-table-layout.spec.ts`