### PR TITLE
refactor!: rename remaining public XY env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN find src -type f -name '*.rs' -exec touch {} + \
     && cargo build --release --locked
 
 # Stage 3: fetch Xray-core (xray) for forward-proxy subscription validation
-# The app defaults to `XY_XRAY_BINARY=xray` (PATH lookup). If the runtime image doesn't bundle
+# The app defaults to `XRAY_BINARY=xray` (PATH lookup). If the runtime image doesn't bundle
 # a real Xray-core binary, subscription validation for share links (vmess/vless/trojan/ss) fails.
 FROM debian:bookworm-slim AS xray-downloader
 ARG XRAY_CORE_VERSION=26.2.6
@@ -74,10 +74,10 @@ COPY --from=xray-downloader /usr/local/share/licenses/xray-core/LICENSE /usr/loc
 COPY --from=web-builder /app/web/dist ./web
 
 ENV DATABASE_PATH=/srv/app/data/codex_vibe_monitor.db \
-    XY_HTTP_BIND=0.0.0.0:8080 \
-    XY_STATIC_DIR=/srv/app/web \
-    XY_POLL_INTERVAL_SECS=10 \
-    XY_REQUEST_TIMEOUT_SECS=60 \
+    HTTP_BIND=0.0.0.0:8080 \
+    STATIC_DIR=/srv/app/web \
+    POLL_INTERVAL_SECS=10 \
+    REQUEST_TIMEOUT_SECS=60 \
     APP_EFFECTIVE_VERSION=${APP_EFFECTIVE_VERSION}
 
 LABEL org.opencontainers.image.version=${APP_EFFECTIVE_VERSION}

--- a/README.md
+++ b/README.md
@@ -64,42 +64,43 @@ npm run dev -- --host 127.0.0.1 --port 60080
 
 ```env
 OPENAI_UPSTREAM_BASE_URL=https://api.openai.com  # (可选，默认 https://api.openai.com/)
-DATABASE_PATH=codex_vibe_monitor.db            # (默认)
-XY_POLL_INTERVAL_SECS=10                       # (10；用于 CRS scheduler 基础节奏)
-XY_REQUEST_TIMEOUT_SECS=60                     # (60)
-OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS=60         # (60，非 compact 上游等待超时)
-OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS=180     # (180，请求体读取总超时)
-OPENAI_PROXY_MAX_REQUEST_BODY_BYTES=268435456  # (256MiB)
-PROXY_RAW_DIR=proxy_raw_payloads                # (相对路径时锚定到 DATABASE_PATH 同级目录)
-PROXY_RAW_MAX_BYTES=0                          # (0=unlimited, set >0 to cap)
-PROXY_RAW_RETENTION_DAYS=7                     # (7)
-PROXY_ENFORCE_STREAM_INCLUDE_USAGE=true        # (true)
-PROXY_USAGE_BACKFILL_ON_STARTUP=true           # (兼容保留；当前历史补数改为后台有界执行，不再阻塞 /health)
-FORWARD_PROXY_ALGO=v2                          # (v2，正向代理权重算法开关: v1|v2)
-XY_MAX_PARALLEL_POLLS=6                        # (6)
-XY_SHARED_CONNECTION_PARALLELISM=2             # (2)
-XY_HTTP_BIND=127.0.0.1:8080                    # (127.0.0.1:8080)
-XY_CORS_ALLOWED_ORIGINS=                        # (可选，逗号分隔，允许跨域 Origin 白名单)
-XY_LIST_LIMIT_MAX=200                          # (200)
-XY_USER_AGENT=codex-vibe-monitor/0.2.0         # (自动)
-XY_STATIC_DIR=web/dist                         # (存在时自动使用)
-XY_RETENTION_ENABLED=false                     # (false，需要显式开启后台保留任务)
-XY_RETENTION_DRY_RUN=false                     # (false)
-XY_RETENTION_INTERVAL_SECS=3600                # (3600)
-XY_RETENTION_BATCH_ROWS=1000                   # (1000)
-XY_ARCHIVE_DIR=archives                        # (archives，相对 DATABASE_PATH 同级目录解析)
-XY_INVOCATION_SUCCESS_FULL_DAYS=30             # (30，上海自然日)
-XY_INVOCATION_MAX_DAYS=90                      # (90，超窗后归档并清理主库)
-XY_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS=30    # (30，上海自然日)
-XY_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS=30    # (30，上海自然日)
-XY_QUOTA_SNAPSHOT_FULL_DAYS=30                 # (30，上海自然日)
-# 注意：XY_FORWARD_PROXY_ALGO 已移除，配置将直接失败，请改用 FORWARD_PROXY_ALGO
+DATABASE_PATH=codex_vibe_monitor.db              # (默认)
+POLL_INTERVAL_SECS=10                            # (10；用于 CRS scheduler 基础节奏)
+REQUEST_TIMEOUT_SECS=60                          # (60)
+OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS=60           # (60，非 compact 上游等待超时)
+OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS=180       # (180，请求体读取总超时)
+OPENAI_PROXY_MAX_REQUEST_BODY_BYTES=268435456    # (256MiB)
+PROXY_RAW_DIR=proxy_raw_payloads                 # (相对路径时锚定到 DATABASE_PATH 同级目录)
+PROXY_RAW_MAX_BYTES=0                            # (0=unlimited, set >0 to cap)
+PROXY_RAW_RETENTION_DAYS=7                       # (7)
+PROXY_ENFORCE_STREAM_INCLUDE_USAGE=true          # (true)
+PROXY_USAGE_BACKFILL_ON_STARTUP=true             # (兼容保留；当前历史补数改为后台有界执行，不再阻塞 /health)
+FORWARD_PROXY_ALGO=v2                            # (v2，正向代理权重算法开关: v1|v2)
+MAX_PARALLEL_POLLS=6                             # (6)
+SHARED_CONNECTION_PARALLELISM=2                  # (2)
+HTTP_BIND=127.0.0.1:8080                         # (127.0.0.1:8080)
+CORS_ALLOWED_ORIGINS=                            # (可选，逗号分隔，允许跨域 Origin 白名单)
+LIST_LIMIT_MAX=200                               # (200)
+USER_AGENT=codex-vibe-monitor/0.2.0              # (自动)
+STATIC_DIR=web/dist                              # (存在时自动使用)
+RETENTION_ENABLED=false                          # (false，需要显式开启后台保留任务)
+RETENTION_DRY_RUN=false                          # (false)
+RETENTION_INTERVAL_SECS=3600                     # (3600)
+RETENTION_BATCH_ROWS=1000                        # (1000)
+ARCHIVE_DIR=archives                             # (archives，相对 DATABASE_PATH 同级目录解析)
+INVOCATION_SUCCESS_FULL_DAYS=30                  # (30，上海自然日)
+INVOCATION_MAX_DAYS=90                           # (90，超窗后归档并清理主库)
+FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS=30         # (30，上海自然日)
+STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS=30         # (30，上海自然日)
+QUOTA_SNAPSHOT_FULL_DAYS=30                      # (30，上海自然日)
+XRAY_BINARY=xray                                 # (PATH lookup)
+XRAY_RUNTIME_DIR=.codex/xray-forward             # (xray 运行时目录)
 
 # CRS 日统计源（可选；未配置则禁用）
 CRS_STATS_BASE_URL=https://claude-relay-service.nsngc.org
 CRS_STATS_API_ID=<apiId>
-CRS_STATS_PERIOD=daily                         # (daily)
-CRS_STATS_POLL_INTERVAL_SECS=10                # (10，默认跟随 XY_POLL_INTERVAL_SECS)
+CRS_STATS_PERIOD=daily                           # (daily)
+CRS_STATS_POLL_INTERVAL_SECS=10                  # (10，默认跟随 POLL_INTERVAL_SECS)
 ```
 
 价格配置已迁移到数据库持久化（可在 Web 设置页 `/settings` 在线编辑）；服务启动会自动写入默认模型价格模板。
@@ -108,7 +109,35 @@ CRS_STATS_POLL_INTERVAL_SECS=10                # (10，默认跟随 XY_POLL_INTE
 
 服务不再读取 XYAI 上游 cookie / base URL / quota endpoint；`/api/quota/latest` 仅返回数据库中已有的历史快照。
 
-`XY_DATABASE_PATH` 已移除；若环境中仍保留该变量，服务会在启动时直接报错并提示迁移到 `DATABASE_PATH`。
+### Breaking change：公开环境变量改名
+
+服务已停止接受 legacy `XY_*` 公共运行时键；若环境中仍保留旧键，启动会直接失败，并给出 `rename <old> to <new>` 的一对一迁移提示。
+
+| Legacy key                                 | Canonical key                           |
+| ------------------------------------------ | --------------------------------------- |
+| `XY_POLL_INTERVAL_SECS`                    | `POLL_INTERVAL_SECS`                    |
+| `XY_REQUEST_TIMEOUT_SECS`                  | `REQUEST_TIMEOUT_SECS`                  |
+| `XY_MAX_PARALLEL_POLLS`                    | `MAX_PARALLEL_POLLS`                    |
+| `XY_SHARED_CONNECTION_PARALLELISM`         | `SHARED_CONNECTION_PARALLELISM`         |
+| `XY_HTTP_BIND`                             | `HTTP_BIND`                             |
+| `XY_CORS_ALLOWED_ORIGINS`                  | `CORS_ALLOWED_ORIGINS`                  |
+| `XY_LIST_LIMIT_MAX`                        | `LIST_LIMIT_MAX`                        |
+| `XY_USER_AGENT`                            | `USER_AGENT`                            |
+| `XY_STATIC_DIR`                            | `STATIC_DIR`                            |
+| `XY_RETENTION_ENABLED`                     | `RETENTION_ENABLED`                     |
+| `XY_RETENTION_DRY_RUN`                     | `RETENTION_DRY_RUN`                     |
+| `XY_RETENTION_INTERVAL_SECS`               | `RETENTION_INTERVAL_SECS`               |
+| `XY_RETENTION_BATCH_ROWS`                  | `RETENTION_BATCH_ROWS`                  |
+| `XY_ARCHIVE_DIR`                           | `ARCHIVE_DIR`                           |
+| `XY_INVOCATION_SUCCESS_FULL_DAYS`          | `INVOCATION_SUCCESS_FULL_DAYS`          |
+| `XY_INVOCATION_MAX_DAYS`                   | `INVOCATION_MAX_DAYS`                   |
+| `XY_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` | `FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` |
+| `XY_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS` | `STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS` |
+| `XY_QUOTA_SNAPSHOT_FULL_DAYS`              | `QUOTA_SNAPSHOT_FULL_DAYS`              |
+| `XY_XRAY_BINARY`                           | `XRAY_BINARY`                           |
+| `XY_XRAY_RUNTIME_DIR`                      | `XRAY_RUNTIME_DIR`                      |
+| `XY_DATABASE_PATH`                         | `DATABASE_PATH`                         |
+| `XY_FORWARD_PROXY_ALGO`                    | `FORWARD_PROXY_ALGO`                    |
 
 上述大部分变量均可使用 CLI 覆盖，例如：
 
@@ -122,7 +151,7 @@ cargo run -- \
 ## 数据分层保留与离线归档
 
 - `codex_invocations` 的成功记录超过 30 个上海自然日后，会先把完整行写入对应月份的离线 archive，再把主库内的原始 payload / raw response / raw file 引用精简为 `structured_only`，但保留结构化统计字段用于在线排障。
-- 任意调用记录超过 90 个上海自然日后，会先归档到 `XY_ARCHIVE_DIR/<table>/<yyyy>/<table>-<yyyy-mm>.sqlite.gz`；若 `XY_ARCHIVE_DIR` 使用相对路径，则实际位置位于 `<DATABASE_PATH 同级目录>/<XY_ARCHIVE_DIR 的值>/...`，写入 `archive_batches` 清单后，再从主库删除。
+- 任意调用记录超过 90 个上海自然日后，会先归档到 `ARCHIVE_DIR/<table>/<yyyy>/<table>-<yyyy-mm>.sqlite.gz`；若 `ARCHIVE_DIR` 使用相对路径，则实际位置位于 `<DATABASE_PATH 同级目录>/<ARCHIVE_DIR 的值>/...`，写入 `archive_batches` 清单后，再从主库删除。
 - `forward_proxy_attempts` 与 `stats_source_snapshots` 只保留最近 30 个上海自然日在线明细；更老数据同样执行“先归档、再清理”。
 - `codex_quota_snapshots` 保留最近 30 天全量，更老日期在主库内压缩为“每个上海自然日最后一条”，被折叠掉的行进入离线归档。
 - `stats_source_deltas` 长期在线保留；`/api/stats` 与 `GET /api/stats/summary?window=all` 通过“在线明细 + invocation_rollup_daily”保证长期 totals 不缩水。
@@ -148,7 +177,7 @@ cargo run -- --retention-run-once
 - `GET /api/settings`：获取统一设置（`proxy + pricing`）。
 - `PUT /api/settings/proxy`：更新 `/v1/models` 劫持与上游合并开关状态（全局持久化）。
 - `PUT /api/settings/pricing`：更新价格目录（全量覆盖、全局持久化、实时生效于新请求成本估算）。
-- `GET /api/invocations?limit=&model=&status=`：最新记录列表（`limit` 上限由 `XY_LIST_LIMIT_MAX` 控制）；每条记录额外返回 `detailLevel`、`detailPrunedAt`、`detailPruneReason`，用于标记在线明细是否仍完整。
+- `GET /api/invocations?limit=&model=&status=`：最新记录列表（`limit` 上限由 `LIST_LIMIT_MAX` 控制）；每条记录额外返回 `detailLevel`、`detailPrunedAt`、`detailPruneReason`，用于标记在线明细是否仍完整。
 - `GET /api/stats`：全量聚合统计；长期 totals 会合并在线明细与 `invocation_rollup_daily`。
 - `GET /api/stats/summary?window=<all|current|1d|6h|30m>&limit=N`：窗口统计；`window=all` 会承接归档前回填的日汇总。
 - `GET /api/stats/timeseries?range=1d&bucket=1h&settlement_hour=0`：时间序列（区间与桶宽支持 `m/h/d/mo`）。
@@ -180,7 +209,7 @@ docker run --rm \
   ghcr.io/ivanli-cn/codex-vibe-monitor:latest
 ```
 
-容器内默认：`DATABASE_PATH=/srv/app/data/codex_vibe_monitor.db`，`XY_HTTP_BIND=0.0.0.0:8080`，`XY_STATIC_DIR=/srv/app/web`，`PROXY_RAW_DIR=proxy_raw_payloads`（解析到 `/srv/app/data/proxy_raw_payloads`）。运行镜像已内置 `curl` 与镜像级 `HEALTHCHECK`，会探测 `http://127.0.0.1:8080/health`。
+容器内默认：`DATABASE_PATH=/srv/app/data/codex_vibe_monitor.db`，`HTTP_BIND=0.0.0.0:8080`，`STATIC_DIR=/srv/app/web`，`PROXY_RAW_DIR=proxy_raw_payloads`（解析到 `/srv/app/data/proxy_raw_payloads`）。运行镜像已内置 `curl` 与镜像级 `HEALTHCHECK`，会探测 `http://127.0.0.1:8080/health`。
 
 推荐在 Compose 中显式覆盖 healthcheck 参数，确保启动窗口内也能正确等待 readiness：
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,7 +85,7 @@ labels:
 
 以下变量均为按需覆盖；未配置时使用服务默认值：
 
-- `DATABASE_PATH`：SQLite 主库路径；`XY_DATABASE_PATH` 已移除，若仍配置会直接阻断启动。
+- `DATABASE_PATH`：SQLite 主库路径；升级旧版本前请先同步新的公开 env 命名，legacy `XY_*` 公共键会在启动期直接被拒绝。
 - `PROXY_RAW_DIR`：原始请求/响应落盘目录；相对路径会锚定到 `DATABASE_PATH` 同级目录，避免跟随容器工作目录漂移。
 - `PROXY_RAW_MAX_BYTES`：单次请求/响应原文采集上限；默认 `0=unlimited`（支持显式配置正整数上限）。
 - `PROXY_RAW_RETENTION_DAYS`：原文留存天数（到期清理原文字段/文件，不影响结构化统计）。
@@ -94,14 +94,14 @@ labels:
 - `OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS`：非 compact 代理路径的上游等待超时，默认 `60` 秒。
 - `OPENAI_PROXY_COMPACT_HANDSHAKE_TIMEOUT_SECS`：`/v1/responses/compact` 的上游等待超时，可选覆盖；默认 `180` 秒。
 - `OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS`：请求体读取总超时，默认 `180` 秒；超时返回 `408`。
-- `XY_RETENTION_ENABLED`：是否启用后台 retention/archive 维护任务，默认 `false`，上线时需要显式开启。
-- `XY_RETENTION_DRY_RUN`：全局 dry-run 开关；开启后 maintenance 只输出计划与计数，不删除数据。
-- `XY_RETENTION_INTERVAL_SECS`：常驻 maintenance 执行间隔；默认按小时调度。
-- `XY_RETENTION_BATCH_ROWS`：单批处理上限；用于降低 SQLite 长事务与锁表风险。
-- `XY_ARCHIVE_DIR`：离线 archive 根目录；相对路径会锚定到 `DATABASE_PATH` 同级目录，建议挂载到持久化卷并纳入备份。
-- `XY_INVOCATION_SUCCESS_FULL_DAYS` / `XY_INVOCATION_MAX_DAYS`：调用明细 30/90 天冷热分层窗口。
-- `XY_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` / `XY_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS`：代理尝试与统计快照的在线保留窗口。
-- `XY_QUOTA_SNAPSHOT_FULL_DAYS`：配额快照全量在线保留窗口；超窗后压缩为“每天最后一条”。
+- `RETENTION_ENABLED`：是否启用后台 retention/archive 维护任务，默认 `false`，上线时需要显式开启。
+- `RETENTION_DRY_RUN`：全局 dry-run 开关；开启后 maintenance 只输出计划与计数，不删除数据。
+- `RETENTION_INTERVAL_SECS`：常驻 maintenance 执行间隔；默认按小时调度。
+- `RETENTION_BATCH_ROWS`：单批处理上限；用于降低 SQLite 长事务与锁表风险。
+- `ARCHIVE_DIR`：离线 archive 根目录；相对路径会锚定到 `DATABASE_PATH` 同级目录，建议挂载到持久化卷并纳入备份。
+- `INVOCATION_SUCCESS_FULL_DAYS` / `INVOCATION_MAX_DAYS`：调用明细 30/90 天冷热分层窗口。
+- `FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` / `STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS`：代理尝试与统计快照的在线保留窗口。
+- `QUOTA_SNAPSHOT_FULL_DAYS`：配额快照全量在线保留窗口；超窗后压缩为“每天最后一条”。
 
 价格配置说明：
 
@@ -167,7 +167,7 @@ labels:
 
 - 首次 backlog cleanup 先执行 `cargo run -- --retention-run-once --retention-dry-run`，确认预计归档行数、目标 archive 路径与磁盘变化。
 - 正式清理使用 `cargo run -- --retention-run-once`；执行顺序必须保持 `导出成功 -> archive_batches manifest 成功 -> 删除源数据`。
-- archive 文件按上海自然月切分；若 `XY_ARCHIVE_DIR` 为相对路径，则实际目录形如 `<DATABASE_PATH 同级目录>/<XY_ARCHIVE_DIR 的值>/<table>/<yyyy>/<table>-<yyyy-mm>.sqlite.gz`（例如 `archives/...`）。
+- archive 文件按上海自然月切分；若 `ARCHIVE_DIR` 为相对路径，则实际目录形如 `<DATABASE_PATH 同级目录>/<ARCHIVE_DIR 的值>/<table>/<yyyy>/<table>-<yyyy-mm>.sqlite.gz`（例如 `archives/...`）。
 - `codex_invocations` 成功记录超过 30 个上海自然日后，会先把完整行写入离线 archive，再在主库内精简为 `structured_only`；任意调用超过 90 天后清理主库明细。
 - `forward_proxy_attempts`、`stats_source_snapshots` 只保留近 30 天在线明细；`codex_quota_snapshots` 近 30 天逐条保留，更老日期压缩为每天最后一条。
 - 原始 payload / preview / raw file 只保证短期排障；长期依赖离线 archive 中的 SQLite 归档行，超窗 raw file 本体不保证继续可用，而不是在线 UI。orphan sweep 只会清理超过宽限期的未引用文件，以避免误删进行中的请求落盘文件。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                         | Status          | Spec                                                     | Last       | Notes                                                   |
 | ----- | ----------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | ------------------------------------------------------- |
+| ts4zf | 修正剩余 `XY_*` 环境变量命名                                                  | 待实现          | `ts4zf-rename-remaining-xy-envs/SPEC.md`                 | 2026-03-10 | fast-track / breaking public config change              |
 | ask3x | 反向代理默认超时口径统一为 60s / 180s                                         | 已完成          | `ask3x-proxy-timeout-defaults/SPEC.md`                   | 2026-03-10 | fast-track / PR #108 / checks green / review-loop clear |
 | 5gqdb | InvocationTable 桌面代理名省略回归热修                                        | 已完成          | `5gqdb-invocation-proxy-name-truncation-hotfix/SPEC.md`  | 2026-03-10 | fast-track / PR #105 / screenshot evidence              |
 | 2uaxk | 移除 XYAI 采集，仅保留历史读取                                                | 已完成（4/4）   | `2uaxk-remove-xyai-legacy-ingest/SPEC.md`                | 2026-03-09 | PR #101 / CI + review-loop                              |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,7 +8,7 @@
 
 | ID    | Title                                                                         | Status          | Spec                                                     | Last       | Notes                                                   |
 | ----- | ----------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- | ---------- | ------------------------------------------------------- |
-| ts4zf | 修正剩余 `XY_*` 环境变量命名                                                  | 待实现          | `ts4zf-rename-remaining-xy-envs/SPEC.md`                 | 2026-03-10 | fast-track / breaking public config change              |
+| ts4zf | 修正剩余 `XY_*` 环境变量命名                                                  | 已完成          | `ts4zf-rename-remaining-xy-envs/SPEC.md`                 | 2026-03-10 | fast-track / PR #110 / checks green / review-loop clear |
 | ask3x | 反向代理默认超时口径统一为 60s / 180s                                         | 已完成          | `ask3x-proxy-timeout-defaults/SPEC.md`                   | 2026-03-10 | fast-track / PR #108 / checks green / review-loop clear |
 | 5gqdb | InvocationTable 桌面代理名省略回归热修                                        | 已完成          | `5gqdb-invocation-proxy-name-truncation-hotfix/SPEC.md`  | 2026-03-10 | fast-track / PR #105 / screenshot evidence              |
 | 2uaxk | 移除 XYAI 采集，仅保留历史读取                                                | 已完成（4/4）   | `2uaxk-remove-xyai-legacy-ingest/SPEC.md`                | 2026-03-09 | PR #101 / CI + review-loop                              |

--- a/docs/specs/ts4zf-rename-remaining-xy-envs/SPEC.md
+++ b/docs/specs/ts4zf-rename-remaining-xy-envs/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 待实现
+- Status: 已完成
 - Created: 2026-03-10
 - Last: 2026-03-10
 - Supersedes: `docs/specs/2uaxk-remove-xyai-legacy-ingest/SPEC.md` 中“仍然通用的 `XY_*` 配置键不重命名”的旧非目标；该 supersede 仅限公开环境变量命名，不恢复任何 XYAI 采集逻辑。
@@ -138,10 +138,10 @@
 
 ## 实现里程碑（Milestones / Delivery checklist）
 
-- [ ] M1: 新建 spec，冻结 rename matrix、breaking policy 与 supersede 边界。
-- [ ] M2: 后端配置解析切换到新 canonical 名称，并为全部 legacy `XY_*` 键补齐统一 hard-fail。
-- [ ] M3: README / 部署文档 / Docker / 测试样例同步更新，并完成残留扫描。
-- [ ] M4: `cargo test`、`cargo fmt --check`、review-loop、push、PR、checks 与标签全部收口到 merge-ready。
+- [x] M1: 新建 spec，冻结 rename matrix、breaking policy 与 supersede 边界。
+- [x] M2: 后端配置解析切换到新 canonical 名称，并为全部 legacy `XY_*` 键补齐统一 hard-fail。
+- [x] M3: README / 部署文档 / Docker / 测试样例同步更新，并完成残留扫描。
+- [x] M4: `cargo test`、`cargo fmt --check`、review-loop、push、PR、checks 与标签全部收口到 merge-ready。
 
 ## 风险 / 假设
 
@@ -152,6 +152,7 @@
 ## 变更记录（Change log）
 
 - 2026-03-10: 创建 spec，冻结剩余公开 `XY_*` env 的 rename matrix、immediate cutover 策略与 breaking migration 口径。
+- 2026-03-10: 完成实现、文档、回归测试、review-loop 与 fast-track 交付；PR [#110](https://github.com/IvanLi-CN/codex-vibe-monitor/pull/110) 已创建，labels=`type:major` + `channel:stable`，checks green。
 
 ## 参考（References）
 

--- a/docs/specs/ts4zf-rename-remaining-xy-envs/SPEC.md
+++ b/docs/specs/ts4zf-rename-remaining-xy-envs/SPEC.md
@@ -1,0 +1,163 @@
+# 修正剩余 `XY_*` 环境变量命名（#ts4zf）
+
+## 状态
+
+- Status: 待实现
+- Created: 2026-03-10
+- Last: 2026-03-10
+- Supersedes: `docs/specs/2uaxk-remove-xyai-legacy-ingest/SPEC.md` 中“仍然通用的 `XY_*` 配置键不重命名”的旧非目标；该 supersede 仅限公开环境变量命名，不恢复任何 XYAI 采集逻辑。
+
+## 背景 / 问题陈述
+
+- 仓库在移除 XYAI 新写入后，仍保留了一组对外公开且运行时继续接受的 `XY_*` 环境变量；它们已经不再对应当前产品边界，却仍然是部署文档、Docker 默认值和配置解析的 canonical 名称。
+- 这种“功能已去 XYAI 化、公开配置仍带 `XY_` 前缀”的状态会误导部署者，以为这些配置仍和历史 XYAI 功能有关，也让 `DATABASE_PATH` 的中性化命名显得不完整。
+- 主人已明确要求对全部剩余公开 `XY_*` runtime env 做一次性 hard cutover：新 canonical 名称统一改成裸名中性键；旧键不做 fallback，不 silently ignore，而是在启动期直接报出一对一 rename 指引。
+
+## 目标 / 非目标
+
+### Goals
+
+- 把所有仍被运行时接受的公开 `XY_*` 环境变量切换为裸名中性的 canonical 命名。
+- 旧 `XY_*` 键一旦出现在环境中就 fail-fast，并统一输出 `rename <old> to <new>` 风格的迁移错误。
+- 保持默认值、运行行为、数据保留策略、proxy / CRS / retention / xray 语义不变；变化仅限公开配置命名与报错口径。
+- README、部署文档、Docker 运行时默认 env、测试样例与用户可见注释只发布新名字；旧名字只出现在专门 migration 说明里。
+
+### Non-goals
+
+- 不回退或恢复任何 XYAI 采集、quota 拉取或 scheduler 写入逻辑。
+- 不修改历史数据库中的 `source='xy'`、历史 `xy` 聚合口径或 quota snapshot 读取语义。
+- 不重命名已经中性的公开键：`DATABASE_PATH`、`OPENAI_UPSTREAM_BASE_URL`、`OPENAI_PROXY_*`、`PROXY_RAW_*`、`PROXY_ENFORCE_STREAM_INCLUDE_USAGE`、`PROXY_USAGE_BACKFILL_ON_STARTUP`、`FORWARD_PROXY_ALGO`、`CRS_STATS_*`。
+- 不把旧键保留为兼容别名，不提供过渡期双读。
+
+## 需求（Requirements）
+
+### MUST
+
+- General/runtime 组 canonical 名称改为：
+  - `POLL_INTERVAL_SECS`
+  - `REQUEST_TIMEOUT_SECS`
+  - `MAX_PARALLEL_POLLS`
+  - `SHARED_CONNECTION_PARALLELISM`
+  - `HTTP_BIND`
+  - `CORS_ALLOWED_ORIGINS`
+  - `LIST_LIMIT_MAX`
+  - `USER_AGENT`
+  - `STATIC_DIR`
+- Retention/archive 组 canonical 名称改为：
+  - `RETENTION_ENABLED`
+  - `RETENTION_DRY_RUN`
+  - `RETENTION_INTERVAL_SECS`
+  - `RETENTION_BATCH_ROWS`
+  - `ARCHIVE_DIR`
+  - `INVOCATION_SUCCESS_FULL_DAYS`
+  - `INVOCATION_MAX_DAYS`
+  - `FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS`
+  - `STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS`
+  - `QUOTA_SNAPSHOT_FULL_DAYS`
+- Xray/runtime 组 canonical 名称改为：
+  - `XRAY_BINARY`
+  - `XRAY_RUNTIME_DIR`
+- 以下 legacy 键继续 hard-error，且报错风格要与本次新增 cutover 键完全统一：
+  - `XY_DATABASE_PATH -> DATABASE_PATH`
+  - `XY_FORWARD_PROXY_ALGO -> FORWARD_PROXY_ALGO`
+- 对所有被移除的旧键，启动期错误文案必须精确到一对一 rename 指引，避免“use ...”这类非矩阵化提示。
+
+### SHOULD
+
+- 用集中化的 legacy-env 校验表维护 rename matrix，避免 README、实现和测试出现漏改或口径漂移。
+- 针对 canonical 解析、legacy hard-fail、Docker / README / 部署文档残留扫描补上回归覆盖。
+
+## 迁移矩阵（Migration Matrix）
+
+| Legacy key                                 | Canonical key                           |
+| ------------------------------------------ | --------------------------------------- |
+| `XY_POLL_INTERVAL_SECS`                    | `POLL_INTERVAL_SECS`                    |
+| `XY_REQUEST_TIMEOUT_SECS`                  | `REQUEST_TIMEOUT_SECS`                  |
+| `XY_MAX_PARALLEL_POLLS`                    | `MAX_PARALLEL_POLLS`                    |
+| `XY_SHARED_CONNECTION_PARALLELISM`         | `SHARED_CONNECTION_PARALLELISM`         |
+| `XY_HTTP_BIND`                             | `HTTP_BIND`                             |
+| `XY_CORS_ALLOWED_ORIGINS`                  | `CORS_ALLOWED_ORIGINS`                  |
+| `XY_LIST_LIMIT_MAX`                        | `LIST_LIMIT_MAX`                        |
+| `XY_USER_AGENT`                            | `USER_AGENT`                            |
+| `XY_STATIC_DIR`                            | `STATIC_DIR`                            |
+| `XY_RETENTION_ENABLED`                     | `RETENTION_ENABLED`                     |
+| `XY_RETENTION_DRY_RUN`                     | `RETENTION_DRY_RUN`                     |
+| `XY_RETENTION_INTERVAL_SECS`               | `RETENTION_INTERVAL_SECS`               |
+| `XY_RETENTION_BATCH_ROWS`                  | `RETENTION_BATCH_ROWS`                  |
+| `XY_ARCHIVE_DIR`                           | `ARCHIVE_DIR`                           |
+| `XY_INVOCATION_SUCCESS_FULL_DAYS`          | `INVOCATION_SUCCESS_FULL_DAYS`          |
+| `XY_INVOCATION_MAX_DAYS`                   | `INVOCATION_MAX_DAYS`                   |
+| `XY_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` | `FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` |
+| `XY_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS` | `STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS` |
+| `XY_QUOTA_SNAPSHOT_FULL_DAYS`              | `QUOTA_SNAPSHOT_FULL_DAYS`              |
+| `XY_XRAY_BINARY`                           | `XRAY_BINARY`                           |
+| `XY_XRAY_RUNTIME_DIR`                      | `XRAY_RUNTIME_DIR`                      |
+| `XY_DATABASE_PATH`                         | `DATABASE_PATH`                         |
+| `XY_FORWARD_PROXY_ALGO`                    | `FORWARD_PROXY_ALGO`                    |
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- 配置解析时仅接受新的 canonical 裸名键；旧 `XY_*` 键一旦出现即直接返回配置错误。
+- CLI override 继续优先于环境变量；本次不改 CLI 参数名。
+- 所有默认值维持现状，例如：轮询节奏 `10s`、请求超时 `60s`、retention 关闭、archive 根目录 `archives`、xray binary 默认 `xray`。
+- `CRS_STATS_POLL_INTERVAL_SECS` 仍然默认跟随 `POLL_INTERVAL_SECS`，而不是保留对旧 `XY_POLL_INTERVAL_SECS` 的任何语义依赖。
+
+### Edge cases / errors
+
+- 如果同时配置新旧键，仍然按旧键非法处理并阻断启动；不能“新键覆盖旧键后继续运行”。
+- 旧键报错必须采用统一口径：`<OLD> is not supported; rename it to <NEW>`。
+- 对新 canonical 键的非法值处理保持现状，不把本次命名调整顺手升级为“更严格解析”。
+
+## 验收标准（Acceptance Criteria）
+
+- Given 仅配置新的 canonical 键，When 服务启动解析配置，Then 所有对应字段可正常生效，默认值与既有行为不变。
+- Given 环境中存在任意一个被移除的 `XY_*` 公开键，When 服务启动，Then 启动直接失败，且错误文案精确指出要迁移到哪个 canonical 键。
+- Given 历史数据库中存在 `source='xy'` 调用记录或 quota snapshot，When 请求相关只读接口与聚合接口，Then 读取与聚合行为保持现状，不受 env rename 影响。
+- Given README、部署文档、Docker 默认 env 与代码中的公开 env 示例，When 进行残留扫描，Then 除专门 migration 说明外，不再发布仍被支持的 `XY_*` 名称。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- `cargo test`
+- 针对 config parsing 的定向回归：新 canonical 名称可成功解析；被移除的旧键会 fail-fast。
+- 文档/代码残留扫描：针对 README、Dockerfile、部署文档与源码中的公开 env 名称执行检索确认。
+
+### Quality checks
+
+- `cargo fmt --check`
+
+## 文档更新（Docs to Update）
+
+- `docs/specs/README.md`：新增本 spec，并在交付完成后写入 PR / checks / review-loop 状态。
+- `README.md`：把公开 env 示例、retention/archive 说明与 migration note 统一到新命名。
+- `docs/deployment.md`：把运维配置说明与 archive 路径描述统一到新命名。
+- `Dockerfile`：把 runtime 默认 env 与 Xray 相关注释更新到新命名。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [ ] M1: 新建 spec，冻结 rename matrix、breaking policy 与 supersede 边界。
+- [ ] M2: 后端配置解析切换到新 canonical 名称，并为全部 legacy `XY_*` 键补齐统一 hard-fail。
+- [ ] M3: README / 部署文档 / Docker / 测试样例同步更新，并完成残留扫描。
+- [ ] M4: `cargo test`、`cargo fmt --check`、review-loop、push、PR、checks 与标签全部收口到 merge-ready。
+
+## 风险 / 假设
+
+- 风险：仍在部署系统中保留旧 `XY_*` 键的实例会在升级后立即启动失败，因此 PR 与迁移说明必须明确这是 breaking public config change。
+- 风险：若实现遗漏任一公开旧键，会出现“部分新命名、部分旧命名仍被接受”的灰区，必须用集中化矩阵和残留扫描兜底。
+- 假设：当前唯一需要保留的 legacy hard-error 键就是 `XY_DATABASE_PATH` 与 `XY_FORWARD_PROXY_ALGO`，其余旧 `XY_*` 键均应迁移到本 spec 的新 canonical 名称。
+
+## 变更记录（Change log）
+
+- 2026-03-10: 创建 spec，冻结剩余公开 `XY_*` env 的 rename matrix、immediate cutover 策略与 breaking migration 口径。
+
+## 参考（References）
+
+- `docs/specs/2uaxk-remove-xyai-legacy-ingest/SPEC.md`
+- `docs/specs/bh43j-database-path-raw-dir-anchor/SPEC.md`
+- `README.md`
+- `docs/deployment.md`
+- `Dockerfile`
+- `src/main.rs`

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,52 @@ const DEFAULT_PROXY_PRICING_CATALOG_PATH: &str = "config/model-pricing.json";
 const DEFAULT_PROXY_RAW_DIR: &str = "proxy_raw_payloads";
 const ENV_DATABASE_PATH: &str = "DATABASE_PATH";
 const LEGACY_ENV_DATABASE_PATH: &str = "XY_DATABASE_PATH";
+const ENV_POLL_INTERVAL_SECS: &str = "POLL_INTERVAL_SECS";
+const LEGACY_ENV_POLL_INTERVAL_SECS: &str = "XY_POLL_INTERVAL_SECS";
+const ENV_REQUEST_TIMEOUT_SECS: &str = "REQUEST_TIMEOUT_SECS";
+const LEGACY_ENV_REQUEST_TIMEOUT_SECS: &str = "XY_REQUEST_TIMEOUT_SECS";
+const ENV_XRAY_BINARY: &str = "XRAY_BINARY";
+const LEGACY_ENV_XRAY_BINARY: &str = "XY_XRAY_BINARY";
+const ENV_XRAY_RUNTIME_DIR: &str = "XRAY_RUNTIME_DIR";
+const LEGACY_ENV_XRAY_RUNTIME_DIR: &str = "XY_XRAY_RUNTIME_DIR";
+const ENV_FORWARD_PROXY_ALGO: &str = "FORWARD_PROXY_ALGO";
+const LEGACY_ENV_FORWARD_PROXY_ALGO: &str = "XY_FORWARD_PROXY_ALGO";
+const ENV_MAX_PARALLEL_POLLS: &str = "MAX_PARALLEL_POLLS";
+const LEGACY_ENV_MAX_PARALLEL_POLLS: &str = "XY_MAX_PARALLEL_POLLS";
+const ENV_SHARED_CONNECTION_PARALLELISM: &str = "SHARED_CONNECTION_PARALLELISM";
+const LEGACY_ENV_SHARED_CONNECTION_PARALLELISM: &str = "XY_SHARED_CONNECTION_PARALLELISM";
+const ENV_HTTP_BIND: &str = "HTTP_BIND";
+const LEGACY_ENV_HTTP_BIND: &str = "XY_HTTP_BIND";
+const ENV_CORS_ALLOWED_ORIGINS: &str = "CORS_ALLOWED_ORIGINS";
+const LEGACY_ENV_CORS_ALLOWED_ORIGINS: &str = "XY_CORS_ALLOWED_ORIGINS";
+const ENV_LIST_LIMIT_MAX: &str = "LIST_LIMIT_MAX";
+const LEGACY_ENV_LIST_LIMIT_MAX: &str = "XY_LIST_LIMIT_MAX";
+const ENV_USER_AGENT: &str = "USER_AGENT";
+const LEGACY_ENV_USER_AGENT: &str = "XY_USER_AGENT";
+const ENV_STATIC_DIR: &str = "STATIC_DIR";
+const LEGACY_ENV_STATIC_DIR: &str = "XY_STATIC_DIR";
+const ENV_RETENTION_ENABLED: &str = "RETENTION_ENABLED";
+const LEGACY_ENV_RETENTION_ENABLED: &str = "XY_RETENTION_ENABLED";
+const ENV_RETENTION_DRY_RUN: &str = "RETENTION_DRY_RUN";
+const LEGACY_ENV_RETENTION_DRY_RUN: &str = "XY_RETENTION_DRY_RUN";
+const ENV_RETENTION_INTERVAL_SECS: &str = "RETENTION_INTERVAL_SECS";
+const LEGACY_ENV_RETENTION_INTERVAL_SECS: &str = "XY_RETENTION_INTERVAL_SECS";
+const ENV_RETENTION_BATCH_ROWS: &str = "RETENTION_BATCH_ROWS";
+const LEGACY_ENV_RETENTION_BATCH_ROWS: &str = "XY_RETENTION_BATCH_ROWS";
+const ENV_ARCHIVE_DIR: &str = "ARCHIVE_DIR";
+const LEGACY_ENV_ARCHIVE_DIR: &str = "XY_ARCHIVE_DIR";
+const ENV_INVOCATION_SUCCESS_FULL_DAYS: &str = "INVOCATION_SUCCESS_FULL_DAYS";
+const LEGACY_ENV_INVOCATION_SUCCESS_FULL_DAYS: &str = "XY_INVOCATION_SUCCESS_FULL_DAYS";
+const ENV_INVOCATION_MAX_DAYS: &str = "INVOCATION_MAX_DAYS";
+const LEGACY_ENV_INVOCATION_MAX_DAYS: &str = "XY_INVOCATION_MAX_DAYS";
+const ENV_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS: &str = "FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS";
+const LEGACY_ENV_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS: &str =
+    "XY_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS";
+const ENV_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS: &str = "STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS";
+const LEGACY_ENV_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS: &str =
+    "XY_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS";
+const ENV_QUOTA_SNAPSHOT_FULL_DAYS: &str = "QUOTA_SNAPSHOT_FULL_DAYS";
+const LEGACY_ENV_QUOTA_SNAPSHOT_FULL_DAYS: &str = "XY_QUOTA_SNAPSHOT_FULL_DAYS";
 const DETAIL_LEVEL_FULL: &str = "full";
 const DETAIL_LEVEL_STRUCTURED_ONLY: &str = "structured_only";
 const DETAIL_PRUNE_REASON_SUCCESS_OVER_30D: &str = "success_over_30d";
@@ -204,7 +250,6 @@ const DEFAULT_PROXY_FAST_MODE_REWRITE_MODE: ProxyFastModeRewriteMode =
     ProxyFastModeRewriteMode::Disabled;
 const DEFAULT_PROXY_USAGE_BACKFILL_ON_STARTUP: bool = true;
 const GPT_5_4_LONG_CONTEXT_THRESHOLD_TOKENS: i64 = 272_000;
-const ENV_CORS_ALLOWED_ORIGINS: &str = "XY_CORS_ALLOWED_ORIGINS";
 const PROMPT_CACHE_CONVERSATION_DEFAULT_LIMIT: i64 = 50;
 const PROMPT_CACHE_CONVERSATION_CACHE_TTL_SECS: u64 = 5;
 const PROXY_PRESET_MODEL_IDS: &[&str] = &[
@@ -222,6 +267,49 @@ const LEGACY_PROXY_PRESET_MODEL_IDS: &[&str] = &[
     "gpt-5.1-codex-max",
     "gpt-5.1-codex-mini",
     "gpt-5.2",
+];
+const LEGACY_ENV_RENAMES: &[(&str, &str)] = &[
+    (LEGACY_ENV_DATABASE_PATH, ENV_DATABASE_PATH),
+    (LEGACY_ENV_POLL_INTERVAL_SECS, ENV_POLL_INTERVAL_SECS),
+    (LEGACY_ENV_REQUEST_TIMEOUT_SECS, ENV_REQUEST_TIMEOUT_SECS),
+    (LEGACY_ENV_XRAY_BINARY, ENV_XRAY_BINARY),
+    (LEGACY_ENV_XRAY_RUNTIME_DIR, ENV_XRAY_RUNTIME_DIR),
+    (LEGACY_ENV_FORWARD_PROXY_ALGO, ENV_FORWARD_PROXY_ALGO),
+    (LEGACY_ENV_MAX_PARALLEL_POLLS, ENV_MAX_PARALLEL_POLLS),
+    (
+        LEGACY_ENV_SHARED_CONNECTION_PARALLELISM,
+        ENV_SHARED_CONNECTION_PARALLELISM,
+    ),
+    (LEGACY_ENV_HTTP_BIND, ENV_HTTP_BIND),
+    (LEGACY_ENV_CORS_ALLOWED_ORIGINS, ENV_CORS_ALLOWED_ORIGINS),
+    (LEGACY_ENV_LIST_LIMIT_MAX, ENV_LIST_LIMIT_MAX),
+    (LEGACY_ENV_USER_AGENT, ENV_USER_AGENT),
+    (LEGACY_ENV_STATIC_DIR, ENV_STATIC_DIR),
+    (LEGACY_ENV_RETENTION_ENABLED, ENV_RETENTION_ENABLED),
+    (LEGACY_ENV_RETENTION_DRY_RUN, ENV_RETENTION_DRY_RUN),
+    (
+        LEGACY_ENV_RETENTION_INTERVAL_SECS,
+        ENV_RETENTION_INTERVAL_SECS,
+    ),
+    (LEGACY_ENV_RETENTION_BATCH_ROWS, ENV_RETENTION_BATCH_ROWS),
+    (LEGACY_ENV_ARCHIVE_DIR, ENV_ARCHIVE_DIR),
+    (
+        LEGACY_ENV_INVOCATION_SUCCESS_FULL_DAYS,
+        ENV_INVOCATION_SUCCESS_FULL_DAYS,
+    ),
+    (LEGACY_ENV_INVOCATION_MAX_DAYS, ENV_INVOCATION_MAX_DAYS),
+    (
+        LEGACY_ENV_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS,
+        ENV_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS,
+    ),
+    (
+        LEGACY_ENV_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS,
+        ENV_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS,
+    ),
+    (
+        LEGACY_ENV_QUOTA_SNAPSHOT_FULL_DAYS,
+        ENV_QUOTA_SNAPSHOT_FULL_DAYS,
+    ),
 ];
 static NEXT_PROXY_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -272,12 +360,28 @@ fn resolve_forward_proxy_algo_config(
     legacy_raw: Option<&str>,
 ) -> Result<ForwardProxyAlgo> {
     if legacy_raw.is_some() {
-        bail!("XY_FORWARD_PROXY_ALGO is not supported; use FORWARD_PROXY_ALGO");
+        bail!(
+            "{LEGACY_ENV_FORWARD_PROXY_ALGO} is not supported; rename it to {ENV_FORWARD_PROXY_ALGO}"
+        );
     }
     match primary_raw {
         Some(primary) => ForwardProxyAlgo::from_str(primary),
         None => Ok(DEFAULT_FORWARD_PROXY_ALGO),
     }
+}
+
+fn reject_legacy_env_var(legacy_name: &str, canonical_name: &str) -> Result<()> {
+    if env::var_os(legacy_name).is_some() {
+        bail!("{legacy_name} is not supported; rename it to {canonical_name}");
+    }
+    Ok(())
+}
+
+fn reject_legacy_env_vars(renames: &[(&str, &str)]) -> Result<()> {
+    for (legacy_name, canonical_name) in renames {
+        reject_legacy_env_var(legacy_name, canonical_name)?;
+    }
+    Ok(())
 }
 
 #[derive(Parser, Debug, Default)]
@@ -9726,9 +9830,7 @@ impl AppConfig {
     }
 
     fn from_sources(overrides: &CliArgs) -> Result<Self> {
-        if env::var_os(LEGACY_ENV_DATABASE_PATH).is_some() {
-            bail!("{LEGACY_ENV_DATABASE_PATH} is not supported; rename it to {ENV_DATABASE_PATH}");
-        }
+        reject_legacy_env_vars(LEGACY_ENV_RENAMES)?;
         let openai_upstream_base_url = env::var("OPENAI_UPSTREAM_BASE_URL")
             .unwrap_or_else(|_| DEFAULT_OPENAI_UPSTREAM_BASE_URL.to_string());
         let database_path = overrides
@@ -9739,7 +9841,7 @@ impl AppConfig {
         let poll_interval = overrides
             .poll_interval_secs
             .or_else(|| {
-                env::var("XY_POLL_INTERVAL_SECS")
+                env::var(ENV_POLL_INTERVAL_SECS)
                     .ok()
                     .and_then(|v| v.parse::<u64>().ok())
             })
@@ -9748,7 +9850,7 @@ impl AppConfig {
         let request_timeout = overrides
             .request_timeout_secs
             .or_else(|| {
-                env::var("XY_REQUEST_TIMEOUT_SECS")
+                env::var(ENV_REQUEST_TIMEOUT_SECS)
                     .ok()
                     .and_then(|v| v.parse::<u64>().ok())
             })
@@ -9816,16 +9918,14 @@ impl AppConfig {
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_PROXY_RAW_DIR));
-        let xray_binary = env::var("XY_XRAY_BINARY")
-            .or_else(|_| env::var("XRAY_BINARY"))
-            .unwrap_or_else(|_| DEFAULT_XRAY_BINARY.to_string());
-        let xray_runtime_dir = env::var("XY_XRAY_RUNTIME_DIR")
-            .or_else(|_| env::var("XRAY_RUNTIME_DIR"))
+        let xray_binary =
+            env::var(ENV_XRAY_BINARY).unwrap_or_else(|_| DEFAULT_XRAY_BINARY.to_string());
+        let xray_runtime_dir = env::var(ENV_XRAY_RUNTIME_DIR)
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_XRAY_RUNTIME_DIR));
-        let forward_proxy_algo_raw = env::var("FORWARD_PROXY_ALGO").ok();
-        let forward_proxy_algo_legacy_raw = env::var("XY_FORWARD_PROXY_ALGO").ok();
+        let forward_proxy_algo_raw = env::var(ENV_FORWARD_PROXY_ALGO).ok();
+        let forward_proxy_algo_legacy_raw = env::var(LEGACY_ENV_FORWARD_PROXY_ALGO).ok();
         let forward_proxy_algo = resolve_forward_proxy_algo_config(
             forward_proxy_algo_raw.as_deref(),
             forward_proxy_algo_legacy_raw.as_deref(),
@@ -9833,7 +9933,7 @@ impl AppConfig {
         let max_parallel_polls = overrides
             .max_parallel_polls
             .or_else(|| {
-                env::var("XY_MAX_PARALLEL_POLLS")
+                env::var(ENV_MAX_PARALLEL_POLLS)
                     .ok()
                     .and_then(|v| v.parse::<usize>().ok())
             })
@@ -9842,7 +9942,7 @@ impl AppConfig {
         let shared_connection_parallelism = overrides
             .shared_connection_parallelism
             .or_else(|| {
-                env::var("XY_SHARED_CONNECTION_PARALLELISM")
+                env::var(ENV_SHARED_CONNECTION_PARALLELISM)
                     .ok()
                     .and_then(|v| v.parse::<usize>().ok())
             })
@@ -9850,18 +9950,18 @@ impl AppConfig {
         let http_bind = if let Some(addr) = overrides.http_bind {
             addr
         } else {
-            env::var("XY_HTTP_BIND")
+            env::var(ENV_HTTP_BIND)
                 .ok()
                 .map(|v| v.parse())
                 .transpose()
-                .context("invalid XY_HTTP_BIND socket address")?
+                .context("invalid HTTP_BIND socket address")?
                 .unwrap_or_else(|| "127.0.0.1:8080".parse().expect("valid default address"))
         };
         let cors_allowed_origins = parse_cors_allowed_origins_env(ENV_CORS_ALLOWED_ORIGINS)?;
         let list_limit_max = overrides
             .list_limit_max
             .or_else(|| {
-                env::var("XY_LIST_LIMIT_MAX")
+                env::var(ENV_LIST_LIMIT_MAX)
                     .ok()
                     .and_then(|v| v.parse::<usize>().ok())
             })
@@ -9870,12 +9970,12 @@ impl AppConfig {
         let user_agent = overrides
             .user_agent
             .clone()
-            .or_else(|| env::var("XY_USER_AGENT").ok())
+            .or_else(|| env::var(ENV_USER_AGENT).ok())
             .unwrap_or_else(|| "codex-vibe-monitor/0.2.0".to_string());
         let static_dir = overrides
             .static_dir
             .clone()
-            .or_else(|| env::var("XY_STATIC_DIR").ok().map(PathBuf::from))
+            .or_else(|| env::var(ENV_STATIC_DIR).ok().map(PathBuf::from))
             .or_else(|| {
                 let default = PathBuf::from("web/dist");
                 if default.exists() {
@@ -9885,35 +9985,35 @@ impl AppConfig {
                 }
             });
         let retention_enabled =
-            parse_bool_env_var("XY_RETENTION_ENABLED", DEFAULT_RETENTION_ENABLED)?;
+            parse_bool_env_var(ENV_RETENTION_ENABLED, DEFAULT_RETENTION_ENABLED)?;
         let retention_dry_run = overrides.retention_dry_run
-            || parse_bool_env_var("XY_RETENTION_DRY_RUN", DEFAULT_RETENTION_DRY_RUN)?;
+            || parse_bool_env_var(ENV_RETENTION_DRY_RUN, DEFAULT_RETENTION_DRY_RUN)?;
         let retention_interval = Duration::from_secs(parse_u64_env_var(
-            "XY_RETENTION_INTERVAL_SECS",
+            ENV_RETENTION_INTERVAL_SECS,
             DEFAULT_RETENTION_INTERVAL_SECS,
         )?);
         let retention_batch_rows =
-            parse_usize_env_var("XY_RETENTION_BATCH_ROWS", DEFAULT_RETENTION_BATCH_ROWS)?.max(1);
-        let archive_dir = env::var("XY_ARCHIVE_DIR")
+            parse_usize_env_var(ENV_RETENTION_BATCH_ROWS, DEFAULT_RETENTION_BATCH_ROWS)?.max(1);
+        let archive_dir = env::var(ENV_ARCHIVE_DIR)
             .ok()
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_ARCHIVE_DIR));
         let invocation_success_full_days = parse_u64_env_var(
-            "XY_INVOCATION_SUCCESS_FULL_DAYS",
+            ENV_INVOCATION_SUCCESS_FULL_DAYS,
             DEFAULT_INVOCATION_SUCCESS_FULL_DAYS,
         )?;
         let invocation_max_days =
-            parse_u64_env_var("XY_INVOCATION_MAX_DAYS", DEFAULT_INVOCATION_MAX_DAYS)?;
+            parse_u64_env_var(ENV_INVOCATION_MAX_DAYS, DEFAULT_INVOCATION_MAX_DAYS)?;
         let forward_proxy_attempts_retention_days = parse_u64_env_var(
-            "XY_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS",
+            ENV_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS,
             DEFAULT_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS,
         )?;
         let stats_source_snapshots_retention_days = parse_u64_env_var(
-            "XY_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS",
+            ENV_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS,
             DEFAULT_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS,
         )?;
         let quota_snapshot_full_days = parse_u64_env_var(
-            "XY_QUOTA_SNAPSHOT_FULL_DAYS",
+            ENV_QUOTA_SNAPSHOT_FULL_DAYS,
             DEFAULT_QUOTA_SNAPSHOT_FULL_DAYS,
         )?;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,7 +16,9 @@ use sqlx::{Connection, SqliteConnection, SqlitePool};
 use std::{
     borrow::Cow,
     collections::HashSet,
-    env, fs,
+    env,
+    ffi::OsString,
+    fs,
     path::{Path, PathBuf},
     sync::{Arc, Mutex as StdMutex},
     time::Duration,
@@ -32,6 +34,10 @@ struct CurrentDirGuard {
     original: PathBuf,
 }
 
+struct EnvVarGuard {
+    previous: Vec<(String, Option<OsString>)>,
+}
+
 impl CurrentDirGuard {
     fn change_to(path: &Path) -> Self {
         let original = env::current_dir().expect("read current dir");
@@ -40,9 +46,38 @@ impl CurrentDirGuard {
     }
 }
 
+impl EnvVarGuard {
+    fn set(cases: &[(&str, Option<&str>)]) -> Self {
+        let previous = cases
+            .iter()
+            .map(|(name, _)| ((*name).to_string(), env::var_os(name)))
+            .collect::<Vec<_>>();
+
+        for (name, value) in cases {
+            match value {
+                Some(value) => unsafe { env::set_var(name, value) },
+                None => unsafe { env::remove_var(name) },
+            }
+        }
+
+        Self { previous }
+    }
+}
+
 impl Drop for CurrentDirGuard {
     fn drop(&mut self) {
         let _ = env::set_current_dir(&self.original);
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        for (name, value) in self.previous.drain(..).rev() {
+            match value {
+                Some(value) => unsafe { env::set_var(&name, value) },
+                None => unsafe { env::remove_var(&name) },
+            }
+        }
     }
 }
 
@@ -760,12 +795,22 @@ fn forward_proxy_algo_config_accepts_primary_env() {
 
 #[test]
 fn forward_proxy_algo_config_rejects_legacy_env() {
-    assert!(resolve_forward_proxy_algo_config(None, Some("v1")).is_err());
+    let err =
+        resolve_forward_proxy_algo_config(None, Some("v1")).expect_err("legacy env should fail");
+    assert_eq!(
+        err.to_string(),
+        "XY_FORWARD_PROXY_ALGO is not supported; rename it to FORWARD_PROXY_ALGO"
+    );
 }
 
 #[test]
 fn forward_proxy_algo_config_rejects_when_both_env_vars_are_set() {
-    assert!(resolve_forward_proxy_algo_config(Some("v2"), Some("v1")).is_err());
+    let err = resolve_forward_proxy_algo_config(Some("v2"), Some("v1"))
+        .expect_err("legacy env should still win as a hard failure");
+    assert_eq!(
+        err.to_string(),
+        "XY_FORWARD_PROXY_ALGO is not supported; rename it to FORWARD_PROXY_ALGO"
+    );
 }
 
 #[test]
@@ -1172,6 +1217,103 @@ fn app_config_from_sources_rejects_legacy_database_path_env() {
             .contains("XY_DATABASE_PATH is not supported; rename it to DATABASE_PATH"),
         "error should point to the DATABASE_PATH migration"
     );
+}
+
+#[test]
+fn app_config_from_sources_reads_renamed_public_envs() {
+    let _guard = APP_CONFIG_ENV_LOCK.lock().expect("env lock");
+    let mut cases = LEGACY_ENV_RENAMES
+        .iter()
+        .map(|(legacy, _)| (*legacy, None))
+        .collect::<Vec<_>>();
+    cases.extend([
+        (ENV_POLL_INTERVAL_SECS, Some("11")),
+        (ENV_REQUEST_TIMEOUT_SECS, Some("61")),
+        (ENV_XRAY_BINARY, Some("/usr/local/bin/xray-custom")),
+        (ENV_XRAY_RUNTIME_DIR, Some("/tmp/xray-runtime")),
+        (ENV_MAX_PARALLEL_POLLS, Some("7")),
+        (ENV_SHARED_CONNECTION_PARALLELISM, Some("3")),
+        (ENV_HTTP_BIND, Some("127.0.0.1:39090")),
+        (
+            ENV_CORS_ALLOWED_ORIGINS,
+            Some("https://app.example.com, http://localhost:5173"),
+        ),
+        (ENV_LIST_LIMIT_MAX, Some("321")),
+        (ENV_USER_AGENT, Some("custom-agent/1.0")),
+        (ENV_STATIC_DIR, Some("/tmp/static")),
+        (ENV_RETENTION_ENABLED, Some("true")),
+        (ENV_RETENTION_DRY_RUN, Some("true")),
+        (ENV_RETENTION_INTERVAL_SECS, Some("7200")),
+        (ENV_RETENTION_BATCH_ROWS, Some("2222")),
+        (ENV_ARCHIVE_DIR, Some("/tmp/archive")),
+        (ENV_INVOCATION_SUCCESS_FULL_DAYS, Some("31")),
+        (ENV_INVOCATION_MAX_DAYS, Some("91")),
+        (ENV_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS, Some("32")),
+        (ENV_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS, Some("33")),
+        (ENV_QUOTA_SNAPSHOT_FULL_DAYS, Some("34")),
+        (ENV_FORWARD_PROXY_ALGO, Some("v2")),
+    ]);
+    let _env = EnvVarGuard::set(&cases);
+
+    let config =
+        AppConfig::from_sources(&CliArgs::default()).expect("renamed public envs should parse");
+
+    assert_eq!(config.poll_interval, Duration::from_secs(11));
+    assert_eq!(config.request_timeout, Duration::from_secs(61));
+    assert_eq!(config.xray_binary, "/usr/local/bin/xray-custom");
+    assert_eq!(config.xray_runtime_dir, PathBuf::from("/tmp/xray-runtime"));
+    assert_eq!(config.forward_proxy_algo, ForwardProxyAlgo::V2);
+    assert_eq!(config.max_parallel_polls, 7);
+    assert_eq!(config.shared_connection_parallelism, 3);
+    assert_eq!(
+        config.http_bind,
+        "127.0.0.1:39090".parse().expect("valid socket address")
+    );
+    assert_eq!(
+        config.cors_allowed_origins,
+        vec![
+            "https://app.example.com".to_string(),
+            "http://localhost:5173".to_string(),
+        ]
+    );
+    assert_eq!(config.list_limit_max, 321);
+    assert_eq!(config.user_agent, "custom-agent/1.0");
+    assert_eq!(config.static_dir, Some(PathBuf::from("/tmp/static")));
+    assert!(config.retention_enabled);
+    assert!(config.retention_dry_run);
+    assert_eq!(config.retention_interval, Duration::from_secs(7200));
+    assert_eq!(config.retention_batch_rows, 2222);
+    assert_eq!(config.archive_dir, PathBuf::from("/tmp/archive"));
+    assert_eq!(config.invocation_success_full_days, 31);
+    assert_eq!(config.invocation_max_days, 91);
+    assert_eq!(config.forward_proxy_attempts_retention_days, 32);
+    assert_eq!(config.stats_source_snapshots_retention_days, 33);
+    assert_eq!(config.quota_snapshot_full_days, 34);
+}
+
+#[test]
+fn app_config_from_sources_rejects_all_legacy_public_env_renames() {
+    let _guard = APP_CONFIG_ENV_LOCK.lock().expect("env lock");
+
+    for (legacy_name, canonical_name) in LEGACY_ENV_RENAMES {
+        let mut cases = LEGACY_ENV_RENAMES
+            .iter()
+            .map(|(legacy, _)| (*legacy, None))
+            .collect::<Vec<_>>();
+        let target = cases
+            .iter_mut()
+            .find(|(name, _)| *name == *legacy_name)
+            .expect("legacy env should be present in helper list");
+        *target = (*legacy_name, Some("legacy-value"));
+        let _env = EnvVarGuard::set(&cases);
+
+        let err = AppConfig::from_sources(&CliArgs::default())
+            .expect_err("legacy env should fail fast with a rename hint");
+        assert_eq!(
+            err.to_string(),
+            format!("{legacy_name} is not supported; rename it to {canonical_name}")
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What changed
- cut over all remaining runtime-supported public `XY_*` env vars to neutral canonical names in `src/main.rs`
- hard-fail every removed legacy key at startup with exact rename guidance in the form ``rename OLD to NEW``
- update README, deployment docs, Docker defaults, and regression tests to publish only the new canonical names

## Breaking change
This PR intentionally changes the public runtime config surface.

Any deployment that still injects the old `XY_*` env keys will now fail fast on startup until the env names are migrated.

## Rename matrix
| Legacy key | Canonical key |
| --- | --- |
| `XY_POLL_INTERVAL_SECS` | `POLL_INTERVAL_SECS` |
| `XY_REQUEST_TIMEOUT_SECS` | `REQUEST_TIMEOUT_SECS` |
| `XY_MAX_PARALLEL_POLLS` | `MAX_PARALLEL_POLLS` |
| `XY_SHARED_CONNECTION_PARALLELISM` | `SHARED_CONNECTION_PARALLELISM` |
| `XY_HTTP_BIND` | `HTTP_BIND` |
| `XY_CORS_ALLOWED_ORIGINS` | `CORS_ALLOWED_ORIGINS` |
| `XY_LIST_LIMIT_MAX` | `LIST_LIMIT_MAX` |
| `XY_USER_AGENT` | `USER_AGENT` |
| `XY_STATIC_DIR` | `STATIC_DIR` |
| `XY_RETENTION_ENABLED` | `RETENTION_ENABLED` |
| `XY_RETENTION_DRY_RUN` | `RETENTION_DRY_RUN` |
| `XY_RETENTION_INTERVAL_SECS` | `RETENTION_INTERVAL_SECS` |
| `XY_RETENTION_BATCH_ROWS` | `RETENTION_BATCH_ROWS` |
| `XY_ARCHIVE_DIR` | `ARCHIVE_DIR` |
| `XY_INVOCATION_SUCCESS_FULL_DAYS` | `INVOCATION_SUCCESS_FULL_DAYS` |
| `XY_INVOCATION_MAX_DAYS` | `INVOCATION_MAX_DAYS` |
| `XY_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` | `FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS` |
| `XY_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS` | `STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS` |
| `XY_QUOTA_SNAPSHOT_FULL_DAYS` | `QUOTA_SNAPSHOT_FULL_DAYS` |
| `XY_XRAY_BINARY` | `XRAY_BINARY` |
| `XY_XRAY_RUNTIME_DIR` | `XRAY_RUNTIME_DIR` |
| `XY_DATABASE_PATH` | `DATABASE_PATH` |
| `XY_FORWARD_PROXY_ALGO` | `FORWARD_PROXY_ALGO` |

## Cutover guide
1. Rename every injected public `XY_*` env key in Compose / systemd / CI / secret manager to the canonical name above.
2. Redeploy with only the canonical keys present.
3. If startup fails, follow the emitted rename hint and remove the legacy key entirely.

## Validation
- `cargo fmt --check`
- `cargo test`
- `cd web && npm run lint -- --max-warnings=0`
- `cd web && npx tsc -b`
- targeted legacy-name scan across `README.md`, `docs/deployment.md`, `Dockerfile`, `src/main.rs`, and `src/tests/mod.rs`

## Spec
- `docs/specs/ts4zf-rename-remaining-xy-envs/SPEC.md`
