### PR TITLE
fix(web): stabilize dashboard usage calendar skeleton layout

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
+| rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track           |
 | 4kkpp | Live 对话统计（按 Prompt Cache Key）— 无统计表方案（索引 + 轻缓存）       | 已完成（5/5）   | `4kkpp-live-prompt-cache-conversations/SPEC.md`          | 2026-03-03 | fast-track           |
 | hrvtt | 请求详情补齐代理信息与本次权重变化                                        | 已完成（4/4）   | `hrvtt-invocation-proxy-weight-delta/SPEC.md`            | 2026-03-02 | fast-track           |
 | t7m4h | Live 代理运行态：新增 24h 权重趋势列与断点适配                            | 已完成（5/5）   | `t7m4h-live-proxy-weight-trend/SPEC.md`                  | 2026-03-02 | fast-track / PR #83  |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 
 | ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
-| rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track           |
+| rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track / PR #88  |
 | 4kkpp | Live 对话统计（按 Prompt Cache Key）— 无统计表方案（索引 + 轻缓存）       | 已完成（5/5）   | `4kkpp-live-prompt-cache-conversations/SPEC.md`          | 2026-03-03 | fast-track           |
 | hrvtt | 请求详情补齐代理信息与本次权重变化                                        | 已完成（4/4）   | `hrvtt-invocation-proxy-weight-delta/SPEC.md`            | 2026-03-02 | fast-track           |
 | t7m4h | Live 代理运行态：新增 24h 权重趋势列与断点适配                            | 已完成（5/5）   | `t7m4h-live-proxy-weight-trend/SPEC.md`                  | 2026-03-02 | fast-track / PR #83  |

--- a/docs/specs/rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md
+++ b/docs/specs/rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md
@@ -1,0 +1,66 @@
+# Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局（#rzxey）
+
+## 状态
+
+- Status: 已完成
+- Created: 2026-03-05
+- Last: 2026-03-05
+
+## 背景 / 问题陈述
+
+- 刷新 Dashboard（`/dashboard`）时，右侧 UsageCalendar 在加载期间会出现明显的水平错位：骨架阶段卡片整体向右偏移，待数据返回后再跳回，产生可感知的 layout shift。
+- 现状原因：UsageCalendar 使用 `react-activity-calendar` 的 `loading` 模式，内部会渲染“整年空数据”且隐藏 weekday/month labels，导致组件在加载期与加载完成后的固有宽度/布局结构不一致，从而影响 Dashboard 顶部 `grid-cols-[minmax(0,1fr)_max-content]` 的列分配。
+
+## 目标 / 非目标
+
+### Goals
+
+- 消除刷新时 UsageCalendar 在加载期间的可感知水平错位（layout shift）。
+- 加载骨架按真实界面结构渲染：
+  - Dashboard 首行在加载期仍保持「今日统计信息」+「使用活动」两个卡片并排（桌面宽度下）。
+  - UsageCalendar 在加载期展示与真实一致的 weekday labels 与 month label overlay，并保持 90d 网格尺度（约 13~14 周列）。
+- 当 timeseries points 为空或全为 0 时，展示“空日历”（最低色）而不是无限 skeleton。
+
+### Non-goals
+
+- 不改变 Dashboard 顶部最终布局比例与 grid track 定义（除非验证仍存在 shift，才考虑追加兜底策略）。
+- 不改动后端统计接口与数据口径。
+
+## 范围（Scope）
+
+### In scope
+
+- `web/src/components/UsageCalendar.tsx`：
+  - 移除对 `ActivityCalendar loading` 的依赖，改为“永远传入非空 90d activities”。
+  - 加载期通过 `skeletonMode`（如 `animate-pulse` + 禁用 tooltip 事件）表达“正在加载”，而不是改变布局结构。
+  - 当 points 为空/全 0，仍渲染空日历并保持结构稳定。
+- `web/tests/e2e/usage-calendar.spec.ts`：
+  - 增加回归用例：对 `range=90d&bucket=1d` 的请求注入延迟，断言加载前后卡片位置稳定、首行两卡可见。
+- `docs/specs/README.md`：登记本 spec 的索引条目，并随实现推进同步状态。
+
+### Out of scope
+
+- `src/` Rust 后端实现与 API 定义调整。
+- 其它 Dashboard 区块（24h/7d 热图、InvocationTable）逻辑与布局改造。
+
+## 验收标准（Acceptance Criteria）
+
+- Given 桌面宽度（>= 1024px）刷新 Dashboard，When UsageCalendar 数据仍在加载，Then 首行保持两卡并排，UsageCalendar 不出现“明显右偏再跳回”的错位感。
+- Given UsageCalendar 加载期，When 渲染骨架，Then weekday labels 与 month label overlay 的占位结构与加载完成后保持一致。
+- Given timeseries points 为空或全为 0，When 渲染 UsageCalendar，Then 显示空日历（最低色）而非无限 skeleton，页面无报错。
+- Given Playwright E2E 注入 timeseries 延迟，When 对比加载前后 `usage-calendar-card` 的 `boundingBox.x`，Then 变化不超过 `2px`，且加载期两卡标题可见。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 新建 Spec 并登记到 `docs/specs/README.md`。
+- [x] M2: UsageCalendar：用 90d 零值占位替换 `react-activity-calendar` 内置 loading 骨架，保证布局稳定。
+- [x] M3: UsageCalendar：空数据/全 0 时展示空日历（最低色），不再无限 skeleton。
+- [x] M4: Playwright：新增延迟回归用例并通过。
+- [x] M5: 本地验证通过（lint/test/build）并完成视觉验收。
+
+## 进度备注
+
+- 已移除 `react-activity-calendar` 内置 `loading` 骨架，改为始终渲染 90d activities（缺失数据自动补 0）以保持布局结构一致。
+- 加载期对 blocks 增加 `animate-pulse`，并禁用 tooltip 事件，避免骨架阶段产生误导性交互。
+- 新增 E2E：注入 `range=90d&bucket=1d` 延迟，断言加载前后首行两卡并排且 `usage-calendar-card` 的 x 位置稳定（≤2px）。
+- 已完成 `web` 的 `npm run lint`、`npm run test`、`npm run build`；Playwright 回归关注点已覆盖在 UsageCalendar spec 内。

--- a/docs/specs/rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md
+++ b/docs/specs/rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md
@@ -64,3 +64,4 @@
 - 加载期对 blocks 增加 `animate-pulse`，并禁用 tooltip 事件，避免骨架阶段产生误导性交互。
 - 新增 E2E：注入 `range=90d&bucket=1d` 延迟，断言加载前后首行两卡并排且 `usage-calendar-card` 的 x 位置稳定（≤2px）。
 - 已完成 `web` 的 `npm run lint`、`npm run test`、`npm run build`；Playwright 回归关注点已覆盖在 UsageCalendar spec 内。
+- PR: #88

--- a/web/src/components/TodayStatsOverview.tsx
+++ b/web/src/components/TodayStatsOverview.tsx
@@ -75,7 +75,7 @@ export function TodayStatsOverview({ stats, loading, error }: TodayStatsOverview
   const tokenValue = numberFormatter.format(totalTokens)
 
   return (
-    <section className="surface-panel h-full">
+    <section className="surface-panel h-full" data-testid="today-stats-overview-card">
       <div className="surface-panel-body gap-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="section-heading">

--- a/web/src/components/UsageCalendar.tsx
+++ b/web/src/components/UsageCalendar.tsx
@@ -2,7 +2,7 @@ import { cloneElement, useCallback, useLayoutEffect, useMemo, useRef, useState }
 import type { ReactElement, CSSProperties, MouseEvent as ReactMouseEvent } from 'react'
 import ActivityCalendar, { type Activity } from 'react-activity-calendar'
 import { useTimeseries } from '../hooks/useTimeseries'
-import type { TimeseriesPoint } from '../lib/api'
+import type { TimeseriesResponse } from '../lib/api'
 import { useTranslation } from '../i18n'
 import type { TranslationKey } from '../i18n'
 import { formatTokensShort } from '../lib/numberFormatters'
@@ -22,6 +22,7 @@ interface MetricOption {
 type AccessibleBlock = ReactElement<{
   title?: string
   'aria-label'?: string
+  className?: string
   style?: CSSProperties
   onMouseEnter?: (event: ReactMouseEvent<SVGElement>) => void
   onMouseLeave?: (event: ReactMouseEvent<SVGElement>) => void
@@ -55,6 +56,7 @@ export function UsageCalendar() {
   const timeZone = getBrowserTimeZone()
   const [metric, setMetric] = useState<MetricKey>('totalCount')
   const { data, isLoading, error } = useTimeseries('90d', { bucket: '1d' })
+  const skeletonMode = isLoading && !data
   const [blockSize, setBlockSize] = useState(DEFAULT_BLOCK_SIZE)
   const containerRef = useRef<HTMLDivElement>(null)
   const [tooltip, setTooltip] = useState<CalendarTooltipState | null>(null)
@@ -108,7 +110,7 @@ export function UsageCalendar() {
   )
 
   const calendarData = useMemo(
-    () => transformPointsToActivities(data?.points ?? [], metric),
+    () => transformTimeseriesToActivities(data, metric),
     [data, metric],
   )
 
@@ -195,8 +197,6 @@ export function UsageCalendar() {
     }
   }, [metric, calendarData.weekCount])
 
-  const calendarLoading = isLoading || calendarData.activities.length === 0
-
   const themeForMetric = useMemo(
     () => ({
       light: calendarPalette(metric, 'light'),
@@ -263,7 +263,6 @@ export function UsageCalendar() {
                   />
                   <ActivityCalendar
                     data={calendarData.activities}
-                    loading={calendarLoading}
                     blockSize={blockSize}
                     // Match the subtle rounding used by the 7-day heatmap.
                     blockRadius={2}
@@ -305,8 +304,9 @@ export function UsageCalendar() {
                       return cloneElement(accessibleBlock, {
                         title,
                         'aria-label': title,
-                        onMouseEnter: handleEnter,
-                        onMouseLeave: handleLeave,
+                        onMouseEnter: skeletonMode ? undefined : handleEnter,
+                        onMouseLeave: skeletonMode ? undefined : handleLeave,
+                        className: cn(accessibleBlock.props?.className, skeletonMode && 'animate-pulse'),
                         // Remove default stroke from react-activity-calendar to align
                         // with the weekly heatmap appearance.
                         style: { ...(accessibleBlock.props?.style ?? {}), stroke: 'none', strokeWidth: 0 },
@@ -362,29 +362,21 @@ interface CalendarComputation {
   monthMarkers: MonthMarker[]
 }
 
-function transformPointsToActivities(points: TimeseriesPoint[], metric: MetricKey): CalendarComputation {
-  if (!points || points.length === 0) {
-    return { activities: [], maxValue: 0, totalValue: 0, thresholds: [], weekCount: 0, monthMarkers: [] }
-  }
-
-  const sortedPoints = [...points].sort((a, b) => parseDateLocal(a.bucketStart) - parseDateLocal(b.bucketStart))
+function transformTimeseriesToActivities(response: TimeseriesResponse | null, metric: MetricKey): CalendarComputation {
+  const points = response?.points ?? []
+  const range = resolveLocalDateRange(response)
 
   const valuesByDate = new Map<string, number>()
-  for (const point of sortedPoints) {
+  for (const point of points) {
     const iso = toLocalISODate(point.bucketStart)
     const current = valuesByDate.get(iso) ?? 0
     valuesByDate.set(iso, current + (point[metric] ?? 0))
   }
 
-  const startIso = toLocalISODate(sortedPoints[0].bucketStart)
-  const endIso = toLocalISODate(sortedPoints[sortedPoints.length - 1].bucketStart)
-  const startDate = parseLocalISODate(startIso)
-  const endDate = parseLocalISODate(endIso)
-
   const activities: Activity[] = []
   const values: number[] = []
-  const cursor = new Date(startDate)
-  while (cursor <= endDate) {
+  const cursor = new Date(range.start)
+  while (cursor <= range.endInclusive) {
     const iso = formatLocalISODate(cursor)
     const value = valuesByDate.get(iso) ?? 0
     values.push(value)
@@ -423,11 +415,6 @@ function formatLocalISODate(date: Date) {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
 }
 
-function parseLocalISODate(value: string) {
-  const [year, month, day] = value.split('-').map(Number)
-  return new Date(year, (month ?? 1) - 1, day ?? 1)
-}
-
 function toLocalISODate(value: string) {
   if (value.includes('T')) {
     // bucketStart/bucketEnd are RFC3339 UTC timestamps; convert to local day.
@@ -437,15 +424,37 @@ function toLocalISODate(value: string) {
   return datePart ?? ''
 }
 
-function parseDateLocal(value: string) {
-  if (value.includes('T')) {
-    const d = new Date(value)
-    return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+function resolveLocalDateRange(response: TimeseriesResponse | null) {
+  // Daily time-series endpoints use [rangeStart, rangeEnd) where rangeEnd is the next local midnight.
+  // We keep the UI stable by always rendering a 90-day calendar, even during the initial load.
+  const today = startOfLocalDay(new Date())
+
+  const rangeStart = response?.rangeStart
+  const rangeEnd = response?.rangeEnd
+  if (rangeStart && rangeEnd) {
+    const start = startOfLocalDay(new Date(rangeStart))
+    const endExclusive = startOfLocalDay(new Date(rangeEnd))
+    if (Number.isFinite(start.getTime()) && Number.isFinite(endExclusive.getTime())) {
+      const endInclusive = addLocalDays(endExclusive, -1)
+      if (start <= endInclusive) {
+        return { start, endInclusive }
+      }
+    }
   }
-  const [datePart] = value.split(' ')
-  if (!datePart) return 0
-  const [year, month, day] = datePart.split('-').map(Number)
-  return new Date(year, (month ?? 1) - 1, day ?? 1).getTime()
+
+  const endInclusive = today
+  const start = addLocalDays(endInclusive, -89)
+  return { start, endInclusive }
+}
+
+function startOfLocalDay(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function addLocalDays(date: Date, days: number) {
+  const next = new Date(date)
+  next.setDate(next.getDate() + days)
+  return startOfLocalDay(next)
 }
 
 interface MonthMarker { weekIndex: number; year: number; month: number }

--- a/web/src/components/UsageCalendar.tsx
+++ b/web/src/components/UsageCalendar.tsx
@@ -279,7 +279,9 @@ export function UsageCalendar() {
                     renderBlock={(block, activity) => {
                       const accessibleBlock = block as AccessibleBlock
                       const formatted = formatMetricValue(activity.count)
-                      const title = `${activity.date}${valueSeparator}${formatted}`
+                      // During skeleton mode, avoid native browser tooltips (title="...") that
+                      // could misleadingly show "0 calls" while loading.
+                      const title = skeletonMode ? undefined : `${activity.date}${valueSeparator}${formatted}`
                       const handleEnter = (event: ReactMouseEvent<SVGElement>) => {
                         if (!containerRef.current) return
                         const target = event.currentTarget as Element
@@ -306,7 +308,7 @@ export function UsageCalendar() {
                         'aria-label': title,
                         onMouseEnter: skeletonMode ? undefined : handleEnter,
                         onMouseLeave: skeletonMode ? undefined : handleLeave,
-                        className: cn(accessibleBlock.props?.className, skeletonMode && 'animate-pulse'),
+                        className: cn(accessibleBlock.props?.className, skeletonMode && 'animate-pulse pointer-events-none'),
                         // Remove default stroke from react-activity-calendar to align
                         // with the weekly heatmap appearance.
                         style: { ...(accessibleBlock.props?.style ?? {}), stroke: 'none', strokeWidth: 0 },

--- a/web/tests/e2e/usage-calendar.spec.ts
+++ b/web/tests/e2e/usage-calendar.spec.ts
@@ -97,4 +97,75 @@ test.describe('UsageCalendar responsive layout', () => {
     test.info().annotations.push({ type: 'center-gaps', description: JSON.stringify(gaps) })
     expect(Math.abs(gaps.leftGap - gaps.rightGap)).toBeLessThanOrEqual(16)
   })
+
+  test('does not shift dashboard top row while 90d timeseries is loading', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    let releaseTimeseries: (() => void) | null = null
+    const gate = new Promise<void>((resolve) => {
+      releaseTimeseries = resolve
+    })
+
+    await page.route('**/api/stats/timeseries**', async (route) => {
+      const requestUrl = new URL(route.request().url())
+      const range = requestUrl.searchParams.get('range')
+      const bucket = requestUrl.searchParams.get('bucket')
+      if (range === '90d' && bucket === '1d') {
+        await gate
+      }
+      await route.continue()
+    })
+
+    await page.goto('/dashboard')
+
+    const todayCard = page.getByTestId('today-stats-overview-card')
+    const usageCard = page.getByTestId('usage-calendar-card')
+    await todayCard.waitFor({ state: 'visible' })
+    await usageCard.waitFor({ state: 'visible' })
+
+    const todayBefore = await todayCard.boundingBox()
+    const usageBefore = await usageCard.boundingBox()
+    expect(todayBefore).not.toBeNull()
+    expect(usageBefore).not.toBeNull()
+
+    const todayBox = todayBefore!
+    const usageBox = usageBefore!
+    test.info().annotations.push({
+      type: 'dashboard-top-row-before',
+      description: JSON.stringify({
+        today: { x: Math.round(todayBox.x), y: Math.round(todayBox.y), w: Math.round(todayBox.width), h: Math.round(todayBox.height) },
+        usage: { x: Math.round(usageBox.x), y: Math.round(usageBox.y), w: Math.round(usageBox.width), h: Math.round(usageBox.height) },
+      }),
+    })
+
+    // Two cards should stay on the same row (desktop layout) even during loading.
+    expect(Math.abs(todayBox.y - usageBox.y)).toBeLessThanOrEqual(8)
+    expect(todayBox.x + todayBox.width).toBeLessThan(usageBox.x)
+
+    releaseTimeseries?.()
+    await page.waitForResponse((resp) => {
+      if (!resp.url().includes('/api/stats/timeseries')) return false
+      try {
+        const url = new URL(resp.url())
+        return url.searchParams.get('range') === '90d' && url.searchParams.get('bucket') === '1d'
+      } catch {
+        return false
+      }
+    })
+
+    await page.waitForTimeout(200)
+
+    const usageAfter = await usageCard.boundingBox()
+    expect(usageAfter).not.toBeNull()
+    const usageAfterBox = usageAfter!
+
+    test.info().annotations.push({
+      type: 'dashboard-top-row-after',
+      description: JSON.stringify({
+        usage: { x: Math.round(usageAfterBox.x), y: Math.round(usageAfterBox.y), w: Math.round(usageAfterBox.width), h: Math.round(usageAfterBox.height) },
+      }),
+    })
+
+    expect(Math.abs(usageAfterBox.x - usageBox.x)).toBeLessThanOrEqual(2)
+  })
 })

--- a/web/tests/e2e/usage-calendar.spec.ts
+++ b/web/tests/e2e/usage-calendar.spec.ts
@@ -123,6 +123,10 @@ test.describe('UsageCalendar responsive layout', () => {
     await todayCard.waitFor({ state: 'visible' })
     await usageCard.waitFor({ state: 'visible' })
 
+    // Ensure we are measuring the loading skeleton state, not the hydrated state.
+    const pulseBefore = await usageCard.locator('rect.animate-pulse').count()
+    expect(pulseBefore).toBeGreaterThan(0)
+
     const todayBefore = await todayCard.boundingBox()
     const usageBefore = await usageCard.boundingBox()
     expect(todayBefore).not.toBeNull()
@@ -142,8 +146,7 @@ test.describe('UsageCalendar responsive layout', () => {
     expect(Math.abs(todayBox.y - usageBox.y)).toBeLessThanOrEqual(8)
     expect(todayBox.x + todayBox.width).toBeLessThan(usageBox.x)
 
-    releaseTimeseries?.()
-    await page.waitForResponse((resp) => {
+    const waitTimeseries = page.waitForResponse((resp) => {
       if (!resp.url().includes('/api/stats/timeseries')) return false
       try {
         const url = new URL(resp.url())
@@ -153,7 +156,11 @@ test.describe('UsageCalendar responsive layout', () => {
       }
     })
 
-    await page.waitForTimeout(200)
+    releaseTimeseries?.()
+    await waitTimeseries
+
+    // Wait until the UI flips from skeleton to hydrated render (pulse class removed).
+    await expect(usageCard.locator('rect.animate-pulse')).toHaveCount(0)
 
     const usageAfter = await usageCard.boundingBox()
     expect(usageAfter).not.toBeNull()
@@ -167,5 +174,40 @@ test.describe('UsageCalendar responsive layout', () => {
     })
 
     expect(Math.abs(usageAfterBox.x - usageBox.x)).toBeLessThanOrEqual(2)
+  })
+
+  test('renders an empty 90d calendar when timeseries returns no points', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route('**/api/stats/timeseries**', async (route) => {
+      const requestUrl = new URL(route.request().url())
+      const range = requestUrl.searchParams.get('range')
+      const bucket = requestUrl.searchParams.get('bucket')
+      if (range === '90d' && bucket === '1d') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            rangeStart: '2026-01-01T00:00:00Z',
+            rangeEnd: '2026-04-01T00:00:00Z',
+            bucketSeconds: 86400,
+            points: [],
+          }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await page.goto('/dashboard')
+
+    const usageCard = page.getByTestId('usage-calendar-card')
+    await usageCard.waitFor({ state: 'visible' })
+    await expect(usageCard.locator('[data-testid="usage-calendar-wrapper"]')).toBeVisible()
+    await expect(usageCard.locator('rect.animate-pulse')).toHaveCount(0)
+
+    // Empty calendar should still render a full grid of blocks (no fallback to library loading skeleton).
+    const blockCount = await usageCard.locator('svg rect').count()
+    expect(blockCount).toBeGreaterThanOrEqual(60)
   })
 })


### PR DESCRIPTION
Spec: docs/specs/rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md
Spec Status: 已完成
Spec Sync: done
Spec Drift: none

Summary:
- Fix /dashboard UsageCalendar loading skeleton layout shift by rendering stable 90d placeholder activities (no react-activity-calendar internal loading).
- Keep the top row as two cards during initial load; add E2E regression.

Test Plan:
- cd web && npm run lint
- cd web && npm run test
- cd web && npm run build
- cd web && npm run test:e2e (UsageCalendar spec)
