### PR TITLE
fix(ci): harden release intent artifact lookup

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -304,6 +304,30 @@ def github_paginate_artifacts(api_root: str, token: str, path: str) -> list[dict
         page += 1
 
 
+def github_paginate_workflow_runs(
+    api_root: str,
+    token: str,
+    path: str,
+    query: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    page = 1
+    items: list[dict[str, Any]] = []
+    while True:
+        page_query = dict(query or {})
+        page_query.update({"per_page": 100, "page": page})
+        payload = github_request_json(api_root, token, path, page_query)
+        if not isinstance(payload, dict):
+            raise SnapshotError(f"GitHub API returned an unexpected workflow runs payload for {path}")
+        workflow_runs = payload.get("workflow_runs") or []
+        if not isinstance(workflow_runs, list):
+            raise SnapshotError(f"GitHub API returned malformed workflow runs data for {path}")
+        normalized = [item for item in workflow_runs if isinstance(item, dict)]
+        items.extend(normalized)
+        if len(workflow_runs) < 100:
+            return items
+        page += 1
+
+
 def parse_github_timestamp(value: str, *, where: str) -> datetime:
     try:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -527,8 +551,137 @@ def merged_pr_head_sha(target_sha: str) -> str | None:
     return None
 
 
+def workflow_run_matches_release_intent(
+    run_payload: dict[str, Any],
+    *,
+    pr_number: int,
+    expected_head_sha: str | None = None,
+) -> bool:
+    if run_payload.get("path") != TRUSTED_RELEASE_INTENT_WORKFLOW_PATH:
+        return False
+    if run_payload.get("event") != TRUSTED_RELEASE_INTENT_EVENT:
+        return False
+    if run_payload.get("status") != "completed":
+        return False
+    if run_payload.get("conclusion") != "success":
+        return False
+    if expected_head_sha is not None and run_payload.get("head_sha") == expected_head_sha:
+        return True
+
+    pull_requests = run_payload.get("pull_requests") or []
+    if not isinstance(pull_requests, list):
+        raise SnapshotError("GitHub API returned malformed workflow run pull_requests")
+    return any(
+        isinstance(item, dict)
+        and item.get("number") == pr_number
+        and (
+            expected_head_sha is None
+            or (isinstance(item.get("head"), dict) and item["head"].get("sha") == expected_head_sha)
+        )
+        for item in pull_requests
+    )
+
+
+def workflow_run_artifacts(
+    api_root: str,
+    repository: str,
+    token: str,
+    *,
+    run_id: int,
+) -> list[dict[str, Any]]:
+    owner, repo = repository.split("/", 1)
+    return github_paginate_artifacts(api_root, token, f"/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts")
+
+
+def find_release_intent_artifact_for_run(
+    api_root: str,
+    repository: str,
+    token: str,
+    *,
+    run_id: int,
+    artifact_name: str,
+    merge_moment: datetime,
+) -> dict[str, Any] | None:
+    for artifact in workflow_run_artifacts(api_root, repository, token, run_id=run_id):
+        if not isinstance(artifact, dict):
+            continue
+        if artifact.get("name") != artifact_name:
+            continue
+        if artifact.get("expired") is not False:
+            continue
+        created_at = artifact.get("created_at")
+        if not isinstance(created_at, str):
+            continue
+        if parse_github_timestamp(created_at, where=f"Artifact {artifact_name} created_at") > merge_moment:
+            continue
+        return artifact
+    return None
+
+
+def discover_release_intent_artifact_via_workflow_runs(
+    api_root: str,
+    repository: str,
+    token: str,
+    *,
+    pr_number: int,
+    merged_at: str,
+    expected_head_sha: str | None,
+    pr_head_ref: str | None,
+) -> dict[str, Any] | None:
+    if expected_head_sha is None or not pr_head_ref:
+        return None
+
+    owner, repo = repository.split("/", 1)
+    merge_moment = parse_github_timestamp(merged_at, where=f"Pull request #{pr_number} merged_at")
+    artifact_name = artifact_name_for_pr(pr_number, expected_head_sha)
+    workflow_runs = github_paginate_workflow_runs(
+        api_root,
+        token,
+        f"/repos/{owner}/{repo}/actions/workflows/label-gate.yml/runs",
+        {"event": TRUSTED_RELEASE_INTENT_EVENT, "branch": pr_head_ref},
+    )
+    candidates: list[tuple[datetime, dict[str, Any]]] = []
+    for run_payload in workflow_runs:
+        created_at = run_payload.get("created_at")
+        if not isinstance(created_at, str):
+            continue
+        created_moment = parse_github_timestamp(created_at, where="Workflow run created_at")
+        if created_moment > merge_moment:
+            continue
+        run_id = run_payload.get("id")
+        if not isinstance(run_id, int):
+            continue
+        if not workflow_run_matches_release_intent(
+            run_payload,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+        ):
+            continue
+        artifact = find_release_intent_artifact_for_run(
+            api_root,
+            repository,
+            token,
+            run_id=run_id,
+            artifact_name=artifact_name,
+            merge_moment=merge_moment,
+        )
+        if artifact is not None:
+            candidates.append((created_moment, artifact))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
 def load_release_intent_artifact(
-    api_root: str, repository: str, token: str, pr_number: int, *, merged_at: str, expected_head_sha: str | None = None
+    api_root: str,
+    repository: str,
+    token: str,
+    pr_number: int,
+    *,
+    merged_at: str,
+    expected_head_sha: str | None = None,
+    pr_head_ref: str | None = None,
 ) -> dict[str, Any] | None:
     owner, repo = repository.split("/", 1)
     artifact_prefix = f"{RELEASE_INTENT_ARTIFACT_PREFIX}{pr_number}-"
@@ -562,36 +715,30 @@ def load_release_intent_artifact(
             if not isinstance(run_payload, dict):
                 raise SnapshotError(f"GitHub API returned malformed workflow run data for artifact {artifact_name}")
             workflow_runs[run_id] = run_payload
-        if run_payload.get("path") != TRUSTED_RELEASE_INTENT_WORKFLOW_PATH:
-            continue
-        if run_payload.get("event") != TRUSTED_RELEASE_INTENT_EVENT:
-            continue
-        if run_payload.get("status") != "completed":
-            continue
-        if run_payload.get("conclusion") != "success":
-            continue
-        if expected_head_sha is not None and artifact_name == artifact_name_for_pr(pr_number, expected_head_sha):
-            candidates.append(artifact)
-            continue
-        pull_requests = run_payload.get("pull_requests") or []
-        if not isinstance(pull_requests, list):
-            raise SnapshotError(f"GitHub API returned malformed workflow run pull_requests for artifact {artifact_name}")
-        if not any(
-            isinstance(item, dict)
-            and item.get("number") == pr_number
-            and (
-                expected_head_sha is None
-                or (isinstance(item.get("head"), dict) and item["head"].get("sha") == expected_head_sha)
-            )
-            for item in pull_requests
+        if not workflow_run_matches_release_intent(
+            run_payload,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
         ):
             continue
         candidates.append(artifact)
     if not candidates:
-        return None
+        run_artifact = discover_release_intent_artifact_via_workflow_runs(
+            api_root,
+            repository,
+            token,
+            pr_number=pr_number,
+            merged_at=merged_at,
+            expected_head_sha=expected_head_sha,
+            pr_head_ref=pr_head_ref,
+        )
+        if run_artifact is None:
+            return None
+        candidates.append(run_artifact)
 
     candidates.sort(key=lambda artifact: str(artifact.get("created_at") or ""), reverse=True)
     artifact = candidates[0]
+    artifact_name = str(artifact.get("name") or f"{artifact_prefix}unknown")
     archive_url = artifact.get("archive_download_url")
     if not isinstance(archive_url, str) or not archive_url:
         raise SnapshotError(f"Artifact {artifact_name} is missing archive_download_url")
@@ -647,6 +794,9 @@ def resolve_release_intent_for_pr(
         raise SnapshotError(f"Pull request #{pr_number} is missing merged_at")
     merged_head_sha = merged_pr_head_sha(target_sha)
     head = pr.get("head") or {}
+    pr_head_ref = head.get("ref") if isinstance(head, dict) else None
+    if not isinstance(pr_head_ref, str) or not pr_head_ref:
+        pr_head_ref = None
     pr_head_sha = head.get("sha") if isinstance(head, dict) else None
     if not isinstance(pr_head_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", pr_head_sha):
         pr_head_sha = None
@@ -659,6 +809,7 @@ def resolve_release_intent_for_pr(
         pr_number,
         merged_at=merged_at,
         expected_head_sha=expected_head_sha,
+        pr_head_ref=pr_head_ref,
     )
     if release_intent is not None:
         pr_head_sha = str(release_intent["pr_head_sha"])

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -525,12 +525,69 @@ finally:
     module.load_release_intent_artifact = real_load_release_intent_artifact
     module.legacy_fallback_allowed_for_target = real_legacy_fallback_allowed_for_target
 
+artifact_payload_fallback = make_release_intent(142, "e" * 40, type_label="type:skip")
+artifact_bytes_fallback = io.BytesIO()
+with zipfile.ZipFile(artifact_bytes_fallback, "w") as archive:
+    archive.writestr("release-intent.json", json.dumps(artifact_payload_fallback))
+
+real_request_json = module.github_request_json
+real_request_bytes = module.github_request_bytes
+try:
+    def fake_request_json(api_root, token, path, query=None):
+        if path.endswith("/actions/artifacts"):
+            return {"artifacts": []}
+        if path.endswith("/actions/workflows/label-gate.yml/runs"):
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 9,
+                        "path": module.TRUSTED_RELEASE_INTENT_WORKFLOW_PATH,
+                        "event": module.TRUSTED_RELEASE_INTENT_EVENT,
+                        "status": "completed",
+                        "conclusion": "success",
+                        "created_at": "2026-03-15T00:00:00Z",
+                        "head_sha": "e" * 40,
+                    }
+                ]
+            }
+        if path.endswith("/actions/runs/9/artifacts"):
+            return {
+                "artifacts": [
+                    {
+                        "name": module.artifact_name_for_pr(142, "e" * 40),
+                        "expired": False,
+                        "created_at": "2026-03-15T00:00:01Z",
+                        "archive_download_url": "https://example.test/artifacts/9/zip",
+                        "workflow_run": {"id": 9},
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected path: {path}")
+
+    module.github_request_json = fake_request_json
+    module.github_request_bytes = lambda url, token: artifact_bytes_fallback.getvalue()
+    loaded_intent = module.load_release_intent_artifact(
+        "https://api.github.com",
+        "IvanLi-CN/codex-vibe-monitor",
+        "token",
+        142,
+        merged_at="2026-03-15T00:00:02Z",
+        expected_head_sha="e" * 40,
+        pr_head_ref="th/fix-release-intent-run-artifact-lookup",
+    )
+    assert loaded_intent is not None
+    assert loaded_intent["type_label"] == "type:skip"
+    assert loaded_intent["pr_head_sha"] == "e" * 40
+finally:
+    module.github_request_json = real_request_json
+    module.github_request_bytes = real_request_bytes
+
 real_merged_pr_head_sha = module.merged_pr_head_sha
 real_load_release_intent_artifact = module.load_release_intent_artifact
 try:
     captured_expected_head_sha = {"value": None}
 
-    def fake_load_release_intent_artifact(api_root, repository, token, pr_number, *, merged_at, expected_head_sha=None):
+    def fake_load_release_intent_artifact(api_root, repository, token, pr_number, *, merged_at, expected_head_sha=None, pr_head_ref=None):
         captured_expected_head_sha["value"] = expected_head_sha
         return make_release_intent(pr_number, "d" * 40, type_label="type:skip")
 


### PR DESCRIPTION
## What
- keep the repository-wide `actions/artifacts` scan, but add a second lookup path that walks successful `Label Gate` workflow runs for the PR head branch and loads the exact `release-intent` artifact from the matching run
- reuse the same trusted-workflow checks for both lookup paths so cancelled or untrusted runs still cannot feed `CI Main`
- add a regression covering the new fallback path when the repository-wide artifact listing does not surface the expected PR artifact

## Why
- `PR #140` merged cleanly, but `CI Main` run `23110484587` still failed in `Release Snapshot`
- the frozen artifact for `PR #140` (`release-intent-pr-140-c6be1eb97823f3966f5469aa62866e6eda9299d8`) exists and contains valid JSON, so the remaining failure is the artifact discovery path rather than label validation itself
- this makes the automatic path resilient even if GitHub's repository-wide artifact listing temporarily omits the exact PR artifact

## Verification
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 -m py_compile .github/scripts/release_snapshot.py`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-live-quality-gates.sh`

## Rollout
1. merge this PR
2. rerun `CI Main` for `681fa9f2b41ad7cea5ab7513e067073c8bdfaee8`
3. confirm `Release Snapshot` succeeds and the follow-up `Release` workflow no longer gets skipped for the repaired path