### PR TITLE
fix: keep main CI non-preemptive for release safety

### DIFF
--- a/.codex/skills/style-playbook-starter/SKILL.md
+++ b/.codex/skills/style-playbook-starter/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: style-playbook-starter
+description: "Starter guide for style-topic skills: how to patch (write), enhance (write), and update (read) topic skills consistently."
+---
+
+# Style Playbook Starter
+
+Use this starter whenever you maintain a `style-topic-*` skill.
+
+## Patch (write)
+
+- Fix factual errors, broken commands, invalid paths, or stale references.
+- Keep behavior changes minimal and explicit.
+- If patching changes expected outputs, update the relevant examples.
+
+## Enhance (write)
+
+- Add reusable defaults and decision rules, not project-specific one-offs.
+- Prefer additive updates; avoid breaking existing command contracts.
+- Add clear guardrails and failure handling where missing.
+
+## Update (read)
+
+- Read latest topic skill + source tag doc before proposing changes.
+- Validate that examples still match current files and scripts.
+- Call out drift between topic guidance and source references.
+
+## Required workflow in topic skills
+
+- Topic skills must cite this starter in a dedicated section.
+- Topic skills should not duplicate starter content verbatim; reference it.

--- a/.codex/skills/style-playbook-starter/agents/openai.yaml
+++ b/.codex/skills/style-playbook-starter/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Style Playbook Starter"
+  short_description: "Starter workflow for topic skill patch and upgrades"
+  default_prompt: "Use $style-playbook-starter to patch, enhance, and update topic skills in a controlled workflow."

--- a/.codex/skills/style-topic-pr-label-release/SKILL.md
+++ b/.codex/skills/style-topic-pr-label-release/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: style-topic-pr-label-release
+description: "Topic skill for 'PR label release' generated from style playbook tags."
+---
+
+# Topic: PR label release
+
+This topic skill is generated from `skills/style-playbook/references/tags/pr-label-release.md`.
+
+## Starter Required
+
+Load `$style-playbook-starter` first for the standard maintenance workflow:
+- patch (write)
+- enhance (write)
+- update (read)
+
+## Source
+
+- Tag token: `PR label release`
+- Tag doc: `skills/style-playbook/references/tags/pr-label-release.md`
+
+## Usage
+
+- Use this skill when you need guidance scoped to this topic.
+- Keep topic-specific rules here; keep maintenance workflow in `$style-playbook-starter`.

--- a/.codex/skills/style-topic-pr-label-release/agents/openai.yaml
+++ b/.codex/skills/style-topic-pr-label-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Topic: PR label release"
+  short_description: "Guidance for PR label release"
+  default_prompt: "Use $style-topic-pr-label-release to align this work with Pr Label Release conventions and output concrete implementation choices."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- install `.codex/skills/style-playbook-starter`
- install `.codex/skills/style-topic-pr-label-release`
- change CI concurrency cancellation to PR-only (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`)

## Why
- keep PR CI preemptible while preventing main branch run preemption that can cause release-chain misses

## Validation
- workflow YAML parse check passed locally