### PR TITLE
fix(ci): use github json accept for artifacts

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -258,7 +258,7 @@ def github_request_json(api_root: str, token: str, path: str, query: dict[str, A
 def github_request_bytes(url: str, token: str) -> bytes:
     headers = {
         "Authorization": f"Bearer {token}",
-        "Accept": "application/octet-stream",
+        "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "codex-vibe-monitor-release-snapshot",
     }

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -712,5 +712,30 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-target-only-") as tmp:
         module.git = original_git
         os.chdir(original_cwd)
 
+captured_headers: dict[str, str] = {}
+original_urlopen = module.request.urlopen
+
+class FakeResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self) -> bytes:
+        return b"artifact-bytes"
+
+try:
+    def fake_urlopen(req):
+        captured_headers.update({key.lower(): value for key, value in req.header_items()})
+        return FakeResponse()
+
+    module.request.urlopen = fake_urlopen
+    payload = module.github_request_bytes("https://api.github.com/repos/demo/actions/artifacts/1/zip", "token")
+    assert payload == b"artifact-bytes"
+    assert captured_headers["accept"] == "application/vnd.github+json"
+finally:
+    module.request.urlopen = original_urlopen
+
 print("test-release-snapshot: all checks passed")
 PY


### PR DESCRIPTION
## What
- switch release-intent artifact downloads to GitHub's JSON media type instead of `application/octet-stream`
- add a regression that asserts the artifact downloader sends the media type GitHub now accepts for Actions artifact archive redirects

## Why
- `CI Main` for `136bc0cf2acc912235088ed641bd8b9dc14fbce7` still failed after the target-only fix
- the failure moved forward to artifact download itself: GitHub now rejects `Accept: application/octet-stream` on the Actions artifact archive endpoint with `415 Unsupported 'Accept' header`
- this keeps the existing frozen-intent flow intact while unblocking the actual artifact fetch path

## Verification
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 -m py_compile .github/scripts/release_snapshot.py`

## Rollout
1. merge this PR
2. rerun `CI Main` for `136bc0cf2acc912235088ed641bd8b9dc14fbce7`
3. if that passes, rerun `CI Main` for `9073e17fe770a8392ca5ec741ec808c1ec5ddf9f` to backfill the previously blocked snapshot path