### PR TITLE
fix(proxy): enforce v2 default and harden backtest gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ PROXY_RAW_MAX_BYTES=0                          # (0=unlimited, set >0 to cap)
 PROXY_RAW_RETENTION_DAYS=7                     # (7)
 PROXY_ENFORCE_STREAM_INCLUDE_USAGE=true        # (true)
 PROXY_USAGE_BACKFILL_ON_STARTUP=true           # (true，启动时回填历史 proxy 空 token 记录)
+FORWARD_PROXY_ALGO=v2                          # (v2，正向代理权重算法开关: v1|v2)
 XY_LEGACY_POLL_ENABLED=false                   # (false，true 时启用 legacy 轮询写入)
 XY_MAX_PARALLEL_POLLS=6                        # (6)
 XY_SHARED_CONNECTION_PARALLELISM=2             # (2)
@@ -115,6 +116,7 @@ XY_LIST_LIMIT_MAX=200                          # (200)
 XY_USER_AGENT=codex-vibe-monitor/0.2.0         # (自动)
 XY_STATIC_DIR=web/dist                         # (存在时自动使用)
 XY_SNAPSHOT_MIN_INTERVAL_SECS=300              # (300)
+# 注意：XY_FORWARD_PROXY_ALGO 已移除，配置将直接失败，请改用 FORWARD_PROXY_ALGO
 
 # CRS 日统计源（可选；未配置则禁用）
 CRS_STATS_BASE_URL=https://claude-relay-service.nsngc.org

--- a/docs/forward-proxy-backtest.md
+++ b/docs/forward-proxy-backtest.md
@@ -1,0 +1,60 @@
+# Forward Proxy Backtest
+
+This project ships a local-only backtest tool for forward proxy weight algorithms.
+
+## Purpose
+
+- Compare baseline `v1` and candidate `v2` on the same SQLite snapshot.
+- Use backtest output as the acceptance gate for algorithm changes.
+- Keep snapshot data local and avoid accidental disclosure.
+
+## Script
+
+- Path: `/Users/ivan/.codex/worktrees/200e/codex-vibe-monitor/scripts/forward_proxy_backtest.py`
+- Input: a local SQLite snapshot containing `forward_proxy_attempts` and `forward_proxy_runtime`.
+- Output: one JSON report and one Markdown report.
+
+## Security Defaults
+
+The script enforces the following checks:
+
+- Opens SQLite with read-only URI mode.
+- Refuses database paths located inside the repository tree.
+- Writes reports to `/tmp` by default.
+- Redacts proxy identifiers by default.
+
+If any required security check fails, acceptance will fail.
+
+## Usage
+
+Run with the same acceptance command used in planning:
+
+```bash
+python3 /Users/ivan/.codex/worktrees/200e/codex-vibe-monitor/scripts/forward_proxy_backtest.py \
+  --db /tmp/cvm-prod-db-Jd0UiY/codex_vibe_monitor.db \
+  --algos v1,v2 \
+  --seeds 7,11,19,23,29 \
+  --requests 50000
+```
+
+Expected output lines:
+
+- `json_report=/tmp/forward-proxy-backtest-<timestamp>.json`
+- `markdown_report=/tmp/forward-proxy-backtest-<timestamp>.md`
+- `acceptance_pass=<true|false>`
+
+## Acceptance Rules
+
+`v2` must satisfy all checks below against `v1` on the same snapshot:
+
+1. `trace_replay.positive_nodes_p50 >= 2`
+2. `trace_replay.single_node_collapse_ratio <= 0.35`
+3. `simulation.top1_share_mean <= 0.55`
+4. `simulation.success_rate_mean >= baseline_success_rate_mean - 0.2%`
+5. `simulation.p95_latency_mean <= baseline_p95_latency_mean * 1.10`
+6. Required security checks all pass
+
+Script exit code behavior:
+
+- `0`: acceptance pass
+- `1`: acceptance fail

--- a/docs/forward-proxy-backtest.md
+++ b/docs/forward-proxy-backtest.md
@@ -10,7 +10,7 @@ This project ships a local-only backtest tool for forward proxy weight algorithm
 
 ## Script
 
-- Path: `/Users/ivan/.codex/worktrees/200e/codex-vibe-monitor/scripts/forward_proxy_backtest.py`
+- Path: `scripts/forward_proxy_backtest.py`
 - Input: a local SQLite snapshot containing `forward_proxy_attempts` and `forward_proxy_runtime`.
 - Output: one JSON report and one Markdown report.
 
@@ -30,7 +30,7 @@ If any required security check fails, acceptance will fail.
 Run with the same acceptance command used in planning:
 
 ```bash
-python3 /Users/ivan/.codex/worktrees/200e/codex-vibe-monitor/scripts/forward_proxy_backtest.py \
+python3 scripts/forward_proxy_backtest.py \
   --db /tmp/cvm-prod-db-Jd0UiY/codex_vibe_monitor.db \
   --algos v1,v2 \
   --seeds 7,11,19,23,29 \

--- a/scripts/forward_proxy_backtest.py
+++ b/scripts/forward_proxy_backtest.py
@@ -645,10 +645,14 @@ def run_simulation(
     seed_runtime: Optional[Dict[str, RuntimeState]],
 ) -> Dict[str, object]:
     proxy_keys = sorted(
-        key for key, profile in profiles.items() if profile.observed_attempts > 0
+        key
+        for key, profile in profiles.items()
+        if profile.observed_attempts > 0 and (insert_direct or key != DIRECT_KEY)
     )
     if not proxy_keys:
-        proxy_keys = sorted(profiles.keys())
+        proxy_keys = sorted(
+            key for key in profiles.keys() if insert_direct or key != DIRECT_KEY
+        )
     if insert_direct and DIRECT_KEY not in proxy_keys:
         proxy_keys.append(DIRECT_KEY)
     allowed_keys = set(proxy_keys)
@@ -664,6 +668,22 @@ def run_simulation(
         for latency in profile.failure_latencies
         if latency is not None
     ]
+
+    def fallback_profile_for(key: str) -> ProxyProfile:
+        return ProxyProfile(
+            key=key,
+            observed_attempts=0,
+            success_rate=0.65,
+            success_latencies=all_success_latencies,
+            failure_latencies=all_failure_latencies,
+            failure_kinds=["handshake_timeout"],
+        )
+
+    def profile_for(key: str) -> ProxyProfile:
+        profile = profiles.get(key)
+        if profile is None:
+            return fallback_profile_for(key)
+        return profile
 
     per_seed = []
     for seed in seeds:
@@ -694,16 +714,7 @@ def run_simulation(
         for _ in range(requests):
             key = machine.select_proxy(rng)
             selection_counter[key] += 1
-            profile = profiles.get(key)
-            if profile is None:
-                profile = ProxyProfile(
-                    key=key,
-                    observed_attempts=0,
-                    success_rate=0.65,
-                    success_latencies=all_success_latencies,
-                    failure_latencies=all_failure_latencies,
-                    failure_kinds=["handshake_timeout"],
-                )
+            profile = profile_for(key)
             success = rng.random() < profile.success_rate
             latency = sample_latency(
                 profile,
@@ -728,7 +739,7 @@ def run_simulation(
 
             probe_key = machine.start_probe(now_secs)
             if probe_key is not None:
-                probe_profile = profiles.get(probe_key, profile)
+                probe_profile = profile_for(probe_key)
                 probe_success = rng.random() < probe_profile.success_rate
                 probe_latency = sample_latency(
                     probe_profile,

--- a/scripts/forward_proxy_backtest.py
+++ b/scripts/forward_proxy_backtest.py
@@ -117,6 +117,7 @@ class AttemptRow:
 @dataclass
 class ProxyProfile:
     key: str
+    observed_attempts: int
     success_rate: float
     success_latencies: List[float]
     failure_latencies: List[float]
@@ -128,23 +129,21 @@ class ForwardProxyStateMachine:
         self,
         algo: AlgoConfig,
         proxy_keys: Iterable[str],
+        insert_direct: bool,
         seed_runtime: Optional[Dict[str, RuntimeState]] = None,
     ) -> None:
         self.algo = algo
         self.proxy_keys = sorted({key for key in proxy_keys if key})
-        if DIRECT_KEY not in self.proxy_keys:
+        if insert_direct and DIRECT_KEY not in self.proxy_keys:
+            self.proxy_keys.append(DIRECT_KEY)
+        if not self.proxy_keys:
             self.proxy_keys.append(DIRECT_KEY)
         self.runtime: Dict[str, RuntimeState] = {
             key: RuntimeState(weight=self._default_weight(key)) for key in self.proxy_keys
         }
         if seed_runtime:
             for key, state in seed_runtime.items():
-                self.runtime[key] = RuntimeState(
-                    weight=state.weight,
-                    success_ema=state.success_ema,
-                    latency_ema_ms=state.latency_ema_ms,
-                    consecutive_failures=state.consecutive_failures,
-                )
+                self.runtime[key] = self._normalize_seed_state(state)
                 if key not in self.proxy_keys:
                     self.proxy_keys.append(key)
         self.selection_counter = 0
@@ -162,6 +161,24 @@ class ForwardProxyStateMachine:
         if isinstance(latency_ms, (float, int)) and math.isfinite(latency_ms) and latency_ms >= 0.0:
             return float(latency_ms)
         return None
+
+    def _normalize_seed_state(self, state: RuntimeState) -> RuntimeState:
+        weight = state.weight if math.isfinite(state.weight) else 0.0
+        weight = max(self.algo.weight_min, min(self.algo.weight_max, weight))
+
+        if math.isfinite(state.success_ema):
+            success_ema = max(0.0, min(1.0, state.success_ema))
+        else:
+            success_ema = 0.65
+
+        latency_ema_ms = self._valid_latency(state.latency_ema_ms)
+        consecutive_failures = max(0, int(state.consecutive_failures))
+        return RuntimeState(
+            weight=weight,
+            success_ema=success_ema,
+            latency_ema_ms=latency_ema_ms,
+            consecutive_failures=consecutive_failures,
+        )
 
     def ensure_min_positive_candidates(self) -> None:
         positive_keys = [
@@ -316,7 +333,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--algos",
         default="v1,v2",
-        help="Comma-separated list of algorithms to run (subset of v1,v2)",
+        help="Comma-separated algorithms to evaluate (must include both v1 and v2)",
     )
     parser.add_argument(
         "--seeds",
@@ -349,7 +366,7 @@ def repo_root_from_script() -> Path:
 def validate_inputs(args: argparse.Namespace) -> Tuple[Path, List[AlgoConfig], List[int], Path, Dict[str, bool]]:
     checks: Dict[str, bool] = {
         "db_exists": False,
-        "db_readonly_uri_mode": True,
+        "db_readonly_uri_mode": False,
         "db_outside_repository": False,
         "output_in_tmp": False,
         "redaction_enabled": not args.no_redact,
@@ -398,16 +415,23 @@ def validate_inputs(args: argparse.Namespace) -> Tuple[Path, List[AlgoConfig], L
         output_prefix = Path(args.output_prefix).expanduser().resolve()
     else:
         output_prefix = Path(f"/tmp/forward-proxy-backtest-{timestamp}")
-    checks["output_in_tmp"] = output_prefix.parent.resolve() == Path("/tmp").resolve()
+    output_prefix = output_prefix.resolve()
+    tmp_root = Path("/tmp").resolve()
+    try:
+        output_prefix.relative_to(tmp_root)
+    except ValueError:
+        checks["output_in_tmp"] = False
+    else:
+        checks["output_in_tmp"] = True
 
     return db_path, algos, seeds, output_prefix, checks
 
 
-def open_readonly_connection(db_path: Path) -> sqlite3.Connection:
+def open_readonly_connection(db_path: Path) -> Tuple[sqlite3.Connection, bool]:
     uri = f"file:{db_path}?mode=ro"
     conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
-    return conn
+    return conn, "mode=ro" in uri.lower()
 
 
 def load_attempts(conn: sqlite3.Connection) -> List[AttemptRow]:
@@ -484,6 +508,28 @@ def load_runtime_states(conn: sqlite3.Connection) -> Dict[str, RuntimeState]:
     return states
 
 
+def load_insert_direct(conn: sqlite3.Connection) -> bool:
+    try:
+        row = conn.execute(
+            """
+            SELECT insert_direct
+            FROM forward_proxy_settings
+            WHERE id = 1
+            """
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return True
+    if row is None:
+        return True
+    raw_value = row["insert_direct"]
+    if raw_value is None:
+        return True
+    try:
+        return bool(int(raw_value))
+    except (TypeError, ValueError):
+        return True
+
+
 def redact_proxy(key: str, enable_redact: bool) -> str:
     if not enable_redact:
         return key
@@ -504,6 +550,7 @@ def build_profiles(attempts: List[AttemptRow], proxy_keys: Iterable[str]) -> Dic
         if not rows:
             profiles[key] = ProxyProfile(
                 key=key,
+                observed_attempts=0,
                 success_rate=0.65,
                 success_latencies=[],
                 failure_latencies=[],
@@ -528,6 +575,7 @@ def build_profiles(attempts: List[AttemptRow], proxy_keys: Iterable[str]) -> Dic
             failure_kinds = ["handshake_timeout"]
         profiles[key] = ProxyProfile(
             key=key,
+            observed_attempts=len(rows),
             success_rate=success_rate,
             success_latencies=success_latencies,
             failure_latencies=failure_latencies,
@@ -545,8 +593,10 @@ def sample_latency(profile: ProxyProfile, success: bool, rng: random.Random, fal
     return None
 
 
-def trace_replay(attempts: List[AttemptRow], algo: AlgoConfig, proxy_keys: Iterable[str]) -> Dict[str, object]:
-    machine = ForwardProxyStateMachine(algo, proxy_keys)
+def trace_replay(
+    attempts: List[AttemptRow], algo: AlgoConfig, proxy_keys: Iterable[str], insert_direct: bool
+) -> Dict[str, object]:
+    machine = ForwardProxyStateMachine(algo, proxy_keys, insert_direct=insert_direct)
     positive_counts: List[int] = []
     collapse_events = 0
     recovery_waits: List[int] = []
@@ -591,9 +641,17 @@ def run_simulation(
     profiles: Dict[str, ProxyProfile],
     seeds: List[int],
     requests: int,
+    insert_direct: bool,
     seed_runtime: Optional[Dict[str, RuntimeState]],
 ) -> Dict[str, object]:
-    proxy_keys = sorted(profiles.keys())
+    proxy_keys = sorted(
+        key for key, profile in profiles.items() if profile.observed_attempts > 0
+    )
+    if not proxy_keys:
+        proxy_keys = sorted(profiles.keys())
+    if insert_direct and DIRECT_KEY not in proxy_keys:
+        proxy_keys.append(DIRECT_KEY)
+    allowed_keys = set(proxy_keys)
     all_success_latencies = [
         latency
         for profile in profiles.values()
@@ -610,7 +668,22 @@ def run_simulation(
     per_seed = []
     for seed in seeds:
         rng = random.Random(seed)
-        machine = ForwardProxyStateMachine(algo, proxy_keys, seed_runtime=seed_runtime)
+        runtime_seed = (
+            {
+                key: state
+                for key, state in seed_runtime.items()
+                if key in allowed_keys
+            }
+            if seed_runtime
+            else None
+        )
+        enable_direct = insert_direct
+        machine = ForwardProxyStateMachine(
+            algo,
+            proxy_keys,
+            insert_direct=enable_direct,
+            seed_runtime=runtime_seed,
+        )
         selection_counter: collections.Counter[str] = collections.Counter()
         failure_kind_counter: collections.Counter[str] = collections.Counter()
 
@@ -625,6 +698,7 @@ def run_simulation(
             if profile is None:
                 profile = ProxyProfile(
                     key=key,
+                    observed_attempts=0,
                     success_rate=0.65,
                     success_latencies=all_success_latencies,
                     failure_latencies=all_failure_latencies,
@@ -790,40 +864,59 @@ def main() -> int:
     args = parse_args()
     db_path, algos, seeds, output_prefix, security_checks = validate_inputs(args)
 
-    if "v1" not in {algo.name for algo in algos} or "v2" not in {algo.name for algo in algos}:
+    algo_by_name = {algo.name: algo for algo in algos}
+    if "v1" not in algo_by_name or "v2" not in algo_by_name:
         raise SystemExit("--algos must include both v1 and v2 for acceptance evaluation")
+    baseline_algo = algo_by_name["v1"]
+    candidate_algo = algo_by_name["v2"]
 
-    conn = open_readonly_connection(db_path)
+    conn, readonly_uri_mode = open_readonly_connection(db_path)
     try:
+        security_checks["db_readonly_uri_mode"] = readonly_uri_mode
         attempts = load_attempts(conn)
         runtime_keys = load_runtime_keys(conn)
         runtime_states = load_runtime_states(conn)
+        insert_direct = load_insert_direct(conn)
     finally:
         conn.close()
 
     if not attempts:
         raise SystemExit("forward_proxy_attempts is empty; cannot run backtest")
 
-    proxy_keys = sorted(set(runtime_keys) | {item.proxy_key for item in attempts})
-    profiles = build_profiles(attempts, proxy_keys)
+    attempt_proxy_keys = sorted({item.proxy_key for item in attempts})
+    trace_proxy_keys = sorted(set(attempt_proxy_keys) | ({DIRECT_KEY} if insert_direct else set()))
+    profile_proxy_keys = sorted(set(runtime_keys) | set(attempt_proxy_keys))
+    profiles = build_profiles(attempts, profile_proxy_keys)
 
     baseline = {
-        "trace_replay": trace_replay(attempts, ALGO_V1, proxy_keys),
+        "trace_replay": trace_replay(
+            attempts,
+            baseline_algo,
+            trace_proxy_keys,
+            insert_direct=insert_direct,
+        ),
         "simulation": run_simulation(
-            ALGO_V1,
+            baseline_algo,
             profiles,
             seeds,
             args.requests,
+            insert_direct,
             runtime_states,
         ),
     }
     candidate = {
-        "trace_replay": trace_replay(attempts, ALGO_V2, proxy_keys),
+        "trace_replay": trace_replay(
+            attempts,
+            candidate_algo,
+            trace_proxy_keys,
+            insert_direct=insert_direct,
+        ),
         "simulation": run_simulation(
-            ALGO_V2,
+            candidate_algo,
             profiles,
             seeds,
             args.requests,
+            insert_direct,
             runtime_states,
         ),
     }
@@ -832,6 +925,17 @@ def main() -> int:
     sanitize_seed_output(candidate["simulation"], redact=not args.no_redact)
 
     acceptance = evaluate_acceptance(baseline, candidate, security_checks)
+    security_failed = [
+        item
+        for item in acceptance["failed_rules"]
+        if item.startswith("security_check_failed:")
+    ]
+    if security_failed:
+        print("acceptance_pass=False")
+        print("failed_rules=")
+        for item in acceptance["failed_rules"]:
+            print(f"- {item}")
+        return 1
 
     result = {
         "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),

--- a/scripts/forward_proxy_backtest.py
+++ b/scripts/forward_proxy_backtest.py
@@ -1,0 +1,868 @@
+#!/usr/bin/env python3
+"""Forward proxy algorithm backtest against a local SQLite snapshot.
+
+The script compares baseline v1 and candidate v2 using:
+1) Trace replay over recorded forward_proxy_attempts in chronological order.
+2) Stochastic simulation from distributions estimated on the same database.
+
+Security defaults:
+- Database is opened with sqlite read-only URI mode.
+- Database path inside repository is rejected.
+- Reports are written under /tmp by default.
+- Proxy identifiers are redacted by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime as dt
+import hashlib
+import json
+import math
+import random
+import sqlite3
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+DIRECT_KEY = "__direct__"
+
+
+@dataclass(frozen=True)
+class AlgoConfig:
+    name: str
+    success_bonus: float
+    latency_divisor: float
+    latency_cap: float
+    success_min_gain: Optional[float]
+    failure_base: float
+    failure_step: float
+    failure_uses_offset: bool
+    failure_cap: Optional[float]
+    weight_min: float
+    weight_max: float
+    success_floor: float
+    probe_every_requests: int
+    probe_interval_secs: int
+    probe_recovery_weight: float
+    min_positive_candidates: int
+    direct_initial_weight: float
+
+
+ALGO_V1 = AlgoConfig(
+    name="v1",
+    success_bonus=0.45,
+    latency_divisor=2500.0,
+    latency_cap=0.6,
+    success_min_gain=None,
+    failure_base=0.9,
+    failure_step=0.35,
+    failure_uses_offset=True,
+    failure_cap=None,
+    weight_min=-12.0,
+    weight_max=12.0,
+    success_floor=0.3,
+    probe_every_requests=100,
+    probe_interval_secs=30 * 60,
+    probe_recovery_weight=0.4,
+    min_positive_candidates=1,
+    direct_initial_weight=1.0,
+)
+
+ALGO_V2 = AlgoConfig(
+    name="v2",
+    success_bonus=0.55,
+    latency_divisor=9000.0,
+    latency_cap=0.35,
+    success_min_gain=0.08,
+    failure_base=0.5,
+    failure_step=0.18,
+    failure_uses_offset=False,
+    failure_cap=1.2,
+    weight_min=-8.0,
+    weight_max=8.0,
+    success_floor=0.25,
+    probe_every_requests=30,
+    probe_interval_secs=5 * 60,
+    probe_recovery_weight=0.55,
+    min_positive_candidates=2,
+    direct_initial_weight=0.7,
+)
+
+ALGO_BY_NAME = {"v1": ALGO_V1, "v2": ALGO_V2}
+
+
+@dataclass
+class RuntimeState:
+    weight: float
+    success_ema: float = 0.65
+    latency_ema_ms: Optional[float] = None
+    consecutive_failures: int = 0
+
+
+@dataclass
+class AttemptRow:
+    event_id: int
+    proxy_key: str
+    occurred_at: str
+    is_success: bool
+    latency_ms: Optional[float]
+    failure_kind: str
+    is_probe: bool
+
+
+@dataclass
+class ProxyProfile:
+    key: str
+    success_rate: float
+    success_latencies: List[float]
+    failure_latencies: List[float]
+    failure_kinds: List[str]
+
+
+class ForwardProxyStateMachine:
+    def __init__(
+        self,
+        algo: AlgoConfig,
+        proxy_keys: Iterable[str],
+        seed_runtime: Optional[Dict[str, RuntimeState]] = None,
+    ) -> None:
+        self.algo = algo
+        self.proxy_keys = sorted({key for key in proxy_keys if key})
+        if DIRECT_KEY not in self.proxy_keys:
+            self.proxy_keys.append(DIRECT_KEY)
+        self.runtime: Dict[str, RuntimeState] = {
+            key: RuntimeState(weight=self._default_weight(key)) for key in self.proxy_keys
+        }
+        if seed_runtime:
+            for key, state in seed_runtime.items():
+                self.runtime[key] = RuntimeState(
+                    weight=state.weight,
+                    success_ema=state.success_ema,
+                    latency_ema_ms=state.latency_ema_ms,
+                    consecutive_failures=state.consecutive_failures,
+                )
+                if key not in self.proxy_keys:
+                    self.proxy_keys.append(key)
+        self.selection_counter = 0
+        self.requests_since_probe = 0
+        self.probe_in_flight = False
+        self.last_probe_at = 0.0
+        self.ensure_min_positive_candidates()
+
+    def _default_weight(self, key: str) -> float:
+        return self.algo.direct_initial_weight if key == DIRECT_KEY else 0.8
+
+    def _valid_latency(self, latency_ms: Optional[float]) -> Optional[float]:
+        if latency_ms is None:
+            return None
+        if isinstance(latency_ms, (float, int)) and math.isfinite(latency_ms) and latency_ms >= 0.0:
+            return float(latency_ms)
+        return None
+
+    def ensure_min_positive_candidates(self) -> None:
+        positive_keys = [
+            key
+            for key, state in self.runtime.items()
+            if state.weight > 0.0 and math.isfinite(state.weight)
+        ]
+        if len(positive_keys) >= self.algo.min_positive_candidates:
+            return
+
+        candidates = sorted(
+            self.runtime.items(), key=lambda item: item[1].weight, reverse=True
+        )
+        for key, state in candidates:
+            if len(positive_keys) >= self.algo.min_positive_candidates:
+                break
+            if state.weight > 0.0 and math.isfinite(state.weight):
+                continue
+            state.weight = self.algo.probe_recovery_weight
+            if self.algo.name == "v2":
+                state.consecutive_failures = 0
+            positive_keys.append(key)
+
+    def record_attempt(self, key: str, success: bool, latency_ms: Optional[float], is_probe: bool) -> None:
+        if key not in self.runtime:
+            self.runtime[key] = RuntimeState(weight=self._default_weight(key))
+            if key not in self.proxy_keys:
+                self.proxy_keys.append(key)
+        state = self.runtime[key]
+
+        latency = self._valid_latency(latency_ms)
+        state.success_ema = state.success_ema * 0.9 + (0.1 if success else 0.0)
+        if latency is not None:
+            if state.latency_ema_ms is None:
+                state.latency_ema_ms = latency
+            else:
+                state.latency_ema_ms = state.latency_ema_ms * 0.8 + latency * 0.2
+
+        if success:
+            state.consecutive_failures = 0
+            latency_penalty = 0.0
+            if state.latency_ema_ms is not None:
+                latency_penalty = min(state.latency_ema_ms / self.algo.latency_divisor, self.algo.latency_cap)
+            success_gain = self.algo.success_bonus - latency_penalty
+            if self.algo.success_min_gain is not None:
+                success_gain = max(self.algo.success_min_gain, success_gain)
+            state.weight += success_gain
+            if is_probe and state.weight <= 0.0:
+                state.weight = self.algo.probe_recovery_weight
+        else:
+            state.consecutive_failures += 1
+            if self.algo.failure_uses_offset:
+                step_factor = max(0, state.consecutive_failures - 1)
+            else:
+                step_factor = state.consecutive_failures
+            failure_penalty = self.algo.failure_base + step_factor * self.algo.failure_step
+            if self.algo.failure_cap is not None:
+                failure_penalty = min(self.algo.failure_cap, failure_penalty)
+            state.weight -= failure_penalty
+
+        state.weight = max(self.algo.weight_min, min(self.algo.weight_max, state.weight))
+
+        if success and state.weight < self.algo.success_floor:
+            state.weight = self.algo.success_floor
+
+        self.ensure_min_positive_candidates()
+
+    def positive_count(self) -> int:
+        return sum(1 for state in self.runtime.values() if state.weight > 0.0 and math.isfinite(state.weight))
+
+    def _select_weighted_key(self, rng: random.Random) -> str:
+        candidates: List[Tuple[str, float]] = [
+            (
+                key,
+                (
+                    (state.weight**2) * max(state.success_ema**8, 0.01)
+                    if self.algo.name == "v2"
+                    else state.weight
+                ),
+            )
+            for key, state in self.runtime.items()
+            if state.weight > 0.0 and math.isfinite(state.weight)
+        ]
+        if not candidates:
+            return DIRECT_KEY if DIRECT_KEY in self.runtime else self.proxy_keys[0]
+
+        if self.algo.name == "v2" and len(candidates) > 3:
+            candidates.sort(key=lambda item: item[1], reverse=True)
+            candidates = candidates[:3]
+
+        total_weight = sum(weight for _, weight in candidates)
+        threshold = rng.random() * total_weight
+        for key, weight in candidates:
+            if threshold <= weight:
+                return key
+            threshold -= weight
+        return candidates[-1][0]
+
+    def select_proxy(self, rng: random.Random) -> str:
+        self.selection_counter += 1
+        self.requests_since_probe += 1
+        self.ensure_min_positive_candidates()
+        return self._select_weighted_key(rng)
+
+    def should_probe_penalized(self, now_secs: float) -> bool:
+        has_penalized = any(state.weight <= 0.0 for state in self.runtime.values())
+        if not has_penalized or self.probe_in_flight:
+            return False
+        if self.requests_since_probe >= self.algo.probe_every_requests:
+            return True
+        return (now_secs - self.last_probe_at) >= self.algo.probe_interval_secs
+
+    def start_probe(self, now_secs: float) -> Optional[str]:
+        if not self.should_probe_penalized(now_secs):
+            return None
+        penalized = [
+            (key, state.weight)
+            for key, state in self.runtime.items()
+            if state.weight <= 0.0
+        ]
+        if not penalized:
+            return None
+        penalized.sort(key=lambda item: item[1], reverse=True)
+        self.probe_in_flight = True
+        self.requests_since_probe = 0
+        self.last_probe_at = now_secs
+        return penalized[0][0]
+
+    def finish_probe(self, now_secs: float) -> None:
+        self.probe_in_flight = False
+        self.last_probe_at = now_secs
+
+
+def percentile(values: List[float], p: float) -> Optional[float]:
+    if not values:
+        return None
+    if len(values) == 1:
+        return float(values[0])
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * (p / 100.0)
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return float(ordered[lower])
+    weight = rank - lower
+    return float(ordered[lower] + (ordered[upper] - ordered[lower]) * weight)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Backtest forward proxy algorithms")
+    parser.add_argument("--db", required=True, help="Path to sqlite database snapshot")
+    parser.add_argument(
+        "--algos",
+        default="v1,v2",
+        help="Comma-separated list of algorithms to run (subset of v1,v2)",
+    )
+    parser.add_argument(
+        "--seeds",
+        default="7,11,19,23,29",
+        help="Comma-separated random seeds for stochastic simulation",
+    )
+    parser.add_argument(
+        "--requests",
+        type=int,
+        default=50_000,
+        help="Number of regular requests per seed in stochastic simulation",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default=None,
+        help="Output prefix path without extension; default /tmp/forward-proxy-backtest-<timestamp>",
+    )
+    parser.add_argument(
+        "--no-redact",
+        action="store_true",
+        help="Disable proxy-key redaction in output reports (not recommended)",
+    )
+    return parser.parse_args()
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def validate_inputs(args: argparse.Namespace) -> Tuple[Path, List[AlgoConfig], List[int], Path, Dict[str, bool]]:
+    checks: Dict[str, bool] = {
+        "db_exists": False,
+        "db_readonly_uri_mode": True,
+        "db_outside_repository": False,
+        "output_in_tmp": False,
+        "redaction_enabled": not args.no_redact,
+    }
+
+    db_path = Path(args.db).expanduser().resolve()
+    if not db_path.exists() or not db_path.is_file():
+        raise SystemExit(f"database not found: {db_path}")
+    checks["db_exists"] = True
+
+    repo_root = repo_root_from_script().resolve()
+    try:
+        db_path.relative_to(repo_root)
+    except ValueError:
+        checks["db_outside_repository"] = True
+    else:
+        raise SystemExit(
+            f"refusing to use repository-local database path: {db_path} (must be outside {repo_root})"
+        )
+
+    algo_names = [part.strip().lower() for part in args.algos.split(",") if part.strip()]
+    if not algo_names:
+        raise SystemExit("--algos must include at least one algorithm")
+    unknown_algos = [name for name in algo_names if name not in ALGO_BY_NAME]
+    if unknown_algos:
+        raise SystemExit(f"unknown algorithms: {', '.join(unknown_algos)}")
+    algos = [ALGO_BY_NAME[name] for name in algo_names]
+
+    seeds: List[int] = []
+    for raw in args.seeds.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            seeds.append(int(raw))
+        except ValueError as exc:
+            raise SystemExit(f"invalid seed: {raw}") from exc
+    if not seeds:
+        raise SystemExit("--seeds must contain at least one integer")
+
+    if args.requests <= 0:
+        raise SystemExit("--requests must be > 0")
+
+    timestamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    if args.output_prefix:
+        output_prefix = Path(args.output_prefix).expanduser().resolve()
+    else:
+        output_prefix = Path(f"/tmp/forward-proxy-backtest-{timestamp}")
+    checks["output_in_tmp"] = output_prefix.parent.resolve() == Path("/tmp").resolve()
+
+    return db_path, algos, seeds, output_prefix, checks
+
+
+def open_readonly_connection(db_path: Path) -> sqlite3.Connection:
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def load_attempts(conn: sqlite3.Connection) -> List[AttemptRow]:
+    rows = conn.execute(
+        """
+        SELECT
+            id,
+            proxy_key,
+            occurred_at,
+            is_success,
+            latency_ms,
+            COALESCE(failure_kind, '') AS failure_kind,
+            is_probe
+        FROM forward_proxy_attempts
+        ORDER BY occurred_at ASC, id ASC
+        """
+    ).fetchall()
+    attempts: List[AttemptRow] = []
+    for row in rows:
+        key = str(row["proxy_key"] or "").strip()
+        if not key:
+            continue
+        attempts.append(
+            AttemptRow(
+                event_id=int(row["id"]),
+                proxy_key=key,
+                occurred_at=str(row["occurred_at"]),
+                is_success=bool(row["is_success"]),
+                latency_ms=float(row["latency_ms"]) if row["latency_ms"] is not None else None,
+                failure_kind=str(row["failure_kind"] or ""),
+                is_probe=bool(row["is_probe"]),
+            )
+        )
+    return attempts
+
+
+def load_runtime_keys(conn: sqlite3.Connection) -> List[str]:
+    rows = conn.execute(
+        "SELECT proxy_key FROM forward_proxy_runtime WHERE proxy_key IS NOT NULL"
+    ).fetchall()
+    keys = []
+    for row in rows:
+        key = str(row["proxy_key"] or "").strip()
+        if key:
+            keys.append(key)
+    return keys
+
+
+def load_runtime_states(conn: sqlite3.Connection) -> Dict[str, RuntimeState]:
+    rows = conn.execute(
+        """
+        SELECT proxy_key, weight, success_ema, latency_ema_ms, consecutive_failures
+        FROM forward_proxy_runtime
+        WHERE proxy_key IS NOT NULL
+        """
+    ).fetchall()
+    states: Dict[str, RuntimeState] = {}
+    for row in rows:
+        key = str(row["proxy_key"] or "").strip()
+        if not key:
+            continue
+        weight = float(row["weight"]) if row["weight"] is not None else 0.0
+        success_ema = float(row["success_ema"]) if row["success_ema"] is not None else 0.65
+        latency_ema_ms = float(row["latency_ema_ms"]) if row["latency_ema_ms"] is not None else None
+        consecutive_failures = (
+            int(row["consecutive_failures"]) if row["consecutive_failures"] is not None else 0
+        )
+        states[key] = RuntimeState(
+            weight=weight,
+            success_ema=max(0.0, min(1.0, success_ema)),
+            latency_ema_ms=latency_ema_ms,
+            consecutive_failures=max(0, consecutive_failures),
+        )
+    return states
+
+
+def redact_proxy(key: str, enable_redact: bool) -> str:
+    if not enable_redact:
+        return key
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+    return f"proxy_{digest}"
+
+
+def build_profiles(attempts: List[AttemptRow], proxy_keys: Iterable[str]) -> Dict[str, ProxyProfile]:
+    grouped: Dict[str, List[AttemptRow]] = collections.defaultdict(list)
+    for item in attempts:
+        if item.is_probe:
+            continue
+        grouped[item.proxy_key].append(item)
+
+    profiles: Dict[str, ProxyProfile] = {}
+    for key in set(proxy_keys) | set(grouped.keys()):
+        rows = grouped.get(key, [])
+        if not rows:
+            profiles[key] = ProxyProfile(
+                key=key,
+                success_rate=0.65,
+                success_latencies=[],
+                failure_latencies=[],
+                failure_kinds=["handshake_timeout"],
+            )
+            continue
+        success_rows = [row for row in rows if row.is_success]
+        failure_rows = [row for row in rows if not row.is_success]
+        success_rate = len(success_rows) / len(rows)
+        success_latencies = [
+            row.latency_ms
+            for row in success_rows
+            if row.latency_ms is not None and math.isfinite(row.latency_ms) and row.latency_ms >= 0
+        ]
+        failure_latencies = [
+            row.latency_ms
+            for row in failure_rows
+            if row.latency_ms is not None and math.isfinite(row.latency_ms) and row.latency_ms >= 0
+        ]
+        failure_kinds = [row.failure_kind or "handshake_timeout" for row in failure_rows]
+        if not failure_kinds:
+            failure_kinds = ["handshake_timeout"]
+        profiles[key] = ProxyProfile(
+            key=key,
+            success_rate=success_rate,
+            success_latencies=success_latencies,
+            failure_latencies=failure_latencies,
+            failure_kinds=failure_kinds,
+        )
+    return profiles
+
+
+def sample_latency(profile: ProxyProfile, success: bool, rng: random.Random, fallback: List[float]) -> Optional[float]:
+    source = profile.success_latencies if success else profile.failure_latencies
+    if source:
+        return float(rng.choice(source))
+    if fallback:
+        return float(rng.choice(fallback))
+    return None
+
+
+def trace_replay(attempts: List[AttemptRow], algo: AlgoConfig, proxy_keys: Iterable[str]) -> Dict[str, object]:
+    machine = ForwardProxyStateMachine(algo, proxy_keys)
+    positive_counts: List[int] = []
+    collapse_events = 0
+    recovery_waits: List[int] = []
+    pending_recovery: Dict[str, int] = {}
+
+    for index, item in enumerate(attempts):
+        machine.record_attempt(item.proxy_key, item.is_success, item.latency_ms, item.is_probe)
+        positive = machine.positive_count()
+        positive_counts.append(positive)
+        if positive <= 1:
+            collapse_events += 1
+
+        runtime = machine.runtime[item.proxy_key]
+        if not item.is_success and runtime.weight <= 0.0 and item.proxy_key not in pending_recovery:
+            pending_recovery[item.proxy_key] = index
+
+        to_remove = []
+        for key, start_idx in pending_recovery.items():
+            state = machine.runtime.get(key)
+            if state is None:
+                to_remove.append(key)
+                continue
+            if state.weight > 0.0:
+                recovery_waits.append(index - start_idx)
+                to_remove.append(key)
+        for key in to_remove:
+            pending_recovery.pop(key, None)
+
+    return {
+        "events": len(attempts),
+        "positive_nodes_p50": float(statistics.median(positive_counts)) if positive_counts else 0.0,
+        "positive_nodes_min": min(positive_counts) if positive_counts else 0,
+        "single_node_collapse_ratio": (collapse_events / len(positive_counts)) if positive_counts else 0.0,
+        "recovery_events_median": float(statistics.median(recovery_waits)) if recovery_waits else None,
+        "recovery_events_p95": percentile(recovery_waits, 95.0) if recovery_waits else None,
+        "recovery_samples": len(recovery_waits),
+    }
+
+
+def run_simulation(
+    algo: AlgoConfig,
+    profiles: Dict[str, ProxyProfile],
+    seeds: List[int],
+    requests: int,
+    seed_runtime: Optional[Dict[str, RuntimeState]],
+) -> Dict[str, object]:
+    proxy_keys = sorted(profiles.keys())
+    all_success_latencies = [
+        latency
+        for profile in profiles.values()
+        for latency in profile.success_latencies
+        if latency is not None
+    ]
+    all_failure_latencies = [
+        latency
+        for profile in profiles.values()
+        for latency in profile.failure_latencies
+        if latency is not None
+    ]
+
+    per_seed = []
+    for seed in seeds:
+        rng = random.Random(seed)
+        machine = ForwardProxyStateMachine(algo, proxy_keys, seed_runtime=seed_runtime)
+        selection_counter: collections.Counter[str] = collections.Counter()
+        failure_kind_counter: collections.Counter[str] = collections.Counter()
+
+        success_count = 0
+        observed_latencies: List[float] = []
+        now_secs = 0.0
+
+        for _ in range(requests):
+            key = machine.select_proxy(rng)
+            selection_counter[key] += 1
+            profile = profiles.get(key)
+            if profile is None:
+                profile = ProxyProfile(
+                    key=key,
+                    success_rate=0.65,
+                    success_latencies=all_success_latencies,
+                    failure_latencies=all_failure_latencies,
+                    failure_kinds=["handshake_timeout"],
+                )
+            success = rng.random() < profile.success_rate
+            latency = sample_latency(
+                profile,
+                success=success,
+                rng=rng,
+                fallback=all_success_latencies if success else all_failure_latencies,
+            )
+
+            if success:
+                success_count += 1
+            else:
+                failure_kind = rng.choice(profile.failure_kinds) if profile.failure_kinds else "handshake_timeout"
+                failure_kind_counter[failure_kind] += 1
+
+            if latency is not None:
+                observed_latencies.append(latency)
+                now_secs += max(latency / 1000.0, 0.05)
+            else:
+                now_secs += 0.2
+
+            machine.record_attempt(key, success, latency, is_probe=False)
+
+            probe_key = machine.start_probe(now_secs)
+            if probe_key is not None:
+                probe_profile = profiles.get(probe_key, profile)
+                probe_success = rng.random() < probe_profile.success_rate
+                probe_latency = sample_latency(
+                    probe_profile,
+                    success=probe_success,
+                    rng=rng,
+                    fallback=all_success_latencies if probe_success else all_failure_latencies,
+                )
+                machine.record_attempt(probe_key, probe_success, probe_latency, is_probe=True)
+                machine.finish_probe(now_secs)
+
+        top1 = max(selection_counter.values()) if selection_counter else 0
+        top1_key = selection_counter.most_common(1)[0][0] if selection_counter else ""
+        per_seed.append(
+            {
+                "seed": seed,
+                "success_rate": success_count / requests,
+                "p95_latency_ms": percentile(observed_latencies, 95.0),
+                "top1_share": top1 / requests,
+                "top1_proxy_key": top1_key,
+                "failure_kind_distribution": dict(failure_kind_counter),
+            }
+        )
+
+    success_values = [item["success_rate"] for item in per_seed]
+    p95_values = [item["p95_latency_ms"] for item in per_seed if item["p95_latency_ms"] is not None]
+    top1_values = [item["top1_share"] for item in per_seed]
+
+    return {
+        "seeds": per_seed,
+        "success_rate_mean": statistics.mean(success_values) if success_values else 0.0,
+        "p95_latency_mean": statistics.mean(p95_values) if p95_values else None,
+        "top1_share_mean": statistics.mean(top1_values) if top1_values else 0.0,
+    }
+
+
+def evaluate_acceptance(
+    baseline: Dict[str, object],
+    candidate: Dict[str, object],
+    security_checks: Dict[str, bool],
+) -> Dict[str, object]:
+    failed: List[str] = []
+
+    c_trace = candidate["trace_replay"]
+    c_sim = candidate["simulation"]
+    b_sim = baseline["simulation"]
+
+    if c_trace["positive_nodes_p50"] < 2:
+        failed.append("trace_replay.positive_nodes_p50 < 2")
+    if c_trace["single_node_collapse_ratio"] > 0.35:
+        failed.append("trace_replay.single_node_collapse_ratio > 0.35")
+    if c_sim["top1_share_mean"] > 0.55:
+        failed.append("simulation.top1_share_mean > 0.55")
+    if c_sim["success_rate_mean"] < (b_sim["success_rate_mean"] - 0.002):
+        failed.append("simulation.success_rate_mean below baseline-0.2%")
+
+    baseline_p95 = b_sim["p95_latency_mean"]
+    candidate_p95 = c_sim["p95_latency_mean"]
+    if baseline_p95 is None or candidate_p95 is None:
+        failed.append("simulation.p95_latency_mean missing")
+    elif candidate_p95 > baseline_p95 * 1.10:
+        failed.append("simulation.p95_latency_mean exceeds baseline*1.10")
+
+    required_security = [
+        "db_exists",
+        "db_readonly_uri_mode",
+        "db_outside_repository",
+        "output_in_tmp",
+        "redaction_enabled",
+    ]
+    for key in required_security:
+        if not security_checks.get(key, False):
+            failed.append(f"security_check_failed:{key}")
+
+    return {
+        "pass": len(failed) == 0,
+        "failed_rules": failed,
+    }
+
+
+def write_markdown_report(
+    output_md: Path,
+    result: Dict[str, object],
+    redact: bool,
+) -> None:
+    baseline = result.get("baseline", {})
+    candidate = result.get("candidate", {})
+    acceptance = result.get("acceptance", {})
+
+    lines = [
+        "# Forward Proxy Backtest Report",
+        "",
+        f"- Generated at: `{result.get('generated_at')}`",
+        f"- Database: `{result.get('db_path')}`",
+        f"- Redaction: `{'enabled' if redact else 'disabled'}`",
+        f"- Acceptance: `{'PASS' if acceptance.get('pass') else 'FAIL'}`",
+        "",
+        "## Trace Replay",
+        "",
+        "| Metric | Baseline (v1) | Candidate (v2) |",
+        "| --- | ---: | ---: |",
+        f"| positive_nodes_p50 | {baseline.get('trace_replay', {}).get('positive_nodes_p50')} | {candidate.get('trace_replay', {}).get('positive_nodes_p50')} |",
+        f"| single_node_collapse_ratio | {baseline.get('trace_replay', {}).get('single_node_collapse_ratio')} | {candidate.get('trace_replay', {}).get('single_node_collapse_ratio')} |",
+        f"| recovery_events_median | {baseline.get('trace_replay', {}).get('recovery_events_median')} | {candidate.get('trace_replay', {}).get('recovery_events_median')} |",
+        "",
+        "## Stochastic Simulation",
+        "",
+        "| Metric | Baseline (v1) | Candidate (v2) |",
+        "| --- | ---: | ---: |",
+        f"| success_rate_mean | {baseline.get('simulation', {}).get('success_rate_mean')} | {candidate.get('simulation', {}).get('success_rate_mean')} |",
+        f"| p95_latency_mean | {baseline.get('simulation', {}).get('p95_latency_mean')} | {candidate.get('simulation', {}).get('p95_latency_mean')} |",
+        f"| top1_share_mean | {baseline.get('simulation', {}).get('top1_share_mean')} | {candidate.get('simulation', {}).get('top1_share_mean')} |",
+        "",
+    ]
+
+    failed_rules = acceptance.get("failed_rules") or []
+    if failed_rules:
+        lines.append("## Failed Rules")
+        lines.append("")
+        for item in failed_rules:
+            lines.append(f"- {item}")
+        lines.append("")
+
+    output_md.write_text("\n".join(lines), encoding="utf-8")
+
+
+def sanitize_seed_output(simulation_result: Dict[str, object], redact: bool) -> None:
+    for item in simulation_result.get("seeds", []):
+        key = item.get("top1_proxy_key", "")
+        item["top1_proxy_key"] = redact_proxy(key, enable_redact=redact)
+
+
+def main() -> int:
+    args = parse_args()
+    db_path, algos, seeds, output_prefix, security_checks = validate_inputs(args)
+
+    if "v1" not in {algo.name for algo in algos} or "v2" not in {algo.name for algo in algos}:
+        raise SystemExit("--algos must include both v1 and v2 for acceptance evaluation")
+
+    conn = open_readonly_connection(db_path)
+    try:
+        attempts = load_attempts(conn)
+        runtime_keys = load_runtime_keys(conn)
+        runtime_states = load_runtime_states(conn)
+    finally:
+        conn.close()
+
+    if not attempts:
+        raise SystemExit("forward_proxy_attempts is empty; cannot run backtest")
+
+    proxy_keys = sorted(set(runtime_keys) | {item.proxy_key for item in attempts})
+    profiles = build_profiles(attempts, proxy_keys)
+
+    baseline = {
+        "trace_replay": trace_replay(attempts, ALGO_V1, proxy_keys),
+        "simulation": run_simulation(
+            ALGO_V1,
+            profiles,
+            seeds,
+            args.requests,
+            runtime_states,
+        ),
+    }
+    candidate = {
+        "trace_replay": trace_replay(attempts, ALGO_V2, proxy_keys),
+        "simulation": run_simulation(
+            ALGO_V2,
+            profiles,
+            seeds,
+            args.requests,
+            runtime_states,
+        ),
+    }
+
+    sanitize_seed_output(baseline["simulation"], redact=not args.no_redact)
+    sanitize_seed_output(candidate["simulation"], redact=not args.no_redact)
+
+    acceptance = evaluate_acceptance(baseline, candidate, security_checks)
+
+    result = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "db_path": str(db_path),
+        "config": {
+            "algos": [algo.name for algo in algos],
+            "seeds": seeds,
+            "requests": args.requests,
+            "redaction_enabled": not args.no_redact,
+        },
+        "security_checks": security_checks,
+        "baseline": baseline,
+        "candidate": candidate,
+        "acceptance": acceptance,
+    }
+
+    output_json = output_prefix.with_suffix(".json")
+    output_md = output_prefix.with_suffix(".md")
+    output_json.write_text(json.dumps(result, ensure_ascii=True, indent=2), encoding="utf-8")
+    write_markdown_report(output_md, result, redact=not args.no_redact)
+
+    print(f"json_report={output_json}")
+    print(f"markdown_report={output_md}")
+    print(f"acceptance_pass={acceptance['pass']}")
+    if acceptance["failed_rules"]:
+        print("failed_rules=")
+        for item in acceptance["failed_rules"]:
+            print(f"- {item}")
+
+    return 0 if acceptance["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,7 @@ const PRICING_SETTINGS_SINGLETON_ID: i64 = 1;
 const FORWARD_PROXY_SETTINGS_SINGLETON_ID: i64 = 1;
 const DEFAULT_FORWARD_PROXY_INSERT_DIRECT: bool = true;
 const DEFAULT_FORWARD_PROXY_SUBSCRIPTION_INTERVAL_SECS: u64 = 60 * 60;
+const DEFAULT_FORWARD_PROXY_ALGO: ForwardProxyAlgo = ForwardProxyAlgo::V1;
 const FORWARD_PROXY_WEIGHT_RECOVERY: f64 = 0.6;
 const FORWARD_PROXY_WEIGHT_SUCCESS_BONUS: f64 = 0.45;
 const FORWARD_PROXY_WEIGHT_FAILURE_PENALTY_BASE: f64 = 0.9;
@@ -115,6 +116,21 @@ const FORWARD_PROXY_WEIGHT_MAX: f64 = 12.0;
 const FORWARD_PROXY_PROBE_EVERY_REQUESTS: u64 = 100;
 const FORWARD_PROXY_PROBE_INTERVAL_SECS: i64 = 30 * 60;
 const FORWARD_PROXY_PROBE_RECOVERY_WEIGHT: f64 = 0.4;
+const FORWARD_PROXY_V2_WEIGHT_SUCCESS_BASE: f64 = 0.55;
+const FORWARD_PROXY_V2_WEIGHT_SUCCESS_LATENCY_DIVISOR: f64 = 9000.0;
+const FORWARD_PROXY_V2_WEIGHT_SUCCESS_LATENCY_CAP: f64 = 0.35;
+const FORWARD_PROXY_V2_WEIGHT_SUCCESS_MIN_GAIN: f64 = 0.08;
+const FORWARD_PROXY_V2_WEIGHT_FAILURE_BASE: f64 = 0.5;
+const FORWARD_PROXY_V2_WEIGHT_FAILURE_STEP: f64 = 0.18;
+const FORWARD_PROXY_V2_WEIGHT_FAILURE_MAX: f64 = 1.2;
+const FORWARD_PROXY_V2_WEIGHT_MIN: f64 = -8.0;
+const FORWARD_PROXY_V2_WEIGHT_MAX: f64 = 8.0;
+const FORWARD_PROXY_V2_WEIGHT_RECOVERY_FLOOR: f64 = 0.25;
+const FORWARD_PROXY_V2_PROBE_EVERY_REQUESTS: u64 = 30;
+const FORWARD_PROXY_V2_PROBE_INTERVAL_SECS: i64 = 5 * 60;
+const FORWARD_PROXY_V2_PROBE_RECOVERY_WEIGHT: f64 = 0.55;
+const FORWARD_PROXY_V2_DIRECT_INITIAL_WEIGHT: f64 = 0.7;
+const FORWARD_PROXY_V2_MIN_POSITIVE_CANDIDATES: usize = 2;
 const FORWARD_PROXY_VALIDATION_TIMEOUT_SECS: u64 = 5;
 const FORWARD_PROXY_SUBSCRIPTION_VALIDATION_TIMEOUT_SECS: u64 = 60;
 const FORWARD_PROXY_DIRECT_KEY: &str = "__direct__";
@@ -144,6 +160,48 @@ const PROXY_PRESET_MODEL_IDS: &[&str] = &[
     "gpt-5.2",
 ];
 static NEXT_PROXY_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum ForwardProxyAlgo {
+    V1,
+    V2,
+}
+
+impl ForwardProxyAlgo {
+    fn probe_every_requests(self) -> u64 {
+        match self {
+            Self::V1 => FORWARD_PROXY_PROBE_EVERY_REQUESTS,
+            Self::V2 => FORWARD_PROXY_V2_PROBE_EVERY_REQUESTS,
+        }
+    }
+
+    fn probe_interval_secs(self) -> i64 {
+        match self {
+            Self::V1 => FORWARD_PROXY_PROBE_INTERVAL_SECS,
+            Self::V2 => FORWARD_PROXY_V2_PROBE_INTERVAL_SECS,
+        }
+    }
+
+    fn probe_recovery_weight(self) -> f64 {
+        match self {
+            Self::V1 => FORWARD_PROXY_PROBE_RECOVERY_WEIGHT,
+            Self::V2 => FORWARD_PROXY_V2_PROBE_RECOVERY_WEIGHT,
+        }
+    }
+}
+
+impl FromStr for ForwardProxyAlgo {
+    type Err = anyhow::Error;
+
+    fn from_str(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "v1" => Ok(Self::V1),
+            "v2" => Ok(Self::V2),
+            _ => bail!("invalid XY_FORWARD_PROXY_ALGO: {raw}"),
+        }
+    }
+}
 
 #[derive(Parser, Debug, Default)]
 #[command(
@@ -261,9 +319,10 @@ async fn main() -> Result<()> {
     let proxy_model_settings = Arc::new(RwLock::new(load_proxy_model_settings(&pool).await?));
     let forward_proxy_settings = load_forward_proxy_settings(&pool).await?;
     let forward_proxy_runtime = load_forward_proxy_runtime_states(&pool).await?;
-    let forward_proxy = Arc::new(Mutex::new(ForwardProxyManager::new(
+    let forward_proxy = Arc::new(Mutex::new(ForwardProxyManager::with_algo(
         forward_proxy_settings,
         forward_proxy_runtime,
+        config.forward_proxy_algo,
     )));
     fs::create_dir_all(&config.proxy_raw_dir).with_context(|| {
         format!(
@@ -9035,14 +9094,17 @@ struct ForwardProxyRuntimeState {
 }
 
 impl ForwardProxyRuntimeState {
-    fn default_for_endpoint(endpoint: &ForwardProxyEndpoint) -> Self {
+    fn default_for_endpoint(endpoint: &ForwardProxyEndpoint, algo: ForwardProxyAlgo) -> Self {
         Self {
             proxy_key: endpoint.key.clone(),
             display_name: endpoint.display_name.clone(),
             source: endpoint.source.clone(),
             endpoint_url: endpoint.raw_url.clone(),
             weight: if endpoint.key == FORWARD_PROXY_DIRECT_KEY {
-                1.0
+                match algo {
+                    ForwardProxyAlgo::V1 => 1.0,
+                    ForwardProxyAlgo::V2 => FORWARD_PROXY_V2_DIRECT_INITIAL_WEIGHT,
+                }
             } else {
                 0.8
             },
@@ -9086,6 +9148,7 @@ impl From<ForwardProxyRuntimeRow> for ForwardProxyRuntimeState {
 
 #[derive(Debug, Clone)]
 struct ForwardProxyManager {
+    algo: ForwardProxyAlgo,
     settings: ForwardProxySettings,
     endpoints: Vec<ForwardProxyEndpoint>,
     runtime: HashMap<String, ForwardProxyRuntimeState>,
@@ -9097,19 +9160,29 @@ struct ForwardProxyManager {
 }
 
 impl ForwardProxyManager {
+    #[cfg(test)]
     fn new(settings: ForwardProxySettings, runtime_rows: Vec<ForwardProxyRuntimeState>) -> Self {
+        Self::with_algo(settings, runtime_rows, ForwardProxyAlgo::V1)
+    }
+
+    fn with_algo(
+        settings: ForwardProxySettings,
+        runtime_rows: Vec<ForwardProxyRuntimeState>,
+        algo: ForwardProxyAlgo,
+    ) -> Self {
         let runtime = runtime_rows
             .into_iter()
             .map(|entry| (entry.proxy_key.clone(), entry))
             .collect::<HashMap<_, _>>();
         let mut manager = Self {
+            algo,
             settings,
             endpoints: Vec::new(),
             runtime,
             selection_counter: 0,
             requests_since_probe: 0,
             probe_in_flight: false,
-            last_probe_at: Utc::now() - ChronoDuration::seconds(FORWARD_PROXY_PROBE_INTERVAL_SECS),
+            last_probe_at: Utc::now() - ChronoDuration::seconds(algo.probe_interval_secs()),
             last_subscription_refresh_at: None,
         };
         manager.rebuild_endpoints(Vec::new());
@@ -9151,6 +9224,7 @@ impl ForwardProxyManager {
         }
         self.endpoints = merged;
 
+        let algo = self.algo;
         for endpoint in &self.endpoints {
             match self.runtime.entry(endpoint.key.clone()) {
                 std::collections::hash_map::Entry::Occupied(mut occupied) => {
@@ -9160,7 +9234,7 @@ impl ForwardProxyManager {
                     runtime.endpoint_url = endpoint.raw_url.clone();
                 }
                 std::collections::hash_map::Entry::Vacant(vacant) => {
-                    vacant.insert(ForwardProxyRuntimeState::default_for_endpoint(endpoint));
+                    vacant.insert(ForwardProxyRuntimeState::default_for_endpoint(endpoint, algo));
                 }
             }
         }
@@ -9168,27 +9242,57 @@ impl ForwardProxyManager {
     }
 
     fn ensure_non_zero_weight(&mut self) {
+        let minimum = match self.algo {
+            ForwardProxyAlgo::V1 => 1,
+            ForwardProxyAlgo::V2 => FORWARD_PROXY_V2_MIN_POSITIVE_CANDIDATES,
+        };
+        self.ensure_min_positive_candidates(minimum, self.algo.probe_recovery_weight());
+    }
+
+    fn ensure_min_positive_candidates(&mut self, minimum: usize, recovery_weight: f64) {
+        if minimum == 0 {
+            return;
+        }
+
         let active_keys = self
             .endpoints
             .iter()
             .map(|endpoint| endpoint.key.as_str())
             .collect::<HashSet<_>>();
-        if self.runtime.values().any(|entry| {
-            active_keys.contains(entry.proxy_key.as_str())
-                && entry.weight > 0.0
-                && entry.weight.is_finite()
-        }) {
+        let mut positive_count = self
+            .runtime
+            .values()
+            .filter(|entry| {
+                active_keys.contains(entry.proxy_key.as_str())
+                    && entry.weight > 0.0
+                    && entry.weight.is_finite()
+            })
+            .count();
+        if positive_count >= minimum {
             return;
         }
-        if let Some(best_key) = self
+
+        let mut candidates = self
             .runtime
             .values()
             .filter(|entry| active_keys.contains(entry.proxy_key.as_str()))
-            .max_by(|a, b| a.weight.total_cmp(&b.weight))
-            .map(|entry| entry.proxy_key.clone())
-            && let Some(entry) = self.runtime.get_mut(&best_key)
-        {
-            entry.weight = FORWARD_PROXY_PROBE_RECOVERY_WEIGHT;
+            .map(|entry| (entry.proxy_key.clone(), entry.weight))
+            .collect::<Vec<_>>();
+        candidates.sort_by(|lhs, rhs| rhs.1.total_cmp(&lhs.1));
+
+        for (proxy_key, _) in candidates {
+            if positive_count >= minimum {
+                break;
+            }
+            if let Some(entry) = self.runtime.get_mut(&proxy_key)
+                && !(entry.weight > 0.0 && entry.weight.is_finite())
+            {
+                entry.weight = recovery_weight;
+                if self.algo == ForwardProxyAlgo::V2 {
+                    entry.consecutive_failures = 0;
+                }
+                positive_count += 1;
+            }
         }
     }
 
@@ -9214,9 +9318,21 @@ impl ForwardProxyManager {
                 && runtime.weight > 0.0
                 && runtime.weight.is_finite()
             {
-                total_weight += runtime.weight;
-                candidates.push((endpoint, runtime.weight));
+                let effective_weight = if self.algo == ForwardProxyAlgo::V2 {
+                    let success_factor = runtime.success_ema.clamp(0.0, 1.0).powi(8).max(0.01);
+                    runtime.weight.powi(2) * success_factor
+                } else {
+                    runtime.weight
+                };
+                total_weight += effective_weight;
+                candidates.push((endpoint, effective_weight));
             }
+        }
+
+        if self.algo == ForwardProxyAlgo::V2 && candidates.len() > 3 {
+            candidates.sort_by(|lhs, rhs| rhs.1.total_cmp(&lhs.1));
+            candidates.truncate(3);
+            total_weight = candidates.iter().map(|(_, weight)| *weight).sum::<f64>();
         }
 
         if candidates.is_empty() {
@@ -9274,6 +9390,19 @@ impl ForwardProxyManager {
             return;
         };
 
+        Self::update_runtime_ema(runtime, success, latency_ms);
+        match self.algo {
+            ForwardProxyAlgo::V1 => Self::record_attempt_v1(runtime, success, is_probe),
+            ForwardProxyAlgo::V2 => Self::record_attempt_v2(runtime, success, is_probe),
+        }
+        self.ensure_non_zero_weight();
+    }
+
+    fn update_runtime_ema(
+        runtime: &mut ForwardProxyRuntimeState,
+        success: bool,
+        latency_ms: Option<f64>,
+    ) {
         runtime.success_ema = runtime.success_ema * 0.9 + if success { 0.1 } else { 0.0 };
         if let Some(latency_ms) = latency_ms.filter(|value| value.is_finite() && *value >= 0.0) {
             runtime.latency_ema_ms = Some(match runtime.latency_ema_ms {
@@ -9281,7 +9410,9 @@ impl ForwardProxyManager {
                 None => latency_ms,
             });
         }
+    }
 
+    fn record_attempt_v1(runtime: &mut ForwardProxyRuntimeState, success: bool, is_probe: bool) {
         if success {
             runtime.consecutive_failures = 0;
             let latency_penalty = runtime
@@ -9307,8 +9438,39 @@ impl ForwardProxyManager {
         if success && runtime.weight < FORWARD_PROXY_WEIGHT_RECOVERY {
             runtime.weight = runtime.weight.max(FORWARD_PROXY_WEIGHT_RECOVERY * 0.5);
         }
+    }
 
-        self.ensure_non_zero_weight();
+    fn record_attempt_v2(runtime: &mut ForwardProxyRuntimeState, success: bool, is_probe: bool) {
+        if success {
+            runtime.consecutive_failures = 0;
+            let latency_penalty = runtime
+                .latency_ema_ms
+                .map(|value| {
+                    (value / FORWARD_PROXY_V2_WEIGHT_SUCCESS_LATENCY_DIVISOR)
+                        .min(FORWARD_PROXY_V2_WEIGHT_SUCCESS_LATENCY_CAP)
+                })
+                .unwrap_or(0.0);
+            let success_gain = (FORWARD_PROXY_V2_WEIGHT_SUCCESS_BASE - latency_penalty)
+                .max(FORWARD_PROXY_V2_WEIGHT_SUCCESS_MIN_GAIN);
+            runtime.weight += success_gain;
+            if is_probe && runtime.weight <= 0.0 {
+                runtime.weight = FORWARD_PROXY_V2_PROBE_RECOVERY_WEIGHT;
+            }
+        } else {
+            runtime.consecutive_failures = runtime.consecutive_failures.saturating_add(1);
+            let failure_penalty = (FORWARD_PROXY_V2_WEIGHT_FAILURE_BASE
+                + f64::from(runtime.consecutive_failures) * FORWARD_PROXY_V2_WEIGHT_FAILURE_STEP)
+                .min(FORWARD_PROXY_V2_WEIGHT_FAILURE_MAX);
+            runtime.weight -= failure_penalty;
+        }
+
+        runtime.weight = runtime
+            .weight
+            .clamp(FORWARD_PROXY_V2_WEIGHT_MIN, FORWARD_PROXY_V2_WEIGHT_MAX);
+
+        if success && runtime.weight < FORWARD_PROXY_V2_WEIGHT_RECOVERY_FLOOR {
+            runtime.weight = FORWARD_PROXY_V2_WEIGHT_RECOVERY_FLOOR;
+        }
     }
 
     fn should_probe_penalized_proxy(&self) -> bool {
@@ -9319,8 +9481,8 @@ impl ForwardProxyManager {
         if !has_penalized || self.probe_in_flight {
             return false;
         }
-        self.requests_since_probe >= FORWARD_PROXY_PROBE_EVERY_REQUESTS
-            || (Utc::now() - self.last_probe_at).num_seconds() >= FORWARD_PROXY_PROBE_INTERVAL_SECS
+        self.requests_since_probe >= self.algo.probe_every_requests()
+            || (Utc::now() - self.last_probe_at).num_seconds() >= self.algo.probe_interval_secs()
     }
 
     fn mark_probe_started(&mut self) -> Option<SelectedForwardProxy> {
@@ -11287,6 +11449,7 @@ struct AppConfig {
     proxy_raw_dir: PathBuf,
     xray_binary: String,
     xray_runtime_dir: PathBuf,
+    forward_proxy_algo: ForwardProxyAlgo,
     max_parallel_polls: usize,
     shared_connection_parallelism: usize,
     http_bind: SocketAddr,
@@ -11429,6 +11592,11 @@ impl AppConfig {
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_XRAY_RUNTIME_DIR));
+        let forward_proxy_algo = env::var("XY_FORWARD_PROXY_ALGO")
+            .ok()
+            .map(|raw| ForwardProxyAlgo::from_str(&raw))
+            .transpose()?
+            .unwrap_or(DEFAULT_FORWARD_PROXY_ALGO);
         let max_parallel_polls = overrides
             .max_parallel_polls
             .or_else(|| {
@@ -11544,6 +11712,7 @@ impl AppConfig {
             proxy_raw_dir,
             xray_binary,
             xray_runtime_dir,
+            forward_proxy_algo,
             max_parallel_polls,
             shared_connection_parallelism,
             http_bind,
@@ -12330,6 +12499,120 @@ mod tests {
     }
 
     #[test]
+    fn forward_proxy_algo_from_str_supports_v1_and_v2() {
+        assert_eq!(
+            ForwardProxyAlgo::from_str("v1").expect("v1 should parse"),
+            ForwardProxyAlgo::V1
+        );
+        assert_eq!(
+            ForwardProxyAlgo::from_str("V2").expect("v2 should parse"),
+            ForwardProxyAlgo::V2
+        );
+        assert!(ForwardProxyAlgo::from_str("unexpected").is_err());
+    }
+
+    #[test]
+    fn forward_proxy_manager_v2_keeps_two_positive_weights() {
+        let mut manager = ForwardProxyManager::with_algo(
+            ForwardProxySettings {
+                proxy_urls: vec!["http://127.0.0.1:7890".to_string()],
+                subscription_urls: vec![],
+                subscription_update_interval_secs: 3600,
+                insert_direct: true,
+            },
+            vec![],
+            ForwardProxyAlgo::V2,
+        );
+
+        for runtime in manager.runtime.values_mut() {
+            runtime.weight = -5.0;
+        }
+        manager.ensure_non_zero_weight();
+
+        let positive_count = manager
+            .endpoints
+            .iter()
+            .filter_map(|endpoint| manager.runtime.get(&endpoint.key))
+            .filter(|entry| entry.weight > 0.0)
+            .count();
+        assert_eq!(positive_count, 2);
+    }
+
+    #[test]
+    fn forward_proxy_manager_v2_success_with_high_latency_still_gains_weight() {
+        let mut manager = ForwardProxyManager::with_algo(
+            ForwardProxySettings {
+                proxy_urls: vec!["http://127.0.0.1:7890".to_string()],
+                subscription_urls: vec![],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+            },
+            vec![],
+            ForwardProxyAlgo::V2,
+        );
+        let proxy_key = manager
+            .endpoints
+            .first()
+            .expect("endpoint should exist")
+            .key
+            .clone();
+        let before = manager
+            .runtime
+            .get(&proxy_key)
+            .expect("runtime should exist")
+            .weight;
+
+        manager.record_attempt(&proxy_key, true, Some(45_000.0), false);
+
+        let after = manager
+            .runtime
+            .get(&proxy_key)
+            .expect("runtime should exist")
+            .weight;
+        assert!(after > before, "v2 success should increase weight");
+    }
+
+    #[test]
+    fn forward_proxy_manager_v2_success_recovers_penalized_proxy() {
+        let mut manager = ForwardProxyManager::with_algo(
+            ForwardProxySettings {
+                proxy_urls: vec!["http://127.0.0.1:7890".to_string()],
+                subscription_urls: vec![],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+            },
+            vec![],
+            ForwardProxyAlgo::V2,
+        );
+        let proxy_key = manager
+            .endpoints
+            .first()
+            .expect("endpoint should exist")
+            .key
+            .clone();
+        if let Some(runtime) = manager.runtime.get_mut(&proxy_key) {
+            runtime.weight = -2.0;
+            runtime.consecutive_failures = 5;
+            runtime.latency_ema_ms = Some(30_000.0);
+        }
+
+        manager.record_attempt(&proxy_key, true, Some(30_000.0), false);
+
+        let runtime = manager
+            .runtime
+            .get(&proxy_key)
+            .expect("runtime should exist");
+        assert!(
+            runtime.weight >= FORWARD_PROXY_V2_WEIGHT_RECOVERY_FLOOR,
+            "successful recovery should restore minimum v2 weight"
+        );
+        assert_eq!(
+            runtime.consecutive_failures, 0,
+            "successful attempt should reset failure streak"
+        );
+    }
+
+    #[test]
     fn classify_invocation_failure_marks_downstream_closed_as_client_abort() {
         let result = classify_invocation_failure(
             Some("http_200"),
@@ -12438,6 +12721,7 @@ mod tests {
             proxy_raw_dir: PathBuf::from("target/proxy-raw-tests"),
             xray_binary: DEFAULT_XRAY_BINARY.to_string(),
             xray_runtime_dir: PathBuf::from("target/xray-forward-tests"),
+            forward_proxy_algo: ForwardProxyAlgo::V1,
             max_parallel_polls: 2,
             shared_connection_parallelism: 1,
             http_bind: "127.0.0.1:38080".parse().expect("valid socket address"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ const PRICING_SETTINGS_SINGLETON_ID: i64 = 1;
 const FORWARD_PROXY_SETTINGS_SINGLETON_ID: i64 = 1;
 const DEFAULT_FORWARD_PROXY_INSERT_DIRECT: bool = true;
 const DEFAULT_FORWARD_PROXY_SUBSCRIPTION_INTERVAL_SECS: u64 = 60 * 60;
-const DEFAULT_FORWARD_PROXY_ALGO: ForwardProxyAlgo = ForwardProxyAlgo::V1;
+const DEFAULT_FORWARD_PROXY_ALGO: ForwardProxyAlgo = ForwardProxyAlgo::V2;
 const FORWARD_PROXY_WEIGHT_RECOVERY: f64 = 0.6;
 const FORWARD_PROXY_WEIGHT_SUCCESS_BONUS: f64 = 0.45;
 const FORWARD_PROXY_WEIGHT_FAILURE_PENALTY_BASE: f64 = 0.9;
@@ -198,8 +198,21 @@ impl FromStr for ForwardProxyAlgo {
         match raw.trim().to_ascii_lowercase().as_str() {
             "v1" => Ok(Self::V1),
             "v2" => Ok(Self::V2),
-            _ => bail!("invalid XY_FORWARD_PROXY_ALGO: {raw}"),
+            _ => bail!("invalid FORWARD_PROXY_ALGO value: {raw}"),
         }
+    }
+}
+
+fn resolve_forward_proxy_algo_config(
+    primary_raw: Option<&str>,
+    legacy_raw: Option<&str>,
+) -> Result<ForwardProxyAlgo> {
+    if legacy_raw.is_some() {
+        bail!("XY_FORWARD_PROXY_ALGO is not supported; use FORWARD_PROXY_ALGO");
+    }
+    match primary_raw {
+        Some(primary) => ForwardProxyAlgo::from_str(primary),
+        None => Ok(DEFAULT_FORWARD_PROXY_ALGO),
     }
 }
 
@@ -9172,7 +9185,10 @@ impl ForwardProxyManager {
     ) -> Self {
         let runtime = runtime_rows
             .into_iter()
-            .map(|entry| (entry.proxy_key.clone(), entry))
+            .map(|mut entry| {
+                Self::normalize_runtime_for_algo(&mut entry, algo);
+                (entry.proxy_key.clone(), entry)
+            })
             .collect::<HashMap<_, _>>();
         let mut manager = Self {
             algo,
@@ -9187,6 +9203,27 @@ impl ForwardProxyManager {
         };
         manager.rebuild_endpoints(Vec::new());
         manager
+    }
+
+    fn normalize_runtime_for_algo(runtime: &mut ForwardProxyRuntimeState, algo: ForwardProxyAlgo) {
+        runtime.success_ema = runtime.success_ema.clamp(0.0, 1.0);
+        if runtime
+            .latency_ema_ms
+            .is_some_and(|value| !value.is_finite() || value < 0.0)
+        {
+            runtime.latency_ema_ms = None;
+        }
+        if !runtime.weight.is_finite() {
+            runtime.weight = 0.0;
+        }
+        runtime.weight = match algo {
+            ForwardProxyAlgo::V1 => runtime
+                .weight
+                .clamp(FORWARD_PROXY_WEIGHT_MIN, FORWARD_PROXY_WEIGHT_MAX),
+            ForwardProxyAlgo::V2 => runtime
+                .weight
+                .clamp(FORWARD_PROXY_V2_WEIGHT_MIN, FORWARD_PROXY_V2_WEIGHT_MAX),
+        };
     }
 
     fn apply_settings(&mut self, settings: ForwardProxySettings) {
@@ -9249,16 +9286,28 @@ impl ForwardProxyManager {
         self.ensure_min_positive_candidates(minimum, self.algo.probe_recovery_weight());
     }
 
+    fn selectable_endpoint_keys(&self) -> HashSet<&str> {
+        self.endpoints
+            .iter()
+            .filter(|endpoint| endpoint.is_selectable())
+            .map(|endpoint| endpoint.key.as_str())
+            .collect::<HashSet<_>>()
+    }
+
     fn ensure_min_positive_candidates(&mut self, minimum: usize, recovery_weight: f64) {
         if minimum == 0 {
             return;
         }
 
-        let active_keys = self
-            .endpoints
-            .iter()
-            .map(|endpoint| endpoint.key.as_str())
-            .collect::<HashSet<_>>();
+        let selectable_keys = self.selectable_endpoint_keys();
+        let active_keys = if selectable_keys.is_empty() {
+            self.endpoints
+                .iter()
+                .map(|endpoint| endpoint.key.as_str())
+                .collect::<HashSet<_>>()
+        } else {
+            selectable_keys
+        };
         let mut positive_count = self
             .runtime
             .values()
@@ -9474,10 +9523,13 @@ impl ForwardProxyManager {
     }
 
     fn should_probe_penalized_proxy(&self) -> bool {
-        let has_penalized = self
-            .runtime
-            .values()
-            .any(ForwardProxyRuntimeState::is_penalized);
+        let selectable_keys = self.selectable_endpoint_keys();
+        if selectable_keys.is_empty() {
+            return false;
+        }
+        let has_penalized = self.runtime.values().any(|entry| {
+            selectable_keys.contains(entry.proxy_key.as_str()) && entry.is_penalized()
+        });
         if !has_penalized || self.probe_in_flight {
             return false;
         }
@@ -9489,15 +9541,18 @@ impl ForwardProxyManager {
         if !self.should_probe_penalized_proxy() {
             return None;
         }
+        let selectable_keys = self.selectable_endpoint_keys();
         let selected = self
             .runtime
             .values()
-            .filter(|entry| entry.is_penalized())
+            .filter(|entry| {
+                entry.is_penalized() && selectable_keys.contains(entry.proxy_key.as_str())
+            })
             .max_by(|lhs, rhs| lhs.weight.total_cmp(&rhs.weight))
             .and_then(|entry| {
                 self.endpoints
                     .iter()
-                    .find(|item| item.key == entry.proxy_key && item.is_selectable())
+                    .find(|item| item.key == entry.proxy_key)
             })
             .cloned()?;
         self.probe_in_flight = true;
@@ -11592,11 +11647,12 @@ impl AppConfig {
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_XRAY_RUNTIME_DIR));
-        let forward_proxy_algo = env::var("XY_FORWARD_PROXY_ALGO")
-            .ok()
-            .map(|raw| ForwardProxyAlgo::from_str(&raw))
-            .transpose()?
-            .unwrap_or(DEFAULT_FORWARD_PROXY_ALGO);
+        let forward_proxy_algo_raw = env::var("FORWARD_PROXY_ALGO").ok();
+        let forward_proxy_algo_legacy_raw = env::var("XY_FORWARD_PROXY_ALGO").ok();
+        let forward_proxy_algo = resolve_forward_proxy_algo_config(
+            forward_proxy_algo_raw.as_deref(),
+            forward_proxy_algo_legacy_raw.as_deref(),
+        )?;
         let max_parallel_polls = overrides
             .max_parallel_polls
             .or_else(|| {
@@ -12512,6 +12568,30 @@ mod tests {
     }
 
     #[test]
+    fn forward_proxy_algo_config_defaults_to_latest_v2() {
+        let algo =
+            resolve_forward_proxy_algo_config(None, None).expect("default algo should resolve");
+        assert_eq!(algo, ForwardProxyAlgo::V2);
+    }
+
+    #[test]
+    fn forward_proxy_algo_config_accepts_primary_env() {
+        let algo = resolve_forward_proxy_algo_config(Some("v2"), None)
+            .expect("primary env should resolve");
+        assert_eq!(algo, ForwardProxyAlgo::V2);
+    }
+
+    #[test]
+    fn forward_proxy_algo_config_rejects_legacy_env() {
+        assert!(resolve_forward_proxy_algo_config(None, Some("v1")).is_err());
+    }
+
+    #[test]
+    fn forward_proxy_algo_config_rejects_when_both_env_vars_are_set() {
+        assert!(resolve_forward_proxy_algo_config(Some("v2"), Some("v1")).is_err());
+    }
+
+    #[test]
     fn forward_proxy_manager_v2_keeps_two_positive_weights() {
         let mut manager = ForwardProxyManager::with_algo(
             ForwardProxySettings {
@@ -12536,6 +12616,138 @@ mod tests {
             .filter(|entry| entry.weight > 0.0)
             .count();
         assert_eq!(positive_count, 2);
+    }
+
+    #[test]
+    fn forward_proxy_manager_v2_clamps_persisted_runtime_weight_on_startup() {
+        let manager = ForwardProxyManager::with_algo(
+            ForwardProxySettings {
+                proxy_urls: vec![],
+                subscription_urls: vec![],
+                subscription_update_interval_secs: 3600,
+                insert_direct: true,
+            },
+            vec![ForwardProxyRuntimeState {
+                proxy_key: FORWARD_PROXY_DIRECT_KEY.to_string(),
+                display_name: FORWARD_PROXY_DIRECT_LABEL.to_string(),
+                source: FORWARD_PROXY_SOURCE_DIRECT.to_string(),
+                endpoint_url: None,
+                weight: 99.0,
+                success_ema: 0.65,
+                latency_ema_ms: None,
+                consecutive_failures: 0,
+            }],
+            ForwardProxyAlgo::V2,
+        );
+
+        let direct_runtime = manager
+            .runtime
+            .get(FORWARD_PROXY_DIRECT_KEY)
+            .expect("direct runtime should exist");
+        assert_eq!(direct_runtime.weight, FORWARD_PROXY_V2_WEIGHT_MAX);
+    }
+
+    #[test]
+    fn forward_proxy_manager_v2_counts_only_selectable_positive_candidates() {
+        let mut manager = ForwardProxyManager::with_algo(
+            ForwardProxySettings {
+                proxy_urls: vec![
+                    "http://127.0.0.1:7890".to_string(),
+                    "http://127.0.0.1:7891".to_string(),
+                    "vless://11111111-1111-1111-1111-111111111111@127.0.0.1:443?encryption=none"
+                        .to_string(),
+                ],
+                subscription_urls: vec![],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+            },
+            vec![],
+            ForwardProxyAlgo::V2,
+        );
+
+        let selectable_keys = manager
+            .endpoints
+            .iter()
+            .filter(|endpoint| endpoint.is_selectable())
+            .map(|endpoint| endpoint.key.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(selectable_keys.len(), 2);
+        let non_selectable_key = manager
+            .endpoints
+            .iter()
+            .find(|endpoint| !endpoint.is_selectable())
+            .map(|endpoint| endpoint.key.clone())
+            .expect("non-selectable endpoint should exist");
+
+        manager
+            .runtime
+            .get_mut(&selectable_keys[0])
+            .expect("selectable runtime should exist")
+            .weight = 1.0;
+        manager
+            .runtime
+            .get_mut(&selectable_keys[1])
+            .expect("selectable runtime should exist")
+            .weight = -5.0;
+        manager
+            .runtime
+            .get_mut(&non_selectable_key)
+            .expect("non-selectable runtime should exist")
+            .weight = 1.0;
+
+        manager.ensure_non_zero_weight();
+
+        let positive_selectable = selectable_keys
+            .iter()
+            .filter_map(|key| manager.runtime.get(key))
+            .filter(|runtime| runtime.weight > 0.0)
+            .count();
+        assert_eq!(positive_selectable, 2);
+    }
+
+    #[test]
+    fn forward_proxy_manager_v2_probe_ignores_non_selectable_penalties() {
+        let mut manager = ForwardProxyManager::with_algo(
+            ForwardProxySettings {
+                proxy_urls: vec![
+                    "http://127.0.0.1:7890".to_string(),
+                    "vless://11111111-1111-1111-1111-111111111111@127.0.0.1:443?encryption=none"
+                        .to_string(),
+                ],
+                subscription_urls: vec![],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+            },
+            vec![],
+            ForwardProxyAlgo::V2,
+        );
+
+        let selectable_key = manager
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.is_selectable())
+            .map(|endpoint| endpoint.key.clone())
+            .expect("selectable endpoint should exist");
+        let non_selectable_key = manager
+            .endpoints
+            .iter()
+            .find(|endpoint| !endpoint.is_selectable())
+            .map(|endpoint| endpoint.key.clone())
+            .expect("non-selectable endpoint should exist");
+
+        manager
+            .runtime
+            .get_mut(&selectable_key)
+            .expect("selectable runtime should exist")
+            .weight = 1.0;
+        manager
+            .runtime
+            .get_mut(&non_selectable_key)
+            .expect("non-selectable runtime should exist")
+            .weight = -2.0;
+
+        assert!(!manager.should_probe_penalized_proxy());
+        assert!(manager.mark_probe_started().is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9271,7 +9271,9 @@ impl ForwardProxyManager {
                     runtime.endpoint_url = endpoint.raw_url.clone();
                 }
                 std::collections::hash_map::Entry::Vacant(vacant) => {
-                    vacant.insert(ForwardProxyRuntimeState::default_for_endpoint(endpoint, algo));
+                    vacant.insert(ForwardProxyRuntimeState::default_for_endpoint(
+                        endpoint, algo,
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## What changed

- set `FORWARD_PROXY_ALGO` as the only supported forward-proxy algo env var
- default forward-proxy algo to `v2`
- hard fail startup when `XY_FORWARD_PROXY_ALGO` is present (intentional hard-cut migration)
- normalize persisted runtime states on manager startup for algo bounds
- ensure v2 positive-candidate/probe logic is based on selectable endpoints
- tighten backtest script safety and fidelity:
  - align trace replay keys with observed attempt keys (+ direct when enabled)
  - include direct in simulation when `insert_direct=true`
  - normalize seeded runtime states before simulation
  - fail fast before writing reports when security checks fail
  - update docs to repository-relative script paths

## Verification

- `cargo check`
- `cargo test`
- `cargo test forward_proxy_manager_v2 -- --nocapture`
- `cargo test forward_proxy_algo_config -- --nocapture`
- `python3 -m py_compile scripts/forward_proxy_backtest.py`
- `python3 scripts/forward_proxy_backtest.py --db /tmp/cvm-prod-db-Jd0UiY/codex_vibe_monitor.db --algos v1,v2 --seeds 7,11,19,23,29 --requests 50000`
  - `acceptance_pass=True`

## Notes

- This change intentionally does **not** keep backward compatibility for `XY_FORWARD_PROXY_ALGO` per requirement.
