### PR TITLE
fix(ci): configure release snapshot git identity

### DIFF
--- a/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
@@ -264,6 +264,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Ensure immutable release snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Resolve target commit
         id: target
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -264,6 +264,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Ensure immutable release snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Resolve target commit
         id: target
         shell: bash


### PR DESCRIPTION
## What
- configure a git committer identity before `release_snapshot.py ensure` writes git notes in `CI Main`
- configure the same identity in `Release` before manual backfill materializes a missing snapshot
- keep the quality-gates contract fixtures aligned with the workflow change

## Verification
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-live-quality-gates.sh`