### PR TITLE
fix(ci): support squash merged release intent

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -645,7 +645,12 @@ def resolve_release_intent_for_pr(
     merged_at = pr.get("merged_at")
     if not isinstance(merged_at, str) or not merged_at:
         raise SnapshotError(f"Pull request #{pr_number} is missing merged_at")
-    expected_head_sha = merged_pr_head_sha(target_sha)
+    merged_head_sha = merged_pr_head_sha(target_sha)
+    head = pr.get("head") or {}
+    pr_head_sha = head.get("sha") if isinstance(head, dict) else None
+    if not isinstance(pr_head_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", pr_head_sha):
+        pr_head_sha = None
+    expected_head_sha = merged_head_sha or pr_head_sha
 
     release_intent = load_release_intent_artifact(
         api_root,
@@ -664,9 +669,7 @@ def resolve_release_intent_for_pr(
             pr_head_sha,
         )
 
-    head = pr.get("head") or {}
-    pr_head_sha = head.get("sha") if isinstance(head, dict) else None
-    if not isinstance(pr_head_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", pr_head_sha):
+    if pr_head_sha is None:
         if expected_head_sha is None:
             raise SnapshotError(f"Pull request #{pr_number} is missing a valid head.sha")
         pr_head_sha = expected_head_sha

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -525,6 +525,34 @@ finally:
     module.load_release_intent_artifact = real_load_release_intent_artifact
     module.legacy_fallback_allowed_for_target = real_legacy_fallback_allowed_for_target
 
+real_merged_pr_head_sha = module.merged_pr_head_sha
+real_load_release_intent_artifact = module.load_release_intent_artifact
+try:
+    captured_expected_head_sha = {"value": None}
+
+    def fake_load_release_intent_artifact(api_root, repository, token, pr_number, *, merged_at, expected_head_sha=None):
+        captured_expected_head_sha["value"] = expected_head_sha
+        return make_release_intent(pr_number, "d" * 40, type_label="type:skip")
+
+    module.merged_pr_head_sha = lambda target_sha: None
+    module.load_release_intent_artifact = fake_load_release_intent_artifact
+
+    type_label, channel_label, snapshot_source, pr_head_sha = module.resolve_release_intent_for_pr(
+        "https://api.github.com",
+        "IvanLi-CN/codex-vibe-monitor",
+        "token",
+        make_pr(141, "Squash merged PR", "d" * 40),
+        target_sha="e" * 40,
+    )
+    assert captured_expected_head_sha["value"] == "d" * 40
+    assert type_label == "type:skip"
+    assert channel_label == "channel:stable"
+    assert snapshot_source == "pr-intent-artifact"
+    assert pr_head_sha == "d" * 40
+finally:
+    module.merged_pr_head_sha = real_merged_pr_head_sha
+    module.load_release_intent_artifact = real_load_release_intent_artifact
+
 with tempfile.TemporaryDirectory(prefix="release-snapshot-target-only-") as tmp:
     repo = Path(tmp)
     run("init", cwd=repo)


### PR DESCRIPTION
## What
- fall back to the merged PR's persisted `head.sha` when the mainline commit is a squash merge and therefore has no second parent to recover the PR head SHA from
- keep the stricter merge-parent path when it is available, but use the PR head SHA as the artifact lookup key for squash merges
- add a regression proving `resolve_release_intent_for_pr()` still matches the frozen artifact for squash-merged PRs

## Why
- PR #139 fixed the case where GitHub omits `workflow_run.pull_requests`
- but the repo merges PRs with squash, so `merged_pr_head_sha(target_sha)` returns `None` on the real mainline path
- that left `CI Main` run `23110227030` failing with the same `Expected exactly 1 type:* label, got 0: (none)` error even after PR #139 merged

## Verification
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 -m py_compile .github/scripts/release_snapshot.py`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-live-quality-gates.sh`

## Rollout
1. merge this PR
2. confirm the next `CI Main` on `main` can write a release snapshot for a squash-merged PR
3. if needed, re-run `Release workflow_dispatch(commit_sha=c263806bbf9cb02e59dec2c50fa854c67a17ee29)` and confirm the PR #132 release is published