### PR TITLE
fix(ci): reuse local snapshot notes during backfill

### DIFF
--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -175,7 +175,9 @@ jobs:
           TARGET_SHA: ${{ steps.target.outputs.target_sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}"
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}"
+          fi
           python3 .github/scripts/release_snapshot.py export \
             --target-sha "${TARGET_SHA}" \
             --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,9 @@ jobs:
           TARGET_SHA: ${{ steps.target.outputs.target_sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}"
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}"
+          fi
           python3 .github/scripts/release_snapshot.py export \
             --target-sha "${TARGET_SHA}" \
             --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \


### PR DESCRIPTION
## What
- stop re-fetching the notes ref from origin during `workflow_dispatch` after the manual backfill step already materialized the target snapshot locally
- keep the existing fetch behavior for the automatic `workflow_run` path
- align the quality-gates release fixture with the workflow change

## Verification
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-live-quality-gates.sh`