### PR TITLE
feat(pricing): add gpt-5.4 pricing, presets, and long-context surcharge

### DIFF
--- a/docs/specs/7272y-gpt-5-4-pricing/SPEC.md
+++ b/docs/specs/7272y-gpt-5-4-pricing/SPEC.md
@@ -1,0 +1,150 @@
+# 内置 GPT-5.4 系列计费规则与下游模型列表（#7272y）
+
+## 状态
+
+- Status: 已完成（4/4）
+- Created: 2026-03-06
+- Last: 2026-03-06
+
+## 背景 / 问题陈述
+
+- 代理侧需要为下游提供可选模型列表（`/v1/models` hijack preset），以及在未配置外部 pricing catalog 时的默认计费目录。
+- 新增 `gpt-5.4` / `gpt-5.4-pro` 后，需要内置默认单价，并在 prompt 超过 272K tokens 时按官方规则加价，避免成本估算偏低。
+- 现有 SQLite 中的 pricing / enabled models 需要做到“缺啥补啥”，且不覆盖用户自定义价格/条目。
+
+## 目标 / 非目标
+
+### Goals
+
+- 默认 pricing catalog 内置 `gpt-5.4` / `gpt-5.4-pro` 的单价。
+- `estimate_proxy_cost` 对 `gpt-5.4*` 在 `usage.input_tokens > 272_000` 时应用加价：
+  - input cost x2（包含 cached input 部分）
+  - output cost x1.5
+  - reasoning cost x1.5
+- `/v1/models` hijack preset 列表可向下游暴露 `gpt-5.4` / `gpt-5.4-pro`（仅扩展 id 集合，不改变 payload 结构）。
+- SQLite 启动/加载阶段自动补齐：
+  - pricing 缺少新模型条目则 `INSERT OR IGNORE` 插入
+  - proxy enabled list 仅在保持 legacy 默认列表时才追加，避免覆盖用户自定义
+
+### Non-goals
+
+- 不引入在线自动同步 pricing 的能力。
+- 不调整已有模型的价格（除 source 字段归一化为 `official`）。
+- 不更改任何 API schema，仅调整默认数据与估算逻辑。
+
+## 范围（Scope）
+
+### In scope
+
+- Rust backend: `src/main.rs` pricing catalog / preset list / surcharge / seed。
+- Unit tests covering surcharge edge and seeding behavior.
+
+### Out of scope
+
+- Web UI changes.
+- 自动更新外部 pricing 配置文件。
+
+## 需求（Requirements）
+
+### MUST
+
+- 不覆盖 `pricing_settings_models` 中已有的同名 model 行（保留用户值）。
+- `gpt-5.4*` 超阈值加价按 whole session 计费（对 input/output/reasoning 部分分别乘倍率）。
+- `/v1/models` hijack 仍返回 `{object:\"list\", data:[{id, object, owned_by, created}, ...]}`。
+
+### SHOULD
+
+- 为新逻辑补齐回归测试（in-memory sqlite + pure unit tests）。
+
+### COULD
+
+- 将阈值/倍率配置化（未来）。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- 当 pricing catalog 为默认目录（或 legacy 默认目录）且 SQLite 缺少 `gpt-5.4` / `gpt-5.4-pro` 行时：启动时自动插入两行（`INSERT OR IGNORE`）。
+- 当 `/v1/models` hijack 开启：
+  - preset 模型列表集合包含 `gpt-5.4` / `gpt-5.4-pro`
+  - enabled list 等于 legacy 默认列表时，自动追加新模型
+  - enabled list 为用户自定义时不自动改动
+- 成本估算：
+  - `model` 以 `\"gpt-5.4\"` 前缀匹配
+  - 若 `usage.input_tokens > 272_000`：input x2、output x1.5、reasoning x1.5
+  - 阈值等于 272_000 时不触发（strictly greater）
+
+### Edge cases / errors
+
+- pricing catalog 为自定义 version 时，不自动插入新模型（避免干预用户自定义目录）。
+- `gpt-5.4-pro` 不提供 cache input 单价时，cached tokens 不作为 cache 计费（保持既有行为）。
+
+## 接口契约（Interfaces & Contracts）
+
+None
+
+## 验收标准（Acceptance Criteria）
+
+- Given SQLite 中缺少 `gpt-5.4` / `gpt-5.4-pro` pricing 行
+  When 启动并加载 pricing catalog（默认/legacy 默认 version）
+  Then 两模型条目会被插入；若行已存在则不会被覆盖
+
+- Given `/v1/models` hijack enabled 且 enabled_models 包含 `gpt-5.4` / `gpt-5.4-pro`
+  When `GET /v1/models`
+  Then 返回列表包含两个 id，payload 结构保持不变
+
+- Given `model=gpt-5.4` 且 `input_tokens=272000`
+  When 估算成本
+  Then 不触发加价
+
+- Given `model=gpt-5.4` 且 `input_tokens=272001`
+  When 估算成本
+  Then input 部分 x2，output 部分 x1.5（reasoning 同 output）
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- Unit tests: `cargo test`
+
+### Quality checks
+
+- `cargo fmt` / `cargo clippy` via lefthook (commit hooks).
+
+## 文档更新（Docs to Update）
+
+- `docs/specs/README.md`: add index row for #7272y
+- `docs/specs/7272y-gpt-5-4-pricing/SPEC.md`: this spec
+
+## Visual Evidence (PR)
+
+None
+
+## 资产晋升（Asset promotion）
+
+None
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: Add `gpt-5.4` / `gpt-5.4-pro` to preset model ids for downstream `/v1/models`.
+- [x] M2: Add default pricing catalog entries and catalog version refresh.
+- [x] M3: Add long-context surcharge rule for `gpt-5.4*`.
+- [x] M4: Add SQLite ensure/seed logic and regression tests.
+
+## 方案概述（Approach, high-level）
+
+- Keep pricing defaults embedded; seed missing rows in SQLite via `INSERT OR IGNORE` to preserve user overrides.
+- Apply long-context surcharge only for `gpt-5.4*` and only when prompt tokens strictly exceed threshold.
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：若 upstream pricing/规则变更，需要再次手动刷新默认目录。
+- 假设：`usage.input_tokens` 代表 prompt token 数量（用于 272K 阈值判定）。
+
+## 变更记录（Change log）
+
+- 2026-03-06: Create spec and record current implementation (PR #89).
+
+## 参考（References）
+
+- PR #89

--- a/docs/specs/7272y-gpt-5-4-pricing/SPEC.md
+++ b/docs/specs/7272y-gpt-5-4-pricing/SPEC.md
@@ -17,14 +17,15 @@
 ### Goals
 
 - 默认 pricing catalog 内置 `gpt-5.4` / `gpt-5.4-pro` 的单价。
-- `estimate_proxy_cost` 对 `gpt-5.4*` 在 `usage.input_tokens > 272_000` 时应用加价：
+- `estimate_proxy_cost` 对 `gpt-5.4` / `gpt-5.4-pro`（可带 `-YYYY-MM-DD` dated suffix）
+  在 `usage.input_tokens > 272_000` 时应用加价：
   - input cost x2（包含 cached input 部分）
   - output cost x1.5
   - reasoning cost x1.5
 - `/v1/models` hijack preset 列表可向下游暴露 `gpt-5.4` / `gpt-5.4-pro`（仅扩展 id 集合，不改变 payload 结构）。
 - SQLite 启动/加载阶段自动补齐：
   - pricing 缺少新模型条目则 `INSERT OR IGNORE` 插入
-  - proxy enabled list 仅在保持 legacy 默认列表时才追加，避免覆盖用户自定义
+  - proxy enabled list 仅在保持 legacy 默认列表时才追加，且迁移仅执行一次（允许后续显式移除）
 
 ### Non-goals
 
@@ -49,7 +50,7 @@
 ### MUST
 
 - 不覆盖 `pricing_settings_models` 中已有的同名 model 行（保留用户值）。
-- `gpt-5.4*` 超阈值加价按 whole session 计费（对 input/output/reasoning 部分分别乘倍率）。
+- `gpt-5.4` / `gpt-5.4-pro`（可带 `-YYYY-MM-DD` dated suffix）超阈值加价按 whole session 计费。
 - `/v1/models` hijack 仍返回 `{object:\"list\", data:[{id, object, owned_by, created}, ...]}`。
 
 ### SHOULD
@@ -69,8 +70,9 @@
   - preset 模型列表集合包含 `gpt-5.4` / `gpt-5.4-pro`
   - enabled list 等于 legacy 默认列表时，自动追加新模型
   - enabled list 为用户自定义时不自动改动
+  - 迁移追加会写入 migration flag，后续重启不再重复自动追加
 - 成本估算：
-  - `model` 以 `\"gpt-5.4\"` 前缀匹配
+  - `model` 精确匹配 `gpt-5.4` / `gpt-5.4-pro`，并允许 `-YYYY-MM-DD` dated suffix
   - 若 `usage.input_tokens > 272_000`：input x2、output x1.5、reasoning x1.5
   - 阈值等于 272_000 时不触发（strictly greater）
 
@@ -129,12 +131,13 @@ None
 - [x] M1: Add `gpt-5.4` / `gpt-5.4-pro` to preset model ids for downstream `/v1/models`.
 - [x] M2: Add default pricing catalog entries and catalog version refresh.
 - [x] M3: Add long-context surcharge rule for `gpt-5.4*`.
+- [x] M3: Add long-context surcharge rule for `gpt-5.4` / `gpt-5.4-pro`.
 - [x] M4: Add SQLite ensure/seed logic and regression tests.
 
 ## 方案概述（Approach, high-level）
 
 - Keep pricing defaults embedded; seed missing rows in SQLite via `INSERT OR IGNORE` to preserve user overrides.
-- Apply long-context surcharge only for `gpt-5.4*` and only when prompt tokens strictly exceed threshold.
+- Apply long-context surcharge only for `gpt-5.4` / `gpt-5.4-pro` and only when prompt tokens strictly exceed threshold.
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                |
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
+| 7272y | 内置 GPT-5.4 系列计费规则与下游模型列表                                   | 已完成（4/4）   | `7272y-gpt-5-4-pricing/SPEC.md`                          | 2026-03-06 | fast-track / PR #89  |
 | rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track / PR #88  |
 | 4kkpp | Live 对话统计（按 Prompt Cache Key）— 无统计表方案（索引 + 轻缓存）       | 已完成（5/5）   | `4kkpp-live-prompt-cache-conversations/SPEC.md`          | 2026-03-03 | fast-track           |
 | hrvtt | 请求详情补齐代理信息与本次权重变化                                        | 已完成（4/4）   | `hrvtt-invocation-proxy-weight-delta/SPEC.md`            | 2026-03-02 | fast-track           |

--- a/src/main.rs
+++ b/src/main.rs
@@ -2564,6 +2564,23 @@ async fn ensure_pricing_models_present(pool: &Pool<Sqlite>) -> Result<()> {
     Ok(())
 }
 
+async fn normalize_default_pricing_sources(pool: &Pool<Sqlite>) -> Result<()> {
+    // Legacy versions used `temporary` for some built-in models; keep the pricing untouched
+    // but normalize the metadata so UI and reporting remain consistent.
+    sqlx::query(
+        r#"
+        UPDATE pricing_settings_models
+        SET source = 'official'
+        WHERE model = 'gpt-5.3-codex'
+          AND lower(trim(source)) = 'temporary'
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to normalize default pricing sources")?;
+    Ok(())
+}
+
 async fn seed_default_pricing_catalog(pool: &Pool<Sqlite>) -> Result<()> {
     let legacy_path = resolve_legacy_pricing_catalog_path();
     seed_default_pricing_catalog_with_legacy_path(pool, Some(&legacy_path)).await
@@ -2601,6 +2618,7 @@ async fn seed_default_pricing_catalog_with_legacy_path(
             || version == LEGACY_DEFAULT_PRICING_CATALOG_VERSION
         {
             ensure_pricing_models_present(pool).await?;
+            normalize_default_pricing_sources(pool).await?;
         }
         return Ok(());
     }
@@ -2628,6 +2646,7 @@ async fn seed_default_pricing_catalog_with_legacy_path(
         .await
         .context("failed to ensure default pricing_settings_meta row")?;
         ensure_pricing_models_present(pool).await?;
+        normalize_default_pricing_sources(pool).await?;
         return Ok(());
     }
 
@@ -2641,6 +2660,12 @@ async fn seed_default_pricing_catalog_with_legacy_path(
                     "migrating legacy pricing catalog into sqlite"
                 );
                 save_pricing_catalog(pool, &catalog).await?;
+                if catalog.version == DEFAULT_PRICING_CATALOG_VERSION
+                    || catalog.version == LEGACY_DEFAULT_PRICING_CATALOG_VERSION
+                {
+                    ensure_pricing_models_present(pool).await?;
+                    normalize_default_pricing_sources(pool).await?;
+                }
                 return Ok(());
             }
             Ok(None) => {}
@@ -2656,6 +2681,7 @@ async fn seed_default_pricing_catalog_with_legacy_path(
 
     save_pricing_catalog(pool, &default_pricing_catalog()).await?;
     ensure_pricing_models_present(pool).await?;
+    normalize_default_pricing_sources(pool).await?;
     Ok(())
 }
 
@@ -16362,6 +16388,52 @@ mod tests {
             .expect("load pricing catalog should succeed");
         assert!(catalog.models.contains_key("gpt-5.4"));
         assert!(catalog.models.contains_key("gpt-5.4-pro"));
+    }
+
+    #[tokio::test]
+    async fn seed_default_pricing_catalog_normalizes_gpt_5_3_codex_source_for_legacy_default_version()
+     {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        save_pricing_catalog(&pool, &default_pricing_catalog())
+            .await
+            .expect("seed default pricing catalog");
+
+        sqlx::query(
+            r#"
+            UPDATE pricing_settings_meta
+            SET catalog_version = ?1
+            WHERE id = ?2
+            "#,
+        )
+        .bind(LEGACY_DEFAULT_PRICING_CATALOG_VERSION)
+        .bind(PRICING_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("downgrade catalog version for test");
+
+        sqlx::query(
+            r#"
+            UPDATE pricing_settings_models
+            SET source = 'temporary'
+            WHERE model = 'gpt-5.3-codex'
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("force legacy gpt-5.3-codex source");
+
+        let catalog = load_pricing_catalog(&pool)
+            .await
+            .expect("load pricing catalog");
+        let pricing = catalog
+            .models
+            .get("gpt-5.3-codex")
+            .expect("gpt-5.3-codex pricing present");
+        assert_eq!(pricing.source, "official");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15489,6 +15489,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ensure_schema_marks_proxy_preset_models_migrated_when_enabled_list_empty() {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        sqlx::query(
+            r#"
+            UPDATE proxy_model_settings
+            SET enabled_preset_models_json = ?1,
+                preset_models_migrated = 0
+            WHERE id = ?2
+            "#,
+        )
+        .bind("[]")
+        .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("force empty enabled preset models list");
+
+        ensure_schema(&pool).await.expect("ensure schema rerun");
+
+        let settings = load_proxy_model_settings(&pool)
+            .await
+            .expect("load proxy model settings");
+        assert!(
+            settings.enabled_preset_models.is_empty(),
+            "empty enabled list should be preserved"
+        );
+
+        let migrated = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT preset_models_migrated
+            FROM proxy_model_settings
+            WHERE id = ?1
+            LIMIT 1
+            "#,
+        )
+        .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+        .fetch_one(&pool)
+        .await
+        .expect("read migration flag");
+        assert_eq!(migrated, 1);
+    }
+
+    #[tokio::test]
     async fn proxy_model_settings_api_rejects_cross_origin_writes() {
         let state = test_state_with_openai_base(
             Url::parse("https://api.example.com/").expect("valid upstream base url"),
@@ -18022,6 +18068,40 @@ mod tests {
     }
 
     #[test]
+    fn estimate_proxy_cost_applies_gpt_5_4_long_context_surcharge_to_reasoning_cost() {
+        let catalog = PricingCatalog {
+            version: "unit-test".to_string(),
+            models: HashMap::from([(
+                "gpt-5.4".to_string(),
+                ModelPricing {
+                    input_per_1m: 2.5,
+                    output_per_1m: 15.0,
+                    cache_input_per_1m: Some(0.25),
+                    reasoning_per_1m: Some(20.0),
+                    source: "custom".to_string(),
+                },
+            )]),
+        };
+        let usage = ParsedUsage {
+            input_tokens: Some(GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS + 1),
+            output_tokens: Some(1_000),
+            cache_input_tokens: Some(1_000),
+            reasoning_tokens: Some(2_000),
+            total_tokens: None,
+        };
+
+        let (cost, estimated, _) = estimate_proxy_cost(&catalog, Some("gpt-5.4"), &usage);
+
+        let input_part = ((271_001.0 * 2.5) + (1_000.0 * 0.25)) / 1_000_000.0;
+        let output_part = (1_000.0 * 15.0) / 1_000_000.0;
+        let reasoning_part = (2_000.0 * 20.0) / 1_000_000.0;
+        let expected = (input_part * 2.0) + (output_part * 1.5) + (reasoning_part * 1.5);
+        let computed = cost.expect("cost should be present");
+        assert!((computed - expected).abs() < 1e-12);
+        assert!(estimated);
+    }
+
+    #[test]
     fn estimate_proxy_cost_applies_gpt_5_4_pro_long_context_surcharge_above_threshold() {
         let catalog = PricingCatalog {
             version: "unit-test".to_string(),
@@ -18049,6 +18129,41 @@ mod tests {
         let input_part = (272_001.0 * 30.0) / 1_000_000.0;
         let output_part = (1_000.0 * 180.0) / 1_000_000.0;
         let expected = (input_part * 2.0) + (output_part * 1.5);
+        let computed = cost.expect("cost should be present");
+        assert!((computed - expected).abs() < 1e-12);
+        assert!(estimated);
+    }
+
+    #[test]
+    fn estimate_proxy_cost_applies_gpt_5_4_pro_long_context_surcharge_for_dated_model_suffix() {
+        let catalog = PricingCatalog {
+            version: "unit-test".to_string(),
+            models: HashMap::from([(
+                "gpt-5.4-pro".to_string(),
+                ModelPricing {
+                    input_per_1m: 30.0,
+                    output_per_1m: 180.0,
+                    cache_input_per_1m: None,
+                    reasoning_per_1m: Some(90.0),
+                    source: "custom".to_string(),
+                },
+            )]),
+        };
+        let usage = ParsedUsage {
+            input_tokens: Some(GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS + 1),
+            output_tokens: Some(1_000),
+            cache_input_tokens: Some(999_999),
+            reasoning_tokens: Some(2_000),
+            total_tokens: None,
+        };
+
+        let (cost, estimated, _) =
+            estimate_proxy_cost(&catalog, Some("gpt-5.4-pro-2026-03-01"), &usage);
+
+        let input_part = (272_001.0 * 30.0) / 1_000_000.0;
+        let output_part = (1_000.0 * 180.0) / 1_000_000.0;
+        let reasoning_part = (2_000.0 * 90.0) / 1_000_000.0;
+        let expected = (input_part * 2.0) + (output_part * 1.5) + (reasoning_part * 1.5);
         let computed = cost.expect("cost should be present");
         assert!((computed - expected).abs() < 1e-12);
         assert!(estimated);

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,16 +145,27 @@ const FORWARD_PROXY_FAILURE_UPSTREAM_HTTP_5XX: &str = "upstream_http_5xx";
 const DEFAULT_XRAY_BINARY: &str = "xray";
 const DEFAULT_XRAY_RUNTIME_DIR: &str = ".codex/xray-forward";
 const XRAY_PROXY_READY_TIMEOUT_MS: u64 = 3_000;
-const DEFAULT_PRICING_CATALOG_VERSION: &str = "openai-standard-2026-02-23";
+const DEFAULT_PRICING_CATALOG_VERSION: &str = "openai-standard-2026-03-06";
+const LEGACY_DEFAULT_PRICING_CATALOG_VERSION: &str = "openai-standard-2026-02-23";
 const DEFAULT_PROXY_ENFORCE_STREAM_INCLUDE_USAGE: bool = true;
 const DEFAULT_XY_LEGACY_POLL_ENABLED: bool = false;
 const DEFAULT_PROXY_MODELS_HIJACK_ENABLED: bool = false;
 const DEFAULT_PROXY_MODELS_MERGE_UPSTREAM_ENABLED: bool = false;
 const DEFAULT_PROXY_USAGE_BACKFILL_ON_STARTUP: bool = true;
+const GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS: i64 = 272_000;
 const ENV_CORS_ALLOWED_ORIGINS: &str = "XY_CORS_ALLOWED_ORIGINS";
 const PROMPT_CACHE_CONVERSATION_DEFAULT_LIMIT: i64 = 50;
 const PROMPT_CACHE_CONVERSATION_CACHE_TTL_SECS: u64 = 5;
 const PROXY_PRESET_MODEL_IDS: &[&str] = &[
+    "gpt-5.3-codex",
+    "gpt-5.2-codex",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
+    "gpt-5.2",
+    "gpt-5.4",
+    "gpt-5.4-pro",
+];
+const LEGACY_PROXY_PRESET_MODEL_IDS: &[&str] = &[
     "gpt-5.3-codex",
     "gpt-5.2-codex",
     "gpt-5.1-codex-max",
@@ -1482,6 +1493,10 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     .await
     .context("failed to ensure default proxy_model_settings row")?;
 
+    ensure_proxy_enabled_models_contains_new_presets(pool)
+        .await
+        .context("failed to ensure proxy preset models list is up-to-date")?;
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS pricing_settings_meta (
@@ -1711,6 +1726,42 @@ async fn save_proxy_model_settings(
     .context("failed to persist proxy_model_settings row")?;
 
     Ok(())
+}
+
+async fn ensure_proxy_enabled_models_contains_new_presets(pool: &Pool<Sqlite>) -> Result<()> {
+    let mut settings = load_proxy_model_settings(pool).await?;
+
+    if settings.enabled_preset_models.is_empty() {
+        return Ok(());
+    }
+
+    let legacy_default = LEGACY_PROXY_PRESET_MODEL_IDS
+        .iter()
+        .map(|id| (*id).to_string())
+        .collect::<Vec<_>>();
+    if settings.enabled_preset_models != legacy_default {
+        // Respect user customizations: only auto-append when the enabled list matches
+        // the legacy default preset list exactly.
+        return Ok(());
+    }
+
+    let mut changed = false;
+    for required in ["gpt-5.4", "gpt-5.4-pro"] {
+        if !settings
+            .enabled_preset_models
+            .iter()
+            .any(|id| id == required)
+        {
+            settings.enabled_preset_models.push(required.to_string());
+            changed = true;
+        }
+    }
+
+    if !changed {
+        return Ok(());
+    }
+
+    save_proxy_model_settings(pool, settings).await
 }
 
 #[derive(Debug, FromRow)]
@@ -2403,6 +2454,65 @@ struct PricingSettingsModelRow {
     source: String,
 }
 
+async fn ensure_pricing_model_present(
+    pool: &Pool<Sqlite>,
+    model: &str,
+    pricing: ModelPricing,
+) -> Result<()> {
+    sqlx::query(
+        r#"
+        INSERT OR IGNORE INTO pricing_settings_models (
+            model,
+            input_per_1m,
+            output_per_1m,
+            cache_input_per_1m,
+            reasoning_per_1m,
+            source
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "#,
+    )
+    .bind(model)
+    .bind(pricing.input_per_1m)
+    .bind(pricing.output_per_1m)
+    .bind(pricing.cache_input_per_1m)
+    .bind(pricing.reasoning_per_1m)
+    .bind(pricing.source)
+    .execute(pool)
+    .await
+    .with_context(|| format!("failed to ensure pricing model exists: {model}"))?;
+
+    Ok(())
+}
+
+async fn ensure_pricing_models_present(pool: &Pool<Sqlite>) -> Result<()> {
+    ensure_pricing_model_present(
+        pool,
+        "gpt-5.4",
+        ModelPricing {
+            input_per_1m: 2.5,
+            output_per_1m: 15.0,
+            cache_input_per_1m: Some(0.25),
+            reasoning_per_1m: None,
+            source: "official".to_string(),
+        },
+    )
+    .await?;
+    ensure_pricing_model_present(
+        pool,
+        "gpt-5.4-pro",
+        ModelPricing {
+            input_per_1m: 30.0,
+            output_per_1m: 180.0,
+            cache_input_per_1m: None,
+            reasoning_per_1m: None,
+            source: "official".to_string(),
+        },
+    )
+    .await?;
+    Ok(())
+}
+
 async fn seed_default_pricing_catalog(pool: &Pool<Sqlite>) -> Result<()> {
     let legacy_path = resolve_legacy_pricing_catalog_path();
     seed_default_pricing_catalog_with_legacy_path(pool, Some(&legacy_path)).await
@@ -2424,6 +2534,23 @@ async fn seed_default_pricing_catalog_with_legacy_path(
     .await
     .context("failed to count pricing_settings_meta rows")?;
     if meta_exists > 0 {
+        let version = sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT catalog_version
+            FROM pricing_settings_meta
+            WHERE id = ?1
+            LIMIT 1
+            "#,
+        )
+        .bind(PRICING_SETTINGS_SINGLETON_ID)
+        .fetch_one(pool)
+        .await
+        .context("failed to load pricing_settings_meta row")?;
+        if version == DEFAULT_PRICING_CATALOG_VERSION
+            || version == LEGACY_DEFAULT_PRICING_CATALOG_VERSION
+        {
+            ensure_pricing_models_present(pool).await?;
+        }
         return Ok(());
     }
 
@@ -2449,6 +2576,7 @@ async fn seed_default_pricing_catalog_with_legacy_path(
         .execute(pool)
         .await
         .context("failed to ensure default pricing_settings_meta row")?;
+        ensure_pricing_models_present(pool).await?;
         return Ok(());
     }
 
@@ -2475,7 +2603,9 @@ async fn seed_default_pricing_catalog_with_legacy_path(
         }
     }
 
-    save_pricing_catalog(pool, &default_pricing_catalog()).await
+    save_pricing_catalog(pool, &default_pricing_catalog()).await?;
+    ensure_pricing_models_present(pool).await?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2663,7 +2793,7 @@ fn default_pricing_catalog() -> PricingCatalog {
                 output_per_1m: 14.0,
                 cache_input_per_1m: Some(0.175),
                 reasoning_per_1m: None,
-                source: "temporary".to_string(),
+                source: "official".to_string(),
             },
         ),
         (
@@ -2702,6 +2832,16 @@ fn default_pricing_catalog() -> PricingCatalog {
                 input_per_1m: 1.75,
                 output_per_1m: 14.0,
                 cache_input_per_1m: Some(0.175),
+                reasoning_per_1m: None,
+                source: "official".to_string(),
+            },
+        ),
+        (
+            "gpt-5.4",
+            ModelPricing {
+                input_per_1m: 2.5,
+                output_per_1m: 15.0,
+                cache_input_per_1m: Some(0.25),
                 reasoning_per_1m: None,
                 source: "official".to_string(),
             },
@@ -2791,6 +2931,16 @@ fn default_pricing_catalog() -> PricingCatalog {
             ModelPricing {
                 input_per_1m: 21.0,
                 output_per_1m: 168.0,
+                cache_input_per_1m: None,
+                reasoning_per_1m: None,
+                source: "official".to_string(),
+            },
+        ),
+        (
+            "gpt-5.4-pro",
+            ModelPricing {
+                input_per_1m: 30.0,
+                output_per_1m: 180.0,
                 cache_input_per_1m: None,
                 reasoning_per_1m: None,
                 source: "official".to_string(),
@@ -6313,6 +6463,9 @@ fn estimate_proxy_cost(
         return (None, false, price_version);
     }
 
+    let apply_long_context_surcharge =
+        model.starts_with("gpt-5.4") && input_tokens > GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS;
+
     let billable_cache_tokens = if pricing.cache_input_per_1m.is_some() {
         cache_input_tokens
     } else {
@@ -6320,14 +6473,28 @@ fn estimate_proxy_cost(
     };
     let non_cached_input_tokens = input_tokens.saturating_sub(billable_cache_tokens);
 
-    let mut cost = (non_cached_input_tokens as f64 / 1_000_000.0) * pricing.input_per_1m
-        + (output_tokens / 1_000_000.0) * pricing.output_per_1m;
-    if let Some(cache_price) = pricing.cache_input_per_1m {
-        cost += (billable_cache_tokens as f64 / 1_000_000.0) * cache_price;
+    let non_cached_input_cost =
+        (non_cached_input_tokens as f64 / 1_000_000.0) * pricing.input_per_1m;
+    let cache_input_cost = pricing
+        .cache_input_per_1m
+        .map(|cache_price| (billable_cache_tokens as f64 / 1_000_000.0) * cache_price)
+        .unwrap_or(0.0);
+    let mut input_cost = non_cached_input_cost + cache_input_cost;
+
+    let mut output_cost = (output_tokens / 1_000_000.0) * pricing.output_per_1m;
+
+    let mut reasoning_cost = pricing
+        .reasoning_per_1m
+        .map(|reasoning_price| (reasoning_tokens / 1_000_000.0) * reasoning_price)
+        .unwrap_or(0.0);
+
+    if apply_long_context_surcharge {
+        input_cost *= 2.0;
+        output_cost *= 1.5;
+        reasoning_cost *= 1.5;
     }
-    if let Some(reasoning_price) = pricing.reasoning_per_1m {
-        cost += (reasoning_tokens / 1_000_000.0) * reasoning_price;
-    }
+
+    let cost = input_cost + output_cost + reasoning_cost;
 
     (Some(cost), true, price_version)
 }
@@ -15120,6 +15287,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ensure_schema_appends_new_proxy_models_when_enabled_list_matches_legacy_default() {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        let legacy_enabled = LEGACY_PROXY_PRESET_MODEL_IDS
+            .iter()
+            .map(|id| (*id).to_string())
+            .collect::<Vec<_>>();
+        let legacy_enabled_json =
+            serde_json::to_string(&legacy_enabled).expect("serialize legacy enabled list");
+
+        sqlx::query(
+            r#"
+            UPDATE proxy_model_settings
+            SET enabled_preset_models_json = ?1
+            WHERE id = ?2
+            "#,
+        )
+        .bind(legacy_enabled_json)
+        .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("force legacy enabled preset models");
+
+        ensure_schema(&pool).await.expect("ensure schema rerun");
+
+        let settings = load_proxy_model_settings(&pool)
+            .await
+            .expect("load proxy model settings");
+        assert!(
+            settings
+                .enabled_preset_models
+                .contains(&"gpt-5.4".to_string())
+        );
+        assert!(
+            settings
+                .enabled_preset_models
+                .contains(&"gpt-5.4-pro".to_string())
+        );
+    }
+
+    #[tokio::test]
     async fn proxy_model_settings_api_rejects_cross_origin_writes() {
         let state = test_state_with_openai_base(
             Url::parse("https://api.example.com/").expect("valid upstream base url"),
@@ -15911,6 +16122,42 @@ mod tests {
             seeded.models.contains_key("gpt-5.2-codex"),
             "default pricing catalog should be seeded"
         );
+    }
+
+    #[tokio::test]
+    async fn seed_default_pricing_catalog_auto_inserts_new_models_for_legacy_default_version() {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        sqlx::query(
+            r#"
+            UPDATE pricing_settings_meta
+            SET catalog_version = ?1
+            WHERE id = ?2
+            "#,
+        )
+        .bind(LEGACY_DEFAULT_PRICING_CATALOG_VERSION)
+        .bind(PRICING_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("downgrade pricing catalog version for test");
+        sqlx::query(
+            r#"
+            DELETE FROM pricing_settings_models
+            WHERE model IN ('gpt-5.4', 'gpt-5.4-pro')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("delete new pricing models for test");
+
+        let catalog = load_pricing_catalog(&pool)
+            .await
+            .expect("load pricing catalog should succeed");
+        assert!(catalog.models.contains_key("gpt-5.4"));
+        assert!(catalog.models.contains_key("gpt-5.4-pro"));
     }
 
     #[tokio::test]
@@ -17403,6 +17650,70 @@ mod tests {
 
         let expected = ((1000.0 * 4.0) + (1000.0 * 5.0)) / 1_000_000.0;
         assert!((cost.expect("cost should be present") - expected).abs() < 1e-12);
+        assert!(estimated);
+    }
+
+    #[test]
+    fn estimate_proxy_cost_does_not_apply_gpt_5_4_long_context_surcharge_at_threshold() {
+        let catalog = PricingCatalog {
+            version: "unit-test".to_string(),
+            models: HashMap::from([(
+                "gpt-5.4".to_string(),
+                ModelPricing {
+                    input_per_1m: 2.5,
+                    output_per_1m: 15.0,
+                    cache_input_per_1m: Some(0.25),
+                    reasoning_per_1m: None,
+                    source: "custom".to_string(),
+                },
+            )]),
+        };
+        let usage = ParsedUsage {
+            input_tokens: Some(GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS),
+            output_tokens: Some(1_000),
+            cache_input_tokens: Some(1_000),
+            reasoning_tokens: None,
+            total_tokens: None,
+        };
+
+        let (cost, estimated, _) = estimate_proxy_cost(&catalog, Some("gpt-5.4"), &usage);
+
+        let expected = ((271_000.0 * 2.5) + (1_000.0 * 0.25) + (1_000.0 * 15.0)) / 1_000_000.0;
+        let computed = cost.expect("cost should be present");
+        assert!((computed - expected).abs() < 1e-12);
+        assert!(estimated);
+    }
+
+    #[test]
+    fn estimate_proxy_cost_applies_gpt_5_4_long_context_surcharge_above_threshold() {
+        let catalog = PricingCatalog {
+            version: "unit-test".to_string(),
+            models: HashMap::from([(
+                "gpt-5.4".to_string(),
+                ModelPricing {
+                    input_per_1m: 2.5,
+                    output_per_1m: 15.0,
+                    cache_input_per_1m: Some(0.25),
+                    reasoning_per_1m: None,
+                    source: "custom".to_string(),
+                },
+            )]),
+        };
+        let usage = ParsedUsage {
+            input_tokens: Some(GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS + 1),
+            output_tokens: Some(1_000),
+            cache_input_tokens: Some(1_000),
+            reasoning_tokens: None,
+            total_tokens: None,
+        };
+
+        let (cost, estimated, _) = estimate_proxy_cost(&catalog, Some("gpt-5.4"), &usage);
+
+        let input_part = ((271_001.0 * 2.5) + (1_000.0 * 0.25)) / 1_000_000.0;
+        let output_part = (1_000.0 * 15.0) / 1_000_000.0;
+        let expected = (input_part * 2.0) + (output_part * 1.5);
+        let computed = cost.expect("cost should be present");
+        assert!((computed - expected).abs() < 1e-12);
         assert!(estimated);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16229,6 +16229,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn seed_default_pricing_catalog_does_not_override_existing_pricing_for_new_models() {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        // Simulate a legacy default catalog version so startup seeding will call
+        // ensure_pricing_models_present, which must not overwrite existing rows.
+        sqlx::query(
+            r#"
+            UPDATE pricing_settings_meta
+            SET catalog_version = ?1
+            WHERE id = ?2
+            "#,
+        )
+        .bind(LEGACY_DEFAULT_PRICING_CATALOG_VERSION)
+        .bind(PRICING_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("set legacy pricing catalog version for test");
+
+        sqlx::query(
+            r#"
+            UPDATE pricing_settings_models
+            SET input_per_1m = ?1,
+                output_per_1m = ?2,
+                cache_input_per_1m = ?3,
+                source = 'custom'
+            WHERE model = 'gpt-5.4'
+            "#,
+        )
+        .bind(99.0)
+        .bind(199.0)
+        .bind(Some(9.9))
+        .execute(&pool)
+        .await
+        .expect("override gpt-5.4 pricing for test");
+
+        sqlx::query(
+            r#"
+            UPDATE pricing_settings_models
+            SET input_per_1m = ?1,
+                output_per_1m = ?2,
+                source = 'custom'
+            WHERE model = 'gpt-5.4-pro'
+            "#,
+        )
+        .bind(88.0)
+        .bind(188.0)
+        .execute(&pool)
+        .await
+        .expect("override gpt-5.4-pro pricing for test");
+
+        let catalog = load_pricing_catalog(&pool)
+            .await
+            .expect("load pricing catalog should succeed");
+        let gpt_5_4 = catalog.models.get("gpt-5.4").expect("gpt-5.4 should exist");
+        assert_eq!(gpt_5_4.input_per_1m, 99.0);
+        assert_eq!(gpt_5_4.output_per_1m, 199.0);
+        assert_eq!(gpt_5_4.cache_input_per_1m, Some(9.9));
+        assert_eq!(gpt_5_4.source, "custom");
+
+        let gpt_5_4_pro = catalog
+            .models
+            .get("gpt-5.4-pro")
+            .expect("gpt-5.4-pro should exist");
+        assert_eq!(gpt_5_4_pro.input_per_1m, 88.0);
+        assert_eq!(gpt_5_4_pro.output_per_1m, 188.0);
+        assert_eq!(gpt_5_4_pro.cache_input_per_1m, None);
+        assert_eq!(gpt_5_4_pro.source, "custom");
+    }
+
+    #[tokio::test]
     async fn proxy_openai_v1_models_passthrough_when_hijack_disabled() {
         let (upstream_base, upstream_handle) = spawn_test_upstream().await;
         let state = test_state_with_openai_base(
@@ -16300,6 +16373,42 @@ mod tests {
             ids,
             vec!["gpt-5.3-codex".to_string(), "gpt-5.2".to_string()]
         );
+
+        upstream_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_openai_v1_models_returns_gpt_5_4_models_when_enabled() {
+        let (upstream_base, upstream_handle) = spawn_test_upstream().await;
+        let state = test_state_with_openai_base(
+            Url::parse(&upstream_base).expect("valid upstream base url"),
+        )
+        .await;
+        {
+            let mut settings = state.proxy_model_settings.write().await;
+            *settings = ProxyModelSettings {
+                hijack_enabled: true,
+                merge_upstream_enabled: false,
+                enabled_preset_models: vec!["gpt-5.4".to_string(), "gpt-5.4-pro".to_string()],
+            };
+        }
+
+        let response = proxy_openai_v1(
+            State(state),
+            OriginalUri("/v1/models".parse().expect("valid uri")),
+            Method::GET,
+            HeaderMap::new(),
+            Body::empty(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let payload: Value = serde_json::from_slice(&body).expect("decode hijacked payload");
+        let ids = extract_model_ids(&payload);
+        assert_eq!(ids, vec!["gpt-5.4".to_string(), "gpt-5.4-pro".to_string()]);
 
         upstream_handle.abort();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15331,6 +15331,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ensure_schema_does_not_append_new_proxy_models_when_enabled_list_is_custom() {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        let custom_enabled = vec!["gpt-5.2-codex".to_string()];
+        let custom_enabled_json =
+            serde_json::to_string(&custom_enabled).expect("serialize custom enabled list");
+        sqlx::query(
+            r#"
+            UPDATE proxy_model_settings
+            SET enabled_preset_models_json = ?1
+            WHERE id = ?2
+            "#,
+        )
+        .bind(custom_enabled_json)
+        .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("force custom enabled preset models");
+
+        ensure_schema(&pool).await.expect("ensure schema rerun");
+
+        let settings = load_proxy_model_settings(&pool)
+            .await
+            .expect("load proxy model settings");
+        assert_eq!(settings.enabled_preset_models, custom_enabled);
+    }
+
+    #[tokio::test]
     async fn proxy_model_settings_api_rejects_cross_origin_writes() {
         let state = test_state_with_openai_base(
             Url::parse("https://api.example.com/").expect("valid upstream base url"),
@@ -16158,6 +16189,43 @@ mod tests {
             .expect("load pricing catalog should succeed");
         assert!(catalog.models.contains_key("gpt-5.4"));
         assert!(catalog.models.contains_key("gpt-5.4-pro"));
+    }
+
+    #[tokio::test]
+    async fn seed_default_pricing_catalog_does_not_auto_insert_new_models_for_custom_catalog_version()
+     {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        sqlx::query(
+            r#"
+            UPDATE pricing_settings_meta
+            SET catalog_version = ?1
+            WHERE id = ?2
+            "#,
+        )
+        .bind("custom-ci")
+        .bind(PRICING_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("set custom pricing catalog version for test");
+        sqlx::query(
+            r#"
+            DELETE FROM pricing_settings_models
+            WHERE model IN ('gpt-5.4', 'gpt-5.4-pro')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("delete new pricing models for test");
+
+        let catalog = load_pricing_catalog(&pool)
+            .await
+            .expect("load pricing catalog should succeed");
+        assert!(!catalog.models.contains_key("gpt-5.4"));
+        assert!(!catalog.models.contains_key("gpt-5.4-pro"));
     }
 
     #[tokio::test]
@@ -17711,6 +17779,39 @@ mod tests {
 
         let input_part = ((271_001.0 * 2.5) + (1_000.0 * 0.25)) / 1_000_000.0;
         let output_part = (1_000.0 * 15.0) / 1_000_000.0;
+        let expected = (input_part * 2.0) + (output_part * 1.5);
+        let computed = cost.expect("cost should be present");
+        assert!((computed - expected).abs() < 1e-12);
+        assert!(estimated);
+    }
+
+    #[test]
+    fn estimate_proxy_cost_applies_gpt_5_4_pro_long_context_surcharge_above_threshold() {
+        let catalog = PricingCatalog {
+            version: "unit-test".to_string(),
+            models: HashMap::from([(
+                "gpt-5.4-pro".to_string(),
+                ModelPricing {
+                    input_per_1m: 30.0,
+                    output_per_1m: 180.0,
+                    cache_input_per_1m: None,
+                    reasoning_per_1m: None,
+                    source: "custom".to_string(),
+                },
+            )]),
+        };
+        let usage = ParsedUsage {
+            input_tokens: Some(GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS + 1),
+            output_tokens: Some(1_000),
+            cache_input_tokens: Some(999_999),
+            reasoning_tokens: None,
+            total_tokens: None,
+        };
+
+        let (cost, estimated, _) = estimate_proxy_cost(&catalog, Some("gpt-5.4-pro"), &usage);
+
+        let input_part = (272_001.0 * 30.0) / 1_000_000.0;
+        let output_part = (1_000.0 * 180.0) / 1_000_000.0;
         let expected = (input_part * 2.0) + (output_part * 1.5);
         let computed = cost.expect("cost should be present");
         assert!((computed - expected).abs() < 1e-12);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1450,6 +1450,7 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
             hijack_enabled INTEGER NOT NULL DEFAULT 0,
             merge_upstream_enabled INTEGER NOT NULL DEFAULT 0,
             enabled_preset_models_json TEXT,
+            preset_models_migrated INTEGER NOT NULL DEFAULT 0,
             updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         )
         "#,
@@ -1469,6 +1470,19 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         && !err.to_string().contains("duplicate column name")
     {
         return Err(err).context("failed to ensure enabled_preset_models_json column");
+    }
+
+    if let Err(err) = sqlx::query(
+        r#"
+        ALTER TABLE proxy_model_settings
+        ADD COLUMN preset_models_migrated INTEGER NOT NULL DEFAULT 0
+        "#,
+    )
+    .execute(pool)
+    .await
+        && !err.to_string().contains("duplicate column name")
+    {
+        return Err(err).context("failed to ensure preset_models_migrated column");
     }
 
     let default_enabled_models_json = serde_json::to_string(&default_enabled_preset_models())
@@ -1729,9 +1743,27 @@ async fn save_proxy_model_settings(
 }
 
 async fn ensure_proxy_enabled_models_contains_new_presets(pool: &Pool<Sqlite>) -> Result<()> {
+    let migrated = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT preset_models_migrated
+        FROM proxy_model_settings
+        WHERE id = ?1
+        LIMIT 1
+        "#,
+    )
+    .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+    .fetch_optional(pool)
+    .await
+    .context("failed to check proxy preset models migration flag")?
+    .unwrap_or(0);
+    if migrated != 0 {
+        return Ok(());
+    }
+
     let mut settings = load_proxy_model_settings(pool).await?;
 
     if settings.enabled_preset_models.is_empty() {
+        mark_proxy_preset_models_migrated(pool).await?;
         return Ok(());
     }
 
@@ -1742,6 +1774,7 @@ async fn ensure_proxy_enabled_models_contains_new_presets(pool: &Pool<Sqlite>) -
     if settings.enabled_preset_models != legacy_default {
         // Respect user customizations: only auto-append when the enabled list matches
         // the legacy default preset list exactly.
+        mark_proxy_preset_models_migrated(pool).await?;
         return Ok(());
     }
 
@@ -1758,10 +1791,28 @@ async fn ensure_proxy_enabled_models_contains_new_presets(pool: &Pool<Sqlite>) -
     }
 
     if !changed {
+        mark_proxy_preset_models_migrated(pool).await?;
         return Ok(());
     }
 
-    save_proxy_model_settings(pool, settings).await
+    save_proxy_model_settings(pool, settings).await?;
+    mark_proxy_preset_models_migrated(pool).await
+}
+
+async fn mark_proxy_preset_models_migrated(pool: &Pool<Sqlite>) -> Result<()> {
+    sqlx::query(
+        r#"
+        UPDATE proxy_model_settings
+        SET preset_models_migrated = 1,
+            updated_at = datetime('now')
+        WHERE id = ?1
+        "#,
+    )
+    .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+    .execute(pool)
+    .await
+    .context("failed to mark proxy preset models as migrated")?;
+    Ok(())
 }
 
 #[derive(Debug, FromRow)]
@@ -6401,6 +6452,11 @@ fn dated_model_alias_base(model: &str) -> Option<&str> {
     if base.is_empty() { None } else { Some(base) }
 }
 
+fn is_gpt_5_4_long_context_surcharge_model(model: &str) -> bool {
+    let base = dated_model_alias_base(model).unwrap_or(model);
+    matches!(base, "gpt-5.4" | "gpt-5.4-pro")
+}
+
 fn pricing_backfill_attempt_version(catalog: &PricingCatalog) -> String {
     fn mix_fvn1a(hash: &mut u64, bytes: &[u8]) {
         for byte in bytes {
@@ -6463,8 +6519,8 @@ fn estimate_proxy_cost(
         return (None, false, price_version);
     }
 
-    let apply_long_context_surcharge =
-        model.starts_with("gpt-5.4") && input_tokens > GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS;
+    let apply_long_context_surcharge = is_gpt_5_4_long_context_surcharge_model(model)
+        && input_tokens > GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS;
 
     let billable_cache_tokens = if pricing.cache_input_per_1m.is_some() {
         cache_input_tokens
@@ -15303,7 +15359,8 @@ mod tests {
         sqlx::query(
             r#"
             UPDATE proxy_model_settings
-            SET enabled_preset_models_json = ?1
+            SET enabled_preset_models_json = ?1,
+                preset_models_migrated = 0
             WHERE id = ?2
             "#,
         )
@@ -15343,7 +15400,8 @@ mod tests {
         sqlx::query(
             r#"
             UPDATE proxy_model_settings
-            SET enabled_preset_models_json = ?1
+            SET enabled_preset_models_json = ?1,
+                preset_models_migrated = 0
             WHERE id = ?2
             "#,
         )
@@ -15359,6 +15417,75 @@ mod tests {
             .await
             .expect("load proxy model settings");
         assert_eq!(settings.enabled_preset_models, custom_enabled);
+    }
+
+    #[tokio::test]
+    async fn ensure_schema_allows_opting_out_of_new_proxy_models_after_migration() {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory sqlite");
+        ensure_schema(&pool).await.expect("ensure schema");
+
+        let legacy_enabled = LEGACY_PROXY_PRESET_MODEL_IDS
+            .iter()
+            .map(|id| (*id).to_string())
+            .collect::<Vec<_>>();
+        let legacy_enabled_json =
+            serde_json::to_string(&legacy_enabled).expect("serialize legacy enabled list");
+
+        sqlx::query(
+            r#"
+            UPDATE proxy_model_settings
+            SET enabled_preset_models_json = ?1,
+                preset_models_migrated = 0
+            WHERE id = ?2
+            "#,
+        )
+        .bind(&legacy_enabled_json)
+        .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("force legacy enabled preset models");
+
+        ensure_schema(&pool)
+            .await
+            .expect("ensure schema migration run");
+        let migrated = load_proxy_model_settings(&pool)
+            .await
+            .expect("load proxy model settings after migration");
+        assert!(
+            migrated
+                .enabled_preset_models
+                .contains(&"gpt-5.4".to_string())
+        );
+        assert!(
+            migrated
+                .enabled_preset_models
+                .contains(&"gpt-5.4-pro".to_string())
+        );
+
+        // User explicitly removes the new models after migration; schema re-run should not
+        // force them back in.
+        sqlx::query(
+            r#"
+            UPDATE proxy_model_settings
+            SET enabled_preset_models_json = ?1,
+                preset_models_migrated = 1
+            WHERE id = ?2
+            "#,
+        )
+        .bind(&legacy_enabled_json)
+        .bind(PROXY_MODEL_SETTINGS_SINGLETON_ID)
+        .execute(&pool)
+        .await
+        .expect("force legacy enabled preset models after migration");
+
+        ensure_schema(&pool).await.expect("ensure schema rerun");
+
+        let settings = load_proxy_model_settings(&pool)
+            .await
+            .expect("load proxy model settings after opt-out");
+        assert_eq!(settings.enabled_preset_models, legacy_enabled);
     }
 
     #[tokio::test]
@@ -17922,6 +18049,71 @@ mod tests {
         let input_part = (272_001.0 * 30.0) / 1_000_000.0;
         let output_part = (1_000.0 * 180.0) / 1_000_000.0;
         let expected = (input_part * 2.0) + (output_part * 1.5);
+        let computed = cost.expect("cost should be present");
+        assert!((computed - expected).abs() < 1e-12);
+        assert!(estimated);
+    }
+
+    #[test]
+    fn estimate_proxy_cost_applies_gpt_5_4_long_context_surcharge_for_dated_model_suffix() {
+        let catalog = PricingCatalog {
+            version: "unit-test".to_string(),
+            models: HashMap::from([(
+                "gpt-5.4".to_string(),
+                ModelPricing {
+                    input_per_1m: 2.5,
+                    output_per_1m: 15.0,
+                    cache_input_per_1m: Some(0.25),
+                    reasoning_per_1m: None,
+                    source: "custom".to_string(),
+                },
+            )]),
+        };
+        let usage = ParsedUsage {
+            input_tokens: Some(GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS + 1),
+            output_tokens: Some(1_000),
+            cache_input_tokens: Some(1_000),
+            reasoning_tokens: None,
+            total_tokens: None,
+        };
+
+        let (cost, estimated, _) =
+            estimate_proxy_cost(&catalog, Some("gpt-5.4-2026-03-01"), &usage);
+
+        let input_part = ((271_001.0 * 2.5) + (1_000.0 * 0.25)) / 1_000_000.0;
+        let output_part = (1_000.0 * 15.0) / 1_000_000.0;
+        let expected = (input_part * 2.0) + (output_part * 1.5);
+        let computed = cost.expect("cost should be present");
+        assert!((computed - expected).abs() < 1e-12);
+        assert!(estimated);
+    }
+
+    #[test]
+    fn estimate_proxy_cost_does_not_apply_gpt_5_4_long_context_surcharge_for_other_models() {
+        let catalog = PricingCatalog {
+            version: "unit-test".to_string(),
+            models: HashMap::from([(
+                "gpt-5.4o".to_string(),
+                ModelPricing {
+                    input_per_1m: 2.5,
+                    output_per_1m: 15.0,
+                    cache_input_per_1m: None,
+                    reasoning_per_1m: None,
+                    source: "custom".to_string(),
+                },
+            )]),
+        };
+        let usage = ParsedUsage {
+            input_tokens: Some(GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS + 1),
+            output_tokens: Some(1_000),
+            cache_input_tokens: None,
+            reasoning_tokens: None,
+            total_tokens: None,
+        };
+
+        let (cost, estimated, _) = estimate_proxy_cost(&catalog, Some("gpt-5.4o"), &usage);
+
+        let expected = ((272_001.0 * 2.5) + (1_000.0 * 15.0)) / 1_000_000.0;
         let computed = cost.expect("cost should be present");
         assert!((computed - expected).abs() < 1e-12);
         assert!(estimated);


### PR DESCRIPTION
## What
- Add `gpt-5.4` / `gpt-5.4-pro` to proxy preset model ids for downstream `/v1/models` hijack.
- Seed built-in pricing for the two models (USD / 1M tokens) and refresh the default catalog version.
- Apply long-context surcharge for `gpt-5.4*` when `input_tokens > 272_000` (input x2, output x1.5; reasoning x1.5).
- Backfill SQLite on startup: insert missing pricing rows via `INSERT OR IGNORE`, and append new preset ids only when the enabled list matches the legacy default (do not overwrite user customizations).

## Verification
- `cargo test`

## Notes
- Seeding logic is intentionally conservative: existing model rows are never overwritten; custom catalog versions are respected.