### PR TITLE
fix(web): unify live chart y-axis scales

### DIFF
--- a/web/src/components/ForwardProxyLiveTable.stories.tsx
+++ b/web/src/components/ForwardProxyLiveTable.stories.tsx
@@ -99,6 +99,83 @@ const stats: ForwardProxyLiveStatsResponse = {
   ],
 }
 
+
+
+const sharedScaleStats: ForwardProxyLiveStatsResponse = {
+  rangeStart: '2026-03-01T00:00:00.000Z',
+  rangeEnd: '2026-03-02T00:00:00.000Z',
+  bucketSeconds: 3600,
+  nodes: [
+    {
+      key: 'tiny-traffic',
+      source: 'manual',
+      displayName: 'tiny-traffic',
+      weight: 0.4,
+      penalized: false,
+      stats: {
+        oneMinute: { attempts: 1, successRate: 1, avgLatencyMs: 120 },
+        fifteenMinutes: { attempts: 4, successRate: 1, avgLatencyMs: 130 },
+        oneHour: { attempts: 8, successRate: 1, avgLatencyMs: 140 },
+        oneDay: { attempts: 32, successRate: 0.97, avgLatencyMs: 150 },
+        sevenDays: { attempts: 180, successRate: 0.96, avgLatencyMs: 160 },
+      },
+      last24h: [
+        { bucketStart: '2026-03-01T00:00:00.000Z', bucketEnd: '2026-03-01T01:00:00.000Z', successCount: 2, failureCount: 0 },
+        { bucketStart: '2026-03-01T01:00:00.000Z', bucketEnd: '2026-03-01T02:00:00.000Z', successCount: 1, failureCount: 0 },
+        ...Array.from({ length: 22 }, (_, index) => ({
+          bucketStart: new Date(Date.parse('2026-03-01T02:00:00.000Z') + index * 3600_000).toISOString(),
+          bucketEnd: new Date(Date.parse('2026-03-01T03:00:00.000Z') + index * 3600_000).toISOString(),
+          successCount: 0,
+          failureCount: 0,
+        })),
+      ],
+      weight24h: Array.from({ length: 24 }, (_, index) => ({
+        bucketStart: new Date(Date.parse('2026-03-01T00:00:00.000Z') + index * 3600_000).toISOString(),
+        bucketEnd: new Date(Date.parse('2026-03-01T01:00:00.000Z') + index * 3600_000).toISOString(),
+        sampleCount: 1,
+        minWeight: 0.35,
+        maxWeight: 0.45,
+        avgWeight: 0.4,
+        lastWeight: 0.4 + (index % 3 === 0 ? 0.02 : 0),
+      })),
+    },
+    {
+      key: 'burst-traffic',
+      source: 'manual',
+      displayName: 'burst-traffic',
+      weight: 2.4,
+      penalized: false,
+      stats: {
+        oneMinute: { attempts: 18, successRate: 0.94, avgLatencyMs: 210 },
+        fifteenMinutes: { attempts: 120, successRate: 0.93, avgLatencyMs: 220 },
+        oneHour: { attempts: 480, successRate: 0.92, avgLatencyMs: 240 },
+        oneDay: { attempts: 4800, successRate: 0.91, avgLatencyMs: 260 },
+        sevenDays: { attempts: 32000, successRate: 0.9, avgLatencyMs: 280 },
+      },
+      last24h: [
+        { bucketStart: '2026-03-01T00:00:00.000Z', bucketEnd: '2026-03-01T01:00:00.000Z', successCount: 22, failureCount: 1 },
+        { bucketStart: '2026-03-01T01:00:00.000Z', bucketEnd: '2026-03-01T02:00:00.000Z', successCount: 18, failureCount: 2 },
+        { bucketStart: '2026-03-01T02:00:00.000Z', bucketEnd: '2026-03-01T03:00:00.000Z', successCount: 30, failureCount: 4 },
+        ...Array.from({ length: 21 }, (_, index) => ({
+          bucketStart: new Date(Date.parse('2026-03-01T03:00:00.000Z') + index * 3600_000).toISOString(),
+          bucketEnd: new Date(Date.parse('2026-03-01T04:00:00.000Z') + index * 3600_000).toISOString(),
+          successCount: index % 4 === 0 ? 12 : 4,
+          failureCount: index % 6 === 0 ? 2 : 0,
+        })),
+      ],
+      weight24h: Array.from({ length: 24 }, (_, index) => ({
+        bucketStart: new Date(Date.parse('2026-03-01T00:00:00.000Z') + index * 3600_000).toISOString(),
+        bucketEnd: new Date(Date.parse('2026-03-01T01:00:00.000Z') + index * 3600_000).toISOString(),
+        sampleCount: 3,
+        minWeight: 1.8,
+        maxWeight: 2.4,
+        avgWeight: 2.1,
+        lastWeight: 2.4 - (index % 5 === 0 ? 0.3 : 0.1),
+      })),
+    },
+  ],
+}
+
 const meta = {
   title: 'Monitoring/ForwardProxyLiveTable',
   component: ForwardProxyLiveTable,
@@ -143,3 +220,12 @@ export const Empty: Story = {
     error: null,
   },
 }
+
+export const SharedScaleComparison: Story = {
+  args: {
+    stats: sharedScaleStats,
+    isLoading: false,
+    error: null,
+  },
+}
+

--- a/web/src/components/ForwardProxyLiveTable.test.tsx
+++ b/web/src/components/ForwardProxyLiveTable.test.tsx
@@ -121,6 +121,88 @@ describe('ForwardProxyLiveTable', () => {
     expect(html).toContain('近 24 小时请求量')
   })
 
+  it('shares request and weight trend scales across proxy rows', () => {
+    const stats: ForwardProxyLiveStatsResponse = {
+      rangeStart: '2026-03-01T00:00:00Z',
+      rangeEnd: '2026-03-02T00:00:00Z',
+      bucketSeconds: 3600,
+      nodes: [
+        {
+          key: 'proxy-low',
+          source: 'manual',
+          displayName: 'Proxy Low',
+          weight: 0.5,
+          penalized: false,
+          stats: {
+            oneMinute: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            fifteenMinutes: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneHour: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneDay: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            sevenDays: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+          },
+          last24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              successCount: 1,
+              failureCount: 0,
+            },
+          ],
+          weight24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              sampleCount: 1,
+              minWeight: 0.5,
+              maxWeight: 0.5,
+              avgWeight: 0.5,
+              lastWeight: 0.5,
+            },
+          ],
+        },
+        {
+          key: 'proxy-high',
+          source: 'manual',
+          displayName: 'Proxy High',
+          weight: 2,
+          penalized: false,
+          stats: {
+            oneMinute: { attempts: 4, successRate: 1, avgLatencyMs: 100 },
+            fifteenMinutes: { attempts: 4, successRate: 1, avgLatencyMs: 100 },
+            oneHour: { attempts: 4, successRate: 1, avgLatencyMs: 100 },
+            oneDay: { attempts: 4, successRate: 1, avgLatencyMs: 100 },
+            sevenDays: { attempts: 4, successRate: 1, avgLatencyMs: 100 },
+          },
+          last24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              successCount: 4,
+              failureCount: 0,
+            },
+          ],
+          weight24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              sampleCount: 1,
+              minWeight: 2,
+              maxWeight: 2,
+              avgWeight: 2,
+              lastWeight: 2,
+            },
+          ],
+        },
+      ],
+    }
+
+    const html = renderTable(stats)
+
+    expect(html).toContain('Proxy Low')
+    expect(countOccurrences(html, 'style="height:25%"')).toBe(1)
+    expect(html).toContain('cy="30"')
+  })
+
   it('uses different colors for positive and negative weight regions', () => {
     const stats: ForwardProxyLiveStatsResponse = {
       rangeStart: '2026-03-01T00:00:00Z',

--- a/web/src/components/ForwardProxyLiveTable.test.tsx
+++ b/web/src/components/ForwardProxyLiveTable.test.tsx
@@ -199,9 +199,163 @@ describe('ForwardProxyLiveTable', () => {
     const html = renderTable(stats)
 
     expect(html).toContain('Proxy Low')
-    expect(countOccurrences(html, 'style="height:25%"')).toBe(1)
+    expect(html).toContain('style="height:10px"')
     expect(html).toContain('cy="30"')
   })
+
+
+  it('keeps tiny non-zero request buckets visible on a shared scale', () => {
+    const stats: ForwardProxyLiveStatsResponse = {
+      rangeStart: '2026-03-01T00:00:00Z',
+      rangeEnd: '2026-03-02T00:00:00Z',
+      bucketSeconds: 3600,
+      nodes: [
+        {
+          key: 'proxy-tiny',
+          source: 'manual',
+          displayName: 'Proxy Tiny',
+          weight: 0.8,
+          penalized: false,
+          stats: {
+            oneMinute: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            fifteenMinutes: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneHour: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneDay: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            sevenDays: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+          },
+          last24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              successCount: 1,
+              failureCount: 0,
+            },
+          ],
+          weight24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              sampleCount: 1,
+              minWeight: 0.8,
+              maxWeight: 0.8,
+              avgWeight: 0.8,
+              lastWeight: 0.8,
+            },
+          ],
+        },
+        {
+          key: 'proxy-huge',
+          source: 'manual',
+          displayName: 'Proxy Huge',
+          weight: 1.2,
+          penalized: false,
+          stats: {
+            oneMinute: { attempts: 1000, successRate: 1, avgLatencyMs: 100 },
+            fifteenMinutes: { attempts: 1000, successRate: 1, avgLatencyMs: 100 },
+            oneHour: { attempts: 1000, successRate: 1, avgLatencyMs: 100 },
+            oneDay: { attempts: 1000, successRate: 1, avgLatencyMs: 100 },
+            sevenDays: { attempts: 1000, successRate: 1, avgLatencyMs: 100 },
+          },
+          last24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              successCount: 1000,
+              failureCount: 0,
+            },
+          ],
+          weight24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              sampleCount: 1,
+              minWeight: 1.2,
+              maxWeight: 1.2,
+              avgWeight: 1.2,
+              lastWeight: 1.2,
+            },
+          ],
+        },
+      ],
+    }
+
+    const html = renderTable(stats)
+
+    expect(html).toContain('Proxy Tiny')
+    expect(html).toContain('style="height:1px"')
+  })
+
+  it('ignores synthetic fallback weights when real history exists on the page', () => {
+    const stats: ForwardProxyLiveStatsResponse = {
+      rangeStart: '2026-03-01T00:00:00Z',
+      rangeEnd: '2026-03-02T00:00:00Z',
+      bucketSeconds: 3600,
+      nodes: [
+        {
+          key: 'proxy-real',
+          source: 'manual',
+          displayName: 'Proxy Real',
+          weight: 1.1,
+          penalized: false,
+          stats: {
+            oneMinute: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            fifteenMinutes: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneHour: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneDay: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            sevenDays: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+          },
+          last24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              successCount: 1,
+              failureCount: 0,
+            },
+          ],
+          weight24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              sampleCount: 1,
+              minWeight: 0.9,
+              maxWeight: 0.9,
+              avgWeight: 0.9,
+              lastWeight: 0.9,
+            },
+          ],
+        },
+        {
+          key: 'proxy-fallback',
+          source: 'manual',
+          displayName: 'Proxy Fallback',
+          weight: 100,
+          penalized: false,
+          stats: {
+            oneMinute: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            fifteenMinutes: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneHour: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            oneDay: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+            sevenDays: { attempts: 1, successRate: 1, avgLatencyMs: 100 },
+          },
+          last24h: [
+            {
+              bucketStart: '2026-03-01T00:00:00Z',
+              bucketEnd: '2026-03-01T01:00:00Z',
+              successCount: 0,
+              failureCount: 0,
+            },
+          ],
+          weight24h: [],
+        },
+      ],
+    }
+
+    const html = renderTable(stats)
+
+    expect(html).toContain('cy="0"')
+    expect(html).not.toContain('cy="-')
+  })
+
 
   it('uses different colors for positive and negative weight regions', () => {
     const stats: ForwardProxyLiveStatsResponse = {

--- a/web/src/components/ForwardProxyLiveTable.tsx
+++ b/web/src/components/ForwardProxyLiveTable.tsx
@@ -105,13 +105,18 @@ interface WeightTrendGeometry {
   points: Array<{ x: number; y: number }>
 }
 
-function buildWeightTrendGeometry(buckets: ForwardProxyWeightBucket[]): WeightTrendGeometry | null {
+interface WeightTrendScale {
+  minValue: number
+  maxValue: number
+}
+
+function buildWeightTrendGeometry(buckets: ForwardProxyWeightBucket[], scale: WeightTrendScale): WeightTrendGeometry | null {
   if (buckets.length === 0) return null
   const chartWidth = 216
   const chartHeight = 40
   const values = buckets.map((bucket) => bucket.lastWeight)
-  const minValue = Math.min(...values, 0)
-  const maxValue = Math.max(...values, 0)
+  const minValue = scale.minValue
+  const maxValue = scale.maxValue
   const span = Math.max(maxValue - minValue, Number.EPSILON)
   const bucketWidth = chartWidth / buckets.length
   const points = values.map((value, index) => {
@@ -153,18 +158,20 @@ function WindowCell({ value }: { value: ForwardProxyWindowStats }) {
 
 function WeightTrendCell({
   buckets,
+  scale,
   localeTag,
   tooltipLabels,
   ariaLabel,
   clipId,
 }: {
   buckets: ForwardProxyWeightBucket[]
+  scale: WeightTrendScale
   localeTag: string
   tooltipLabels: WeightTooltipLabels
   ariaLabel: string
   clipId: string
 }) {
-  const geometry = buildWeightTrendGeometry(buckets)
+  const geometry = buildWeightTrendGeometry(buckets, scale)
   if (!geometry) {
     return <div className="text-[11px] text-base-content/55">—</div>
   }
@@ -259,17 +266,31 @@ export function ForwardProxyLiveTable({ stats, isLoading, error }: ForwardProxyL
     [t],
   )
 
-  const rowData = useMemo(
-    () =>
-      (stats?.nodes ?? []).map((node) => ({
+  const { rowData, requestBucketScaleMax, weightTrendScale } = useMemo(() => {
+    const rows = (stats?.nodes ?? []).map((node) => {
+      const weightBuckets = resolveWeightBuckets(node)
+      return {
         node,
         windows: [node.stats.oneMinute, node.stats.fifteenMinutes, node.stats.oneHour, node.stats.oneDay, node.stats.sevenDays],
         total24h: sumLast24h(node),
-        weightBuckets: resolveWeightBuckets(node),
-        maxBucketTotal24h: Math.max(...node.last24h.map((bucket) => bucket.successCount + bucket.failureCount), 0),
-      })),
-    [stats?.nodes],
-  )
+        weightBuckets,
+      }
+    })
+    const requestBucketScaleMax = Math.max(
+      ...rows.flatMap(({ node }) => node.last24h.map((bucket) => bucket.successCount + bucket.failureCount)),
+      0,
+    )
+    const weightValues = rows.flatMap(({ weightBuckets }) => weightBuckets.map((bucket) => bucket.lastWeight))
+    const weightTrendScale = {
+      minValue: Math.min(...weightValues, 0),
+      maxValue: Math.max(...weightValues, 0),
+    }
+    return {
+      rowData: rows,
+      requestBucketScaleMax,
+      weightTrendScale,
+    }
+  }, [stats?.nodes])
 
   if (error) {
     return (
@@ -323,7 +344,7 @@ export function ForwardProxyLiveTable({ stats, isLoading, error }: ForwardProxyL
           </tr>
         </thead>
         <tbody className="divide-y divide-base-300/65">
-          {rowData.map(({ node, windows, total24h, weightBuckets, maxBucketTotal24h }) => (
+          {rowData.map(({ node, windows, total24h, weightBuckets }) => (
             <tr key={node.key} className={cn('transition-colors hover:bg-primary/6', node.penalized && 'bg-warning/8')}>
               <td className="max-w-0 px-2 py-2 align-middle sm:px-3 sm:py-3">
                 <div className="min-w-0">
@@ -359,8 +380,8 @@ export function ForwardProxyLiveTable({ stats, isLoading, error }: ForwardProxyL
                   <div className="flex h-11 items-end gap-px sm:gap-[1.5px] md:gap-[2px]">
                     {node.last24h.map((bucket, index) => {
                       const total = bucket.successCount + bucket.failureCount
-                      const successHeight = maxBucketTotal24h > 0 ? (bucket.successCount / maxBucketTotal24h) * 100 : 0
-                      const failureHeight = maxBucketTotal24h > 0 ? (bucket.failureCount / maxBucketTotal24h) * 100 : 0
+                      const successHeight = requestBucketScaleMax > 0 ? (bucket.successCount / requestBucketScaleMax) * 100 : 0
+                      const failureHeight = requestBucketScaleMax > 0 ? (bucket.failureCount / requestBucketScaleMax) * 100 : 0
                       const emptyHeight = Math.max(0, 100 - Math.round(successHeight + failureHeight))
                       return (
                         <div
@@ -394,6 +415,7 @@ export function ForwardProxyLiveTable({ stats, isLoading, error }: ForwardProxyL
               <td className="px-2 py-2 align-middle sm:px-3 sm:py-3">
                 <WeightTrendCell
                   buckets={weightBuckets}
+                  scale={weightTrendScale}
                   localeTag={localeTag}
                   tooltipLabels={weightTooltipLabels}
                   ariaLabel={weightTrendAriaLabel}

--- a/web/src/components/ForwardProxyLiveTable.tsx
+++ b/web/src/components/ForwardProxyLiveTable.tsx
@@ -52,6 +52,46 @@ function resolveWeightBuckets(node: ForwardProxyLiveNode): ForwardProxyWeightBuc
   }))
 }
 
+function buildVisibleBarHeights(successCount: number, failureCount: number, scaleMax: number, totalHeightPx: number) {
+  if (scaleMax <= 0 || totalHeightPx <= 0) {
+    return { empty: totalHeightPx, failure: 0, success: 0 }
+  }
+
+  let success = successCount > 0 ? Math.max((successCount / scaleMax) * totalHeightPx, 1) : 0
+  let failure = failureCount > 0 ? Math.max((failureCount / scaleMax) * totalHeightPx, 1) : 0
+  const maxVisible = Math.max(totalHeightPx, 0)
+  let overflow = success + failure - maxVisible
+
+  const shrink = (value: number, minVisible: number, amount: number) => {
+    if (amount <= 0 || value <= minVisible) return { nextValue: value, remaining: amount }
+    const delta = Math.min(value - minVisible, amount)
+    return { nextValue: value - delta, remaining: amount - delta }
+  }
+
+  if (overflow > 0) {
+    const first = success >= failure ? 'success' : 'failure'
+    const second = first == 'success' ? 'failure' : 'success'
+    for (const key of [first, second] as const) {
+      const minVisible = key == 'success' ? (successCount > 0 ? 1 : 0) : failureCount > 0 ? 1 : 0
+      const current = key == 'success' ? success : failure
+      const result = shrink(current, minVisible, overflow)
+      if (key == 'success') {
+        success = result.nextValue
+      } else {
+        failure = result.nextValue
+      }
+      overflow = result.remaining
+    }
+  }
+
+  const used = Math.min(success + failure, maxVisible)
+  return {
+    empty: Math.max(maxVisible - used, 0),
+    failure,
+    success,
+  }
+}
+
 function bucketTooltipLabel(bucket: ForwardProxyHourlyBucket, localeTag: string, successLabel: string, failureLabel: string) {
   const start = new Date(bucket.bucketStart)
   const end = new Date(bucket.bucketEnd)
@@ -120,7 +160,7 @@ function buildWeightTrendGeometry(buckets: ForwardProxyWeightBucket[], scale: We
   const span = Math.max(maxValue - minValue, Number.EPSILON)
   const bucketWidth = chartWidth / buckets.length
   const points = values.map((value, index) => {
-    const ratio = (value - minValue) / span
+    const ratio = Math.max(0, Math.min(1, (value - minValue) / span))
     const x = bucketWidth * index + bucketWidth / 2
     const y = chartHeight - ratio * chartHeight
     return { x, y }
@@ -280,10 +320,12 @@ export function ForwardProxyLiveTable({ stats, isLoading, error }: ForwardProxyL
       ...rows.flatMap(({ node }) => node.last24h.map((bucket) => bucket.successCount + bucket.failureCount)),
       0,
     )
-    const weightValues = rows.flatMap(({ weightBuckets }) => weightBuckets.map((bucket) => bucket.lastWeight))
+    const actualWeightValues = (stats?.nodes ?? []).flatMap((node) => node.weight24h.map((bucket) => bucket.lastWeight))
+    const fallbackWeightValues = rows.flatMap(({ weightBuckets }) => weightBuckets.map((bucket) => bucket.lastWeight))
+    const scaleWeightValues = actualWeightValues.length > 0 ? actualWeightValues : fallbackWeightValues
     const weightTrendScale = {
-      minValue: Math.min(...weightValues, 0),
-      maxValue: Math.max(...weightValues, 0),
+      minValue: Math.min(...scaleWeightValues, 0),
+      maxValue: Math.max(...scaleWeightValues, 0),
     }
     return {
       rowData: rows,
@@ -380,9 +422,7 @@ export function ForwardProxyLiveTable({ stats, isLoading, error }: ForwardProxyL
                   <div className="flex h-11 items-end gap-px sm:gap-[1.5px] md:gap-[2px]">
                     {node.last24h.map((bucket, index) => {
                       const total = bucket.successCount + bucket.failureCount
-                      const successHeight = requestBucketScaleMax > 0 ? (bucket.successCount / requestBucketScaleMax) * 100 : 0
-                      const failureHeight = requestBucketScaleMax > 0 ? (bucket.failureCount / requestBucketScaleMax) * 100 : 0
-                      const emptyHeight = Math.max(0, 100 - Math.round(successHeight + failureHeight))
+                      const heights = buildVisibleBarHeights(bucket.successCount, bucket.failureCount, requestBucketScaleMax, 40)
                       return (
                         <div
                           key={`${node.key}-${index}`}
@@ -394,17 +434,14 @@ export function ForwardProxyLiveTable({ stats, isLoading, error }: ForwardProxyL
                             t('stats.cards.failures'),
                           )}
                         >
-                          <div
-                            className="bg-transparent"
-                            style={{ height: `${emptyHeight}%` }}
-                          />
+                          <div className="bg-transparent" style={{ height: `${heights.empty}px` }} />
                           <div
                             className={cn(total > 0 ? 'bg-error/85' : 'bg-transparent')}
-                            style={{ height: `${Math.round(failureHeight)}%` }}
+                            style={{ height: `${heights.failure}px` }}
                           />
                           <div
                             className={cn(total > 0 ? 'bg-success/85' : 'bg-transparent')}
-                            style={{ height: `${Math.round(successHeight)}%` }}
+                            style={{ height: `${heights.success}px` }}
                           />
                         </div>
                       )

--- a/web/src/components/PromptCacheConversationTable.stories.tsx
+++ b/web/src/components/PromptCacheConversationTable.stories.tsx
@@ -93,6 +93,77 @@ const stats: PromptCacheConversationsResponse = {
   ],
 }
 
+
+
+const sharedScaleStats: PromptCacheConversationsResponse = {
+  rangeStart: '2026-03-02T00:00:00.000Z',
+  rangeEnd: '2026-03-03T00:00:00.000Z',
+  conversations: [
+    {
+      promptCacheKey: 'pck-low-volume',
+      requestCount: 3,
+      totalTokens: 420,
+      totalCost: 0.01,
+      createdAt: '2026-03-02T03:00:00.000Z',
+      lastActivityAt: '2026-03-02T05:00:00.000Z',
+      last24hRequests: [
+        {
+          occurredAt: '2026-03-02T03:00:00.000Z',
+          status: 'completed',
+          isSuccess: true,
+          requestTokens: 100,
+          cumulativeTokens: 100,
+        },
+        {
+          occurredAt: '2026-03-02T05:00:00.000Z',
+          status: 'completed',
+          isSuccess: true,
+          requestTokens: 120,
+          cumulativeTokens: 220,
+        },
+      ],
+    },
+    {
+      promptCacheKey: 'pck-high-volume',
+      requestCount: 8,
+      totalTokens: 8600,
+      totalCost: 0.21,
+      createdAt: '2026-03-02T02:30:00.000Z',
+      lastActivityAt: '2026-03-02T23:40:00.000Z',
+      last24hRequests: [
+        {
+          occurredAt: '2026-03-02T02:30:00.000Z',
+          status: 'completed',
+          isSuccess: true,
+          requestTokens: 1200,
+          cumulativeTokens: 1200,
+        },
+        {
+          occurredAt: '2026-03-02T09:10:00.000Z',
+          status: 'completed',
+          isSuccess: true,
+          requestTokens: 1800,
+          cumulativeTokens: 3000,
+        },
+        {
+          occurredAt: '2026-03-02T18:50:00.000Z',
+          status: 'upstream_stream_error',
+          isSuccess: false,
+          requestTokens: 900,
+          cumulativeTokens: 3900,
+        },
+        {
+          occurredAt: '2026-03-02T23:40:00.000Z',
+          status: 'completed',
+          isSuccess: true,
+          requestTokens: 2200,
+          cumulativeTokens: 6100,
+        },
+      ],
+    },
+  ],
+}
+
 const meta = {
   title: 'Monitoring/PromptCacheConversationTable',
   component: PromptCacheConversationTable,
@@ -152,3 +223,12 @@ export const ErrorState: Story = {
     error: 'Network error',
   },
 }
+
+export const SharedScaleComparison: Story = {
+  args: {
+    stats: sharedScaleStats,
+    isLoading: false,
+    error: null,
+  },
+}
+

--- a/web/src/components/PromptCacheConversationTable.test.tsx
+++ b/web/src/components/PromptCacheConversationTable.test.tsx
@@ -56,6 +56,54 @@ describe('PromptCacheConversationTable', () => {
     expect(html).toContain('stroke="oklch(var(--color-error) / 0.92)"')
   })
 
+  it('shares the 24h token chart scale across visible conversations', () => {
+    const stats: PromptCacheConversationsResponse = {
+      rangeStart: '2026-03-02T00:00:00Z',
+      rangeEnd: '2026-03-03T00:00:00Z',
+      conversations: [
+        {
+          promptCacheKey: 'pck-low',
+          requestCount: 1,
+          totalTokens: 50,
+          totalCost: 0.01,
+          createdAt: '2026-03-02T01:00:00Z',
+          lastActivityAt: '2026-03-02T01:00:00Z',
+          last24hRequests: [
+            {
+              occurredAt: '2026-03-02T01:00:00Z',
+              status: 'success',
+              isSuccess: true,
+              requestTokens: 50,
+              cumulativeTokens: 50,
+            },
+          ],
+        },
+        {
+          promptCacheKey: 'pck-high',
+          requestCount: 1,
+          totalTokens: 100,
+          totalCost: 0.02,
+          createdAt: '2026-03-02T02:00:00Z',
+          lastActivityAt: '2026-03-02T02:00:00Z',
+          last24hRequests: [
+            {
+              occurredAt: '2026-03-02T02:00:00Z',
+              status: 'success',
+              isSuccess: true,
+              requestTokens: 100,
+              cumulativeTokens: 100,
+            },
+          ],
+        },
+      ],
+    }
+
+    const html = renderTable(stats)
+
+    expect(html).toContain('aria-label="pck-low"')
+    expect(html).toContain('y1="24"')
+  })
+
   it('renders empty state when there are no conversations', () => {
     const stats: PromptCacheConversationsResponse = {
       rangeStart: '2026-03-02T00:00:00Z',

--- a/web/src/components/PromptCacheConversationTable.test.tsx
+++ b/web/src/components/PromptCacheConversationTable.test.tsx
@@ -104,6 +104,63 @@ describe('PromptCacheConversationTable', () => {
     expect(html).toContain('y1="24"')
   })
 
+
+  it('ignores malformed timestamps when computing the shared chart scale', () => {
+    const stats: PromptCacheConversationsResponse = {
+      rangeStart: '2026-03-02T00:00:00Z',
+      rangeEnd: '2026-03-03T00:00:00Z',
+      conversations: [
+        {
+          promptCacheKey: 'pck-low-valid',
+          requestCount: 1,
+          totalTokens: 50,
+          totalCost: 0.01,
+          createdAt: '2026-03-02T01:00:00Z',
+          lastActivityAt: '2026-03-02T01:00:00Z',
+          last24hRequests: [
+            {
+              occurredAt: '2026-03-02T01:00:00Z',
+              status: 'success',
+              isSuccess: true,
+              requestTokens: 50,
+              cumulativeTokens: 50,
+            },
+          ],
+        },
+        {
+          promptCacheKey: 'pck-bad-point',
+          requestCount: 2,
+          totalTokens: 100,
+          totalCost: 0.02,
+          createdAt: '2026-03-02T02:00:00Z',
+          lastActivityAt: '2026-03-02T02:00:00Z',
+          last24hRequests: [
+            {
+              occurredAt: 'not-a-date',
+              status: 'success',
+              isSuccess: true,
+              requestTokens: 9999,
+              cumulativeTokens: 10000,
+            },
+            {
+              occurredAt: '2026-03-02T02:00:00Z',
+              status: 'success',
+              isSuccess: true,
+              requestTokens: 100,
+              cumulativeTokens: 100,
+            },
+          ],
+        },
+      ],
+    }
+
+    const html = renderTable(stats)
+
+    expect(html).toContain('aria-label="pck-low-valid"')
+    expect(html).toContain('y1="24"')
+  })
+
+
   it('renders empty state when there are no conversations', () => {
     const stats: PromptCacheConversationsResponse = {
       rangeStart: '2026-03-02T00:00:00Z',

--- a/web/src/components/PromptCacheConversationTable.tsx
+++ b/web/src/components/PromptCacheConversationTable.tsx
@@ -86,22 +86,39 @@ function buildSegments(
   return segments
 }
 
+function resolveRangeEpochs(rangeStart: string, rangeEnd: string) {
+  const rangeStartEpoch = parseEpoch(rangeStart)
+  const rangeEndEpoch = parseEpoch(rangeEnd)
+  if (rangeStartEpoch == null || rangeEndEpoch == null || rangeEndEpoch <= rangeStartEpoch) return null
+  return { rangeStartEpoch, rangeEndEpoch }
+}
+
+function findVisibleConversationChartMax(conversations: PromptCacheConversation[], rangeStart: string, rangeEnd: string) {
+  const range = resolveRangeEpochs(rangeStart, rangeEnd)
+  if (!range) return 0
+  return Math.max(
+    ...conversations.flatMap((conversation) =>
+      buildSegments(conversation.last24hRequests, range.rangeStartEpoch, range.rangeEndEpoch).map((segment) => segment.cumulativeTokens),
+    ),
+    0,
+  )
+}
+
 function buildGeometry(
   points: PromptCacheConversationRequestPoint[],
   rangeStart: string,
   rangeEnd: string,
   maxCumulativeTokens: number,
 ): ConversationChartGeometry | null {
-  const rangeStartEpoch = parseEpoch(rangeStart)
-  const rangeEndEpoch = parseEpoch(rangeEnd)
-  if (rangeStartEpoch == null || rangeEndEpoch == null || rangeEndEpoch <= rangeStartEpoch) return null
+  const range = resolveRangeEpochs(rangeStart, rangeEnd)
+  if (!range) return null
 
-  const segments = buildSegments(points, rangeStartEpoch, rangeEndEpoch)
+  const segments = buildSegments(points, range.rangeStartEpoch, range.rangeEndEpoch)
   if (segments.length === 0) return null
 
   const maxCumulative = Math.max(maxCumulativeTokens, ...segments.map((segment) => segment.cumulativeTokens), 1)
-  const span = rangeEndEpoch - rangeStartEpoch
-  const xForEpoch = (epoch: number) => ((epoch - rangeStartEpoch) / span) * CHART_WIDTH
+  const span = range.rangeEndEpoch - range.rangeStartEpoch
+  const xForEpoch = (epoch: number) => ((epoch - range.rangeStartEpoch) / span) * CHART_WIDTH
   const yForTokens = (tokens: number) => CHART_HEIGHT - (tokens / maxCumulative) * CHART_HEIGHT
 
   const positioned = segments.map((segment) => ({
@@ -265,14 +282,8 @@ export function PromptCacheConversationTable({ stats, isLoading, error }: Prompt
   const rangeStart = stats?.rangeStart ?? ''
   const rangeEnd = stats?.rangeEnd ?? ''
   const conversationChartMax = useMemo(
-    () =>
-      Math.max(
-        ...(stats?.conversations ?? []).flatMap((conversation) =>
-          conversation.last24hRequests.map((point) => Math.max(point.cumulativeTokens, 0)),
-        ),
-        0,
-      ),
-    [stats?.conversations],
+    () => findVisibleConversationChartMax(stats?.conversations ?? [], rangeStart, rangeEnd),
+    [rangeEnd, rangeStart, stats?.conversations],
   )
 
   if (error) {

--- a/web/src/components/PromptCacheConversationTable.tsx
+++ b/web/src/components/PromptCacheConversationTable.tsx
@@ -90,6 +90,7 @@ function buildGeometry(
   points: PromptCacheConversationRequestPoint[],
   rangeStart: string,
   rangeEnd: string,
+  maxCumulativeTokens: number,
 ): ConversationChartGeometry | null {
   const rangeStartEpoch = parseEpoch(rangeStart)
   const rangeEndEpoch = parseEpoch(rangeEnd)
@@ -98,7 +99,7 @@ function buildGeometry(
   const segments = buildSegments(points, rangeStartEpoch, rangeEndEpoch)
   if (segments.length === 0) return null
 
-  const maxCumulative = Math.max(...segments.map((segment) => segment.cumulativeTokens), 1)
+  const maxCumulative = Math.max(maxCumulativeTokens, ...segments.map((segment) => segment.cumulativeTokens), 1)
   const span = rangeEndEpoch - rangeStartEpoch
   const xForEpoch = (epoch: number) => ((epoch - rangeStartEpoch) / span) * CHART_WIDTH
   const yForTokens = (tokens: number) => CHART_HEIGHT - (tokens / maxCumulative) * CHART_HEIGHT
@@ -153,12 +154,14 @@ function ConversationSparkline({
   conversation,
   rangeStart,
   rangeEnd,
+  maxCumulativeTokens,
   localeTag,
   tooltipLabels,
 }: {
   conversation: PromptCacheConversation
   rangeStart: string
   rangeEnd: string
+  maxCumulativeTokens: number
   localeTag: string
   tooltipLabels: {
     status: string
@@ -167,8 +170,8 @@ function ConversationSparkline({
   }
 }) {
   const geometry = useMemo(
-    () => buildGeometry(conversation.last24hRequests, rangeStart, rangeEnd),
-    [conversation.last24hRequests, rangeEnd, rangeStart],
+    () => buildGeometry(conversation.last24hRequests, rangeStart, rangeEnd, maxCumulativeTokens),
+    [conversation.last24hRequests, maxCumulativeTokens, rangeEnd, rangeStart],
   )
 
   if (!geometry) {
@@ -261,6 +264,16 @@ export function PromptCacheConversationTable({ stats, isLoading, error }: Prompt
 
   const rangeStart = stats?.rangeStart ?? ''
   const rangeEnd = stats?.rangeEnd ?? ''
+  const conversationChartMax = useMemo(
+    () =>
+      Math.max(
+        ...(stats?.conversations ?? []).flatMap((conversation) =>
+          conversation.last24hRequests.map((point) => Math.max(point.cumulativeTokens, 0)),
+        ),
+        0,
+      ),
+    [stats?.conversations],
+  )
 
   if (error) {
     return (
@@ -344,6 +357,7 @@ export function PromptCacheConversationTable({ stats, isLoading, error }: Prompt
                   conversation={conversation}
                   rangeStart={rangeStart}
                   rangeEnd={rangeEnd}
+                  maxCumulativeTokens={conversationChartMax}
                   localeTag={localeTag}
                   tooltipLabels={tooltipLabels}
                 />
@@ -407,6 +421,7 @@ export function PromptCacheConversationTable({ stats, isLoading, error }: Prompt
                     conversation={conversation}
                     rangeStart={rangeStart}
                     rangeEnd={rangeEnd}
+                    maxCumulativeTokens={conversationChartMax}
                     localeTag={localeTag}
                     tooltipLabels={tooltipLabels}
                   />


### PR DESCRIPTION
## Summary
- unify 24h request bucket heights in the live proxy table so rows on the page share one Y-axis scale
- unify 24h proxy weight trend ranges and prompt cache 24h token sparklines across the current page
- add Storybook `SharedScaleComparison` states for both tables to make the shared-scale behavior easy to review

## Testing
- `cd web && npm run test -- src/components/ForwardProxyLiveTable.test.tsx src/components/PromptCacheConversationTable.test.tsx`
- `cd web && npm run build`
- `cd web && npm run build-storybook`

## Notes
- Storybook local review pages were verified for both `ForwardProxyLiveTable` and `PromptCacheConversationTable` shared-scale states.