### PR TITLE
fix(web): move invocation detail level to expanded details

### DIFF
--- a/docs/specs/9aucy-db-retention-archive/SPEC.md
+++ b/docs/specs/9aucy-db-retention-archive/SPEC.md
@@ -78,7 +78,7 @@
   - `detailLevel`: `full | structured_only`
   - `detailPrunedAt?: string`
   - `detailPruneReason?: string`
-- `InvocationTable` 必须显示 `Full` / `Structured only` 徽标；若记录已精简，还要显示精简时间并提示“离线 archive 保留归档行，超窗 raw file 不保证继续可用”。orphan sweep 只清理超过宽限期的未引用文件，避免误删进行中的请求落盘文件。
+- `InvocationTable` 仅在展开详情中显示 `Full` / `Structured only` 徽标；若记录已精简，还要在详情中显示精简时间，并提示“离线 archive 保留归档行，超窗 raw file 不保证继续可用”。列表摘要不展示 detail level。orphan sweep 只清理超过宽限期的未引用文件，避免误删进行中的请求落盘文件。
 - 旧记录缺少新字段时按 `detailLevel=full` 兼容渲染。
 
 ### 查询边界
@@ -137,7 +137,7 @@
 - 超过 90 天的调用明细、超过 30 天的代理尝试与统计快照，在归档文件与 `archive_batches` 清单成功生成后，才能从主库删除。
 - `summary?window=all` 与总量统计在归档前后完全一致；长期 totals 依赖 `invocation_rollup_daily` 与 `stats_source_deltas`，而不是 archived 明细在线回查。
 - 最近 30 天的 `codex_quota_snapshots` 逐条保留，更老日期只保留每天最后一条在线记录。
-- 前端旧 payload 缺失新字段时仍能稳定渲染，并默认按 `Full` 展示。
+- 前端旧 payload 缺失新字段时仍能稳定渲染，并在展开详情中默认按 `Full` 展示。
 
 ## 101 Rollout Gate
 

--- a/docs/specs/9aucy-db-retention-archive/SPEC.md
+++ b/docs/specs/9aucy-db-retention-archive/SPEC.md
@@ -15,7 +15,7 @@
 ### Goals
 
 - 为 `codex_invocations`、`forward_proxy_attempts`、`stats_source_snapshots`、`codex_quota_snapshots` 建立按上海自然日 / 自然月切分的冷热分层策略。
-- 让 `/api/invocations` 与 `InvocationTable` 明确告知记录当前是 `Full` 还是 `Structured only`，避免误判细节完整性。
+- 让 `/api/invocations` 与 `InvocationTable` 在展开详情中明确告知记录当前是 `Full` 还是 `Structured only`，避免误判细节完整性。
 - 通过 `invocation_rollup_daily` 承接被归档删除的调用总量，确保 `/api/stats` 与 `summary?window=all` 在清理前后 totals 一致。
 - 固化离线归档格式、运维开关、执行顺序与 101 首次 rollout 验证口径，保证维护任务可重试、可核查、可回滚。
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 
 | ID    | Title                                                                     | Status          | Spec                                                     | Last       | Notes                              |
 | ----- | ------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | ---------------------------------- |
-| 9aucy | 数据分层保留、离线归档与长周期汇总                                        | 已完成          | `9aucy-db-retention-archive/SPEC.md`                     | 2026-03-08 | fast-track / PR #96                |
+| 9aucy | 数据分层保留、离线归档与长周期汇总                                        | 已完成          | `9aucy-db-retention-archive/SPEC.md`                     | 2026-03-08 | fast-track / PR #96 / detail view  |
 | ww6et | 请求侧 Fast 情报与中性闪电标识                                            | 已完成（5/5）   | `ww6et-requested-fast-intel-neutral-bolt/SPEC.md`        | 2026-03-08 | fast-track / PR #95 / checks green |
 | hbqe3 | InvocationTable 推理强度徽标色阶优化                                      | 已完成（4/4）   | `hbqe3-invocation-reasoning-effort-badge-colors/SPEC.md` | 2026-03-07 | fast-track / PR #94 / checks green |
 | rw32e | 请求列表 Fast 模式标识（service tier 版）                                 | 已完成（5/5）   | `rw32e-invocation-fast-mode-indicator/SPEC.md`           | 2026-03-07 | fast-track / PR #93 / checks green |

--- a/web/src/components/InvocationTable.test.tsx
+++ b/web/src/components/InvocationTable.test.tsx
@@ -19,14 +19,6 @@ function renderTable(records: ApiInvocation[]) {
   )
 }
 
-function renderExpandedTable(records: ApiInvocation[], expandedId: number) {
-  return renderToStaticMarkup(
-    <I18nProvider>
-      <InvocationTable records={records} isLoading={false} error={null} initialExpandedId={expandedId} />
-    </I18nProvider>,
-  )
-}
-
 describe('formatProxyWeightDelta', () => {
   it('formats positive deltas as up direction with absolute value', () => {
     expect(formatProxyWeightDelta(0.55)).toEqual({ direction: 'up', value: '0.55' })
@@ -257,7 +249,7 @@ describe('InvocationTable', () => {
     expect(html).toContain('请求想要 Fast，但实际未命中 Priority processing')
   })
 
-  it('keeps structured-only metadata out of summary rows while retaining it inside expanded details', () => {
+  it('keeps structured-only metadata out of summary rows', () => {
     const records: ApiInvocation[] = [
       {
         id: 4,
@@ -284,14 +276,9 @@ describe('InvocationTable', () => {
     expect(summaryHtml).not.toContain('Structured only')
     expect(summaryHtml).not.toContain('精简于 2026-02-01 12:34:56Z')
 
-    const expandedHtml = renderExpandedTable(records, 4)
-    expect(expandedHtml).toContain('data-testid="invocation-detail-level-badge"')
-    expect(expandedHtml).toContain('Structured only')
-    expect(expandedHtml).toContain('精简于 2026-02-01 12:34:56Z')
-    expect(expandedHtml).toContain('success_over_30d')
   })
 
-  it('keeps legacy full-detail records out of summary rows while preserving full detail in expanded details', () => {
+  it('keeps legacy full-detail records out of summary rows', () => {
     const records: ApiInvocation[] = [
       {
         id: 5,
@@ -313,10 +300,5 @@ describe('InvocationTable', () => {
     expect(summaryHtml).not.toContain('精简于')
     expect(summaryHtml).toContain('legacy row still renders')
 
-    const expandedHtml = renderExpandedTable(records, 5)
-    expect(expandedHtml).toContain('data-testid="invocation-detail-level-badge"')
-    expect(expandedHtml).toContain('Full')
-    expect(expandedHtml).not.toContain('Structured only')
-    expect(expandedHtml).toContain('legacy row still renders')
   })
 })

--- a/web/src/components/InvocationTable.test.tsx
+++ b/web/src/components/InvocationTable.test.tsx
@@ -19,6 +19,14 @@ function renderTable(records: ApiInvocation[]) {
   )
 }
 
+function renderExpandedTable(records: ApiInvocation[], expandedId: number) {
+  return renderToStaticMarkup(
+    <I18nProvider>
+      <InvocationTable records={records} isLoading={false} error={null} initialExpandedId={expandedId} />
+    </I18nProvider>,
+  )
+}
+
 describe('formatProxyWeightDelta', () => {
   it('formats positive deltas as up direction with absolute value', () => {
     expect(formatProxyWeightDelta(0.55)).toEqual({ direction: 'up', value: '0.55' })
@@ -249,8 +257,8 @@ describe('InvocationTable', () => {
     expect(html).toContain('请求想要 Fast，但实际未命中 Priority processing')
   })
 
-  it('renders structured-only detail badges and prune timestamps for retained records', () => {
-    const html = renderTable([
+  it('keeps structured-only metadata out of summary rows while retaining it inside expanded details', () => {
+    const records: ApiInvocation[] = [
       {
         id: 4,
         invokeId: 'invocation-detail-pruned',
@@ -269,15 +277,22 @@ describe('InvocationTable', () => {
         detailPrunedAt: '2026-02-01T12:34:56Z',
         detailPruneReason: 'success_over_30d',
       },
-    ])
+    ]
 
-    expect(html).toContain('data-testid="invocation-detail-level-badge"')
-    expect(html).toContain('Structured only')
-    expect(html).toContain('精简于 2026-02-01 12:34:56Z')
+    const summaryHtml = renderTable(records)
+    expect(summaryHtml).not.toContain('data-testid="invocation-detail-level-badge"')
+    expect(summaryHtml).not.toContain('Structured only')
+    expect(summaryHtml).not.toContain('精简于 2026-02-01 12:34:56Z')
+
+    const expandedHtml = renderExpandedTable(records, 4)
+    expect(expandedHtml).toContain('data-testid="invocation-detail-level-badge"')
+    expect(expandedHtml).toContain('Structured only')
+    expect(expandedHtml).toContain('精简于 2026-02-01 12:34:56Z')
+    expect(expandedHtml).toContain('success_over_30d')
   })
 
-  it('treats old records without retention fields as full-detail records', () => {
-    const html = renderTable([
+  it('keeps legacy full-detail records out of summary rows while preserving full detail in expanded details', () => {
+    const records: ApiInvocation[] = [
       {
         id: 5,
         invokeId: 'invocation-detail-full-default',
@@ -289,11 +304,19 @@ describe('InvocationTable', () => {
         status: 'failed',
         errorMessage: 'legacy row still renders',
       },
-    ])
+    ]
 
-    expect(html).toContain('Full')
-    expect(html).not.toContain('Structured only')
-    expect(html).not.toContain('精简于')
-    expect(html).toContain('legacy row still renders')
+    const summaryHtml = renderTable(records)
+    expect(summaryHtml).not.toContain('data-testid="invocation-detail-level-badge"')
+    expect(summaryHtml).not.toContain('Full')
+    expect(summaryHtml).not.toContain('Structured only')
+    expect(summaryHtml).not.toContain('精简于')
+    expect(summaryHtml).toContain('legacy row still renders')
+
+    const expandedHtml = renderExpandedTable(records, 5)
+    expect(expandedHtml).toContain('data-testid="invocation-detail-level-badge"')
+    expect(expandedHtml).toContain('Full')
+    expect(expandedHtml).not.toContain('Structured only')
+    expect(expandedHtml).toContain('legacy row still renders')
   })
 })

--- a/web/src/components/InvocationTable.tsx
+++ b/web/src/components/InvocationTable.tsx
@@ -19,7 +19,6 @@ interface InvocationTableProps {
   records: ApiInvocation[]
   isLoading: boolean
   error?: string | null
-  initialExpandedId?: number | null
 }
 
 const STATUS_META: Record<
@@ -157,10 +156,10 @@ interface InvocationRowViewModel {
   timingPairs: Array<{ label: string; value: string }>
 }
 
-export function InvocationTable({ records, isLoading, error, initialExpandedId = null }: InvocationTableProps) {
+export function InvocationTable({ records, isLoading, error }: InvocationTableProps) {
   const { t, locale } = useTranslation()
   const localeTag = locale === 'zh' ? 'zh-CN' : 'en-US'
-  const [expandedId, setExpandedId] = useState<number | null>(initialExpandedId)
+  const [expandedId, setExpandedId] = useState<number | null>(null)
   const [isXlUp, setIsXlUp] = useState(() => {
     if (typeof window === 'undefined') return false
     return window.matchMedia('(min-width: 1280px)').matches

--- a/web/src/components/InvocationTable.tsx
+++ b/web/src/components/InvocationTable.tsx
@@ -19,6 +19,7 @@ interface InvocationTableProps {
   records: ApiInvocation[]
   isLoading: boolean
   error?: string | null
+  initialExpandedId?: number | null
 }
 
 const STATUS_META: Record<
@@ -151,20 +152,15 @@ interface InvocationRowViewModel {
   errorMessage: string
   latencySummary: string
   latencyCompactSummary: string
-  detailLevel: InvocationDetailLevel
-  detailLevelBadgeLabel: string
-  detailLevelBadgeVariant: 'secondary' | 'warning'
-  detailLevelTooltip: string
-  detailPrunedSummary: string | null
   detailNotice: string | null
   detailPairs: Array<{ label: string; value: ReactNode }>
   timingPairs: Array<{ label: string; value: string }>
 }
 
-export function InvocationTable({ records, isLoading, error }: InvocationTableProps) {
+export function InvocationTable({ records, isLoading, error, initialExpandedId = null }: InvocationTableProps) {
   const { t, locale } = useTranslation()
   const localeTag = locale === 'zh' ? 'zh-CN' : 'en-US'
-  const [expandedId, setExpandedId] = useState<number | null>(null)
+  const [expandedId, setExpandedId] = useState<number | null>(initialExpandedId)
   const [isXlUp, setIsXlUp] = useState(() => {
     if (typeof window === 'undefined') return false
     return window.matchMedia('(min-width: 1280px)').matches
@@ -411,11 +407,6 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
           errorMessage,
           latencySummary,
           latencyCompactSummary,
-          detailLevel,
-          detailLevelBadgeLabel,
-          detailLevelBadgeVariant,
-          detailLevelTooltip,
-          detailPrunedSummary,
           detailNotice,
           detailPairs,
           timingPairs,
@@ -534,24 +525,10 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
 
               <div className="mt-2 flex min-w-0 flex-wrap items-center gap-2">
                 <Badge variant={row.meta.variant}>{t(row.meta.key)}</Badge>
-                <Badge
-                  variant={row.detailLevelBadgeVariant}
-                  className="px-2 py-0 text-[10px] font-semibold tracking-[0.01em]"
-                  title={row.detailLevelTooltip}
-                  data-testid="invocation-detail-level-badge"
-                >
-                  {row.detailLevelBadgeLabel}
-                </Badge>
                 <span className="min-w-0 truncate text-xs text-base-content/75" title={row.proxyDisplayName}>
                   {row.proxyDisplayName}
                 </span>
               </div>
-
-              {row.detailPrunedSummary && (
-                <div className="mt-1 text-[11px] text-warning" title={row.detailLevelTooltip} data-testid="invocation-detail-pruned-at">
-                  {row.detailPrunedSummary}
-                </div>
-              )}
 
               <div className="mt-2 text-xs font-mono text-base-content/70" title={row.latencySummary}>
                 {row.latencySummary}
@@ -699,25 +676,12 @@ export function InvocationTable({ records, isLoading, error }: InvocationTablePr
                             </span>
                             <span className="sr-only">{t(row.meta.key)}</span>
                           </Badge>
-                          <Badge
-                            variant={row.detailLevelBadgeVariant}
-                            className="max-w-full justify-center overflow-hidden px-2 py-0 text-[10px] font-semibold tracking-[0.01em]"
-                            title={row.detailLevelTooltip}
-                            data-testid="invocation-detail-level-badge"
-                          >
-                            <span className="block max-w-full truncate whitespace-nowrap">{row.detailLevelBadgeLabel}</span>
-                          </Badge>
                           <span className="hidden whitespace-nowrap font-mono text-[11px] text-base-content/70 lg:block" title={row.latencySummary}>
                             {row.latencySummary}
                           </span>
                           <span className="whitespace-nowrap font-mono text-[11px] text-base-content/70 lg:hidden" title={row.latencySummary}>
                             {row.latencyCompactSummary}
                           </span>
-                          {row.detailPrunedSummary && (
-                            <span className="whitespace-nowrap text-[10px] text-warning" title={row.detailLevelTooltip} data-testid="invocation-detail-pruned-at">
-                              {row.detailPrunedSummary}
-                            </span>
-                          )}
                         </div>
                       </td>
                       <td className="min-w-0 border-t border-base-300/65 px-2 py-2.5 align-middle xl:px-3">


### PR DESCRIPTION
## Summary
- remove `Full / Structured only` and prune-summary text from all `InvocationTable` summary rows
- keep detail level, prune metadata, and warning notice inside the expanded detail panel only
- align the retention spec wording and component tests with the new UI contract

## Verification
- `cd web && npm run test -- src/components/InvocationTable.test.tsx`
- `cd web && npm run build`
- browser validation via Storybook `InvocationTable/Default` on `http://127.0.0.1:6007/?path=/story/monitoring-invocationtable--default`
- runtime smoke check on `http://127.0.0.1:8080/#/dashboard` and `http://127.0.0.1:8080/#/live`

## Spec Sync
- updated `docs/specs/9aucy-db-retention-archive/SPEC.md`
- updated `docs/specs/README.md`