### PR TITLE
fix(ci): follow artifact redirects without auth

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -255,18 +255,44 @@ def github_request_json(api_root: str, token: str, path: str, query: dict[str, A
         raise SnapshotError(f"GitHub API request failed on {path}: {exc}") from exc
 
 
+class _NoRedirectHandler(request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
 def github_request_bytes(url: str, token: str) -> bytes:
-    headers = {
+    api_headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "codex-vibe-monitor-release-snapshot",
     }
-    req = request.Request(url, headers=headers)
+    opener = request.build_opener(_NoRedirectHandler)
+    req = request.Request(url, headers=api_headers)
     try:
-        with request.urlopen(req) as resp:
+        with opener.open(req) as resp:
             return resp.read()
     except error.HTTPError as exc:
+        if exc.code in {301, 302, 303, 307, 308}:
+            redirect_url = exc.headers.get("Location")
+            if not redirect_url:
+                body = exc.read().decode("utf-8", errors="replace")
+                raise SnapshotError(f"GitHub artifact download failed on {url}: redirect missing Location header: {body}") from exc
+            download_headers = {
+                "Accept": "application/octet-stream",
+                "User-Agent": "codex-vibe-monitor-release-snapshot",
+            }
+            download_req = request.Request(redirect_url, headers=download_headers)
+            try:
+                with request.urlopen(download_req) as resp:
+                    return resp.read()
+            except error.HTTPError as redirect_exc:
+                body = redirect_exc.read().decode("utf-8", errors="replace")
+                raise SnapshotError(
+                    f"GitHub artifact download failed on {redirect_url}: {redirect_exc.code} {body}"
+                ) from redirect_exc
+            except error.URLError as redirect_exc:
+                raise SnapshotError(f"GitHub artifact download failed on {redirect_url}: {redirect_exc}") from redirect_exc
         body = exc.read().decode("utf-8", errors="replace")
         raise SnapshotError(f"GitHub artifact download failed on {url}: {exc.code} {body}") from exc
     except error.URLError as exc:

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -712,8 +712,10 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-target-only-") as tmp:
         module.git = original_git
         os.chdir(original_cwd)
 
-captured_headers: dict[str, str] = {}
+api_headers: dict[str, str] = {}
+blob_headers: dict[str, str] = {}
 original_urlopen = module.request.urlopen
+original_build_opener = module.request.build_opener
 
 class FakeResponse:
     def __enter__(self):
@@ -725,16 +727,32 @@ class FakeResponse:
     def read(self) -> bytes:
         return b"artifact-bytes"
 
+class FakeOpener:
+    def open(self, req):
+        api_headers.update({key.lower(): value for key, value in req.header_items()})
+        raise module.error.HTTPError(
+            req.full_url,
+            302,
+            "Found",
+            {"Location": "https://blob.example/artifact.zip"},
+            None,
+        )
+
 try:
     def fake_urlopen(req):
-        captured_headers.update({key.lower(): value for key, value in req.header_items()})
+        blob_headers.update({key.lower(): value for key, value in req.header_items()})
         return FakeResponse()
 
+    module.request.build_opener = lambda *handlers: FakeOpener()
     module.request.urlopen = fake_urlopen
     payload = module.github_request_bytes("https://api.github.com/repos/demo/actions/artifacts/1/zip", "token")
     assert payload == b"artifact-bytes"
-    assert captured_headers["accept"] == "application/vnd.github+json"
+    assert api_headers["accept"] == "application/vnd.github+json"
+    assert api_headers["authorization"] == "Bearer token"
+    assert blob_headers["accept"] == "application/octet-stream"
+    assert "authorization" not in blob_headers
 finally:
+    module.request.build_opener = original_build_opener
     module.request.urlopen = original_urlopen
 
 print("test-release-snapshot: all checks passed")


### PR DESCRIPTION
## What
- change release-intent artifact downloads to resolve the GitHub API redirect first, then fetch the blob URL without the GitHub bearer token
- keep the API request on the GitHub JSON media type, but make the redirected blob fetch explicit and unauthenticated
- add a regression that asserts the API hop keeps auth while the redirected blob hop does not

## Why
- `CI Main` for `473a8de863c1dde4cece46d679bfa97dcd44d8e8` moved past the old `415` but still failed in `Release Snapshot`
- GitHub now returns a redirect for artifact downloads; `urllib` followed it while leaking the `Authorization` header to blob storage, which then rejected the request with `401 InvalidAuthenticationInfo`
- this keeps the current frozen-intent architecture, but makes artifact downloads match GitHub's redirect model instead of depending on `urllib` defaults

## Verification
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 -m py_compile .github/scripts/release_snapshot.py`

## Rollout
1. merge this PR
2. rerun `CI Main` for `473a8de863c1dde4cece46d679bfa97dcd44d8e8`
3. if that passes, rerun `CI Main` for `9073e17fe770a8392ca5ec741ec808c1ec5ddf9f` to backfill the older blocked snapshot path