### PR TITLE
fix(ci): accept release intent runs without PR metadata

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -570,6 +570,9 @@ def load_release_intent_artifact(
             continue
         if run_payload.get("conclusion") != "success":
             continue
+        if expected_head_sha is not None and artifact_name == artifact_name_for_pr(pr_number, expected_head_sha):
+            candidates.append(artifact)
+            continue
         pull_requests = run_payload.get("pull_requests") or []
         if not isinstance(pull_requests, list):
             raise SnapshotError(f"GitHub API returned malformed workflow run pull_requests for artifact {artifact_name}")

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -486,7 +486,7 @@ try:
                 "event": module.TRUSTED_RELEASE_INTENT_EVENT,
                 "status": "completed",
                 "conclusion": "success",
-                "pull_requests": [{"number": 140, "head": {"sha": "a" * 40}}],
+                "head_sha": "a" * 40,
             }
         if path.endswith("/actions/runs/2"):
             return {


### PR DESCRIPTION
## What
- let `release_snapshot.py` trust the deterministic `release-intent-pr-<pr>-<head_sha>` artifact naming when the workflow run payload omits `pull_requests`
- keep the existing trusted run checks (`label-gate`, `pull_request`, completed, success) before accepting an artifact
- add a regression that matches the real GitHub Actions payload shape from PR #132, where the run exposes `head_sha` but no `pull_requests`

## Why
- PR #132 merged on `2026-03-15`, but `CI Main` run `23109928967` failed in `Release Snapshot`
- the trusted `Label Gate` run `23109723208` succeeded for head SHA `9e1712f31b62b785ad69e188b006119dd86b2494`
- GitHub's workflow run payload for that run omitted `pull_requests`, so the current artifact filter rejected the valid pre-frozen release intent and fell back into the old `type:*` missing error path

## Verification
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 -m py_compile .github/scripts/release_snapshot.py`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-live-quality-gates.sh`

## Rollout
1. merge this PR
2. rerun `CI Main` for commit `c263806bbf9cb02e59dec2c50fa854c67a17ee29`
3. confirm `Release` runs for that commit instead of skipping
4. verify the next stable release is published for PR #132