### PR TITLE
feat(web): add storybook accessibility gate

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -194,6 +194,14 @@ jobs:
         working-directory: web
         run: bun run test
 
+      - name: Install Playwright Chromium for Storybook
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run Storybook accessibility suite
+        working-directory: web
+        run: bun run test-storybook
+
   records-overlay-e2e:
     name: Records Overlay E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -260,6 +260,14 @@ jobs:
         working-directory: web
         run: bun run test
 
+      - name: Install Playwright Chromium for Storybook
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run Storybook accessibility suite
+        working-directory: web
+        run: bun run test-storybook
+
   records-overlay-e2e:
     name: Records Overlay E2E
     runs-on: ubuntu-latest

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,6 +7,7 @@
 ## Index
 
 | ID    | Title                                                                         | Status                          | Spec                                                     | Last       | Notes                                                                                                                                              |
+| sbacc | Storybook 可访问性门禁 | 已实现，待 PR CI 收敛 | `sbacc-storybook-accessibility/SPEC.md` | 2026-04-26 | PR #123 基于最新 main 复活；Storybook a11y gate 接入现有 Front-end Tests 状态上下文 |
 | wjowd | `main` 主干保护禁止直推与 PR 全检查必过 | 已实现，待 PR / CI / review-proof 收敛 | `wjowd-main-branch-protection/SPEC.md` | 2026-04-22 | fast-track / main direct pushes blocked via GitHub ruleset / PR required checks expanded to 7 gate jobs / live quality-gates now reports bypass actor verification as verified vs unverified instead of assuming empty bypass actors |
 | 5uxj8 | pool `/v1/*` live 路由显式综合打分 follow-up | 已实现，待 PR / CI / review-proof 收敛 | `5uxj8-pool-live-routing-score-followup/SPEC.md` | 2026-04-18 | fast-track / follow-up of `#6b9ra` / live routing explicit score breakdown + node-shunt soft-degrade fallback + assigned-account blocked preservation for InvocationTable + current Dashboard cards |
 | 47ran | 当前 pool `/v1/models` 路径级覆盖与 GPT-5.5 默认价格刷新 | 已实现，待 PR / CI / review-proof 收敛 | `47ran-pool-models-override-gpt55-pricing/SPEC.md` | 2026-04-25 | fast-track / restore settings proxy contract + pool `/v1/models` hijack/merge/fallback / hardcode GPT-5.5 + GPT-5.5 Pro + GPT-5.4 mini into repo-managed default pricing |

--- a/docs/specs/sbacc-storybook-accessibility/SPEC.md
+++ b/docs/specs/sbacc-storybook-accessibility/SPEC.md
@@ -1,0 +1,41 @@
+# Storybook Accessibility Gate
+
+## Status
+
+- Spec ID: `sbacc`
+- Status: Implemented, pending PR CI convergence
+- Created: 2026-03-13
+- Updated: 2026-04-26
+
+## Context
+
+PR #123 originally added a Storybook accessibility gate, but its branch drifted behind the current split CI topology and conflicted with the retired single-workflow layout. The branch is revived on top of the current `main` baseline with the gate wired into the active PR and main CI workflows.
+
+Current Storybook contains many legacy interaction stories and known light-theme color contrast debt. The CI gate therefore uses an explicit opt-in Storybook test surface instead of auto-running every existing story. This keeps the gate deterministic while preserving Storybook build coverage for the full catalog.
+
+## Requirements
+
+- Storybook accessibility checks run through Vitest browser mode with Chromium.
+- CI executes the Storybook accessibility suite as part of the existing `Front-end Tests` check so branch protection does not require a new status context rollout.
+- Existing non-test stories are excluded from Vitest component execution by default.
+- The opt-in accessibility fixture must fail CI on axe semantic violations.
+- Color contrast remains disabled in the axe run until the tracked palette contrast debt is handled separately.
+
+## Implementation
+
+- `web/vitest.config.ts` defines separate `unit` and `storybook` Vitest projects.
+- `web/.storybook/main.ts` registers `@storybook/addon-vitest`.
+- `web/.storybook/preview.ts` enables addon-a11y `test: 'error'`, disables `color-contrast`, and sets default `!test` tags for legacy stories.
+- `web/src/components/AccessibilityGate.stories.tsx` is the opt-in `test` story used by CI.
+- `.github/workflows/ci-pr.yml` and `.github/workflows/ci-main.yml` run `bun run test-storybook` inside `Front-end Tests` after the unit suite.
+
+## Verification
+
+- `cd web && bun run test-storybook`
+- `cd web && bun run test`
+- `cd web && bun run lint`
+- `cd web && bun run build`
+- `cd web && bun run storybook:build -- --quiet`
+- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --declaration .github/quality-gates.json --metadata-script .github/scripts/metadata_gate.py`
+- `bash .github/scripts/test-quality-gates-contract.sh`
+- `bash .github/scripts/test-live-quality-gates.sh`

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-docs',
+    '@storybook/addon-vitest',
   ],
   framework: '@storybook/react-vite',
 }

--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -52,6 +52,7 @@ function StorybookThemeBridge({ themeMode }: { themeMode: ThemeMode }) {
 }
 
 const preview: Preview = {
+  tags: ['!test'],
   globalTypes: {
     themeMode: {
       name: 'Theme',
@@ -90,7 +91,19 @@ const preview: Preview = {
       // 'todo' - show a11y violations in the test UI only
       // 'error' - fail CI on a11y violations
       // 'off' - skip a11y checks entirely
-      test: 'todo',
+      test: 'error',
+      options: {
+        rules: {
+          // Existing light-theme palette contrast debt is tracked separately; keep
+          // Storybook CI strict for every other axe rule while that palette work lands.
+          'color-contrast': { enabled: false },
+        },
+      },
+      config: {
+        rules: [
+          { id: 'color-contrast', enabled: false },
+        ],
+      },
     },
     viewport: {
       options: COMMON_VIEWPORTS,

--- a/web/.storybook/vitest.setup.ts
+++ b/web/.storybook/vitest.setup.ts
@@ -1,0 +1,10 @@
+import { beforeAll } from 'vitest'
+import { setProjectAnnotations } from '@storybook/react-vite'
+import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview'
+import preview from './preview'
+
+const project = setProjectAnnotations([a11yAddonAnnotations, preview])
+
+if (project.beforeAll) {
+  beforeAll(project.beforeAll)
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -29,11 +29,14 @@
         "@playwright/test": "^1.49.0",
         "@storybook/addon-a11y": "^10.2.12",
         "@storybook/addon-docs": "^10.2.12",
+        "@storybook/addon-vitest": "10.2.17",
         "@storybook/react-vite": "^10.2.12",
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.4",
+        "@vitest/browser": "4.1.0",
+        "@vitest/browser-playwright": "4.1.0",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -46,7 +49,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.45.0",
         "vite": "^7.1.7",
-        "vitest": "^4.0.18",
+        "vitest": "4.1.0",
       },
     },
   },
@@ -102,6 +105,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -233,6 +238,8 @@
 
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
@@ -359,6 +366,8 @@
 
     "@storybook/addon-docs": ["@storybook/addon-docs@10.2.17", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "10.2.17", "@storybook/icons": "^2.0.1", "@storybook/react-dom-shim": "10.2.17", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.17" } }, "sha512-c414xi7rxlaHn92qWOxtEkcOMm0/+cvBui0gUsgiWOZOM8dHChGZ/RjMuf1pPDyOrSsybLsPjZhP0WthsMDkdQ=="],
 
+    "@storybook/addon-vitest": ["@storybook/addon-vitest@10.2.17", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1" }, "peerDependencies": { "@vitest/browser": "^3.0.0 || ^4.0.0", "@vitest/browser-playwright": "^4.0.0", "@vitest/runner": "^3.0.0 || ^4.0.0", "storybook": "^10.2.17", "vitest": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@vitest/browser", "@vitest/browser-playwright", "@vitest/runner", "vitest"] }, "sha512-47mo952M/dHZQn1yTVMEUnri5KuIwWynPqamv6Q9KFXrSPOnBt/8IdrTcPUXFo5XO1ZmIWclgQjJtIvGe4z+ag=="],
+
     "@storybook/builder-vite": ["@storybook/builder-vite@10.2.17", "", { "dependencies": { "@storybook/csf-plugin": "10.2.17", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.17", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-m/OBveTLm5ds/tUgHmmbKzgSi/oeCpQwm5rZa49vP2BpAd41Q7ER6TzkOoISzPoNNMAcbVmVc5vn7k6hdbPSHw=="],
 
     "@storybook/csf-plugin": ["@storybook/csf-plugin@10.2.17", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.2.17", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-crHH8i/4mwzeXpWRPgwvwX2vjytW42zyzTRySUax5dTU8o9sjk4y+Z9hkGx3Nmu1TvqseS8v1Z20saZr/tQcWw=="],
@@ -454,6 +463,10 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.0", "", { "dependencies": { "@typescript-eslint/types": "8.57.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+
+    "@vitest/browser": ["@vitest/browser@4.1.0", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.0", "@vitest/utils": "4.1.0", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.0.3", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.0" } }, "sha512-tG/iOrgbiHQks0ew7CdelUyNEHkv8NLrt+CqdTivIuoSnXvO7scWMn4Kqo78/UGY1NJ6Hv+vp8BvRnED/bjFdQ=="],
+
+    "@vitest/browser-playwright": ["@vitest/browser-playwright@4.1.0", "", { "dependencies": { "@vitest/browser": "4.1.0", "@vitest/mocker": "4.1.0", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "playwright": "*", "vitest": "4.1.0" } }, "sha512-2RU7pZELY9/aVMLmABNy1HeZ4FX23FXGY1jRuHLHgWa2zaAE49aNW2GLzebW+BmbTZIKKyFF1QXvk7DEWViUCQ=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -791,6 +804,8 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -844,6 +859,8 @@
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -937,6 +954,8 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -986,6 +1005,8 @@
     "tldts-core": ["tldts-core@7.0.25", "", {}, "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,10 +8,12 @@
     "dev": "vite",
     "build": "tsc -b && vite build && bun scripts/write-version.mjs",
     "lint": "eslint .",
-    "test": "vitest run src",
+    "test": "vitest run --project=unit",
+    "test-storybook": "vitest run --project=storybook",
     "preview": "vite preview",
     "test:e2e": "playwright test",
     "storybook": "bun run scripts/run-storybook.mjs",
+    "storybook:ci": "bun run scripts/run-storybook.mjs --ci",
     "storybook:build": "storybook build",
     "build-storybook": "bun run storybook:build"
   },
@@ -40,11 +42,14 @@
     "@playwright/test": "^1.49.0",
     "@storybook/addon-a11y": "^10.2.12",
     "@storybook/addon-docs": "^10.2.12",
+    "@storybook/addon-vitest": "10.2.17",
     "@storybook/react-vite": "^10.2.12",
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
+    "@vitest/browser": "4.1.0",
+    "@vitest/browser-playwright": "4.1.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -57,6 +62,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
     "vite": "^7.1.7",
-    "vitest": "^4.0.18"
+    "vitest": "4.1.0"
   }
 }

--- a/web/scripts/run-storybook.mjs
+++ b/web/scripts/run-storybook.mjs
@@ -1,13 +1,14 @@
 const defaultPort = '60082'
 const host = process.env.STORYBOOK_HOST || '127.0.0.1'
 const port = process.env.STORYBOOK_PORT || defaultPort
+const args = process.argv.slice(2)
 
 if (port === '6006') {
   console.error('Port 6006 is reserved for other worktrees; choose a different STORYBOOK_PORT.')
   process.exit(1)
 }
 
-const child = Bun.spawn(['storybook', 'dev', '--host', host, '--port', port, '--no-open'], {
+const child = Bun.spawn(['storybook', 'dev', '--host', host, '--port', port, '--no-open', ...args], {
   stdin: 'inherit',
   stdout: 'inherit',
   stderr: 'inherit',

--- a/web/src/components/AccessibilityGate.stories.tsx
+++ b/web/src/components/AccessibilityGate.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Button } from './ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
+import { Input } from './ui/input'
+import { SelectField } from './ui/select-field'
+
+function AccessibilityGateFixture() {
+  return (
+    <main className="min-h-screen bg-base-100 p-8 text-base-content">
+      <Card className="mx-auto max-w-2xl">
+        <CardHeader>
+          <CardTitle>Storybook accessibility gate fixture</CardTitle>
+          <CardDescription>
+            A stable opt-in Storybook surface used by CI to prove the axe integration fails on accessibility regressions.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <section aria-labelledby="gate-form-title" className="space-y-3">
+            <h2 id="gate-form-title" className="text-base font-semibold">
+              Labeled controls
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label htmlFor="gate-name" className="text-sm font-medium text-base-content">Display name</label>
+                <Input id="gate-name" defaultValue="Koha monitor" />
+              </div>
+              <SelectField
+                id="gate-release-channel"
+                label="Release channel"
+                value="stable"
+                onValueChange={() => undefined}
+                options={[
+                  { value: 'stable', label: 'Stable' },
+                  { value: 'rc', label: 'Release candidate' },
+                ]}
+              />
+            </div>
+          </section>
+
+          <section aria-labelledby="gate-status-title" className="space-y-3">
+            <h2 id="gate-status-title" className="text-base font-semibold">
+              Status summary
+            </h2>
+            <dl className="grid gap-3 rounded-lg border border-base-300 bg-base-100 p-4 sm:grid-cols-2">
+              <div>
+                <dt className="text-sm font-medium text-base-content/75">CI gate</dt>
+                <dd className="mt-1 text-sm text-base-content">Storybook Accessibility</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-base-content/75">Mode</dt>
+                <dd className="mt-1 text-sm text-base-content">axe semantic checks</dd>
+              </div>
+            </dl>
+          </section>
+
+          <div className="flex flex-wrap gap-3">
+            <Button type="button">Primary action</Button>
+            <Button type="button" variant="outline">
+              Secondary action
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}
+
+const meta = {
+  title: 'Quality Gates/Accessibility Gate',
+  component: AccessibilityGateFixture,
+  tags: ['test'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof AccessibilityGateFixture>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const SemanticFixture: Story = {}

--- a/web/src/components/account-pool/OauthMailboxChip.tsx
+++ b/web/src/components/account-pool/OauthMailboxChip.tsx
@@ -59,6 +59,7 @@ function buildMailboxManualTooltip(
       <div
         ref={valueRef}
         role="textbox"
+        aria-label={manualCopyLabel}
         aria-readonly="true"
         tabIndex={0}
         translate="no"

--- a/web/src/components/ui/inline-chart-tooltip.tsx
+++ b/web/src/components/ui/inline-chart-tooltip.tsx
@@ -172,17 +172,17 @@ export function InlineChartTooltipSurface({
       )}
     >
       <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-base-content/60">{activeTooltip.title}</div>
-      <dl className="mt-2 space-y-1.5">
+      <div className="mt-2 space-y-1.5">
         {activeTooltip.rows.map((row) => (
           <div key={`${row.label}-${row.value}`} className="flex items-start gap-2">
             <span className={cn('mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full', toneClasses(row.tone))} aria-hidden="true" />
             <div className="min-w-0 flex-1">
-              <dt className="text-base-content/62">{row.label}</dt>
-              <dd className="mt-0.5 font-mono text-[12px] font-semibold tracking-tight text-base-content">{row.value}</dd>
+              <div className="text-base-content/62">{row.label}</div>
+              <div className="mt-0.5 font-mono text-[12px] font-semibold tracking-tight text-base-content">{row.value}</div>
             </div>
           </div>
         ))}
-      </dl>
+      </div>
     </div>
   ) : null
 

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -23,6 +23,7 @@ const PopoverContent = React.forwardRef<
   const resolvedContainer = useResolvedOverlayContainer(container)
   const { hostElement, ref: contentRef } = useOverlayHostElement(ref)
   const hostValue = hostElement ?? (container === undefined ? resolvedContainer : container)
+  const hasAccessibleName = props['aria-label'] || props['aria-labelledby'] || props.title
 
   return (
     <PopoverPrimitive.Portal container={resolvedContainer ?? undefined}>
@@ -31,6 +32,7 @@ const PopoverContent = React.forwardRef<
           ref={contentRef}
           align={align}
           sideOffset={sideOffset}
+          aria-label={hasAccessibleName ? undefined : 'Popover content'}
           className={cn(
             'z-50 w-72 rounded-md border border-base-300 bg-base-100 p-1 text-base-content shadow-md outline-none',
             'data-[state=open]:animate-in data-[state=closed]:animate-out',

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig, loadEnv } from 'vite'
+import 'vitest/config'
+import { defineConfig, loadEnv, type UserConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig(({ mode }) => {
+export function createAppViteConfig(mode: string): UserConfig {
   const env = loadEnv(mode, process.cwd(), 'VITE_')
   const backend = env.VITE_BACKEND_PROXY ?? 'http://localhost:8080'
 
@@ -29,4 +30,6 @@ export default defineConfig(({ mode }) => {
       },
     },
   }
-})
+}
+
+export default defineConfig(({ mode }) => createAppViteConfig(mode))

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'
+import { playwright } from '@vitest/browser-playwright'
+
+import { createAppViteConfig } from './vite.config'
+
+const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url))
+
+export default mergeConfig(
+  createAppViteConfig('test'),
+  defineConfig({
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'unit',
+            include: ['src/**/*.{test,spec}.{ts,tsx}'],
+          },
+        },
+        {
+          extends: true,
+          plugins: [
+            storybookTest({
+              configDir: path.join(dirname, '.storybook'),
+              storybookScript: 'bun run storybook:ci',
+            }),
+          ],
+          test: {
+            name: 'storybook',
+            browser: {
+              enabled: true,
+              headless: true,
+              provider: playwright({}),
+              instances: [{ browser: 'chromium' }],
+            },
+            setupFiles: ['./.storybook/vitest.setup.ts'],
+          },
+        },
+      ],
+    },
+  }),
+)


### PR DESCRIPTION
## Summary

- Rebased/reimplemented PR #123 on the latest `main` baseline instead of resolving the obsolete split-topology conflicts from the old branch.
- Adds Storybook + Vitest browser integration for a deterministic accessibility gate.
- Runs the Storybook accessibility suite inside the existing `Front-end Tests` CI context to avoid introducing a new required-status rollout.
- Keeps legacy Storybook stories out of Vitest execution by default and adds an opt-in a11y fixture story for CI.
- Enables addon-a11y as CI-failing (`test: error`) while temporarily disabling `color-contrast` for the known light-theme palette debt.

## References

- Specs: `docs/specs/sbacc-storybook-accessibility/SPEC.md`
- Solutions: -
- Project Docs: -

## Verification

- `cd web && bun run test-storybook`
- `cd web && bun run test`
- `cd web && bun run lint` (passes with existing warnings)
- `cd web && bun run build`
- `cd web && bun run storybook:build -- --quiet`
- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --declaration .github/quality-gates.json --metadata-script .github/scripts/metadata_gate.py`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-live-quality-gates.sh`

## Notes

- The old PR head was conflicted against current `main`; this update force-refreshes the same PR branch to a clean latest-main implementation.
- No branch-protection status context is added in this cut; Storybook a11y is enforced by the existing `Front-end Tests` check.