### PR TITLE
feat(dev): add worktree bootstrap sync

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Install docs-site dependencies
         run: bun install --cwd docs-site --frozen-lockfile
 
+      - name: Worktree bootstrap smoke
+        run: bash scripts/test-worktree-bootstrap.sh
+
       - name: Bun-first guard
         run: bun run check:bun-first
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@
 - `cargo fmt` — format Rust sources with project defaults.
 - `cargo check` — type-check backend without producing binaries.
 - `cargo run` — start the backend (reads `.env.local`, listens on `127.0.0.1:8080`).
-- `bun install` — install repo-level tooling for hooks and docs checks.
+- `bun install` — install repo-level tooling for hooks, worktree bootstrap, and docs checks.
+- `bun run hooks:install` — install shared Git hooks for every linked worktree in this repository.
+- `bun run worktree:bootstrap` — manually rerun the copy-missing-only local config sync for the current worktree.
 - `cd web && bun install` — install SPA dependencies once per setup.
 - `cd web && bun run dev -- --host 127.0.0.1 --port 60080` — run the front-end dev server with proxy to the backend.
 - `cd web && bun run build` — produce production assets for `web/dist`.
@@ -71,5 +73,6 @@ Use non-blocking runtime management for long-lived services, but do not require 
 ## Security & Configuration Tips
 
 - Store authentication cookies and secrets in `.env.local`; the file is ignored—never commit credentials.
+- Worktree bootstrap only copies missing resources declared in `scripts/worktree-sync.paths`; the current contract syncs `.env.local` from the primary worktree into new linked worktrees, never overwrites existing local files, and never copies dependency or runtime directories.
 - SQLite files default to `codex_vibe_monitor.db` in the repo root; add alternate paths via `DATABASE_PATH` if running in containers.
 - SSE and HTTP clients depend on stable polling; monitor logs (`RUST_LOG=info cargo run`) when adjusting concurrency or timeouts.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,23 @@ bun run dev
 - docs-site: `http://127.0.0.1:60081`
 - Storybook: `http://127.0.0.1:60082`
 
+## Worktree bootstrap
+
+首次拉到包含该功能的版本后，在任一 worktree 执行一次：
+
+```bash
+bun install
+bun run hooks:install
+```
+
+之后新建 linked worktree 时，shared Git `post-checkout` hook 会自动补齐缺失的 `.env.local`。如果需要手动重跑，可执行：
+
+```bash
+bun run worktree:bootstrap
+```
+
+该 bootstrap 只会复制 `scripts/worktree-sync.paths` 中声明的缺失本地资源；当前首版仅同步 `.env.local`，不会覆盖已有本地文件，也不会复制 `node_modules`、数据库文件或 `.codex/xray-forward` 一类运行态目录。
+
 ## 第一次部署最该先确认的配置
 
 | 变量 | 作用 |

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@commitlint/config-conventional": "^20.0.0",
         "commitlint-plugin-function-rules": "^4.1.0",
         "dprint": "^0.47.5",
+        "lefthook": "^1.12.4",
       },
     },
   },
@@ -160,6 +161,28 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
+
+    "lefthook": ["lefthook@1.13.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "1.13.6", "lefthook-darwin-x64": "1.13.6", "lefthook-freebsd-arm64": "1.13.6", "lefthook-freebsd-x64": "1.13.6", "lefthook-linux-arm64": "1.13.6", "lefthook-linux-x64": "1.13.6", "lefthook-openbsd-arm64": "1.13.6", "lefthook-openbsd-x64": "1.13.6", "lefthook-windows-arm64": "1.13.6", "lefthook-windows-x64": "1.13.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@1.13.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@1.13.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@1.13.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@1.13.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@1.13.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@1.13.6", "", { "os": "linux", "cpu": "x64" }, "sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@1.13.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@1.13.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@1.13.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@1.13.6", "", { "os": "win32", "cpu": "x64" }, "sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,7 +7,7 @@
 ## Index
 
 | ID    | Title                                                                         | Status                          | Spec                                                     | Last       | Notes                                                                                                                                              |
-| v7se4 | Worktree bootstrap 同步开发环境配置 | 待实现 | `v7se4-worktree-bootstrap/SPEC.md` | 2026-03-14 | fast-track / shared hooks / linked worktree bootstrap |
+| v7se4 | Worktree bootstrap 同步开发环境配置 | 已完成 | `v7se4-worktree-bootstrap/SPEC.md` | 2026-03-14 | fast-track / PR #129 / checks green / review fixes landed |
 | sbacc | Storybook 可访问性门禁 | 已实现，待 PR CI 收敛 | `sbacc-storybook-accessibility/SPEC.md` | 2026-04-26 | PR #123 基于最新 main 复活；Storybook a11y gate 接入现有 Front-end Tests 状态上下文 |
 | wjowd | `main` 主干保护禁止直推与 PR 全检查必过 | 已实现，待 PR / CI / review-proof 收敛 | `wjowd-main-branch-protection/SPEC.md` | 2026-04-22 | fast-track / main direct pushes blocked via GitHub ruleset / PR required checks expanded to 7 gate jobs / live quality-gates now reports bypass actor verification as verified vs unverified instead of assuming empty bypass actors |
 | 5uxj8 | pool `/v1/*` live 路由显式综合打分 follow-up | 已实现，待 PR / CI / review-proof 收敛 | `5uxj8-pool-live-routing-score-followup/SPEC.md` | 2026-04-18 | fast-track / follow-up of `#6b9ra` / live routing explicit score breakdown + node-shunt soft-degrade fallback + assigned-account blocked preservation for InvocationTable + current Dashboard cards |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,6 +7,7 @@
 ## Index
 
 | ID    | Title                                                                         | Status                          | Spec                                                     | Last       | Notes                                                                                                                                              |
+| v7se4 | Worktree bootstrap 同步开发环境配置 | 待实现 | `v7se4-worktree-bootstrap/SPEC.md` | 2026-03-14 | fast-track / shared hooks / linked worktree bootstrap |
 | sbacc | Storybook 可访问性门禁 | 已实现，待 PR CI 收敛 | `sbacc-storybook-accessibility/SPEC.md` | 2026-04-26 | PR #123 基于最新 main 复活；Storybook a11y gate 接入现有 Front-end Tests 状态上下文 |
 | wjowd | `main` 主干保护禁止直推与 PR 全检查必过 | 已实现，待 PR / CI / review-proof 收敛 | `wjowd-main-branch-protection/SPEC.md` | 2026-04-22 | fast-track / main direct pushes blocked via GitHub ruleset / PR required checks expanded to 7 gate jobs / live quality-gates now reports bypass actor verification as verified vs unverified instead of assuming empty bypass actors |
 | 5uxj8 | pool `/v1/*` live 路由显式综合打分 follow-up | 已实现，待 PR / CI / review-proof 收敛 | `5uxj8-pool-live-routing-score-followup/SPEC.md` | 2026-04-18 | fast-track / follow-up of `#6b9ra` / live routing explicit score breakdown + node-shunt soft-degrade fallback + assigned-account blocked preservation for InvocationTable + current Dashboard cards |

--- a/docs/specs/v7se4-worktree-bootstrap/SPEC.md
+++ b/docs/specs/v7se4-worktree-bootstrap/SPEC.md
@@ -1,0 +1,195 @@
+# Worktree bootstrap 同步开发环境配置（#v7se4）
+
+## 状态
+
+- Status: 待实现
+- Created: 2026-03-14
+- Last: 2026-03-14
+
+## 背景 / 问题陈述
+
+- 当前仓库已经固定了 Bun-first、`lefthook.yml`、`.env.local` 与 linked worktree 的使用方式，但新 worktree 仍需要手工补本地配置，容易漏掉环境文件。
+- 现有仓库没有 `worktree bootstrap` 入口，也没有把自动同步做成 shared Git hook contract，导致 linked worktree 之间的开发机配置不能稳定复用。
+- `$style-playbook` 的 `worktree-bootstrap` 参考把这类能力定义为“共享 hooks + checkout 自动触发 + copy-missing-only + CI smoke”的仓库契约；当前仓库缺少这层约束。
+
+## 目标 / 非目标
+
+### Goals
+
+- 为当前仓库补齐 shared Git hooks 驱动的 worktree bootstrap，让 linked worktree 自动拿到缺失的本地开发配置。
+- 提供自动与手动双入口：`post-checkout` 自动同步，`bun run worktree:bootstrap` 可手动重跑。
+- 首版同步范围只包含被忽略的 `.env.local`，并严格保持 copy-missing-only，不覆盖目标 worktree 已存在的本地文件。
+- 用真实 linked worktree smoke test 把这条路径纳入 CI，避免后续回归。
+
+### Non-goals
+
+- 不同步 `node_modules`、`web/node_modules`、SQLite DB、`.codex/xray-forward` 等运行态或大体积目录。
+- 不修改任何 HTTP API、SSE、数据库 schema 或前端业务逻辑。
+- 不引入需要联网安装或 checkout 时执行重型命令的自动动作。
+
+## 范围（Scope）
+
+### In scope
+
+- `docs/specs/v7se4-worktree-bootstrap/SPEC.md`
+- `docs/specs/README.md`
+- `package.json`
+- `bun.lock`
+- `lefthook.yml`
+- `scripts/install-hooks.sh`
+- `scripts/run-lefthook-hook.sh`
+- `scripts/worktree-bootstrap.sh`
+- `scripts/sync-worktree-resources.sh`
+- `scripts/worktree-sync.paths`
+- `scripts/test-worktree-bootstrap.sh`
+- `README.md`
+- `AGENTS.md`
+- `.github/workflows/ci.yml`
+
+### Out of scope
+
+- `src/**`
+- `web/src/**`
+- `.env.local` 内容本身
+- 本地依赖安装自动化（例如 checkout 时自动跑 `bun install`）
+
+## 需求（Requirements）
+
+### MUST
+
+- `bun run hooks:install` 必须把 hook 链安装到 shared Git hooks 层，而不是某个单独 worktree 私有目录。
+- `post-checkout` 必须在 linked worktree 可用，并在目标 worktree 缺失 `.env.local` 时自动复制主 worktree 的同名文件。
+- 自动与手动同步都必须遵守 copy-missing-only；目标文件已存在时不得覆盖。
+- 若存在外部自定义 `core.hooksPath`，安装脚本必须 warning + exit 0，不改写他人的 hook 目录。
+- 若当前 revision 缺少 bootstrap 脚本/manifest，hook 必须安全 no-op，不能让 checkout 失败。
+- CI 必须执行真实 linked worktree smoke test。
+
+### SHOULD
+
+- root tooling 使用 repo-local `lefthook` 依赖，避免依赖开发机全局安装。
+- 同步清单用受版本控制的 manifest 文件维护，后续扩表时不需要改同步语义。
+
+### COULD
+
+- 在同步脚本中预留内部 override 环境变量，便于测试夹具注入 source/target 路径。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- 在任一 worktree 执行 `bun install && bun run hooks:install` 后，shared Git hooks 目录会安装 `pre-commit`、`commit-msg`、`post-checkout` 三个 wrapper，wrapper 统一回到当前 checkout 的仓库根目录寻找 `scripts/run-lefthook-hook.sh`。
+- 当新 linked worktree 被 checkout/add 时，shared `post-checkout` wrapper 会直接回到当前 checkout 的仓库根目录执行 bootstrap runner；若当前 revision 里的 `scripts/sync-worktree-resources.sh` 不存在或不可执行，则静默退出。
+- `scripts/sync-worktree-resources.sh` 默认把 `dirname("$(git rev-parse --git-common-dir)")` 视为主 worktree 根目录，把 `git rev-parse --show-toplevel` 视为当前 worktree 根目录，并按 `scripts/worktree-sync.paths` 逐项复制缺失资源。
+- `bun run worktree:bootstrap` 会先执行 `hooks:install`，再执行同步脚本，作为幂等的手动补跑入口。
+
+### Edge cases / errors
+
+- 当当前 worktree 就是主 worktree 时，同步脚本直接 no-op。
+- 当主 worktree 缺少 `.env.local` 时，同步脚本只打印提示，不失败。
+- 当目标 worktree 已有 `.env.local` 时，自动/手动 bootstrap 都必须跳过，不覆盖。
+- 当切换到不包含 runner/sync 脚本的历史 commit 时，shared hook wrapper 必须因为找不到 repo 脚本而直接 exit 0。
+- 当 repo 设置了自定义 `core.hooksPath` 时，`hooks:install` 必须保留现状，不写入 managed marker。
+
+## 接口契约（Interfaces & Contracts）
+
+### 接口清单（Inventory）
+
+| 接口（Name）                  | 类型（Kind） | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner） | 使用方（Consumers） | 备注（Notes）         |
+| ----------------------------- | ------------ | ------------- | -------------- | ------------------------ | --------------- | ------------------- | --------------------- |
+| `bun run hooks:install`       | CLI          | internal      | New            | None                     | repo tooling    | contributors        | 安装 shared Git hooks |
+| `bun run worktree:bootstrap`  | CLI          | internal      | New            | None                     | repo tooling    | contributors        | 手动重跑 bootstrap    |
+| `scripts/worktree-sync.paths` | file format  | internal      | New            | None                     | repo tooling    | bootstrap scripts   | 受版本控制的同步清单  |
+| `post-checkout` bootstrap     | Git hook     | internal      | New            | None                     | repo tooling    | linked worktrees    | 只补缺失本地资源      |
+
+### 契约文档（按 Kind 拆分）
+
+None
+
+## 验收标准（Acceptance Criteria）
+
+- Given 主 worktree 存在 `.env.local`
+  When 创建并 checkout 一个新的 linked worktree
+  Then 新 worktree 会自动获得缺失的 `.env.local`。
+- Given 目标 worktree 已存在 `.env.local`
+  When 自动 bootstrap 或手动执行 `bun run worktree:bootstrap`
+  Then 目标文件内容保持不变。
+- Given 执行 `bun run hooks:install`
+  When 检查 `git rev-parse --git-path hooks`
+  Then `pre-commit`、`commit-msg`、`post-checkout` wrapper 带有 managed marker，且位于 shared hooks 目录。
+- Given repo 配置了外部 `core.hooksPath`
+  When 执行 `bun run hooks:install`
+  Then 命令退出码为 0，打印 warning，且不改写该自定义 hooks 目录。
+- Given 已安装 shared hooks
+  When checkout 到不包含 bootstrap 脚本的历史 revision
+  Then checkout 成功且 hook 安全 no-op。
+- Given CI 运行 `scripts/test-worktree-bootstrap.sh`
+  When linked worktree smoke 流程执行
+  Then 上述关键路径全部通过。
+
+## 实现前置条件（Definition of Ready / Preconditions）
+
+- [x] 目标/非目标与同步边界已冻结。
+- [x] 自动入口、手动入口与 copy-missing-only 语义已确定。
+- [x] 接口契约明确为内部 CLI / Git hook，不涉及业务接口变更。
+- [x] 快车道交付授权已确认。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- `bun install`
+- `bash scripts/test-worktree-bootstrap.sh`
+- `bun run check:bun-first`
+
+### Quality checks
+
+- 继续保持现有 `Lint & Format Check` job 名称不变。
+- 不新增业务代码验证范围之外的 required check 名称。
+
+## 文档更新（Docs to Update）
+
+- `README.md`: 增加 worktree bootstrap 的首次安装、自动行为与手动补跑说明。
+- `AGENTS.md`: 增加 repo-level hook/bootstrap 命令与 linked worktree 行为说明。
+- `docs/specs/README.md`: 登记该 spec。
+
+## 计划资产（Plan assets）
+
+None
+
+## Visual Evidence (PR)
+
+None
+
+## 资产晋升（Asset promotion）
+
+None
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [ ] M1: 建立 spec/index 并冻结 worktree bootstrap 契约。
+- [ ] M2: 完成 shared hook 安装链、bootstrap runner 与 sync manifest。
+- [ ] M3: 完成 linked worktree smoke test、CI 接入与文档更新。
+- [ ] M4: 完成本地验证、PR 与 review-loop 收敛。
+
+## 方案概述（Approach, high-level）
+
+- 参考 `$style-playbook` 的 `worktree-bootstrap` 默认，把 linked worktree 的本地环境同步定义为 repo contract，而不是个人脚本。
+- hook 层使用 shared Git hooks wrapper，避免每个 worktree 各装一遍；实际行为由当前 checkout 的 repo 脚本决定，从而兼容历史 revision。
+- 自动路径保持轻量，只复制 manifest 中声明的缺失资源，不执行依赖安装、格式化或其他重型命令。
+- smoke test 使用临时独立 repo + real `git worktree add` 验证，避免 CI 与本仓库共享 hooks 状态互相污染。
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：`post-checkout` 的执行时机在不同 Git 操作上可能略有差异，因此必须以真实 linked worktree smoke test 锁住行为。
+- 风险：部分开发机可能已有自定义 `core.hooksPath`；本计划选择保守退出，不尝试接管。
+- 开放问题：None。
+- 假设：主 worktree 可稳定由 `git-common-dir` 的父目录推导得到；当前仓库布局满足该假设。
+
+## 变更记录（Change log）
+
+- 2026-03-14: 创建 spec，冻结 shared hooks + `post-checkout` + `.env.local` copy-missing-only + fast-track 的实现口径。
+
+## 参考（References）
+
+- `$style-playbook` tag `worktree-bootstrap`
+- `$style-playbook` project snapshot `codex-vibe-monitor`

--- a/docs/specs/v7se4-worktree-bootstrap/SPEC.md
+++ b/docs/specs/v7se4-worktree-bootstrap/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 待实现
+- Status: 已完成
 - Created: 2026-03-14
 - Last: 2026-03-14
 
@@ -171,10 +171,10 @@ None
 
 ## 实现里程碑（Milestones / Delivery checklist）
 
-- [ ] M1: 建立 spec/index 并冻结 worktree bootstrap 契约。
-- [ ] M2: 完成 shared hook 安装链、bootstrap runner 与 sync manifest。
-- [ ] M3: 完成 linked worktree smoke test、CI 接入与文档更新。
-- [ ] M4: 完成本地验证、PR 与 review-loop 收敛。
+- [x] M1: 建立 spec/index 并冻结 worktree bootstrap 契约。
+- [x] M2: 完成 shared hook 安装链、bootstrap runner 与 sync manifest。
+- [x] M3: 完成 linked worktree smoke test、CI 接入与文档更新。
+- [x] M4: 完成本地验证、PR 与 review-loop 收敛。
 
 ## 方案概述（Approach, high-level）
 
@@ -193,6 +193,7 @@ None
 ## 变更记录（Change log）
 
 - 2026-03-14: 创建 spec，冻结 shared hooks + `post-checkout` + `.env.local` copy-missing-only + fast-track 的实现口径。
+- 2026-03-14: 完成 shared hooks、copy-missing-only sync、linked worktree smoke、PR #129 与 review 修复收敛。
 
 ## 参考（References）
 

--- a/docs/specs/v7se4-worktree-bootstrap/SPEC.md
+++ b/docs/specs/v7se4-worktree-bootstrap/SPEC.md
@@ -61,6 +61,7 @@
 - `post-checkout` 必须在 linked worktree 可用，并在目标 worktree 缺失 `.env.local` 时自动复制主 worktree 的同名文件。
 - 自动与手动同步都必须遵守 copy-missing-only；目标文件已存在时不得覆盖。
 - 若存在外部自定义 `core.hooksPath`，安装脚本必须 warning + exit 0，不改写他人的 hook 目录。
+- 若 shared hooks 目录中已存在未知来源的 hook 文件，安装脚本必须保留原文件并仅对该 hook 打 warning，不得静默覆盖。
 - 若当前 revision 缺少 bootstrap 脚本/manifest，hook 必须安全 no-op，不能让 checkout 失败。
 - CI 必须执行真实 linked worktree smoke test。
 
@@ -86,6 +87,7 @@
 
 - 当当前 worktree 就是主 worktree 时，同步脚本直接 no-op。
 - 当主 worktree 缺少 `.env.local` 时，同步脚本只打印提示，不失败。
+- 当脚本从仓库外通过绝对路径调用时，`git-common-dir` 的相对返回值仍必须锚定到目标 repo 根目录，不能错误读取调用者当前目录。
 - 当目标 worktree 已有 `.env.local` 时，自动/手动 bootstrap 都必须跳过，不覆盖。
 - 当切换到不包含 runner/sync 脚本的历史 commit 时，shared hook wrapper 必须因为找不到 repo 脚本而直接 exit 0。
 - 当 repo 设置了自定义 `core.hooksPath` 时，`hooks:install` 必须保留现状，不写入 managed marker。
@@ -119,6 +121,9 @@ None
 - Given repo 配置了外部 `core.hooksPath`
   When 执行 `bun run hooks:install`
   Then 命令退出码为 0，打印 warning，且不改写该自定义 hooks 目录。
+- Given shared hooks 目录中已有未知来源的 hook 文件
+  When 执行 `bun run hooks:install`
+  Then 该 hook 文件保持原样，安装脚本仅对该 hook 输出 warning，并继续处理其他可托管 hook。
 - Given 已安装 shared hooks
   When checkout 到不包含 bootstrap 脚本的历史 revision
   Then checkout 成功且 hook 安全 no-op。

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,3 +22,8 @@ commit-msg:
   commands:
     commitlint:
       run: ./node_modules/.bin/commitlint --edit {1}
+
+post-checkout:
+  commands:
+    worktree-bootstrap:
+      run: ./scripts/sync-worktree-resources.sh

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "version": "0.0.0",
   "packageManager": "bun@1.3.10",
   "scripts": {
-    "check:bun-first": "bash .github/scripts/check-bun-first.sh"
+    "check:bun-first": "bash .github/scripts/check-bun-first.sh",
+    "hooks:install": "bash scripts/install-hooks.sh",
+    "worktree:bootstrap": "bash scripts/worktree-bootstrap.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
     "commitlint-plugin-function-rules": "^4.1.0",
-    "dprint": "^0.47.5"
+    "dprint": "^0.47.5",
+    "lefthook": "^1.12.4"
   }
 }

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+managed_marker='# managed by codex-vibe-monitor hooks:install'
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+common_dir="$(git -C "$repo_root" rev-parse --git-common-dir)"
+case "$common_dir" in
+  /*) ;;
+  *) common_dir="$repo_root/$common_dir" ;;
+esac
+hooks_dir="$common_dir/hooks"
+custom_hooks_path="$(git -C "$repo_root" config --get core.hooksPath || true)"
+
+if [ -n "$custom_hooks_path" ]; then
+  printf '[worktree-bootstrap] core.hooksPath is set to %s; leaving hooks untouched\n' "$custom_hooks_path" >&2
+  exit 0
+fi
+
+mkdir -p "$hooks_dir"
+
+write_wrapper() {
+  hook_name="$1"
+  hook_path="$hooks_dir/$hook_name"
+  cat > "$hook_path" <<EOF_HOOK
+#!/bin/sh
+$managed_marker
+repo_root="\$(git rev-parse --show-toplevel 2>/dev/null || printf '')"
+[ -n "\$repo_root" ] || exit 0
+runner="\$repo_root/scripts/run-lefthook-hook.sh"
+[ -x "\$runner" ] || exit 0
+exec "\$runner" "$hook_name" "\$@"
+EOF_HOOK
+  chmod +x "$hook_path"
+}
+
+write_wrapper pre-commit
+write_wrapper commit-msg
+write_wrapper post-checkout
+
+printf '[worktree-bootstrap] installed shared hooks in %s\n' "$hooks_dir"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -19,9 +19,32 @@ fi
 
 mkdir -p "$hooks_dir"
 
+is_managed_hook() {
+  hook_path="$1"
+  if [ ! -e "$hook_path" ] && [ ! -L "$hook_path" ]; then
+    return 0
+  fi
+
+  if grep -Fq "$managed_marker" "$hook_path" 2>/dev/null; then
+    return 0
+  fi
+
+  if grep -Fq 'call_lefthook()' "$hook_path" 2>/dev/null && grep -Fq 'lefthook -h >/dev/null 2>&1' "$hook_path" 2>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
 write_wrapper() {
   hook_name="$1"
   hook_path="$hooks_dir/$hook_name"
+
+  if ! is_managed_hook "$hook_path"; then
+    printf '[worktree-bootstrap] %s already exists and is unmanaged; skipping install for this hook\n' "$hook_name" >&2
+    return 0
+  fi
+
   cat > "$hook_path" <<EOF_HOOK
 #!/bin/sh
 $managed_marker

--- a/scripts/run-lefthook-hook.sh
+++ b/scripts/run-lefthook-hook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_name="${1:?hook name is required}"
+shift || true
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repo_root" ]; then
+  exit 0
+fi
+cd "$repo_root"
+
+sync_script="$repo_root/scripts/sync-worktree-resources.sh"
+
+if [ "$hook_name" = "post-checkout" ]; then
+  if [ -x "$sync_script" ]; then
+    "$sync_script" "$@"
+  fi
+  exit 0
+fi
+
+if [ -x "$repo_root/node_modules/.bin/lefthook" ]; then
+  exec "$repo_root/node_modules/.bin/lefthook" run "$hook_name" "$@"
+fi
+
+if command -v lefthook >/dev/null 2>&1; then
+  exec lefthook run "$hook_name" "$@"
+fi
+
+printf '[worktree-bootstrap] lefthook unavailable for %s; skipping.\n' "$hook_name" >&2

--- a/scripts/run-lefthook-hook.sh
+++ b/scripts/run-lefthook-hook.sh
@@ -19,8 +19,44 @@ if [ "$hook_name" = "post-checkout" ]; then
   exit 0
 fi
 
-if [ -x "$repo_root/node_modules/.bin/lefthook" ]; then
-  exec "$repo_root/node_modules/.bin/lefthook" run "$hook_name" "$@"
+os_arch="$(uname | tr '[:upper:]' '[:lower:]')"
+cpu_arch="$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')"
+
+candidate_roots() {
+  printf '%s\n' "$repo_root"
+  git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}'
+}
+
+resolve_lefthook_binary() {
+  seen=''
+  while IFS= read -r candidate_root; do
+    if [ -z "$candidate_root" ] || [ ! -d "$candidate_root" ]; then
+      continue
+    fi
+
+    case ":$seen:" in
+      *":$candidate_root:"*) continue ;;
+      *) seen="$seen:$candidate_root" ;;
+    esac
+
+    native_bin="$candidate_root/node_modules/lefthook-$os_arch-$cpu_arch/bin/lefthook"
+    if [ -x "$native_bin" ]; then
+      printf '%s\n' "$native_bin"
+      return 0
+    fi
+
+    legacy_bin="$candidate_root/node_modules/@evilmartians/lefthook/bin/lefthook-$os_arch-$cpu_arch/lefthook"
+    if [ -x "$legacy_bin" ]; then
+      printf '%s\n' "$legacy_bin"
+      return 0
+    fi
+  done < <(candidate_roots)
+
+  return 1
+}
+
+if lefthook_bin="$(resolve_lefthook_binary)"; then
+  exec "$lefthook_bin" run "$hook_name" "$@"
 fi
 
 if command -v lefthook >/dev/null 2>&1; then

--- a/scripts/run-lefthook-hook.sh
+++ b/scripts/run-lefthook-hook.sh
@@ -56,11 +56,11 @@ resolve_lefthook_binary() {
 }
 
 if lefthook_bin="$(resolve_lefthook_binary)"; then
-  exec "$lefthook_bin" run "$hook_name" "$@"
+  exec "$lefthook_bin" run "$hook_name" --no-auto-install "$@"
 fi
 
 if command -v lefthook >/dev/null 2>&1; then
-  exec lefthook run "$hook_name" "$@"
+  exec lefthook run "$hook_name" --no-auto-install "$@"
 fi
 
 printf '[worktree-bootstrap] lefthook unavailable for %s; skipping.\n' "$hook_name" >&2

--- a/scripts/sync-worktree-resources.sh
+++ b/scripts/sync-worktree-resources.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[worktree-bootstrap] %s\n' "$*"
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "$script_dir/.." && pwd)"
+repo_root="${WORKTREE_BOOTSTRAP_TARGET_ROOT:-$default_repo_root}"
+if [ -z "$repo_root" ]; then
+  exit 0
+fi
+repo_root="$(cd "$repo_root" && pwd)"
+
+common_dir="${WORKTREE_BOOTSTRAP_GIT_COMMON_DIR:-$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null || true)}"
+if [ -z "$common_dir" ]; then
+  exit 0
+fi
+
+source_root="${WORKTREE_BOOTSTRAP_SOURCE_ROOT:-$(cd "$(dirname "$common_dir")" && pwd)}"
+manifest_path="${WORKTREE_BOOTSTRAP_MANIFEST:-$repo_root/scripts/worktree-sync.paths}"
+
+if [ ! -f "$manifest_path" ]; then
+  exit 0
+fi
+
+source_root="$(cd "$source_root" && pwd)"
+
+if [ "$repo_root" = "$source_root" ]; then
+  exit 0
+fi
+
+copied_count=0
+missing_count=0
+
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+  line="${raw_line%%#*}"
+  line="${line#${line%%[![:space:]]*}}"
+  line="${line%${line##*[![:space:]]}}"
+
+  if [ -z "$line" ]; then
+    continue
+  fi
+
+  src="$source_root/$line"
+  dest="$repo_root/$line"
+
+  if [ -e "$dest" ] || [ -L "$dest" ]; then
+    continue
+  fi
+
+  if [ ! -e "$src" ] && [ ! -L "$src" ]; then
+    log "source missing, skipped: $line"
+    missing_count=$((missing_count + 1))
+    continue
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  cp -pR "$src" "$dest"
+  log "copied $line"
+  copied_count=$((copied_count + 1))
+done < "$manifest_path"
+
+if [ "$copied_count" -eq 0 ] && [ "$missing_count" -eq 0 ]; then
+  log "nothing to sync"
+fi

--- a/scripts/sync-worktree-resources.sh
+++ b/scripts/sync-worktree-resources.sh
@@ -17,6 +17,10 @@ common_dir="${WORKTREE_BOOTSTRAP_GIT_COMMON_DIR:-$(git -C "$repo_root" rev-parse
 if [ -z "$common_dir" ]; then
   exit 0
 fi
+case "$common_dir" in
+  /*) ;;
+  *) common_dir="$repo_root/$common_dir" ;;
+esac
 
 source_root="${WORKTREE_BOOTSTRAP_SOURCE_ROOT:-$(cd "$(dirname "$common_dir")" && pwd)}"
 manifest_path="${WORKTREE_BOOTSTRAP_MANIFEST:-$repo_root/scripts/worktree-sync.paths}"

--- a/scripts/test-worktree-bootstrap.sh
+++ b/scripts/test-worktree-bootstrap.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-vibe-monitor-worktree-bootstrap.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+copy_repo() {
+  src="$1"
+  dest="$2"
+  mkdir -p "$dest"
+  rsync -a \
+    --exclude '.git' \
+    --exclude 'node_modules' \
+    --exclude 'web/node_modules' \
+    --exclude 'target' \
+    --exclude 'web/dist' \
+    --exclude '.codex/logs' \
+    --exclude '.codex/evidence' \
+    "$src/" "$dest/"
+}
+
+init_repo() {
+  repo="$1"
+  git -C "$repo" init -b main >/dev/null
+  git -C "$repo" config user.name 'Codex Test'
+  git -C "$repo" config user.email 'codex-test@example.com'
+  git -C "$repo" add .
+  LEFTHOOK=0 git -C "$repo" commit -m 'test fixture' >/dev/null
+}
+
+assert_file_contains() {
+  file="$1"
+  needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    printf 'expected %s to contain %s\n' "$file" "$needle" >&2
+    exit 1
+  fi
+}
+
+assert_equal_file() {
+  expected="$1"
+  actual="$2"
+  if ! cmp -s "$expected" "$actual"; then
+    printf 'expected %s to match %s\n' "$actual" "$expected" >&2
+    exit 1
+  fi
+}
+
+fixture_repo="$tmp_dir/fixture"
+copy_repo "$repo_root" "$fixture_repo"
+init_repo "$fixture_repo"
+
+printf 'PRIMARY_SECRET=from-primary\n' > "$fixture_repo/.env.local"
+
+install_output="$(bash "$fixture_repo/scripts/install-hooks.sh" 2>&1)"
+assert_file_contains <(printf '%s' "$install_output") 'installed shared hooks'
+
+hooks_dir="$(git -C "$fixture_repo" rev-parse --absolute-git-dir)/hooks"
+assert_file_contains "$hooks_dir/pre-commit" '# managed by codex-vibe-monitor hooks:install'
+assert_file_contains "$hooks_dir/commit-msg" '# managed by codex-vibe-monitor hooks:install'
+assert_file_contains "$hooks_dir/post-checkout" '# managed by codex-vibe-monitor hooks:install'
+
+worktree_dir="$tmp_dir/linked"
+git -C "$fixture_repo" worktree add --detach "$worktree_dir" HEAD >/dev/null
+assert_equal_file "$fixture_repo/.env.local" "$worktree_dir/.env.local"
+
+printf 'TARGET_SECRET=keep-me\n' > "$worktree_dir/.env.local"
+git -C "$worktree_dir" checkout --detach HEAD >/dev/null 2>&1
+assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+
+bash "$worktree_dir/scripts/worktree-bootstrap.sh" >/dev/null
+assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+
+rm -f "$fixture_repo/scripts/run-lefthook-hook.sh" \
+  "$fixture_repo/scripts/sync-worktree-resources.sh" \
+  "$fixture_repo/scripts/worktree-bootstrap.sh" \
+  "$fixture_repo/scripts/worktree-sync.paths"
+git -C "$fixture_repo" add -A
+LEFTHOOK=0 git -C "$fixture_repo" commit -m 'legacy fixture without bootstrap scripts' >/dev/null
+legacy_sha="$(git -C "$fixture_repo" rev-parse HEAD)"
+head_sha="$(git -C "$fixture_repo" rev-parse HEAD^)"
+
+git -C "$worktree_dir" checkout --detach "$legacy_sha" >/dev/null
+git -C "$worktree_dir" checkout --detach "$head_sha" >/dev/null
+assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+
+custom_repo="$tmp_dir/custom-hooks"
+copy_repo "$repo_root" "$custom_repo"
+init_repo "$custom_repo"
+git -C "$custom_repo" config core.hooksPath .custom-hooks
+mkdir -p "$custom_repo/.custom-hooks"
+custom_output="$(bash "$custom_repo/scripts/install-hooks.sh" 2>&1)"
+assert_file_contains <(printf '%s' "$custom_output") 'core.hooksPath is set'
+if [ -e "$custom_repo/.custom-hooks/post-checkout" ]; then
+  printf 'custom hooks path should remain untouched\n' >&2
+  exit 1
+fi
+
+printf 'worktree bootstrap smoke passed\n'

--- a/scripts/test-worktree-bootstrap.sh
+++ b/scripts/test-worktree-bootstrap.sh
@@ -49,11 +49,26 @@ assert_equal_file() {
   fi
 }
 
+write_fake_lefthook() {
+  repo="$1"
+  os_arch="$(uname | tr '[:upper:]' '[:lower:]')"
+  cpu_arch="$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')"
+  native_dir="$repo/node_modules/lefthook-$os_arch-$cpu_arch/bin"
+  mkdir -p "$native_dir"
+  cat > "$native_dir/lefthook" <<'EOF_FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > .lefthook-run.log
+EOF_FAKE
+  chmod +x "$native_dir/lefthook"
+}
+
 fixture_repo="$tmp_dir/fixture"
 copy_repo "$repo_root" "$fixture_repo"
 init_repo "$fixture_repo"
 
 printf 'PRIMARY_SECRET=from-primary\n' > "$fixture_repo/.env.local"
+write_fake_lefthook "$fixture_repo"
 
 install_output="$(bash "$fixture_repo/scripts/install-hooks.sh" 2>&1)"
 assert_file_contains <(printf '%s' "$install_output") 'installed shared hooks'
@@ -70,6 +85,13 @@ assert_equal_file "$fixture_repo/.env.local" "$worktree_dir/.env.local"
 printf 'TARGET_SECRET=keep-me\n' > "$worktree_dir/.env.local"
 git -C "$worktree_dir" checkout --detach HEAD >/dev/null 2>&1
 assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+
+rm -rf "$worktree_dir/node_modules"
+(
+  cd "$worktree_dir"
+  "$hooks_dir/pre-commit" >/dev/null
+)
+assert_file_contains "$worktree_dir/.lefthook-run.log" 'run pre-commit'
 
 bash "$worktree_dir/scripts/worktree-bootstrap.sh" >/dev/null
 assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'

--- a/scripts/test-worktree-bootstrap.sh
+++ b/scripts/test-worktree-bootstrap.sh
@@ -11,6 +11,8 @@ copy_repo() {
   mkdir -p "$dest"
   rsync -a \
     --exclude '.git' \
+    --exclude '.env.local' \
+    --exclude 'web/.env.local' \
     --exclude 'node_modules' \
     --exclude 'web/node_modules' \
     --exclude 'target' \
@@ -84,6 +86,31 @@ head_sha="$(git -C "$fixture_repo" rev-parse HEAD^)"
 git -C "$worktree_dir" checkout --detach "$legacy_sha" >/dev/null
 git -C "$worktree_dir" checkout --detach "$head_sha" >/dev/null
 assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+
+preserve_repo="$tmp_dir/preserve-existing-hook"
+copy_repo "$repo_root" "$preserve_repo"
+init_repo "$preserve_repo"
+printf '#!/bin/sh\necho custom-pre-commit\n' > "$preserve_repo/.git/hooks/pre-commit"
+chmod +x "$preserve_repo/.git/hooks/pre-commit"
+preserve_output="$(bash "$preserve_repo/scripts/install-hooks.sh" 2>&1)"
+assert_file_contains <(printf '%s' "$preserve_output") 'pre-commit already exists and is unmanaged'
+assert_file_contains "$preserve_repo/.git/hooks/pre-commit" 'custom-pre-commit'
+assert_file_contains "$preserve_repo/.git/hooks/post-checkout" '# managed by codex-vibe-monitor hooks:install'
+
+path_repo="$tmp_dir/path-resolution"
+copy_repo "$repo_root" "$path_repo"
+init_repo "$path_repo"
+caller_dir="$tmp_dir/outside-caller"
+mkdir -p "$caller_dir"
+printf 'CALLER_SECRET=outside\n' > "$caller_dir/.env.local"
+(
+  cd "$caller_dir"
+  bash "$path_repo/scripts/sync-worktree-resources.sh" >/dev/null
+)
+if [ -e "$path_repo/.env.local" ]; then
+  printf 'sync script must not resolve source_root from the caller working directory\n' >&2
+  exit 1
+fi
 
 custom_repo="$tmp_dir/custom-hooks"
 copy_repo "$repo_root" "$custom_repo"

--- a/scripts/test-worktree-bootstrap.sh
+++ b/scripts/test-worktree-bootstrap.sh
@@ -34,7 +34,7 @@ init_repo() {
 assert_file_contains() {
   file="$1"
   needle="$2"
-  if ! grep -Fq "$needle" "$file"; then
+  if ! grep -Fq -- "$needle" "$file"; then
     printf 'expected %s to contain %s\n' "$file" "$needle" >&2
     exit 1
   fi
@@ -92,6 +92,7 @@ rm -rf "$worktree_dir/node_modules"
   "$hooks_dir/pre-commit" >/dev/null
 )
 assert_file_contains "$worktree_dir/.lefthook-run.log" 'run pre-commit'
+assert_file_contains "$worktree_dir/.lefthook-run.log" '--no-auto-install'
 
 bash "$worktree_dir/scripts/worktree-bootstrap.sh" >/dev/null
 assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+bash "$repo_root/scripts/install-hooks.sh"
+bash "$repo_root/scripts/sync-worktree-resources.sh"

--- a/scripts/worktree-sync.paths
+++ b/scripts/worktree-sync.paths
@@ -1,0 +1,3 @@
+# Paths are resolved relative to the primary worktree root.
+# Sync semantics are copy-missing-only: existing targets are never overwritten.
+.env.local


### PR DESCRIPTION
## Summary
- add shared Git hook bootstrap scripts and Bun entrypoints for linked worktrees
- sync missing `.env.local` into new worktrees with copy-missing-only semantics
- cover the flow with a linked worktree smoke test in CI and document the contract

## Verification
- `bun install`
- `bash scripts/test-worktree-bootstrap.sh`
- `bun run check:bun-first`