### PR TITLE
fix(dashboard): optimize sse refresh pipeline

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,33 +6,34 @@
 
 ## Index
 
-| ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                |
-| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
-| 7272y | 内置 GPT-5.4 系列计费规则与下游模型列表                                   | 已完成（4/4）   | `7272y-gpt-5-4-pricing/SPEC.md`                          | 2026-03-06 | fast-track / PR #89  |
-| rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track / PR #88  |
-| 4kkpp | Live 对话统计（按 Prompt Cache Key）— 无统计表方案（索引 + 轻缓存）       | 已完成（5/5）   | `4kkpp-live-prompt-cache-conversations/SPEC.md`          | 2026-03-03 | fast-track           |
-| hrvtt | 请求详情补齐代理信息与本次权重变化                                        | 已完成（4/4）   | `hrvtt-invocation-proxy-weight-delta/SPEC.md`            | 2026-03-02 | fast-track           |
-| t7m4h | Live 代理运行态：新增 24h 权重趋势列与断点适配                            | 已完成（5/5）   | `t7m4h-live-proxy-weight-trend/SPEC.md`                  | 2026-03-02 | fast-track / PR #83  |
-| rkc7k | 修复 Live 实时统计闪烁与数字滚动被打断                                    | 已完成（6/6）   | `rkc7k-live-summary-flicker-fix/SPEC.md`                 | 2026-03-02 | fast-track / PR #80  |
-| c58kc | 实况页新增“代理”统计表与 24h 成败示意图                                   | 已完成（5/5）   | `c58kc-live-forward-proxy-table/SPEC.md`                 | 2026-03-02 | fast-track / PR #77  |
-| wv3m7 | Forward Proxy 新增后异步首轮探测补齐                                      | 已完成（3/3）   | `wv3m7-forward-proxy-bootstrap-probe/SPEC.md`            | 2026-03-02 | fast-track           |
-| r8m3k | InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化               | 已完成（5/5）   | `r8m3k-invocation-table-responsive-no-overflow/SPEC.md`  | 2026-03-02 | fast-track / PR #79  |
-| k52tw | Forward proxy 验证放宽：404 视为可达（proxyUrl + subscriptionUrl）        | 已完成（3/3）   | `k52tw-forward-proxy-validation-allow-404/SPEC.md`       | 2026-03-01 | fast-track / hotfix  |
-| zanzr | Release 构建加速：arm64 迁移到 GitHub-hosted ARM runner                   | 部分完成（3/4） | `zanzr-release-arm64-native-runner/SPEC.md`              | 2026-03-01 | fast-track           |
-| wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix  |
-| m96jw | 修复订阅验证路径下 xray 运行目录缺失导致添加失败                          | 已完成（3/3）   | `m96jw-subscription-validation-xray-runtime-dir/SPEC.md` | 2026-03-01 | PR #71 / fast-track  |
-| c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md`       | 2026-03-01 | fast-track           |
-| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`                     | 2026-03-01 | hotfix               |
-| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`                     | 2026-03-01 | fast-track / hotfix  |
-| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`                | 2026-03-01 | PR #66 / fast-track  |
-| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`                     | 2026-03-01 | PR #65 / fast-track  |
-| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`                   | 2026-02-28 | fast-track           |
-| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`               | 2026-02-27 | PR #61               |
-| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`                | 2026-02-27 | 补按钮交互回归断言   |
-| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`                | 2026-02-26 | PR #56 / fast-track  |
-| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`              | 2026-02-26 | PR #58               |
-| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`                      | 2026-02-25 | PR #52               |
-| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`                  | 2026-02-25 | 已完成并通过视觉确认 |
-| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`                        | 2026-02-24 | PR #50               |
-| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`                  | 2026-02-24 | PR #51               |
-| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md`             | 2026-02-25 | PR #57               |
+| ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                         |
+| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | ----------------------------- |
+| xvdhm | Dashboard SSE 更新链路优化                                                | 部分完成（5/6） | `xvdhm-dashboard-sse-refresh-optimization/SPEC.md`       | 2026-03-07 | fast-track / browser verified |
+| 7272y | 内置 GPT-5.4 系列计费规则与下游模型列表                                   | 已完成（4/4）   | `7272y-gpt-5-4-pricing/SPEC.md`                          | 2026-03-06 | fast-track / PR #89           |
+| rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track / PR #88           |
+| 4kkpp | Live 对话统计（按 Prompt Cache Key）— 无统计表方案（索引 + 轻缓存）       | 已完成（5/5）   | `4kkpp-live-prompt-cache-conversations/SPEC.md`          | 2026-03-03 | fast-track                    |
+| hrvtt | 请求详情补齐代理信息与本次权重变化                                        | 已完成（4/4）   | `hrvtt-invocation-proxy-weight-delta/SPEC.md`            | 2026-03-02 | fast-track                    |
+| t7m4h | Live 代理运行态：新增 24h 权重趋势列与断点适配                            | 已完成（5/5）   | `t7m4h-live-proxy-weight-trend/SPEC.md`                  | 2026-03-02 | fast-track / PR #83           |
+| rkc7k | 修复 Live 实时统计闪烁与数字滚动被打断                                    | 已完成（6/6）   | `rkc7k-live-summary-flicker-fix/SPEC.md`                 | 2026-03-02 | fast-track / PR #80           |
+| c58kc | 实况页新增“代理”统计表与 24h 成败示意图                                   | 已完成（5/5）   | `c58kc-live-forward-proxy-table/SPEC.md`                 | 2026-03-02 | fast-track / PR #77           |
+| wv3m7 | Forward Proxy 新增后异步首轮探测补齐                                      | 已完成（3/3）   | `wv3m7-forward-proxy-bootstrap-probe/SPEC.md`            | 2026-03-02 | fast-track                    |
+| r8m3k | InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化               | 已完成（5/5）   | `r8m3k-invocation-table-responsive-no-overflow/SPEC.md`  | 2026-03-02 | fast-track / PR #79           |
+| k52tw | Forward proxy 验证放宽：404 视为可达（proxyUrl + subscriptionUrl）        | 已完成（3/3）   | `k52tw-forward-proxy-validation-allow-404/SPEC.md`       | 2026-03-01 | fast-track / hotfix           |
+| zanzr | Release 构建加速：arm64 迁移到 GitHub-hosted ARM runner                   | 部分完成（3/4） | `zanzr-release-arm64-native-runner/SPEC.md`              | 2026-03-01 | fast-track                    |
+| wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix           |
+| m96jw | 修复订阅验证路径下 xray 运行目录缺失导致添加失败                          | 已完成（3/3）   | `m96jw-subscription-validation-xray-runtime-dir/SPEC.md` | 2026-03-01 | PR #71 / fast-track           |
+| c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md`       | 2026-03-01 | fast-track                    |
+| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`                     | 2026-03-01 | hotfix                        |
+| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`                     | 2026-03-01 | fast-track / hotfix           |
+| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`                | 2026-03-01 | PR #66 / fast-track           |
+| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`                     | 2026-03-01 | PR #65 / fast-track           |
+| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`                   | 2026-02-28 | fast-track                    |
+| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`               | 2026-02-27 | PR #61                        |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`                | 2026-02-27 | 补按钮交互回归断言            |
+| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`                | 2026-02-26 | PR #56 / fast-track           |
+| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`              | 2026-02-26 | PR #58                        |
+| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`                      | 2026-02-25 | PR #52                        |
+| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`                  | 2026-02-25 | 已完成并通过视觉确认          |
+| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`                        | 2026-02-24 | PR #50                        |
+| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`                  | 2026-02-24 | PR #51                        |
+| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md`             | 2026-02-25 | PR #57                        |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,34 +6,34 @@
 
 ## Index
 
-| ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                         |
-| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | ----------------------------- |
-| xvdhm | Dashboard SSE 更新链路优化                                                | 部分完成（5/6） | `xvdhm-dashboard-sse-refresh-optimization/SPEC.md`       | 2026-03-07 | fast-track / browser verified |
-| 7272y | 内置 GPT-5.4 系列计费规则与下游模型列表                                   | 已完成（4/4）   | `7272y-gpt-5-4-pricing/SPEC.md`                          | 2026-03-06 | fast-track / PR #89           |
-| rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track / PR #88           |
-| 4kkpp | Live 对话统计（按 Prompt Cache Key）— 无统计表方案（索引 + 轻缓存）       | 已完成（5/5）   | `4kkpp-live-prompt-cache-conversations/SPEC.md`          | 2026-03-03 | fast-track                    |
-| hrvtt | 请求详情补齐代理信息与本次权重变化                                        | 已完成（4/4）   | `hrvtt-invocation-proxy-weight-delta/SPEC.md`            | 2026-03-02 | fast-track                    |
-| t7m4h | Live 代理运行态：新增 24h 权重趋势列与断点适配                            | 已完成（5/5）   | `t7m4h-live-proxy-weight-trend/SPEC.md`                  | 2026-03-02 | fast-track / PR #83           |
-| rkc7k | 修复 Live 实时统计闪烁与数字滚动被打断                                    | 已完成（6/6）   | `rkc7k-live-summary-flicker-fix/SPEC.md`                 | 2026-03-02 | fast-track / PR #80           |
-| c58kc | 实况页新增“代理”统计表与 24h 成败示意图                                   | 已完成（5/5）   | `c58kc-live-forward-proxy-table/SPEC.md`                 | 2026-03-02 | fast-track / PR #77           |
-| wv3m7 | Forward Proxy 新增后异步首轮探测补齐                                      | 已完成（3/3）   | `wv3m7-forward-proxy-bootstrap-probe/SPEC.md`            | 2026-03-02 | fast-track                    |
-| r8m3k | InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化               | 已完成（5/5）   | `r8m3k-invocation-table-responsive-no-overflow/SPEC.md`  | 2026-03-02 | fast-track / PR #79           |
-| k52tw | Forward proxy 验证放宽：404 视为可达（proxyUrl + subscriptionUrl）        | 已完成（3/3）   | `k52tw-forward-proxy-validation-allow-404/SPEC.md`       | 2026-03-01 | fast-track / hotfix           |
-| zanzr | Release 构建加速：arm64 迁移到 GitHub-hosted ARM runner                   | 部分完成（3/4） | `zanzr-release-arm64-native-runner/SPEC.md`              | 2026-03-01 | fast-track                    |
-| wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix           |
-| m96jw | 修复订阅验证路径下 xray 运行目录缺失导致添加失败                          | 已完成（3/3）   | `m96jw-subscription-validation-xray-runtime-dir/SPEC.md` | 2026-03-01 | PR #71 / fast-track           |
-| c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md`       | 2026-03-01 | fast-track                    |
-| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`                     | 2026-03-01 | hotfix                        |
-| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`                     | 2026-03-01 | fast-track / hotfix           |
-| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`                | 2026-03-01 | PR #66 / fast-track           |
-| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`                     | 2026-03-01 | PR #65 / fast-track           |
-| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`                   | 2026-02-28 | fast-track                    |
-| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`               | 2026-02-27 | PR #61                        |
-| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`                | 2026-02-27 | 补按钮交互回归断言            |
-| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`                | 2026-02-26 | PR #56 / fast-track           |
-| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`              | 2026-02-26 | PR #58                        |
-| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`                      | 2026-02-25 | PR #52                        |
-| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`                  | 2026-02-25 | 已完成并通过视觉确认          |
-| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`                        | 2026-02-24 | PR #50                        |
-| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`                  | 2026-02-24 | PR #51                        |
-| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md`             | 2026-02-25 | PR #57                        |
+| ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                |
+| ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | -------------------- |
+| xvdhm | Dashboard SSE 更新链路优化                                                | 已完成（6/6）   | `xvdhm-dashboard-sse-refresh-optimization/SPEC.md`       | 2026-03-07 | fast-track / PR #90  |
+| 7272y | 内置 GPT-5.4 系列计费规则与下游模型列表                                   | 已完成（4/4）   | `7272y-gpt-5-4-pricing/SPEC.md`                          | 2026-03-06 | fast-track / PR #89  |
+| rzxey | Dashboard：修复 UsageCalendar 加载骨架右偏 + 首行骨架按真实两卡布局       | 已完成（5/5）   | `rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`  | 2026-03-05 | fast-track / PR #88  |
+| 4kkpp | Live 对话统计（按 Prompt Cache Key）— 无统计表方案（索引 + 轻缓存）       | 已完成（5/5）   | `4kkpp-live-prompt-cache-conversations/SPEC.md`          | 2026-03-03 | fast-track           |
+| hrvtt | 请求详情补齐代理信息与本次权重变化                                        | 已完成（4/4）   | `hrvtt-invocation-proxy-weight-delta/SPEC.md`            | 2026-03-02 | fast-track           |
+| t7m4h | Live 代理运行态：新增 24h 权重趋势列与断点适配                            | 已完成（5/5）   | `t7m4h-live-proxy-weight-trend/SPEC.md`                  | 2026-03-02 | fast-track / PR #83  |
+| rkc7k | 修复 Live 实时统计闪烁与数字滚动被打断                                    | 已完成（6/6）   | `rkc7k-live-summary-flicker-fix/SPEC.md`                 | 2026-03-02 | fast-track / PR #80  |
+| c58kc | 实况页新增“代理”统计表与 24h 成败示意图                                   | 已完成（5/5）   | `c58kc-live-forward-proxy-table/SPEC.md`                 | 2026-03-02 | fast-track / PR #77  |
+| wv3m7 | Forward Proxy 新增后异步首轮探测补齐                                      | 已完成（3/3）   | `wv3m7-forward-proxy-bootstrap-probe/SPEC.md`            | 2026-03-02 | fast-track           |
+| r8m3k | InvocationTable 响应式修复：lg+ 无横向滚动、sm 及以下列表化               | 已完成（5/5）   | `r8m3k-invocation-table-responsive-no-overflow/SPEC.md`  | 2026-03-02 | fast-track / PR #79  |
+| k52tw | Forward proxy 验证放宽：404 视为可达（proxyUrl + subscriptionUrl）        | 已完成（3/3）   | `k52tw-forward-proxy-validation-allow-404/SPEC.md`       | 2026-03-01 | fast-track / hotfix  |
+| zanzr | Release 构建加速：arm64 迁移到 GitHub-hosted ARM runner                   | 部分完成（3/4） | `zanzr-release-arm64-native-runner/SPEC.md`              | 2026-03-01 | fast-track           |
+| wtwsn | GHCR 发布切换多架构 manifest（amd64 + arm64）                             | 已完成（5/5）   | `wtwsn-ghcr-multiarch-release-manifest/SPEC.md`          | 2026-03-01 | fast-track / hotfix  |
+| m96jw | 修复订阅验证路径下 xray 运行目录缺失导致添加失败                          | 已完成（3/3）   | `m96jw-subscription-validation-xray-runtime-dir/SPEC.md` | 2026-03-01 | PR #71 / fast-track  |
+| c5yag | 订阅验证超时改为 60 秒（单条验证保持 5 秒）                               | 已完成（3/3）   | `c5yag-subscription-validation-timeout-60/SPEC.md`       | 2026-03-01 | fast-track           |
+| 9anzf | Docker 镜像内置 Xray-core（xray）以支持订阅代理验证                       | 部分完成（2/3） | `9anzf-bundle-xray-in-image/SPEC.md`                     | 2026-03-01 | hotfix               |
+| vdukd | 修复 GHCR 镜像 GLIBC 漂移导致 bookworm runtime 启动失败                   | 已完成（3/3）   | `vdukd-ghcr-glibc-drift-fix/SPEC.md`                     | 2026-03-01 | fast-track / hotfix  |
+| 9mbsz | Release 前 Docker Smoke Gate（Push 镜像前先验证）                         | 已完成          | `9mbsz-release-docker-smoke-gate/SPEC.md`                | 2026-03-01 | PR #66 / fast-track  |
+| zrxcd | Sticky Footer 修复：页脚在短页面贴底                                      | 已完成          | `zrxcd-sticky-footer-layout/SPEC.md`                     | 2026-03-01 | PR #65 / fast-track  |
+| ykn4w | 日期后缀模型成本回退与历史空成本补算                                      | 已完成          | `ykn4w-pricing-alias-backfill/SPEC.md`                   | 2026-02-28 | fast-track           |
+| 8dun3 | 统计页成功/失败图增加首字耗时折线与悬浮统计（均值 + P95）                 | 已完成          | `8dun3-stats-success-failure-ttfb/SPEC.md`               | 2026-02-27 | PR #61               |
+| 67acu | 修复更新提示可读性（更新横幅 + 同类透明度语义 + 可访问性回归）            | 已完成          | `67acu-update-banner-readability/SPEC.md`                | 2026-02-27 | 补按钮交互回归断言   |
+| 26knq | 修复 InvocationTable 异常横向滚动并补 E2E 回归                            | 已完成          | `26knq-invocation-table-overflow/SPEC.md`                | 2026-02-26 | PR #56 / fast-track  |
+| s8d2w | Dashboard 顶部替换“配额概览”为“今日统计信息”（Bento）                     | 已完成          | `s8d2w-dashboard-today-stats-bento/SPEC.md`              | 2026-02-26 | PR #58               |
+| 5932d | SSE 驱动的请求记录与统计实时更新                                          | 已完成          | `5932d-sse-proxy-live-sync/SPEC.md`                      | 2026-02-25 | PR #52               |
+| jpg66 | 设置页切换为 shadcn 风格并优化亮/暗主题可读性                             | 已完成          | `jpg66-settings-shadcn-refresh/SPEC.md`                  | 2026-02-25 | 已完成并通过视觉确认 |
+| q86c7 | 接入 ui-ux-pro-max（Codex）并修正 .gitignore 追踪策略                     | 已完成          | `q86c7-setup-uipro-codex/SPEC.md`                        | 2026-02-24 | PR #50               |
+| gwpsb | 线上失败请求分类治理与可观测性增强                                        | 已完成          | `gwpsb-proxy-failure-hardening/SPEC.md`                  | 2026-02-24 | PR #51               |
+| z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | 已完成          | `z9h7v-invocation-log-observability/SPEC.md`             | 2026-02-25 | PR #57               |

--- a/docs/specs/xvdhm-dashboard-sse-refresh-optimization/SPEC.md
+++ b/docs/specs/xvdhm-dashboard-sse-refresh-optimization/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 部分完成（5/6）
+- Status: 已完成（6/6）
 - Created: 2026-03-07
 - Last: 2026-03-07
 
@@ -157,7 +157,7 @@ None
 - [x] M3: `useSummary` / `useTimeseries` 收敛 dashboard 相关刷新策略并补请求去重保护。
 - [x] M4: 补齐 Rust / Vitest 自动化回归。
 - [x] M5: 完成浏览器验证并确认 Dashboard records 更新、no-storm 与 reconnect backfill 行为。
-- [ ] M6: 完成 fast-track PR、checks 跟踪与 review-loop 收敛。
+- [x] M6: 完成 fast-track PR、checks 跟踪与 review-loop 收敛。
 
 ## 方案概述（Approach, high-level）
 
@@ -176,6 +176,7 @@ None
 - 2026-03-07: 创建规格并冻结优化边界、验收标准与快车道交付目标。
 - 2026-03-07: 完成后端 changed-only 广播与前端 summary/timeseries 刷新策略收敛，`cargo test`、`cd web && npm test`、`cd web && npm run build` 通过。
 - 2026-03-07: 浏览器实测 `/dashboard`，确认 records 推送后 recent table / `today` / `24h` / `7d` / `90d` 当前桶可见更新，且 reconnect 仅触发一轮静默 backfill 请求。
+- 2026-03-07: 创建 PR #90，补齐 `type:patch` + `channel:stable` labels，并确认 Label Gate / CI Pipeline 全绿；review 复查未发现阻塞项。
 
 ## 参考（References）
 

--- a/docs/specs/xvdhm-dashboard-sse-refresh-optimization/SPEC.md
+++ b/docs/specs/xvdhm-dashboard-sse-refresh-optimization/SPEC.md
@@ -1,0 +1,184 @@
+# Dashboard SSE 更新链路优化（#xvdhm）
+
+## 状态
+
+- Status: 部分完成（5/6）
+- Created: 2026-03-07
+- Last: 2026-03-07
+
+## 背景 / 问题陈述
+
+- Dashboard 当前复用单一 `/events` SSE 通道，但总览页多个共享 hook 对同一批事件的处理策略不一致。
+- scheduler 与 proxy capture 会重复计算/广播 summary 与 quota，即使当前无 SSE 订阅者，或 payload 与上次广播完全一致。
+- `today` 等 calendar window 仍依赖“收到其他 summary 后最多 60 秒一次”的 fallback HTTP 刷新，导致总览页主要卡片与 records 的实时性不一致。
+- `UsageCalendar` 的 `90d / 1d` timeseries 在收到 records 时会触发整段回源重算，容易形成无效请求风暴。
+- `useTimeseries` 目前缺少 request sequencing、abort 与 in-flight dedupe，慢网/重连场景下存在重复请求与 stale response 覆盖风险。
+
+## 目标 / 非目标
+
+### Goals
+
+- 保留现有公共 `/events`、`/api/stats/summary`、`/api/stats/timeseries` 接口与 payload schema 不变。
+- 让 Dashboard 核心区块（recent records、`1d summary`、`24h/7d` 热力图、`today` 卡片）在新 records 入库后 1–2 秒内完成可见更新。
+- 让 scheduler / proxy capture 在 `receiver_count == 0` 时跳过无意义的 summary/quota 计算与广播。
+- 对 summary/quota 广播引入 changed-only 去重，避免重复 payload 触发前端白刷。
+- 收敛共享 hooks 的刷新策略：calendar summary 走 records 驱动静默刷新，timeseries 走显式同步策略与请求去重。
+
+### Non-goals
+
+- 不新增 SSE event type、额外 SSE 通道或新的 HTTP route。
+- 不改 Dashboard 视觉布局、文案结构或组件组合关系。
+- 不把服务端改成按订阅者时区维持独立的 stateful calendar-window summary 广播。
+- 不做全站状态管理重构，不引入新的全局 store 框架。
+
+## 范围（Scope）
+
+### In scope
+
+- `src/main.rs` 中 scheduler / proxy-capture 的 summary/quota 广播链路。
+- `web/src/hooks/useStats.ts`
+- `web/src/hooks/useTimeseries.ts`
+- `web/src/hooks/useInvocations.ts`（仅必要兼容调整）
+- 相关 Rust / Vitest 测试。
+- `docs/specs/README.md`
+
+### Out of scope
+
+- 页面组件树与视觉样式改造。
+- 新增 quota 概览在 Dashboard 的展示。
+- `Stats` / `Live` 页面额外产品行为 redesign。
+
+## 需求（Requirements）
+
+### MUST
+
+- scheduler 在无 SSE 订阅者时仍执行 poll/persist，但不得计算或广播 summary/quota。
+- proxy capture 路径在 records 广播后，仅当 summary/quota payload 与最近一次已广播值不同才发送对应事件。
+- `today` / `thisWeek` / `thisMonth` 的 summary 刷新必须由 `records` 驱动，使用静默模式与 1 秒节流，不得在初次 hydration 后反复闪烁 loading。
+- `useTimeseries` 必须具备 request sequencing、abort/cancel、in-flight dedupe 与 stale response 抑制能力。
+- `90d / 1d` UsageCalendar 在同一本地日内收到 records 时，只允许本地修补当前日 bucket；全量回源只能发生在 reconnect/open、页面回前台或跨日校准时。
+- `preferServerAggregation=true` 的 timeseries 仍以服务端结果为准，但 records 触发的回源必须节流（3 秒）且不会并发风暴。
+
+### SHOULD
+
+- 对未变化的 summary/quota payload 不触发前端 state update。
+- 为关键节流/同步 helper 提供可测试的纯函数或稳定行为边界。
+- 浏览器验证中确认 Dashboard Network 面板不再出现每条 records 都触发的 `range=90d&bucket=1d` timeseries 请求。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- scheduler tick：
+  - 持续完成现有 poll / persist。
+  - 若 `receiver_count == 0`，直接跳过 summary/quota 计算与广播。
+  - 若有订阅者，仅广播 changed-only 的 summary/quota payload。
+- proxy capture 新增记录：
+  - 立即广播 `records`。
+  - 复用 changed-only 逻辑尝试广播 summary/quota。
+- Dashboard summary：
+  - `1d` 直接消费 SSE `summary(window=1d)`。
+  - `today/thisWeek/thisMonth` 消费 `records` 触发的 1 秒节流静默回源，并在 SSE `open` 后做一次静默补拉。
+- Dashboard timeseries：
+  - `1d/1m` 与 `7d/1h` 继续基于 records 本地增量更新。
+  - `90d/1d` 仅修补当前本地日 bucket；历史 bucket 保持原值，依赖 reconnect/回前台/跨日校准时的全量回源纠正。
+  - `preferServerAggregation=true` 继续走服务端聚合，但 records/open 只触发节流后的静默回源。
+
+### Edge cases / errors
+
+- summary/quota 计算失败仅记录 `warn`，不得影响 records 广播或主请求。
+- 若同一时间存在 in-flight timeseries 请求，后续刷新必须复用或排队，不得无界叠加并发。
+- 若旧请求晚于新请求返回，旧响应不得覆盖新状态。
+- 若页面在后台，非强制刷新场景下不主动触发 records-driven 回源；页面恢复可见后再补拉一次。
+
+## 接口契约（Interfaces & Contracts）
+
+### 接口清单（Inventory）
+
+| 接口（Name）                             | 类型（Kind） | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner） | 使用方（Consumers）      | 备注（Notes）                      |
+| ---------------------------------------- | ------------ | ------------- | -------------- | ------------------------ | --------------- | ------------------------ | ---------------------------------- |
+| `/events` payload schema                 | Event        | external      | Modify         | None                     | backend         | web dashboard/live/stats | 仅调整发送条件，不改 payload shape |
+| `useSummary(window)` behavior            | Hook         | internal      | Modify         | None                     | web             | dashboard/stats/live     | 保持调用签名不变                   |
+| `useTimeseries(range, options)` behavior | Hook         | internal      | Modify         | None                     | web             | dashboard/stats          | 保持调用签名不变                   |
+
+### 契约文档（按 Kind 拆分）
+
+None
+
+## 验收标准（Acceptance Criteria）
+
+- Given `/dashboard` 处于打开状态，When 新 invocation 入库并通过 SSE 收到 records，Then recent table 立即更新，且 `1d summary`、`24h` 热力图、`7d` 热力图在 1–2 秒内反映变化。
+- Given Dashboard 显示 `today` 卡片，When 高频 records 连续到达，Then summary 以静默 HTTP 刷新为主、频率不超过每 1 秒 1 次，且初次 hydration 后不出现 loading 闪烁。
+- Given UsageCalendar 已挂载，When 同一本地日内连续收到 records，Then 不会为每条 records 触发一次完整 `range=90d&bucket=1d` timeseries 请求，但当天格子数值仍可见更新。
+- Given SSE 断线后重连，When `open` 事件触发，Then Dashboard 各相关数据执行一次静默 backfill/resync，并与后端状态收敛。
+- Given scheduler tick 时没有 SSE 订阅者，When poll 正常完成，Then 仍完成持久化，但不会执行 summary/quota 计算与广播。
+- Given summary/quota payload 与最近一次广播值一致，When scheduler 或 proxy capture 尝试广播，Then 不发送重复 `summary` / `quota` 事件。
+
+## 实现前置条件（Definition of Ready / Preconditions）
+
+- 目标、非目标与范围已冻结。
+- Dashboard 近实时定义为“records 入库后 1–2 秒内核心区块可见更新”，而不是所有区块同帧同步。
+- calendar windows 继续以浏览器时区配合现有 HTTP summary 计算，不新增时区态 SSE 契约。
+- `90d / 1d` UsageCalendar 的历史 bucket 实时一致性依赖 reconnect/回前台/跨日校准，允许非同帧强一致。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- Rust tests: 覆盖 no-subscriber skip 与 changed-only summary/quota broadcast。
+- Unit tests: 覆盖 calendar summary 1 秒节流、timeseries request sequencing / stale suppression / no-storm 行为。
+- E2E / browser check: 验证 Dashboard 在真实浏览器中的网络请求数量与重连补拉行为。
+
+### Quality checks
+
+- `cargo test`
+- `cd web && npm run test`
+- `cd web && npm run build`
+
+## 文档更新（Docs to Update）
+
+- `docs/specs/README.md`: 新增 #xvdhm 索引，并在实现推进后更新状态与 Notes。
+
+## 计划资产（Plan assets）
+
+- Directory: `docs/specs/xvdhm-dashboard-sse-refresh-optimization/assets/`
+- PR visual evidence source: maintain `## Visual Evidence (PR)` in this spec when PR screenshots are needed.
+
+## Visual Evidence (PR)
+
+## 资产晋升（Asset promotion）
+
+None
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 新建 spec 并登记 `docs/specs/README.md`。
+- [x] M2: 后端 scheduler / proxy capture 增加 no-subscriber skip 与 changed-only summary/quota broadcast。
+- [x] M3: `useSummary` / `useTimeseries` 收敛 dashboard 相关刷新策略并补请求去重保护。
+- [x] M4: 补齐 Rust / Vitest 自动化回归。
+- [x] M5: 完成浏览器验证并确认 Dashboard records 更新、no-storm 与 reconnect backfill 行为。
+- [ ] M6: 完成 fast-track PR、checks 跟踪与 review-loop 收敛。
+
+## 方案概述（Approach, high-level）
+
+- 后端通过内部缓存最近一次已发送的 summary/quota 值，避免重复 payload 触发无效前端刷新。
+- 前端继续复用单一 SSE 通道，但把“何时回源、何时本地增量、何时忽略旧响应”的策略内聚到共享 hooks。
+- Dashboard 只承接共享层行为收益，不新增页面级状态容器。
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：`90d / 1d` 本地修补策略若边界处理错误，可能出现跨日时一天偏差；需用 reconnect/visibility/day-rollover 测试兜住。
+- 风险：changed-only 比较若忽略浮点稳定性，可能因为序列化差异造成误判；应基于结构化值比较，而非 JSON 字符串文本。
+- 假设：Dashboard 近实时优先级高于严格历史 bucket 同帧一致性。
+
+## 变更记录（Change log）
+
+- 2026-03-07: 创建规格并冻结优化边界、验收标准与快车道交付目标。
+- 2026-03-07: 完成后端 changed-only 广播与前端 summary/timeseries 刷新策略收敛，`cargo test`、`cd web && npm test`、`cd web && npm run build` 通过。
+- 2026-03-07: 浏览器实测 `/dashboard`，确认 records 推送后 recent table / `today` / `24h` / `7d` / `90d` 当前桶可见更新，且 reconnect 仅触发一轮静默 backfill 请求。
+
+## 参考（References）
+
+- `docs/specs/5932d-sse-proxy-live-sync/SPEC.md`
+- `docs/specs/rkc7k-live-summary-flicker-fix/SPEC.md`
+- `docs/specs/rzxey-dashboard-usage-calendar-skeleton-shift/SPEC.md`

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,7 @@ async fn main() -> Result<()> {
         pool,
         http_clients,
         broadcaster: tx.clone(),
+        broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
         proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
         proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
         semaphore: semaphore.clone(),
@@ -540,7 +541,8 @@ async fn schedule_poll(state: Arc<AppState>) -> Result<JoinHandle<()>> {
     let state_clone = state.clone();
 
     let handle = tokio::spawn(async move {
-        let fut = fetch_and_store(&state_clone, force_new_connection);
+        let collect_broadcast_state = state_clone.broadcaster.receiver_count() > 0;
+        let fut = fetch_and_store(&state_clone, force_new_connection, collect_broadcast_state);
         match timeout(state_clone.config.request_timeout, fut).await {
             Ok(Ok(publish)) => {
                 let PublishResult {
@@ -549,7 +551,8 @@ async fn schedule_poll(state: Arc<AppState>) -> Result<JoinHandle<()>> {
                     quota_snapshot,
                 } = publish;
 
-                if let Some(records) = records.filter(|v| !v.is_empty())
+                if state_clone.broadcaster.receiver_count() > 0
+                    && let Some(records) = records.filter(|v| !v.is_empty())
                     && let Err(err) = state_clone
                         .broadcaster
                         .send(BroadcastPayload::Records { records })
@@ -558,18 +561,25 @@ async fn schedule_poll(state: Arc<AppState>) -> Result<JoinHandle<()>> {
                 }
 
                 for summary in summaries {
-                    if let Err(err) = state_clone.broadcaster.send(BroadcastPayload::Summary {
-                        window: summary.window,
-                        summary: summary.summary,
-                    }) {
+                    if let Err(err) = broadcast_summary_if_changed(
+                        &state_clone.broadcaster,
+                        state_clone.broadcast_state_cache.as_ref(),
+                        &summary.window,
+                        summary.summary,
+                    )
+                    .await
+                    {
                         warn!(?err, "failed to broadcast summary payload");
                     }
                 }
 
                 if let Some(snapshot) = quota_snapshot
-                    && let Err(err) = state_clone.broadcaster.send(BroadcastPayload::Quota {
-                        snapshot: Box::new(snapshot),
-                    })
+                    && let Err(err) = broadcast_quota_if_changed(
+                        &state_clone.broadcaster,
+                        state_clone.broadcast_state_cache.as_ref(),
+                        snapshot,
+                    )
+                    .await
                 {
                     warn!(?err, "failed to broadcast quota snapshot");
                 }
@@ -698,7 +708,11 @@ struct SummaryPublish {
     summary: StatsResponse,
 }
 
-async fn fetch_and_store(state: &AppState, force_new_connection: bool) -> Result<PublishResult> {
+async fn fetch_and_store(
+    state: &AppState,
+    force_new_connection: bool,
+    collect_broadcast_state: bool,
+) -> Result<PublishResult> {
     let client = state
         .http_clients
         .client_for_parallelism(force_new_connection)?;
@@ -740,8 +754,14 @@ async fn fetch_and_store(state: &AppState, force_new_connection: bool) -> Result
         }
     }
 
-    let summaries = collect_summary_snapshots(&state.pool, relay_config.as_ref()).await?;
-    let quota_payload = QuotaSnapshotResponse::fetch_latest(&state.pool).await?;
+    let (summaries, quota_payload) = if collect_broadcast_state {
+        (
+            collect_summary_snapshots(&state.pool, relay_config.as_ref()).await?,
+            QuotaSnapshotResponse::fetch_latest(&state.pool).await?,
+        )
+    } else {
+        (Vec::new(), None)
+    };
 
     Ok(PublishResult {
         records: if inserted.is_empty() {
@@ -4766,6 +4786,51 @@ async fn latest_quota_snapshot(
         .unwrap_or_else(QuotaSnapshotResponse::degraded_default);
     Ok(Json(snapshot))
 }
+
+async fn broadcast_summary_if_changed(
+    broadcaster: &broadcast::Sender<BroadcastPayload>,
+    cache: &Mutex<BroadcastStateCache>,
+    window: &str,
+    summary: StatsResponse,
+) -> Result<bool, broadcast::error::SendError<BroadcastPayload>> {
+    let mut cache = cache.lock().await;
+    if cache
+        .summaries
+        .get(window)
+        .is_some_and(|current| current == &summary)
+    {
+        return Ok(false);
+    }
+
+    broadcaster.send(BroadcastPayload::Summary {
+        window: window.to_string(),
+        summary: summary.clone(),
+    })?;
+    cache.summaries.insert(window.to_string(), summary);
+    Ok(true)
+}
+
+async fn broadcast_quota_if_changed(
+    broadcaster: &broadcast::Sender<BroadcastPayload>,
+    cache: &Mutex<BroadcastStateCache>,
+    snapshot: QuotaSnapshotResponse,
+) -> Result<bool, broadcast::error::SendError<BroadcastPayload>> {
+    let mut cache = cache.lock().await;
+    if cache
+        .quota
+        .as_ref()
+        .is_some_and(|current| current == &snapshot)
+    {
+        return Ok(false);
+    }
+
+    broadcaster.send(BroadcastPayload::Quota {
+        snapshot: Box::new(snapshot.clone()),
+    })?;
+    cache.quota = Some(snapshot);
+    Ok(true)
+}
+
 async fn sse_stream(
     State(state): State<Arc<AppState>>,
 ) -> Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>> {
@@ -6673,6 +6738,7 @@ async fn persist_and_broadcast_proxy_capture(
     let broadcast_running = state.proxy_summary_quota_broadcast_running.clone();
     let pool = state.pool.clone();
     let broadcaster = state.broadcaster.clone();
+    let broadcast_state_cache = state.broadcast_state_cache.clone();
     let relay_config = state.config.crs_stats.clone();
     tokio::spawn(async move {
         let mut synced_seq = 0_u64;
@@ -6698,10 +6764,14 @@ async fn persist_and_broadcast_proxy_capture(
             match collect_summary_snapshots(&pool, relay_config.as_ref()).await {
                 Ok(summaries) => {
                     for summary in summaries {
-                        if let Err(err) = broadcaster.send(BroadcastPayload::Summary {
-                            window: summary.window.clone(),
-                            summary: summary.summary,
-                        }) {
+                        if let Err(err) = broadcast_summary_if_changed(
+                            &broadcaster,
+                            broadcast_state_cache.as_ref(),
+                            &summary.window,
+                            summary.summary,
+                        )
+                        .await
+                        {
                             warn!(
                                 ?err,
                                 invoke_id = %invoke_id,
@@ -6726,9 +6796,13 @@ async fn persist_and_broadcast_proxy_capture(
 
             match QuotaSnapshotResponse::fetch_latest(&pool).await {
                 Ok(Some(snapshot)) => {
-                    if let Err(err) = broadcaster.send(BroadcastPayload::Quota {
-                        snapshot: Box::new(snapshot),
-                    }) {
+                    if let Err(err) = broadcast_quota_if_changed(
+                        &broadcaster,
+                        broadcast_state_cache.as_ref(),
+                        snapshot,
+                    )
+                    .await
+                    {
                         warn!(
                             ?err,
                             invoke_id = %invoke_id,
@@ -9329,6 +9403,7 @@ struct AppState {
     pool: Pool<Sqlite>,
     http_clients: HttpClients,
     broadcaster: broadcast::Sender<BroadcastPayload>,
+    broadcast_state_cache: Arc<Mutex<BroadcastStateCache>>,
     proxy_summary_quota_broadcast_seq: Arc<AtomicU64>,
     proxy_summary_quota_broadcast_running: Arc<AtomicBool>,
     semaphore: Arc<Semaphore>,
@@ -9341,6 +9416,12 @@ struct AppState {
     pricing_settings_update_lock: Arc<Mutex<()>>,
     pricing_catalog: Arc<RwLock<PricingCatalog>>,
     prompt_cache_conversation_cache: Arc<Mutex<PromptCacheConversationsCacheState>>,
+}
+
+#[derive(Debug, Default)]
+struct BroadcastStateCache {
+    summaries: HashMap<String, StatsResponse>,
+    quota: Option<QuotaSnapshotResponse>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -9442,7 +9523,7 @@ struct ListResponse {
     records: Vec<ApiInvocation>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct StatsResponse {
     total_count: i64,
@@ -9534,7 +9615,7 @@ struct TimeseriesPoint {
     first_byte_p95_ms: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct QuotaSnapshotResponse {
     #[serde(serialize_with = "serialize_local_or_utc_to_utc_iso")]
@@ -14219,6 +14300,7 @@ mod tests {
             pool,
             http_clients,
             broadcaster,
+            broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
             proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
             proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
             semaphore,
@@ -16773,6 +16855,7 @@ mod tests {
             pool,
             http_clients,
             broadcaster,
+            broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
             proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
             proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
             semaphore,
@@ -17165,6 +17248,193 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_and_store_skips_summary_and_quota_collection_when_broadcast_state_disabled() {
+        let state = test_state_with_openai_base(
+            Url::parse("https://example-upstream.invalid/").expect("valid upstream base url"),
+        )
+        .await;
+        let now_local = format_naive(Utc::now().with_timezone(&Shanghai).naive_local());
+        seed_quota_snapshot(&state.pool, &now_local).await;
+
+        let publish = fetch_and_store(state.as_ref(), false, false)
+            .await
+            .expect("fetch_and_store should succeed");
+
+        assert!(publish.summaries.is_empty());
+        assert!(publish.quota_snapshot.is_none());
+    }
+
+    #[tokio::test]
+    async fn broadcast_summary_if_changed_skips_duplicate_payloads() {
+        let state = test_state_with_openai_base(
+            Url::parse("https://example-upstream.invalid/").expect("valid upstream base url"),
+        )
+        .await;
+        let mut rx = state.broadcaster.subscribe();
+        let first = StatsResponse {
+            total_count: 1,
+            success_count: 1,
+            failure_count: 0,
+            total_cost: 0.5,
+            total_tokens: 42,
+        };
+
+        assert!(
+            broadcast_summary_if_changed(
+                &state.broadcaster,
+                state.broadcast_state_cache.as_ref(),
+                "1d",
+                first.clone(),
+            )
+            .await
+            .expect("first summary broadcast should succeed")
+        );
+
+        let payload = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for first summary payload")
+            .expect("broadcast should stay open");
+        match payload {
+            BroadcastPayload::Summary { window, summary } => {
+                assert_eq!(window, "1d");
+                assert_eq!(summary, first);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        assert!(
+            !broadcast_summary_if_changed(
+                &state.broadcaster,
+                state.broadcast_state_cache.as_ref(),
+                "1d",
+                first.clone(),
+            )
+            .await
+            .expect("duplicate summary broadcast should succeed")
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), rx.recv())
+                .await
+                .is_err()
+        );
+
+        let updated = StatsResponse {
+            total_count: 2,
+            ..first
+        };
+        assert!(
+            broadcast_summary_if_changed(
+                &state.broadcaster,
+                state.broadcast_state_cache.as_ref(),
+                "1d",
+                updated.clone(),
+            )
+            .await
+            .expect("changed summary broadcast should succeed")
+        );
+
+        let payload = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for updated summary payload")
+            .expect("broadcast should stay open");
+        match payload {
+            BroadcastPayload::Summary { window, summary } => {
+                assert_eq!(window, "1d");
+                assert_eq!(summary, updated);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_quota_if_changed_skips_duplicate_payloads() {
+        let state = test_state_with_openai_base(
+            Url::parse("https://example-upstream.invalid/").expect("valid upstream base url"),
+        )
+        .await;
+        let mut rx = state.broadcaster.subscribe();
+        let first = QuotaSnapshotResponse {
+            captured_at: "2026-03-07 10:00:00".to_string(),
+            amount_limit: Some(100.0),
+            used_amount: Some(10.0),
+            remaining_amount: Some(90.0),
+            period: Some("monthly".to_string()),
+            period_reset_time: Some("2026-04-01 00:00:00".to_string()),
+            expire_time: None,
+            is_active: true,
+            total_cost: 10.0,
+            total_requests: 9,
+            total_tokens: 150,
+            last_request_time: Some("2026-03-07 10:00:00".to_string()),
+            billing_type: Some("prepaid".to_string()),
+            remaining_count: Some(91),
+            used_count: Some(9),
+            sub_type_name: Some("unit".to_string()),
+        };
+
+        assert!(
+            broadcast_quota_if_changed(
+                &state.broadcaster,
+                state.broadcast_state_cache.as_ref(),
+                first.clone(),
+            )
+            .await
+            .expect("first quota broadcast should succeed")
+        );
+
+        let payload = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for first quota payload")
+            .expect("broadcast should stay open");
+        match payload {
+            BroadcastPayload::Quota { snapshot } => {
+                assert_eq!(*snapshot, first);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        assert!(
+            !broadcast_quota_if_changed(
+                &state.broadcaster,
+                state.broadcast_state_cache.as_ref(),
+                first.clone(),
+            )
+            .await
+            .expect("duplicate quota broadcast should succeed")
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), rx.recv())
+                .await
+                .is_err()
+        );
+
+        let updated = QuotaSnapshotResponse {
+            total_requests: 10,
+            ..first
+        };
+        assert!(
+            broadcast_quota_if_changed(
+                &state.broadcaster,
+                state.broadcast_state_cache.as_ref(),
+                updated.clone(),
+            )
+            .await
+            .expect("changed quota broadcast should succeed")
+        );
+
+        let payload = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for updated quota payload")
+            .expect("broadcast should stay open");
+        match payload {
+            BroadcastPayload::Quota { snapshot } => {
+                assert_eq!(*snapshot, updated);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn read_request_body_timeout_returns_408() {
         #[derive(sqlx::FromRow)]
         struct PersistedRow {
@@ -17421,6 +17691,7 @@ mod tests {
             pool,
             http_clients,
             broadcaster,
+            broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
             proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
             proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
             semaphore,
@@ -17548,6 +17819,7 @@ mod tests {
             pool,
             http_clients,
             broadcaster,
+            broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
             proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
             proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
             semaphore,
@@ -17717,6 +17989,7 @@ mod tests {
             pool,
             http_clients,
             broadcaster,
+            broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
             proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
             proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
             semaphore,
@@ -17785,6 +18058,7 @@ mod tests {
             pool,
             http_clients,
             broadcaster,
+            broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
             proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
             proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
             semaphore,
@@ -20023,6 +20297,7 @@ mod tests {
             pool,
             http_clients,
             broadcaster,
+            broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
             proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
             proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
             semaphore,

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,11 +547,30 @@ async fn schedule_poll(state: Arc<AppState>) -> Result<JoinHandle<()>> {
             Ok(Ok(publish)) => {
                 let PublishResult {
                     records,
-                    summaries,
-                    quota_snapshot,
+                    mut summaries,
+                    mut quota_snapshot,
+                    collected_broadcast_state,
                 } = publish;
 
-                if state_clone.broadcaster.receiver_count() > 0
+                let receiver_count = state_clone.broadcaster.receiver_count();
+                if should_collect_late_broadcast_state(receiver_count, collected_broadcast_state) {
+                    match collect_broadcast_state_snapshots(
+                        &state_clone.pool,
+                        state_clone.config.crs_stats.as_ref(),
+                    )
+                    .await
+                    {
+                        Ok((latest_summaries, latest_quota_snapshot)) => {
+                            summaries = latest_summaries;
+                            quota_snapshot = latest_quota_snapshot;
+                        }
+                        Err(err) => {
+                            warn!(?err, "failed to collect late-subscriber broadcast state");
+                        }
+                    }
+                }
+
+                if receiver_count > 0
                     && let Some(records) = records.filter(|v| !v.is_empty())
                     && let Err(err) = state_clone
                         .broadcaster
@@ -701,11 +720,29 @@ struct PublishResult {
     records: Option<Vec<ApiInvocation>>,
     summaries: Vec<SummaryPublish>,
     quota_snapshot: Option<QuotaSnapshotResponse>,
+    collected_broadcast_state: bool,
 }
 
 struct SummaryPublish {
     window: String,
     summary: StatsResponse,
+}
+
+fn should_collect_late_broadcast_state(
+    receiver_count: usize,
+    collected_broadcast_state: bool,
+) -> bool {
+    receiver_count > 0 && !collected_broadcast_state
+}
+
+async fn collect_broadcast_state_snapshots(
+    pool: &Pool<Sqlite>,
+    relay: Option<&CrsStatsConfig>,
+) -> Result<(Vec<SummaryPublish>, Option<QuotaSnapshotResponse>)> {
+    Ok((
+        collect_summary_snapshots(pool, relay).await?,
+        QuotaSnapshotResponse::fetch_latest(pool).await?,
+    ))
 }
 
 async fn fetch_and_store(
@@ -755,10 +792,7 @@ async fn fetch_and_store(
     }
 
     let (summaries, quota_payload) = if collect_broadcast_state {
-        (
-            collect_summary_snapshots(&state.pool, relay_config.as_ref()).await?,
-            QuotaSnapshotResponse::fetch_latest(&state.pool).await?,
-        )
+        collect_broadcast_state_snapshots(&state.pool, relay_config.as_ref()).await?
     } else {
         (Vec::new(), None)
     };
@@ -771,6 +805,7 @@ async fn fetch_and_store(
         },
         summaries,
         quota_snapshot: quota_payload,
+        collected_broadcast_state: collect_broadcast_state,
     })
 }
 
@@ -17262,6 +17297,14 @@ mod tests {
 
         assert!(publish.summaries.is_empty());
         assert!(publish.quota_snapshot.is_none());
+        assert!(!publish.collected_broadcast_state);
+    }
+
+    #[test]
+    fn should_collect_late_broadcast_state_when_subscribers_arrive_mid_poll() {
+        assert!(should_collect_late_broadcast_state(1, false));
+        assert!(!should_collect_late_broadcast_state(0, false));
+        assert!(!should_collect_late_broadcast_state(1, true));
     }
 
     #[tokio::test]

--- a/web/src/hooks/useStats.test.ts
+++ b/web/src/hooks/useStats.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  CALENDAR_SUMMARY_RECORDS_REFRESH_THROTTLE_MS,
   CURRENT_SUMMARY_MAX_RETRY_ATTEMPTS,
   CURRENT_SUMMARY_OPEN_RESYNC_COOLDOWN_MS,
   CURRENT_SUMMARY_RECORDS_REFRESH_THROTTLE_MS,
   CURRENT_SUMMARY_RETRY_DELAY_MS,
   createUnsupportedRefreshGate,
   getCurrentSummarySseRefreshDelay,
+  isCalendarSummaryWindow,
   mergePendingSummarySilentOption,
+  runCalendarSummaryRefresh,
   runUnsupportedSummaryRefresh,
   shouldTriggerCurrentSummaryOpenResync,
   shouldRetryCurrentSummaryError,
@@ -67,7 +70,30 @@ describe('useSummary unsupported window fallback', () => {
     expect(shouldHandleUnsupportedSummaryRefresh('1d', '1d', true)).toBe(false)
     expect(shouldHandleUnsupportedSummaryRefresh('30m', '1d', true)).toBe(false)
     expect(shouldHandleUnsupportedSummaryRefresh('1h', 'current', false)).toBe(false)
-    expect(shouldHandleUnsupportedSummaryRefresh('1h', 'today', false)).toBe(true)
+    expect(shouldHandleUnsupportedSummaryRefresh('1h', 'today', false)).toBe(false)
+    expect(shouldHandleUnsupportedSummaryRefresh('1h', '7d', false)).toBe(true)
+  })
+
+  it('recognizes calendar windows that should refresh from records', () => {
+    expect(isCalendarSummaryWindow('today')).toBe(true)
+    expect(isCalendarSummaryWindow('thisWeek')).toBe(true)
+    expect(isCalendarSummaryWindow('thisMonth')).toBe(true)
+    expect(isCalendarSummaryWindow('1d')).toBe(false)
+  })
+
+  it('throttles calendar-window records refreshes to 1 second', async () => {
+    const gate = createUnsupportedRefreshGate()
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const base = CALENDAR_SUMMARY_RECORDS_REFRESH_THROTTLE_MS
+
+    const first = await runCalendarSummaryRefresh(gate, base, refresh)
+    const tooEarly = await runCalendarSummaryRefresh(gate, base + CALENDAR_SUMMARY_RECORDS_REFRESH_THROTTLE_MS - 1, refresh)
+    const reopened = await runCalendarSummaryRefresh(gate, base + CALENDAR_SUMMARY_RECORDS_REFRESH_THROTTLE_MS, refresh)
+
+    expect(first).toBe(true)
+    expect(tooEarly).toBe(false)
+    expect(reopened).toBe(true)
+    expect(refresh).toHaveBeenCalledTimes(2)
   })
 
   it('returns zero delay when current summary refresh is outside throttle window', () => {

--- a/web/src/hooks/useStats.ts
+++ b/web/src/hooks/useStats.ts
@@ -8,7 +8,9 @@ interface UseSummaryOptions {
 }
 
 const SUPPORTED_SSE_WINDOWS = new Set(['all', '30m', '1h', '1d', '1mo'])
+const CALENDAR_SUMMARY_WINDOWS = new Set(['today', 'thisWeek', 'thisMonth'])
 export const UNSUPPORTED_SSE_REFRESH_INTERVAL_MS = 60_000
+export const CALENDAR_SUMMARY_RECORDS_REFRESH_THROTTLE_MS = 1_000
 export const CURRENT_SUMMARY_RECORDS_REFRESH_THROTTLE_MS = 600
 export const CURRENT_SUMMARY_OPEN_RESYNC_COOLDOWN_MS = 3_000
 export const CURRENT_SUMMARY_REQUEST_TIMEOUT_MS = 10_000
@@ -36,6 +38,10 @@ export function createUnsupportedRefreshGate(): UnsupportedRefreshGate {
   return { inFlight: false, lastTriggerAt: 0 }
 }
 
+export function isCalendarSummaryWindow(window: string) {
+  return CALENDAR_SUMMARY_WINDOWS.has(window)
+}
+
 export function getCurrentSummarySseRefreshDelay(lastRefreshAt: number, now: number) {
   return Math.max(0, CURRENT_SUMMARY_RECORDS_REFRESH_THROTTLE_MS - (now - lastRefreshAt))
 }
@@ -50,7 +56,7 @@ export function shouldTriggerCurrentSummaryOpenResync(lastResyncAt: number, now:
 }
 
 export function shouldHandleUnsupportedSummaryRefresh(payloadWindow: string, currentWindow: string, supportsSse: boolean): boolean {
-  return payloadWindow !== currentWindow && !supportsSse && currentWindow !== 'current'
+  return payloadWindow !== currentWindow && !supportsSse && currentWindow !== 'current' && !isCalendarSummaryWindow(currentWindow)
 }
 
 export function shouldRetryCurrentSummaryError(error: string): boolean {
@@ -71,12 +77,13 @@ function resolvePendingLoad(pending: PendingLoad | null) {
   pending.waiters.forEach((resolve) => resolve())
 }
 
-export async function runUnsupportedSummaryRefresh(
+async function runThrottledSummaryRefresh(
   gate: UnsupportedRefreshGate,
   now: number,
+  refreshIntervalMs: number,
   refresh: () => Promise<void>,
 ): Promise<boolean> {
-  if (gate.inFlight || now - gate.lastTriggerAt < UNSUPPORTED_SSE_REFRESH_INTERVAL_MS) {
+  if (gate.inFlight || now - gate.lastTriggerAt < refreshIntervalMs) {
     return false
   }
 
@@ -92,11 +99,28 @@ export async function runUnsupportedSummaryRefresh(
   return true
 }
 
+export async function runUnsupportedSummaryRefresh(
+  gate: UnsupportedRefreshGate,
+  now: number,
+  refresh: () => Promise<void>,
+): Promise<boolean> {
+  return runThrottledSummaryRefresh(gate, now, UNSUPPORTED_SSE_REFRESH_INTERVAL_MS, refresh)
+}
+
+export async function runCalendarSummaryRefresh(
+  gate: UnsupportedRefreshGate,
+  now: number,
+  refresh: () => Promise<void>,
+): Promise<boolean> {
+  return runThrottledSummaryRefresh(gate, now, CALENDAR_SUMMARY_RECORDS_REFRESH_THROTTLE_MS, refresh)
+}
+
 export function useSummary(window: string, options?: UseSummaryOptions) {
   const [stats, setStats] = useState<StatsResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const unsupportedRefreshRef = useRef<UnsupportedRefreshGate>(createUnsupportedRefreshGate())
+  const calendarRefreshRef = useRef<UnsupportedRefreshGate>(createUnsupportedRefreshGate())
   const summaryContextRef = useRef<{ window: string; limit?: number }>({
     window,
     limit: options?.limit,
@@ -241,10 +265,7 @@ export function useSummary(window: string, options?: UseSummaryOptions) {
     refreshTimerRef.current = setTimeout(run, delay)
   }, [clearPendingRefreshTimer, load])
 
-  const triggerCurrentOpenResync = useCallback(() => {
-    if (window !== 'current') {
-      return
-    }
+  const triggerOpenResync = useCallback(() => {
     if (!hasHydratedRef.current) {
       pendingOpenResyncRef.current = true
       return
@@ -255,7 +276,7 @@ export function useSummary(window: string, options?: UseSummaryOptions) {
     }
     lastOpenResyncAtRef.current = now
     void load({ silent: true, force: true })
-  }, [load, window])
+  }, [load])
 
   useEffect(() => {
     // Invalidate prior async loads when summary query context changes.
@@ -265,6 +286,8 @@ export function useSummary(window: string, options?: UseSummaryOptions) {
     lastCurrentRecordsRefreshAtRef.current = 0
     lastOpenResyncAtRef.current = 0
     currentRetryAttemptRef.current = 0
+    unsupportedRefreshRef.current = createUnsupportedRefreshGate()
+    calendarRefreshRef.current = createUnsupportedRefreshGate()
     clearPendingLoad()
     clearPendingRefreshTimer()
     void load({ force: true })
@@ -299,6 +322,7 @@ export function useSummary(window: string, options?: UseSummaryOptions) {
   )
 
   const supportsSse = useMemo(() => SUPPORTED_SSE_WINDOWS.has(window), [window])
+  const isCalendarWindow = useMemo(() => isCalendarSummaryWindow(window), [window])
 
   useEffect(() => {
     const unsubscribe = subscribeToSse((payload) => {
@@ -309,23 +333,27 @@ export function useSummary(window: string, options?: UseSummaryOptions) {
           setError(null)
           setIsLoading(false)
         } else if (shouldHandleUnsupportedSummaryRefresh(payload.window, window, supportsSse)) {
-          // Unsupported windows (e.g. today) are refreshed at a fixed cadence to avoid request storms.
           void runUnsupportedSummaryRefresh(unsupportedRefreshRef.current, Date.now(), () => load({ silent: true }))
         }
-      } else if (payload.type === 'records' && window === 'current') {
-        // current 窗口通过节流静默刷新，避免高频事件导致闪烁。
-        triggerCurrentWindowRefresh()
+      } else if (payload.type === 'records') {
+        if (window === 'current') {
+          // current 窗口通过节流静默刷新，避免高频事件导致闪烁。
+          triggerCurrentWindowRefresh()
+        } else if (isCalendarWindow) {
+          // calendar windows 依旧通过 HTTP 计算，但 records 到达时以 1s 节流静默补拉。
+          void runCalendarSummaryRefresh(calendarRefreshRef.current, Date.now(), () => load({ silent: true }))
+        }
       }
     })
     return unsubscribe
-  }, [load, supportsSse, triggerCurrentWindowRefresh, window])
+  }, [isCalendarWindow, load, supportsSse, triggerCurrentWindowRefresh, window])
 
   useEffect(() => {
     const unsubscribe = subscribeToSseOpen(() => {
-      triggerCurrentOpenResync()
+      triggerOpenResync()
     })
     return unsubscribe
-  }, [triggerCurrentOpenResync])
+  }, [triggerOpenResync])
 
   return {
     summary: stats,

--- a/web/src/hooks/useTimeseries.test.ts
+++ b/web/src/hooks/useTimeseries.test.ts
@@ -1,8 +1,43 @@
 import { describe, expect, it } from 'vitest'
-import { shouldResyncOnRecordsEvent } from './useTimeseries'
+import type { TimeseriesResponse } from '../lib/api'
+import {
+  TIMESERIES_OPEN_RESYNC_COOLDOWN_MS,
+  TIMESERIES_RECORDS_RESYNC_THROTTLE_MS,
+  applyRecordsToCurrentDayBucket,
+  getCurrentDayBucketEndEpoch,
+  getTimeseriesRecordsResyncDelay,
+  mergePendingTimeseriesSilentOption,
+  resolveTimeseriesSyncPolicy,
+  shouldPatchCurrentDayBucketOnRecordsEvent,
+  shouldResyncForCurrentDayBucket,
+  shouldResyncOnRecordsEvent,
+  shouldTriggerTimeseriesOpenResync,
+} from './useTimeseries'
 
 describe('useTimeseries records sync strategy', () => {
+  it('uses explicit local incremental policy for dashboard 24h heatmap', () => {
+    expect(resolveTimeseriesSyncPolicy('1d', { bucket: '1m' }).mode).toBe('local')
+    expect(shouldResyncOnRecordsEvent('1d', { bucket: '1m' })).toBe(false)
+  })
+
+  it('uses explicit local incremental policy for dashboard 7d heatmap', () => {
+    expect(resolveTimeseriesSyncPolicy('7d', { bucket: '1h' }).mode).toBe('local')
+    expect(shouldResyncOnRecordsEvent('7d', { bucket: '1h' })).toBe(false)
+  })
+
+  it('uses current-day patch policy for dashboard usage calendar', () => {
+    expect(resolveTimeseriesSyncPolicy('90d', { bucket: '1d' }).mode).toBe('current-day-local')
+    expect(shouldPatchCurrentDayBucketOnRecordsEvent('90d', { bucket: '1d' })).toBe(true)
+    expect(shouldResyncOnRecordsEvent('90d', { bucket: '1d' })).toBe(false)
+  })
+
   it('forces server resync when backend aggregation is preferred', () => {
+    expect(
+      resolveTimeseriesSyncPolicy('1d', {
+        bucket: '15m',
+        preferServerAggregation: true,
+      }).mode,
+    ).toBe('server')
     expect(
       shouldResyncOnRecordsEvent('1d', {
         bucket: '15m',
@@ -11,19 +46,111 @@ describe('useTimeseries records sync strategy', () => {
     ).toBe(true)
   })
 
-  it('forces server resync for daily buckets to preserve timezone alignment', () => {
-    expect(
-      shouldResyncOnRecordsEvent('7d', {
-        bucket: '1d',
-      }),
-    ).toBe(true)
+  it('falls back to server resync for other daily buckets', () => {
+    expect(resolveTimeseriesSyncPolicy('30d', { bucket: '1d' }).mode).toBe('server')
+    expect(shouldResyncOnRecordsEvent('30d', { bucket: '1d' })).toBe(true)
+  })
+})
+
+describe('useTimeseries current-day bucket patching', () => {
+  const base: TimeseriesResponse = {
+    rangeStart: '2026-03-05T00:00:00Z',
+    rangeEnd: '2026-03-07T00:00:00Z',
+    bucketSeconds: 86_400,
+    points: [
+      {
+        bucketStart: '2026-03-05T00:00:00Z',
+        bucketEnd: '2026-03-06T00:00:00Z',
+        totalCount: 4,
+        successCount: 3,
+        failureCount: 1,
+        totalTokens: 400,
+        totalCost: 2,
+      },
+      {
+        bucketStart: '2026-03-06T00:00:00Z',
+        bucketEnd: '2026-03-07T00:00:00Z',
+        totalCount: 1,
+        successCount: 1,
+        failureCount: 0,
+        totalTokens: 100,
+        totalCost: 0.5,
+      },
+    ],
+  }
+
+  it('patches only the active local-day bucket for repeated records events', () => {
+    const next = applyRecordsToCurrentDayBucket(
+      base,
+      [
+        {
+          id: 1,
+          invokeId: 'older',
+          occurredAt: '2026-03-05T10:00:00Z',
+          status: 'success',
+          totalTokens: 10,
+          cost: 0.1,
+          createdAt: '2026-03-05T10:00:00Z',
+        },
+        {
+          id: 2,
+          invokeId: 'today',
+          occurredAt: '2026-03-06T08:30:00Z',
+          status: 'failed',
+          totalTokens: 25,
+          cost: 0.2,
+          createdAt: '2026-03-06T08:30:00Z',
+        },
+      ],
+      Math.floor(Date.parse('2026-03-06T12:00:00Z') / 1000),
+    )
+
+    expect(next?.points[0]).toEqual(base.points[0])
+    expect(next?.points[1]).toMatchObject({
+      totalCount: 2,
+      successCount: 1,
+      failureCount: 1,
+      totalTokens: 125,
+      totalCost: 0.7,
+    })
   })
 
-  it('keeps local incremental updates for sub-daily buckets by default', () => {
+  it('requests a full resync when the current day is no longer covered', () => {
     expect(
-      shouldResyncOnRecordsEvent('1d', {
-        bucket: '15m',
-      }),
+      shouldResyncForCurrentDayBucket(base, Math.floor(Date.parse('2026-03-07T01:00:00Z') / 1000)),
+    ).toBe(true)
+    expect(getCurrentDayBucketEndEpoch(base, Math.floor(Date.parse('2026-03-06T12:00:00Z') / 1000))).toBe(
+      Math.floor(Date.parse('2026-03-07T00:00:00Z') / 1000),
+    )
+  })
+})
+
+describe('useTimeseries refresh coordination helpers', () => {
+  it('reports the remaining resync delay inside the 3s throttle window', () => {
+    expect(getTimeseriesRecordsResyncDelay(10_000, 10_250)).toBe(
+      TIMESERIES_RECORDS_RESYNC_THROTTLE_MS - 250,
+    )
+    expect(
+      getTimeseriesRecordsResyncDelay(
+        20_000,
+        20_000 + TIMESERIES_RECORDS_RESYNC_THROTTLE_MS,
+      ),
+    ).toBe(0)
+  })
+
+  it('merges pending silent loads without losing a non-silent refresh', () => {
+    expect(mergePendingTimeseriesSilentOption(null, true)).toBe(true)
+    expect(mergePendingTimeseriesSilentOption(true, false)).toBe(false)
+    expect(mergePendingTimeseriesSilentOption(false, true)).toBe(false)
+  })
+
+  it('throttles reconnect resync unless the caller forces it', () => {
+    expect(
+      shouldTriggerTimeseriesOpenResync(
+        30_000,
+        30_000 + TIMESERIES_OPEN_RESYNC_COOLDOWN_MS - 1,
+      ),
     ).toBe(false)
+    expect(shouldTriggerTimeseriesOpenResync(30_000, 30_250, true)).toBe(true)
   })
 })

--- a/web/src/hooks/useTimeseries.test.ts
+++ b/web/src/hooks/useTimeseries.test.ts
@@ -123,6 +123,19 @@ describe('useTimeseries current-day bucket patching', () => {
       Math.floor(Date.parse('2026-03-07T00:00:00Z') / 1000),
     )
   })
+
+  it('requests a full resync when there is no current-day bucket to patch yet', () => {
+    expect(shouldResyncForCurrentDayBucket(null, Math.floor(Date.parse('2026-03-06T12:00:00Z') / 1000))).toBe(true)
+    expect(
+      shouldResyncForCurrentDayBucket(
+        {
+          ...base,
+          points: [],
+        },
+        Math.floor(Date.parse('2026-03-06T12:00:00Z') / 1000),
+      ),
+    ).toBe(true)
+  })
 })
 
 describe('useTimeseries refresh coordination helpers', () => {

--- a/web/src/hooks/useTimeseries.ts
+++ b/web/src/hooks/useTimeseries.ts
@@ -9,6 +9,103 @@ export interface UseTimeseriesOptions {
   preferServerAggregation?: boolean
 }
 
+export type TimeseriesSyncMode = 'local' | 'current-day-local' | 'server'
+
+export interface TimeseriesSyncPolicy {
+  mode: TimeseriesSyncMode
+  recordsRefreshThrottleMs: number
+}
+
+interface LoadOptions {
+  silent?: boolean
+  force?: boolean
+}
+
+interface PendingLoad {
+  silent: boolean
+  waiters: Array<() => void>
+}
+
+interface UpdateContext {
+  range: string
+  bucketSeconds?: number
+  settlementHour?: number
+}
+
+export const TIMESERIES_RECORDS_RESYNC_THROTTLE_MS = 3_000
+export const TIMESERIES_OPEN_RESYNC_COOLDOWN_MS = 3_000
+
+export function resolveTimeseriesSyncPolicy(range: string, options?: UseTimeseriesOptions): TimeseriesSyncPolicy {
+  if (options?.preferServerAggregation) {
+    return {
+      mode: 'server',
+      recordsRefreshThrottleMs: TIMESERIES_RECORDS_RESYNC_THROTTLE_MS,
+    }
+  }
+
+  if (range === '1d' && options?.bucket === '1m') {
+    return {
+      mode: 'local',
+      recordsRefreshThrottleMs: 0,
+    }
+  }
+
+  if (range === '7d' && options?.bucket === '1h') {
+    return {
+      mode: 'local',
+      recordsRefreshThrottleMs: 0,
+    }
+  }
+
+  if (range === '90d' && options?.bucket === '1d') {
+    return {
+      mode: 'current-day-local',
+      recordsRefreshThrottleMs: 0,
+    }
+  }
+
+  const bucketSeconds = guessBucketSeconds(options?.bucket) ?? defaultBucketSecondsForRange(range)
+  return {
+    mode: bucketSeconds >= 86_400 ? 'server' : 'local',
+    recordsRefreshThrottleMs: bucketSeconds >= 86_400 ? TIMESERIES_RECORDS_RESYNC_THROTTLE_MS : 0,
+  }
+}
+
+export function shouldResyncOnRecordsEvent(range: string, options?: UseTimeseriesOptions) {
+  return resolveTimeseriesSyncPolicy(range, options).mode === 'server'
+}
+
+export function shouldPatchCurrentDayBucketOnRecordsEvent(range: string, options?: UseTimeseriesOptions) {
+  return resolveTimeseriesSyncPolicy(range, options).mode === 'current-day-local'
+}
+
+export function getTimeseriesRecordsResyncDelay(lastRefreshAt: number, now: number, throttleMs = TIMESERIES_RECORDS_RESYNC_THROTTLE_MS) {
+  return Math.max(0, throttleMs - (now - lastRefreshAt))
+}
+
+export function shouldTriggerTimeseriesOpenResync(lastResyncAt: number, now: number, force = false) {
+  if (force) return true
+  return now - lastResyncAt >= TIMESERIES_OPEN_RESYNC_COOLDOWN_MS
+}
+
+export function mergePendingTimeseriesSilentOption(existingSilent: boolean | null, incomingSilent: boolean) {
+  return (existingSilent ?? true) && incomingSilent
+}
+
+function resolvePendingLoad(pending: PendingLoad | null) {
+  if (!pending) return
+  pending.waiters.forEach((resolve) => resolve())
+}
+
+function createSeededTimeseries(range: string, bucket?: string) {
+  const bucketSeconds = guessBucketSeconds(bucket) ?? defaultBucketSecondsForRange(range)
+  const now = Date.now()
+  const rangeSeconds = parseRangeSpec(range) ?? 86_400
+  const start = formatEpochToIso(Math.floor((now - rangeSeconds * 1000) / 1000))
+  const end = formatEpochToIso(Math.floor(now / 1000))
+  return { rangeStart: start, rangeEnd: end, bucketSeconds, points: [] satisfies TimeseriesPoint[] }
+}
+
 export function useTimeseries(range: string, options?: UseTimeseriesOptions) {
   const [data, setData] = useState<TimeseriesResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -17,7 +114,17 @@ export function useTimeseries(range: string, options?: UseTimeseriesOptions) {
   const settlementHour = options?.settlementHour
   const preferServerAggregation = options?.preferServerAggregation ?? false
   const hasHydratedRef = useRef(false)
-  const lastResyncAtRef = useRef(0)
+  const activeLoadCountRef = useRef(0)
+  const pendingLoadRef = useRef<PendingLoad | null>(null)
+  const pendingOpenResyncRef = useRef(false)
+  const requestSeqRef = useRef(0)
+  const activeRequestControllerRef = useRef<AbortController | null>(null)
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const dayRolloverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastRecordsRefreshAtRef = useRef(0)
+  const lastOpenResyncAtRef = useRef(0)
+  const localRevisionRef = useRef(0)
+  const dataRef = useRef<TimeseriesResponse | null>(null)
 
   const normalizedOptions = useMemo<UseTimeseriesOptions>(
     () => ({
@@ -28,36 +135,196 @@ export function useTimeseries(range: string, options?: UseTimeseriesOptions) {
     [bucket, settlementHour, preferServerAggregation],
   )
 
-  const load = useCallback(async (opts?: { silent?: boolean }) => {
-    const shouldShowLoading = !(opts?.silent && hasHydratedRef.current)
+  const syncPolicy = useMemo(
+    () => resolveTimeseriesSyncPolicy(range, normalizedOptions),
+    [normalizedOptions, range],
+  )
+
+  const clearPendingRefreshTimer = useCallback(() => {
+    if (!refreshTimerRef.current) return
+    clearTimeout(refreshTimerRef.current)
+    refreshTimerRef.current = null
+  }, [])
+
+  const clearDayRolloverTimer = useCallback(() => {
+    if (!dayRolloverTimerRef.current) return
+    clearTimeout(dayRolloverTimerRef.current)
+    dayRolloverTimerRef.current = null
+  }, [])
+
+  const clearPendingLoad = useCallback(() => {
+    resolvePendingLoad(pendingLoadRef.current)
+    pendingLoadRef.current = null
+  }, [])
+
+  const runLoad = useCallback(async ({ silent = false }: LoadOptions = {}) => {
+    activeLoadCountRef.current += 1
+    const requestSeq = requestSeqRef.current + 1
+    requestSeqRef.current = requestSeq
+    const baselineLocalRevision = localRevisionRef.current
+    const controller = new AbortController()
+    activeRequestControllerRef.current = controller
+    const shouldShowLoading = !(silent && hasHydratedRef.current)
     if (shouldShowLoading) {
       setIsLoading(true)
     }
+
     try {
-      const response = await fetchTimeseries(range, normalizedOptions)
-      setData(response)
+      const response = await fetchTimeseries(range, {
+        ...normalizedOptions,
+        signal: controller.signal,
+      })
+      if (requestSeq !== requestSeqRef.current) {
+        return
+      }
+
+      const shouldPreserveLocallyPatchedData =
+        syncPolicy.mode !== 'server' && baselineLocalRevision !== localRevisionRef.current
+
+      if (shouldPreserveLocallyPatchedData) {
+        if (pendingLoadRef.current) {
+          pendingLoadRef.current.silent = mergePendingTimeseriesSilentOption(
+            pendingLoadRef.current.silent,
+            true,
+          )
+        } else {
+          pendingLoadRef.current = { silent: true, waiters: [] }
+        }
+      } else {
+        dataRef.current = response
+        setData(response)
+      }
+
       hasHydratedRef.current = true
       setError(null)
+
+      if (pendingOpenResyncRef.current) {
+        pendingOpenResyncRef.current = false
+        lastOpenResyncAtRef.current = Date.now()
+        if (pendingLoadRef.current) {
+          pendingLoadRef.current.silent = mergePendingTimeseriesSilentOption(
+            pendingLoadRef.current.silent,
+            true,
+          )
+        } else {
+          pendingLoadRef.current = { silent: true, waiters: [] }
+        }
+      }
     } catch (err) {
+      if (requestSeq !== requestSeqRef.current) {
+        return
+      }
+      if (err instanceof Error && err.name === 'AbortError') {
+        return
+      }
       setError(err instanceof Error ? err.message : String(err))
-      // Bootstrap an empty timeseries so SSE records can hydrate the view
-      const bucketSeconds = guessBucketSeconds(bucket) ?? defaultBucketSecondsForRange(range)
-      const now = Date.now()
-      const rangeSeconds = parseRangeSpec(range) ?? 86_400
-      const start = formatEpochToIso(Math.floor((now - rangeSeconds * 1000) / 1000))
-      const end = formatEpochToIso(Math.floor(now / 1000))
-      setData({ rangeStart: start, rangeEnd: end, bucketSeconds, points: [] })
+      const fallback = createSeededTimeseries(range, normalizedOptions.bucket)
+      dataRef.current = fallback
+      setData(fallback)
       hasHydratedRef.current = true
     } finally {
-      setIsLoading(false)
+      if (activeRequestControllerRef.current === controller) {
+        activeRequestControllerRef.current = null
+      }
+      if (requestSeq === requestSeqRef.current && shouldShowLoading) {
+        setIsLoading(false)
+      }
+      activeLoadCountRef.current = Math.max(0, activeLoadCountRef.current - 1)
+      if (activeLoadCountRef.current === 0) {
+        const pendingLoad = pendingLoadRef.current
+        if (pendingLoad) {
+          pendingLoadRef.current = null
+          void runLoad({ silent: pendingLoad.silent }).finally(() => {
+            pendingLoad.waiters.forEach((resolve) => resolve())
+          })
+        }
+      }
     }
-  }, [normalizedOptions, range, bucket])
+  }, [normalizedOptions, range, syncPolicy.mode])
 
-  useEffect(() => {
-    void load()
+  const load = useCallback(async ({ silent = false, force = false }: LoadOptions = {}) => {
+    if (force) {
+      activeRequestControllerRef.current?.abort()
+      clearPendingLoad()
+      clearPendingRefreshTimer()
+    }
+
+    if (!force && activeLoadCountRef.current > 0) {
+      return new Promise<void>((resolve) => {
+        if (pendingLoadRef.current) {
+          pendingLoadRef.current.silent = mergePendingTimeseriesSilentOption(
+            pendingLoadRef.current.silent,
+            silent,
+          )
+          pendingLoadRef.current.waiters.push(resolve)
+          return
+        }
+        pendingLoadRef.current = { silent, waiters: [resolve] }
+      })
+    }
+
+    if (syncPolicy.mode === 'server') {
+      lastRecordsRefreshAtRef.current = Date.now()
+    }
+
+    await runLoad({ silent })
+  }, [clearPendingLoad, clearPendingRefreshTimer, runLoad, syncPolicy.mode])
+
+  const triggerRecordsResync = useCallback(() => {
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+    const now = Date.now()
+    const delay = getTimeseriesRecordsResyncDelay(
+      lastRecordsRefreshAtRef.current,
+      now,
+      syncPolicy.recordsRefreshThrottleMs,
+    )
+    const run = () => {
+      refreshTimerRef.current = null
+      lastRecordsRefreshAtRef.current = Date.now()
+      void load({ silent: true })
+    }
+
+    if (delay === 0) {
+      clearPendingRefreshTimer()
+      run()
+      return
+    }
+
+    if (refreshTimerRef.current) {
+      return
+    }
+    refreshTimerRef.current = setTimeout(run, delay)
+  }, [clearPendingRefreshTimer, load, syncPolicy.recordsRefreshThrottleMs])
+
+  const triggerOpenResync = useCallback((force = false) => {
+    if (!hasHydratedRef.current) {
+      pendingOpenResyncRef.current = true
+      return
+    }
+    const now = Date.now()
+    if (!shouldTriggerTimeseriesOpenResync(lastOpenResyncAtRef.current, now, force)) {
+      return
+    }
+    lastOpenResyncAtRef.current = now
+    void load({ silent: true, force: true })
   }, [load])
 
-  // Auto-retry on transient failures (e.g., backend temporarily unavailable)
+  useEffect(() => {
+    requestSeqRef.current += 1
+    activeRequestControllerRef.current?.abort()
+    activeRequestControllerRef.current = null
+    hasHydratedRef.current = false
+    pendingOpenResyncRef.current = false
+    lastRecordsRefreshAtRef.current = 0
+    lastOpenResyncAtRef.current = 0
+    localRevisionRef.current = 0
+    dataRef.current = null
+    clearPendingLoad()
+    clearPendingRefreshTimer()
+    clearDayRolloverTimer()
+    void load({ force: true })
+  }, [clearDayRolloverTimer, clearPendingLoad, clearPendingRefreshTimer, load, options?.bucket, options?.preferServerAggregation, options?.settlementHour, range])
+
   useEffect(() => {
     if (!error) return
     const id = setTimeout(() => {
@@ -66,59 +333,94 @@ export function useTimeseries(range: string, options?: UseTimeseriesOptions) {
     return () => clearTimeout(id)
   }, [error, load])
 
-  const requestResync = useCallback(() => {
-    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
-    const now = Date.now()
-    if (now - lastResyncAtRef.current < 3000) return
-    lastResyncAtRef.current = now
-    void load({ silent: true })
-  }, [load])
-
   useEffect(() => {
     const unsubscribe = subscribeToSse((payload) => {
-      if (payload.type === 'records') {
-        // When consumers rely on backend-only aggregations (e.g., percentile series),
-        // use server-side recalculation instead of local incremental updates.
-        if (shouldResyncOnRecordsEvent(range, normalizedOptions)) {
-          requestResync()
+      if (payload.type !== 'records') return
+
+      if (syncPolicy.mode === 'server') {
+        triggerRecordsResync()
+        return
+      }
+
+      if (syncPolicy.mode === 'current-day-local') {
+        const nowEpochSeconds = Math.floor(Date.now() / 1000)
+        if (shouldResyncForCurrentDayBucket(dataRef.current, nowEpochSeconds)) {
+          triggerOpenResync(true)
           return
         }
         setData((current) => {
-          const seeded =
-            current ?? {
-              rangeStart: formatEpochToIso(Math.floor((Date.now() - (parseRangeSpec(range) ?? 86_400) * 1000) / 1000)),
-              rangeEnd: formatEpochToIso(Math.floor(Date.now() / 1000)),
-              bucketSeconds: guessBucketSeconds(normalizedOptions.bucket) ?? defaultBucketSecondsForRange(range),
-              points: [],
-            }
-          return applyRecordsToTimeseries(seeded, payload.records, {
-            range,
-            bucketSeconds: seeded.bucketSeconds,
-            settlementHour: normalizedOptions.settlementHour,
-          })
+          const next = applyRecordsToCurrentDayBucket(current, payload.records, nowEpochSeconds)
+          if (next !== current) {
+            dataRef.current = next
+            localRevisionRef.current += 1
+          }
+          return next
         })
+        return
       }
+
+      setData((current) => {
+        const seeded = current ?? createSeededTimeseries(range, normalizedOptions.bucket)
+        const next = applyRecordsToTimeseries(seeded, payload.records, {
+          range,
+          bucketSeconds: seeded.bucketSeconds,
+          settlementHour: normalizedOptions.settlementHour,
+        })
+        if (next !== current) {
+          dataRef.current = next
+          localRevisionRef.current += 1
+        }
+        return next
+      })
     })
     return unsubscribe
-  }, [normalizedOptions, range, requestResync])
+  }, [normalizedOptions.bucket, normalizedOptions.settlementHour, range, syncPolicy.mode, triggerOpenResync, triggerRecordsResync])
 
-  // Backfill missed SSE records when the page returns to the foreground or the SSE transport reconnects.
   useEffect(() => {
     if (typeof document === 'undefined') return
     const onVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return
-      requestResync()
+      triggerOpenResync(syncPolicy.mode === 'current-day-local')
     }
     document.addEventListener('visibilitychange', onVisibilityChange)
     return () => document.removeEventListener('visibilitychange', onVisibilityChange)
-  }, [requestResync])
+  }, [syncPolicy.mode, triggerOpenResync])
 
   useEffect(() => {
     const unsubscribe = subscribeToSseOpen(() => {
-      requestResync()
+      triggerOpenResync()
     })
     return unsubscribe
-  }, [requestResync])
+  }, [triggerOpenResync])
+
+  useEffect(() => {
+    clearDayRolloverTimer()
+    if (syncPolicy.mode !== 'current-day-local') {
+      return
+    }
+    const currentBucketEndEpoch = getCurrentDayBucketEndEpoch(data)
+    if (currentBucketEndEpoch == null) {
+      return
+    }
+    const delay = Math.max(0, currentBucketEndEpoch * 1000 - Date.now() + 50)
+    dayRolloverTimerRef.current = setTimeout(() => {
+      void load({ silent: true, force: true })
+    }, delay)
+    return clearDayRolloverTimer
+  }, [clearDayRolloverTimer, data, load, syncPolicy.mode])
+
+  useEffect(
+    () => () => {
+      requestSeqRef.current += 1
+      activeRequestControllerRef.current?.abort()
+      activeRequestControllerRef.current = null
+      clearPendingLoad()
+      clearPendingRefreshTimer()
+      clearDayRolloverTimer()
+      pendingOpenResyncRef.current = false
+    },
+    [clearDayRolloverTimer, clearPendingLoad, clearPendingRefreshTimer],
+  )
 
   return {
     data,
@@ -128,20 +430,88 @@ export function useTimeseries(range: string, options?: UseTimeseriesOptions) {
   }
 }
 
-export function shouldResyncOnRecordsEvent(range: string, options?: UseTimeseriesOptions) {
-  if (options?.preferServerAggregation) return true
-  const bucketSeconds = guessBucketSeconds(options?.bucket) ?? defaultBucketSecondsForRange(range)
-  // Daily buckets depend on IANA timezone rules (incl. DST). Let backend be source of truth.
-  return bucketSeconds >= 86_400
+export function getCurrentDayBucketEndEpoch(current: TimeseriesResponse | null, nowEpochSeconds = Math.floor(Date.now() / 1000)) {
+  const currentBucket = getCurrentDayBucket(current, nowEpochSeconds)
+  return parseIsoEpoch(currentBucket?.bucketEnd)
 }
 
-interface UpdateContext {
-  range: string
-  bucketSeconds?: number
-  settlementHour?: number
+export function shouldResyncForCurrentDayBucket(current: TimeseriesResponse | null, nowEpochSeconds = Math.floor(Date.now() / 1000)) {
+  if (!current || current.points.length === 0) {
+    return false
+  }
+  return getCurrentDayBucket(current, nowEpochSeconds) == null
 }
 
-function applyRecordsToTimeseries(
+function getCurrentDayBucket(current: TimeseriesResponse | null, nowEpochSeconds: number) {
+  if (!current) return null
+  for (let index = current.points.length - 1; index >= 0; index -= 1) {
+    const point = current.points[index]
+    const bucketStartEpoch = parseIsoEpoch(point.bucketStart)
+    const bucketEndEpoch = parseIsoEpoch(point.bucketEnd)
+    if (bucketStartEpoch == null || bucketEndEpoch == null) continue
+    if (nowEpochSeconds >= bucketStartEpoch && nowEpochSeconds < bucketEndEpoch) {
+      return point
+    }
+  }
+  return null
+}
+
+export function applyRecordsToCurrentDayBucket(
+  current: TimeseriesResponse | null,
+  records: ApiInvocation[],
+  nowEpochSeconds = Math.floor(Date.now() / 1000),
+) {
+  if (!current || records.length === 0) {
+    return current
+  }
+
+  const currentBucket = getCurrentDayBucket(current, nowEpochSeconds)
+  if (!currentBucket) {
+    return current
+  }
+
+  const bucketStartEpoch = parseIsoEpoch(currentBucket.bucketStart)
+  const bucketEndEpoch = parseIsoEpoch(currentBucket.bucketEnd)
+  if (bucketStartEpoch == null || bucketEndEpoch == null) {
+    return current
+  }
+
+  const nextPoints = current.points.map((point) =>
+    point.bucketStart === currentBucket.bucketStart ? { ...point } : point,
+  )
+  const nextBucket = nextPoints.find((point) => point.bucketStart === currentBucket.bucketStart)
+  if (!nextBucket) {
+    return current
+  }
+
+  let mutating = false
+  for (const record of records) {
+    const occurredEpoch = parseIsoEpoch(record.occurredAt)
+    if (occurredEpoch == null || occurredEpoch < bucketStartEpoch || occurredEpoch >= bucketEndEpoch) {
+      continue
+    }
+    nextBucket.totalCount += 1
+    if (record.status === 'success') {
+      nextBucket.successCount += 1
+    } else {
+      nextBucket.failureCount += 1
+    }
+    nextBucket.totalTokens += record.totalTokens ?? 0
+    nextBucket.totalCost += record.cost ?? 0
+    mutating = true
+  }
+
+  if (!mutating) {
+    return current
+  }
+
+  return {
+    ...current,
+    points: nextPoints,
+  }
+}
+
+export function applyRecordsToTimeseries(
   current: TimeseriesResponse | null,
   records: ApiInvocation[],
   context: UpdateContext,

--- a/web/src/hooks/useTimeseries.ts
+++ b/web/src/hooks/useTimeseries.ts
@@ -436,8 +436,9 @@ export function getCurrentDayBucketEndEpoch(current: TimeseriesResponse | null, 
 }
 
 export function shouldResyncForCurrentDayBucket(current: TimeseriesResponse | null, nowEpochSeconds = Math.floor(Date.now() / 1000)) {
+  // Without a current bucket, the next live record cannot be patched locally and needs a server resync.
   if (!current || current.points.length === 0) {
-    return false
+    return true
   }
   return getCurrentDayBucket(current, nowEpochSeconds) == null
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -711,13 +711,16 @@ export async function fetchPromptCacheConversations(limit: number) {
   return normalizePromptCacheConversationsResponse(response)
 }
 
-export async function fetchTimeseries(range: string, params?: { bucket?: string; settlementHour?: number; timeZone?: string }) {
+export async function fetchTimeseries(
+  range: string,
+  params?: { bucket?: string; settlementHour?: number; timeZone?: string; signal?: AbortSignal },
+) {
   const search = new URLSearchParams()
   search.set('range', range)
   search.set('timeZone', params?.timeZone ?? getBrowserTimeZone())
   if (params?.bucket) search.set('bucket', params.bucket)
   if (params?.settlementHour !== undefined) search.set('settlementHour', String(params.settlementHour))
-  return fetchJson<TimeseriesResponse>(`/api/stats/timeseries?${search.toString()}`)
+  return fetchJson<TimeseriesResponse>(`/api/stats/timeseries?${search.toString()}`, { signal: params?.signal })
 }
 
 export async function fetchErrorDistribution(


### PR DESCRIPTION
## What
- avoid redundant summary/quota work when no SSE subscribers are connected and skip unchanged broadcasts
- throttle calendar-summary refreshes from `records` events while keeping dashboard `1d` summary on SSE
- harden `useTimeseries` with explicit sync policies, abort/cancel, stale-response protection, reconnect backfill, and current-day bucket patching for `90d/1d`
- add/update Rust and Vitest coverage plus the dashboard refresh optimization spec

## Spec
- `docs/specs/xvdhm-dashboard-sse-refresh-optimization/SPEC.md`

## Verification
- `cargo test`
- `cd web && npm test`
- `cd web && npm run build`
- browser check on `http://127.0.0.1:8080/dashboard#/dashboard`
  - a proxy-produced `records` event updated recent records, `today`, `24h`, `7d`, and the current `90d/1d` bucket within ~1-2s
  - repeated `records` events no longer triggered repeated `range=90d&bucket=1d` full refetches
  - after forcing an SSE reconnect, dashboard hooks performed one silent backfill round (`summary`, `timeseries`, `invocations`) and converged to the latest persisted state