### PR TITLE
fix(ci): bootstrap the serial release contract

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -213,6 +213,15 @@ def step_config(job: dict[str, Any], step_name: str, where: str) -> dict[str, An
     raise ContractError(f"{where}: missing step {step_name!r}")
 
 
+def maybe_step_config(job: dict[str, Any], step_name: str) -> dict[str, Any] | None:
+    steps = job.get("steps")
+    require(isinstance(steps, list), "job.steps must be a list")
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == step_name:
+            return step
+    return None
+
+
 def uses_step_config(job: dict[str, Any], step_name: str, expected_uses: str, where: str) -> dict[str, Any]:
     step = step_config(job, step_name, where)
     require(step.get("uses") == expected_uses, f"{where}.steps[{step_name!r}].uses must stay {expected_uses!r}")
@@ -498,7 +507,10 @@ def validate_ci_main(path: Path, contract: ContractModel) -> None:
     assert_event_branches(push_config, {"main"}, "ci-main.yml.on.push")
 
     concurrency = require_mapping(workflow.get("concurrency"), "ci-main.yml.concurrency")
-    require(concurrency.get("group") == "ci-main-${{ github.sha }}", "ci-main.yml.concurrency.group drifted")
+    require(
+        concurrency.get("group") in {"ci-main-${{ github.sha }}", "ci-main-main"},
+        "ci-main.yml.concurrency.group drifted",
+    )
     require(concurrency.get("cancel-in-progress") is False, "ci-main.yml.concurrency.cancel-in-progress must stay false")
 
     permissions = require_mapping(workflow.get("permissions"), "ci-main.yml.permissions")
@@ -549,9 +561,10 @@ def validate_ci_main(path: Path, contract: ContractModel) -> None:
         "RELEASE_SNAPSHOT_NOTES_REF" in ensure_run,
         "ci-main.yml.jobs.release-snapshot: notes-ref plumbing drifted",
     )
+    target_only = "--target-only" in ensure_run
     require(
-        "--target-only" in ensure_run,
-        "ci-main.yml.jobs.release-snapshot: automatic snapshot ensure must stay target-only",
+        target_only or "TARGET_SHA" not in ensure_run,
+        "ci-main.yml.jobs.release-snapshot: automatic snapshot ensure must not use TARGET_SHA without --target-only",
     )
 
 
@@ -596,22 +609,7 @@ def validate_label_gate(path: Path, contract: ContractModel) -> None:
     require(candidate_checkout.get("path") == "candidate", "label-gate.yml: candidate checkout path drifted")
     require(candidate_checkout.get("persist-credentials") is False, "label-gate.yml: candidate checkout must disable persisted credentials")
 
-    rollout_step = step_config(job, "Detect rollout contract support", "label-gate.yml.jobs.validate-pr-labels")
-    rollout_run = str(rollout_step.get("run", ""))
-    require(
-        "supports_final_contract=false" in rollout_run and "supports_final_contract=true" in rollout_run,
-        "label-gate.yml: rollout support detection outputs drifted",
-    )
-    require(
-        "skipping trusted contract validation during rollout" in rollout_run,
-        "label-gate.yml: rollout warning drifted",
-    )
-
     contract_step = step_config(job, "Validate trusted label-gate contract", "label-gate.yml.jobs.validate-pr-labels")
-    require(
-        contract_step.get("if") == "steps.rollout.outputs.supports_final_contract == 'true'",
-        "label-gate.yml: trusted contract validation gate drifted",
-    )
     contract_command = require_command(
         contract_step,
         ["python3", "trusted/.github/scripts/check_quality_gates_contract.py"],
@@ -642,61 +640,85 @@ def validate_label_gate(path: Path, contract: ContractModel) -> None:
         "label-gate.yml: Evaluate PR labels must validate labels before any release-intent write step",
     )
 
-    trusted_write_step = step_config(job, "Write trusted release intent artifact", "label-gate.yml.jobs.validate-pr-labels")
-    require(
-        trusted_write_step.get("if") == "steps.rollout.outputs.supports_final_contract == 'true'",
-        "label-gate.yml: trusted release intent write gate drifted",
-    )
-    trusted_write_env = require_mapping(
-        trusted_write_step.get("env"),
-        "label-gate.yml.jobs.validate-pr-labels.steps['Write trusted release intent artifact'].env",
-    )
-    require(
-        trusted_write_env.get("GITHUB_TOKEN") == "${{ secrets.GITHUB_TOKEN }}",
-        "label-gate.yml: trusted release intent write step must pass GITHUB_TOKEN via env",
-    )
-    trusted_write_command = require_command(
-        trusted_write_step,
-        ["python3", "trusted/.github/scripts/metadata_gate.py", "label"],
-        "label-gate.yml.jobs.validate-pr-labels.steps['Write trusted release intent artifact']",
-        "label-gate.yml: trusted release intent write step must invoke the trusted metadata gate in label mode",
-    )
-    trusted_write_options = command_option_map(
-        trusted_write_command[3:],
-        "label-gate.yml: trusted release intent write command options",
-    )
-    require(
-        trusted_write_options.get("--write-intent") == "$RUNNER_TEMP/release-intent.json",
-        "label-gate.yml: trusted release intent write step must write to the runner temp artifact path",
-    )
+    rollout_step = maybe_step_config(job, "Detect rollout contract support")
+    trusted_write_step = maybe_step_config(job, "Write trusted release intent artifact")
+    upload_step = maybe_step_config(job, "Upload release intent artifact")
+    if rollout_step is not None:
+        rollout_run = str(rollout_step.get("run", ""))
+        require(
+            "supports_final_contract=false" in rollout_run and "supports_final_contract=true" in rollout_run,
+            "label-gate.yml: rollout support detection outputs drifted",
+        )
+        require(
+            "skipping trusted contract validation during rollout" in rollout_run,
+            "label-gate.yml: rollout warning drifted",
+        )
+        require(
+            contract_step.get("if") == "steps.rollout.outputs.supports_final_contract == 'true'",
+            "label-gate.yml: trusted contract validation gate drifted",
+        )
+        require(trusted_write_step is not None, "label-gate.yml: rollout topology must retain trusted release intent write step")
+        require(upload_step is not None, "label-gate.yml: rollout topology must retain release intent upload step")
+    else:
+        require("if" not in contract_step, "label-gate.yml: simplified trusted contract step must run unconditionally")
+        require(trusted_write_step is None, "label-gate.yml: simplified topology must not write release intent artifacts")
+        require(upload_step is None, "label-gate.yml: simplified topology must not upload release intent artifacts")
 
-    upload_step = step_config(job, "Upload release intent artifact", "label-gate.yml.jobs.validate-pr-labels")
-    require(
-        upload_step.get("if") == "steps.rollout.outputs.supports_final_contract == 'true'",
-        "label-gate.yml: release intent artifact upload gate drifted",
-    )
-    uses_value = str(upload_step.get("uses") or "")
-    require(
-        uses_value == "actions/upload-artifact@v4",
-        "label-gate.yml: release intent artifact step must use actions/upload-artifact@v4",
-    )
-    upload_with = require_mapping(upload_step.get("with"), "label-gate.yml.jobs.validate-pr-labels.steps['Upload release intent artifact'].with")
-    require(
-        upload_with.get("name") == "release-intent-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}",
-        "label-gate.yml: release intent artifact name drifted",
-    )
-    require(
-        upload_with.get("path") == "${{ runner.temp }}/release-intent.json",
-        "label-gate.yml: release intent artifact path drifted",
-    )
-    require(
-        upload_with.get("retention-days") == 30,
-        "label-gate.yml: release intent artifact retention must stay 30 days",
-    )
-    require(
-        upload_with.get("if-no-files-found") == "error",
-        "label-gate.yml: release intent artifact must fail when the JSON is missing",
-    )
+    if trusted_write_step is not None:
+        require(
+            trusted_write_step.get("if") == "steps.rollout.outputs.supports_final_contract == 'true'",
+            "label-gate.yml: trusted release intent write gate drifted",
+        )
+        trusted_write_env = require_mapping(
+            trusted_write_step.get("env"),
+            "label-gate.yml.jobs.validate-pr-labels.steps['Write trusted release intent artifact'].env",
+        )
+        require(
+            trusted_write_env.get("GITHUB_TOKEN") == "${{ secrets.GITHUB_TOKEN }}",
+            "label-gate.yml: trusted release intent write step must pass GITHUB_TOKEN via env",
+        )
+        trusted_write_command = require_command(
+            trusted_write_step,
+            ["python3", "trusted/.github/scripts/metadata_gate.py", "label"],
+            "label-gate.yml.jobs.validate-pr-labels.steps['Write trusted release intent artifact']",
+            "label-gate.yml: trusted release intent write step must invoke the trusted metadata gate in label mode",
+        )
+        trusted_write_options = command_option_map(
+            trusted_write_command[3:],
+            "label-gate.yml: trusted release intent write command options",
+        )
+        require(
+            trusted_write_options.get("--write-intent") == "$RUNNER_TEMP/release-intent.json",
+            "label-gate.yml: trusted release intent write step must write to the runner temp artifact path",
+        )
+
+    if upload_step is not None:
+        require(
+            upload_step.get("if") == "steps.rollout.outputs.supports_final_contract == 'true'",
+            "label-gate.yml: release intent artifact upload gate drifted",
+        )
+        uses_value = str(upload_step.get("uses") or "")
+        require(
+            uses_value == "actions/upload-artifact@v4",
+            "label-gate.yml: release intent artifact step must use actions/upload-artifact@v4",
+        )
+        upload_with = require_mapping(upload_step.get("with"), "label-gate.yml.jobs.validate-pr-labels.steps['Upload release intent artifact'].with")
+        require(
+            upload_with.get("name") == "release-intent-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}",
+            "label-gate.yml: release intent artifact name drifted",
+        )
+        require(
+            upload_with.get("path") == "${{ runner.temp }}/release-intent.json",
+            "label-gate.yml: release intent artifact path drifted",
+        )
+        require(
+            upload_with.get("retention-days") == 30,
+            "label-gate.yml: release intent artifact retention must stay 30 days",
+        )
+        require(
+            upload_with.get("if-no-files-found") == "error",
+            "label-gate.yml: release intent artifact must fail when the JSON is missing",
+        )
 
 
 def validate_review_policy(path: Path, contract: ContractModel) -> None:
@@ -768,7 +790,10 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     concurrency = require_mapping(workflow.get("concurrency"), "release.yml.concurrency")
     require(
         concurrency.get("group")
-        == "release-${{ github.event_name == 'workflow_dispatch' && inputs.commit_sha || github.event.workflow_run.head_sha }}",
+        in {
+            "release-${{ github.event_name == 'workflow_dispatch' && inputs.commit_sha || github.event.workflow_run.head_sha }}",
+            "release-main",
+        },
         "release.yml.concurrency.group drifted",
     )
     require(concurrency.get("cancel-in-progress") is False, "release.yml.concurrency.cancel-in-progress must stay false")
@@ -794,32 +819,56 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     outputs = require_mapping(release_meta.get("outputs"), "release.yml.jobs.release-meta.outputs")
     require("target_sha" in outputs, "release.yml.jobs.release-meta.outputs.target_sha must be exported")
 
-    target_step = step_config(release_meta, "Resolve target commit", "release.yml.jobs.release-meta")
+    requested_step = maybe_step_config(release_meta, "Resolve requested commit")
+    legacy_target_step = maybe_step_config(release_meta, "Resolve target commit")
+    require(
+        (requested_step is None) != (legacy_target_step is None),
+        "release.yml.jobs.release-meta must define exactly one target resolution step",
+    )
+    target_step_name = "Resolve requested commit" if requested_step is not None else "Resolve target commit"
+    target_step = requested_step or legacy_target_step
     target_run = str(target_step.get("run", ""))
-    require("inputs.commit_sha" in target_run, "release.yml.jobs.release-meta: manual commit_sha resolution drifted")
-    require("git merge-base --is-ancestor" in target_run, "release.yml.jobs.release-meta: main ancestry gate drifted")
+    require("inputs.commit_sha" in target_run, f"release.yml.jobs.release-meta: {target_step_name} manual commit_sha resolution drifted")
+    require("git merge-base --is-ancestor" in target_run, f"release.yml.jobs.release-meta: {target_step_name} main ancestry gate drifted")
 
     backfill_step = step_config(release_meta, "Validate manual backfill target passed CI Main", "release.yml.jobs.release-meta")
     require(backfill_step.get("if") == "github.event_name == 'workflow_dispatch'", "release.yml.jobs.release-meta: manual backfill validation gate drifted")
     backfill_env = require_mapping(backfill_step.get("env"), "release.yml.jobs.release-meta.steps['Validate manual backfill target passed CI Main'].env")
-    require(backfill_env.get("TARGET_SHA") == "${{ steps.target.outputs.target_sha }}", "release.yml.jobs.release-meta: manual backfill validation must consume target_sha")
+    expected_backfill_target = "${{ steps.requested-target.outputs.target_sha }}" if requested_step is not None else "${{ steps.target.outputs.target_sha }}"
+    require(backfill_env.get("TARGET_SHA") == expected_backfill_target, "release.yml.jobs.release-meta: manual backfill validation must consume target_sha")
     backfill_script = str(backfill_step.get("with", {}).get("script", ""))
     require("snapshot-only CI Main failure" in backfill_script, "release.yml.jobs.release-meta: snapshot-only backfill exception drifted")
     require("listJobsForWorkflowRun" in backfill_script, "release.yml.jobs.release-meta: snapshot-only backfill job inspection drifted")
     ensure_step = step_config(release_meta, "Ensure immutable release snapshot for manual backfill", "release.yml.jobs.release-meta")
     require(ensure_step.get("if") == "github.event_name == 'workflow_dispatch'", "release.yml.jobs.release-meta: manual snapshot ensure gate drifted")
     ensure_env = require_mapping(ensure_step.get("env"), "release.yml.jobs.release-meta.steps['Ensure immutable release snapshot for manual backfill'].env")
-    require(ensure_env.get("TARGET_SHA") == "${{ steps.target.outputs.target_sha }}", "release.yml.jobs.release-meta: manual snapshot ensure must consume target_sha")
+    require(ensure_env.get("TARGET_SHA") == expected_backfill_target, "release.yml.jobs.release-meta: manual snapshot ensure must consume target_sha")
     require(ensure_env.get("GITHUB_TOKEN") == "${{ secrets.GITHUB_TOKEN }}", "release.yml.jobs.release-meta: manual snapshot ensure must use GITHUB_TOKEN")
     ensure_run = str(ensure_step.get("run", ""))
     require("release_snapshot.py ensure" in ensure_run, "release.yml.jobs.release-meta: manual snapshot ensure must use release_snapshot.py ensure")
-    require("--allow-current-pr-label-fallback" in ensure_run, "release.yml.jobs.release-meta: manual snapshot ensure must allow current PR label fallback")
+
+    pending_step = maybe_step_config(release_meta, "Select pending release target")
+    if pending_step is None:
+        require("--allow-current-pr-label-fallback" in ensure_run, "release.yml.jobs.release-meta: legacy manual snapshot ensure must allow current PR label fallback")
+
     snapshot_step = step_config(release_meta, "Load immutable release snapshot", "release.yml.jobs.release-meta")
     snapshot_env = require_mapping(snapshot_step.get("env"), "release.yml.jobs.release-meta.steps['Load immutable release snapshot'].env")
+    expected_snapshot_target = "${{ steps.pending-target.outputs.target_sha }}" if pending_step is not None else "${{ steps.target.outputs.target_sha }}"
     require(
-        snapshot_env.get("TARGET_SHA") == "${{ steps.target.outputs.target_sha }}",
+        snapshot_env.get("TARGET_SHA") == expected_snapshot_target,
         "release.yml.jobs.release-meta: snapshot loader must consume target_sha",
     )
+    if pending_step is not None:
+        require(
+            pending_step.get("id") == "pending-target",
+            "release.yml.jobs.release-meta: pending release target step must expose pending-target outputs",
+        )
+        require(
+            snapshot_step.get("if") == "steps.pending-target.outputs.target_sha != ''",
+            "release.yml.jobs.release-meta: pending snapshot loader gate drifted",
+        )
+        pending_run = str(pending_step.get("run", ""))
+        require("release_snapshot.py next-pending" in pending_run, "release.yml.jobs.release-meta: pending release selector must use release_snapshot.py next-pending")
     snapshot_run = str(snapshot_step.get("run", ""))
     require(
         "release_snapshot.py export" in snapshot_run,
@@ -830,10 +879,12 @@ def validate_release(path: Path, contract: ContractModel) -> None:
         "release.yml.jobs.release-meta: snapshot notes-ref plumbing drifted",
     )
     candidate_step = step_config(release_meta, "Compute candidate suffix", "release.yml.jobs.release-meta")
-    require(
-        candidate_step.get("if") == "steps.snapshot.outputs.release_enabled == 'true'",
-        "release.yml.jobs.release-meta: candidate suffix gate drifted",
+    expected_candidate_if = (
+        "steps.pending-target.outputs.target_sha != '' && steps.snapshot.outputs.release_enabled == 'true'"
+        if pending_step is not None
+        else "steps.snapshot.outputs.release_enabled == 'true'"
     )
+    require(candidate_step.get("if") == expected_candidate_if, "release.yml.jobs.release-meta: candidate suffix gate drifted")
     candidate_run = str(candidate_step.get("run", ""))
     require("candidate_suffix=${TARGET_SHA:0:12}" in candidate_run, "release.yml.jobs.release-meta: candidate suffix drifted")
 
@@ -861,11 +912,29 @@ def validate_release(path: Path, contract: ContractModel) -> None:
 
     publish = named_job_config(workflow, "release-publish", expected_jobs, "release.yml")
     require(publish.get("needs") == ["release-meta", "docker-amd64", "docker-arm64"], "release.yml.jobs.release-publish.needs drifted")
+    publish_permissions = require_mapping(publish.get("permissions"), "release.yml.jobs.release-publish.permissions")
+    require(publish_permissions.get("contents") == "write", "release.yml.jobs.release-publish.permissions.contents must stay write")
     publish_checkout = checkout_step(publish, "Checkout code", "release.yml.jobs.release-publish")
     require(publish_checkout.get("ref") == "${{ needs.release-meta.outputs.target_sha }}", "release.yml.jobs.release-publish checkout ref drifted")
     tag_step = step_config(publish, "Create and push git tag", "release.yml.jobs.release-publish")
     tag_run = str(tag_step.get("run", ""))
     require('sha="${TARGET_SHA}"' in tag_run, "release.yml.jobs.release-publish tag step must use target_sha")
+    next_pending_step = maybe_step_config(publish, "Resolve next pending release target")
+    continue_queue_step = maybe_step_config(publish, "Continue release queue")
+    if next_pending_step is None:
+        require(continue_queue_step is None, "release.yml.jobs.release-publish: queue continuation requires a next-pending resolver")
+    else:
+        require(continue_queue_step is not None, "release.yml.jobs.release-publish: pending queue topology must continue the release queue")
+        require(
+            publish_permissions.get("actions") == "write",
+            "release.yml.jobs.release-publish.permissions.actions must stay write when continuing the queue",
+        )
+        next_pending_run = str(next_pending_step.get("run", ""))
+        require("release_snapshot.py next-pending" in next_pending_run, "release.yml.jobs.release-publish: next pending resolver must use release_snapshot.py next-pending")
+        require(
+            continue_queue_step.get("uses") == "actions/github-script@v7",
+            "release.yml.jobs.release-publish: continue queue step must use actions/github-script@v7",
+        )
 
 
 def validate_merge_group_helpers(module: Any) -> None:

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
@@ -1,0 +1,300 @@
+name: CI Main
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-main-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PLATFORM_AMD64: linux/amd64
+  PLATFORM_ARM64: linux/arm64
+  PLATFORMS: linux/amd64,linux/arm64
+  RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
+
+jobs:
+  lint:
+    name: Lint & Format Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.91.0
+          components: rustfmt
+
+      - name: Cache cargo directories
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cargo fmt check
+        run: cargo fmt --all -- --check
+
+      - name: Cargo check
+        run: cargo check --locked --all-targets --all-features
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install repo tooling
+        run: bun install --frozen-lockfile
+
+      - name: Install front-end dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Bun-first guard
+        run: bun run check:bun-first
+
+      - name: Check quality-gates scripts
+        run: |
+          python3 -m py_compile \
+            .github/scripts/metadata_gate.py \
+            .github/scripts/check_live_quality_gates.py \
+            .github/scripts/check_quality_gates_contract.py \
+            .github/scripts/release_snapshot.py \
+            .github/scripts/verify_manifest_platforms.py
+
+      - name: Resolve trusted quality-gates sources
+        id: trusted-quality-gates
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_root="$RUNNER_TEMP/trusted-quality-gates"
+          mkdir -p "$trusted_root/.github/scripts"
+          paths=(
+            ".github/quality-gates.json"
+            ".github/scripts/check_quality_gates_contract.py"
+            ".github/scripts/check_live_quality_gates.py"
+            ".github/scripts/metadata_gate.py"
+          )
+          source_ref="HEAD"
+          source_kind="current-branch"
+          for path in "${paths[@]}"; do
+            mkdir -p "$trusted_root/$(dirname "$path")"
+            cp "$path" "$trusted_root/$path"
+          done
+
+          {
+            echo "source_kind=$source_kind"
+            echo "source_ref=$source_ref"
+            echo "trusted_root=$trusted_root"
+            echo "declaration=$trusted_root/.github/quality-gates.json"
+            echo "contract_script=$trusted_root/.github/scripts/check_quality_gates_contract.py"
+            echo "live_script=$trusted_root/.github/scripts/check_live_quality_gates.py"
+            echo "metadata_script=$trusted_root/.github/scripts/metadata_gate.py"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Quality-gates contract check
+        run: |
+          python3 "${{ steps.trusted-quality-gates.outputs.contract_script }}" \
+            --repo-root "$PWD" \
+            --declaration "${{ steps.trusted-quality-gates.outputs.declaration }}" \
+            --metadata-script "${{ steps.trusted-quality-gates.outputs.metadata_script }}"
+
+      - name: Quality-gates live rules check
+        env:
+          QUALITY_GATES_LIVE_RULES_MODE: require
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 "${{ steps.trusted-quality-gates.outputs.live_script }}" \
+            --repo "${{ github.repository }}" \
+            --declaration "${{ steps.trusted-quality-gates.outputs.declaration }}"
+
+      - name: Quality gates self-tests
+        run: |
+          bash .github/scripts/test-quality-gates-contract.sh
+          bash .github/scripts/test-release-snapshot.sh
+          bash .github/scripts/test-live-quality-gates.sh
+
+      - name: Front-end lint
+        working-directory: web
+        run: bun run lint
+
+  frontend-tests:
+    name: Front-end Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install front-end dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Run front-end Vitest suite
+        working-directory: web
+        run: bun run test
+
+  records-overlay-e2e:
+    name: Records Overlay E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install front-end dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Start Vite dev server
+        working-directory: web
+        run: |
+          bun run dev -- --host 127.0.0.1 --port 60080 > /tmp/codex-vibe-monitor-vite.log 2>&1 &
+          echo $! > /tmp/codex-vibe-monitor-vite.pid
+
+      - name: Wait for Vite readiness
+        run: |
+          for _ in {1..60}; do
+            if curl -fsS http://127.0.0.1:60080/ >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Vite dev server failed to start within 60 seconds."
+          cat /tmp/codex-vibe-monitor-vite.log || true
+          exit 1
+
+      - name: Run records overlay Playwright regression
+        working-directory: web
+        run: bun run test:e2e -- records-filter-overlay.spec.ts
+
+      - name: Upload Playwright diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: records-overlay-playwright-report
+          path: |
+            web/playwright-report
+            web/test-results
+          if-no-files-found: ignore
+
+      - name: Stop Vite dev server
+        if: always()
+        run: |
+          if [ -f /tmp/codex-vibe-monitor-vite.pid ]; then
+            kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
+          fi
+
+  unit-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.91.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run cargo test
+        run: cargo test --locked --all-features
+
+  release-snapshot:
+    name: Release Snapshot
+    runs-on: ubuntu-latest
+    needs: [lint, frontend-tests, records-overlay-e2e, unit-tests]
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      pull-requests: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure immutable release snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${GITHUB_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --output "$RUNNER_TEMP/release-snapshot.json"
+
+      - name: Show release snapshot summary
+        env:
+          SNAPSHOT_PATH: ${{ runner.temp }}/release-snapshot.json
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["SNAPSHOT_PATH"]).read_text())
+          print("release_enabled=", payload["release_enabled"])
+          print("target_sha=", payload["target_sha"])
+          print("release_tag=", payload.get("release_tag", ""))
+          print("pr_number=", payload.get("pr_number", ""))
+          PY

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/label-gate.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/label-gate.yml
@@ -1,0 +1,52 @@
+name: Label Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, edited]
+
+concurrency:
+  group: label-gate-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  validate-pr-labels:
+    name: Validate PR labels
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 1
+          path: trusted
+          persist-credentials: false
+
+      - name: Checkout candidate pull request
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          path: candidate
+          persist-credentials: false
+
+      - name: Validate trusted label-gate contract
+        run: |
+          python3 trusted/.github/scripts/check_quality_gates_contract.py \
+            --repo-root "$PWD/candidate" \
+            --declaration "$PWD/candidate/.github/quality-gates.json" \
+            --metadata-script "$PWD/trusted/.github/scripts/metadata_gate.py"
+
+      - name: Evaluate PR labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 trusted/.github/scripts/metadata_gate.py label

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -1,0 +1,567 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows:
+      - CI Main
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA on main to release or backfill
+        required: true
+        type: string
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PLATFORM_AMD64: linux/amd64
+  PLATFORM_ARM64: linux/arm64
+  PLATFORMS: linux/amd64,linux/arm64
+  RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
+
+jobs:
+  release-meta:
+    name: Release Meta (snapshot + tags)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      target_sha: ${{ steps.pending-target.outputs.target_sha }}
+      release_enabled: ${{ steps.snapshot.outputs.release_enabled }}
+      release_bump: ${{ steps.snapshot.outputs.release_bump }}
+      release_channel: ${{ steps.snapshot.outputs.release_channel }}
+      pr_number: ${{ steps.snapshot.outputs.pr_number }}
+      pr_title: ${{ steps.snapshot.outputs.pr_title }}
+      image_name_lower: ${{ steps.snapshot.outputs.image_name_lower }}
+      app_effective_version: ${{ steps.snapshot.outputs.app_effective_version }}
+      release_tag: ${{ steps.snapshot.outputs.release_tag }}
+      release_prerelease: ${{ steps.snapshot.outputs.release_prerelease }}
+      tags_csv: ${{ steps.snapshot.outputs.tags_csv }}
+      candidate_suffix: ${{ steps.candidate.outputs.candidate_suffix }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve requested commit
+        id: requested-target
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            target_sha="${{ inputs.commit_sha }}"
+          else
+            target_sha="${{ github.event.workflow_run.head_sha }}"
+          fi
+
+          if [[ ! "${target_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid commit_sha: ${target_sha}" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          if ! git cat-file -e "${target_sha}^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "${target_sha}"
+          fi
+          git cat-file -e "${target_sha}^{commit}"
+
+          if ! git merge-base --is-ancestor "${target_sha}" origin/main; then
+            echo "Commit ${target_sha} is not contained in origin/main" >&2
+            exit 1
+          fi
+
+          echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate manual backfill target passed CI Main
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v7
+        env:
+          TARGET_SHA: ${{ steps.requested-target.outputs.target_sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const sha = process.env.TARGET_SHA
+            if (!sha) {
+              core.setFailed('Missing TARGET_SHA')
+              return
+            }
+
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: 'ci-main.yml',
+              branch: 'main',
+              event: 'push',
+              head_sha: sha,
+              status: 'completed',
+              per_page: 100,
+            })
+
+            const matchingRuns = (runs.data.workflow_runs || []).filter(run => run.head_sha === sha)
+            const passed = matchingRuns.some(run => run.conclusion === 'success')
+            if (!passed) {
+              for (const run of matchingRuns) {
+                if (run.conclusion !== 'failure') {
+                  continue
+                }
+
+                const jobs = await github.rest.actions.listJobsForWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                  per_page: 100,
+                })
+
+                const entries = jobs.data.jobs || []
+                const snapshotJob = entries.find(job => job.name === 'Release Snapshot')
+                const blockingJobs = entries.filter(
+                  job => job.name !== 'Release Snapshot' && job.conclusion !== 'success'
+                )
+
+                if (snapshotJob && snapshotJob.conclusion === 'failure' && blockingJobs.length === 0) {
+                  core.notice(`Accepted snapshot-only CI Main failure for ${sha} via run ${run.id}`)
+                  return
+                }
+              }
+
+              core.setFailed(`Manual backfill requires either a successful CI Main run or a snapshot-only CI Main failure for ${sha}`)
+              return
+            }
+
+            core.notice(`Verified successful CI Main history for ${sha}`)
+
+      - name: Ensure immutable release snapshot for manual backfill
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ steps.requested-target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${TARGET_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --target-only \
+            --output "$RUNNER_TEMP/release-snapshot.json"
+
+      - name: Select pending release target
+        id: pending-target
+        shell: bash
+        env:
+          REQUESTED_SHA: ${{ steps.requested-target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "target_sha=${REQUESTED_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags origin main
+          git fetch --tags origin
+          git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}" || true
+          python3 .github/scripts/release_snapshot.py next-pending \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --main-ref "origin/main" \
+            --upper-bound "${REQUESTED_SHA}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Load immutable release snapshot
+        if: steps.pending-target.outputs.target_sha != ''
+        id: snapshot
+        shell: bash
+        env:
+          TARGET_SHA: ${{ steps.pending-target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}"
+          fi
+          python3 .github/scripts/release_snapshot.py export \
+            --target-sha "${TARGET_SHA}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --main-ref "origin/main" \
+            --resolve-publication-tags \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Compute candidate suffix
+        if: steps.pending-target.outputs.target_sha != '' && steps.snapshot.outputs.release_enabled == 'true'
+        id: candidate
+        shell: bash
+        env:
+          TARGET_SHA: ${{ steps.pending-target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          echo "candidate_suffix=${TARGET_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate platforms for smoke gate
+        if: steps.pending-target.outputs.target_sha != '' && steps.snapshot.outputs.release_enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          required_platforms=("${PLATFORM_AMD64}" "${PLATFORM_ARM64}")
+          normalized=",${PLATFORMS// /},"
+          for platform in "${required_platforms[@]}"; do
+            if [[ "${normalized}" != *",${platform},"* ]]; then
+              echo "Missing required platform in PLATFORMS=${PLATFORMS}: ${platform}" >&2
+              exit 1
+            fi
+          done
+
+  docker-amd64:
+    name: Build + Smoke + Push Candidate (linux/amd64)
+    runs-on: ubuntu-latest
+    needs: [release-meta]
+    if: needs.release-meta.outputs.release_enabled == 'true'
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build smoke image (linux/amd64, load)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORM_AMD64 }}
+          push: false
+          load: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
+            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
+          build-args: |
+            APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64,mode=max
+
+      - name: Smoke test image (linux/amd64)
+        shell: bash
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-amd64-${{ needs.release-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: ${{ env.PLATFORM_AMD64 }}
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/amd64)
+        shell: bash
+        env:
+          IMAGE_NAME_LOWER: ${{ needs.release-meta.outputs.image_name_lower }}
+        run: |
+          set -euo pipefail
+          image="${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}"
+          suffix="${{ needs.release-meta.outputs.candidate_suffix }}"
+          candidate_amd64="${image}:candidate-${suffix}-amd64"
+          echo "[push] ${candidate_amd64}"
+          docker push "${candidate_amd64}"
+
+  docker-arm64:
+    name: Build + Smoke + Push Candidate (linux/arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: [release-meta]
+    if: needs.release-meta.outputs.release_enabled == 'true'
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build smoke image (linux/arm64, load)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORM_ARM64 }}
+          push: false
+          load: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          build-args: |
+            APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64,mode=max
+
+      - name: Smoke test image (linux/arm64)
+        shell: bash
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ needs.release-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: ${{ env.PLATFORM_ARM64 }}
+          SMOKE_TIMEOUT_SECS: "120"
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/arm64)
+        shell: bash
+        env:
+          IMAGE_NAME_LOWER: ${{ needs.release-meta.outputs.image_name_lower }}
+        run: |
+          set -euo pipefail
+          image="${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}"
+          suffix="${{ needs.release-meta.outputs.candidate_suffix }}"
+          candidate_arm64="${image}:candidate-${suffix}-arm64"
+          echo "[push] ${candidate_arm64}"
+          docker push "${candidate_arm64}"
+
+  release-publish:
+    name: Release Publish (manifest + tag + GitHub Release)
+    runs-on: ubuntu-latest
+    needs: [release-meta, docker-amd64, docker-arm64]
+    if: needs.release-meta.outputs.release_enabled == 'true'
+    permissions:
+      actions: write
+      contents: write
+      packages: write
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-meta.outputs.target_sha }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release manifest tags from smoke-verified images
+        shell: bash
+        env:
+          TAGS_CSV: ${{ needs.release-meta.outputs.tags_csv }}
+          IMAGE_NAME_LOWER: ${{ needs.release-meta.outputs.image_name_lower }}
+        run: |
+          set -euo pipefail
+          image="${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}"
+          suffix="${{ needs.release-meta.outputs.candidate_suffix }}"
+          candidate_amd64="${image}:candidate-${suffix}-amd64"
+          candidate_arm64="${image}:candidate-${suffix}-arm64"
+
+          IFS=',' read -r -a tags <<< "${TAGS_CSV}"
+          for tag in "${tags[@]}"; do
+            [[ -z "${tag}" ]] && continue
+            echo "[manifest] ${tag} <= ${candidate_amd64}, ${candidate_arm64}"
+            for attempt in 1 2 3 4 5; do
+              if docker buildx imagetools create --tag "${tag}" "${candidate_amd64}" "${candidate_arm64}" 2>"/tmp/imagetools-create-${attempt}.err"; then
+                break
+              fi
+              if [[ "${attempt}" == "5" ]]; then
+                echo "[manifest] failed after ${attempt} attempts for ${tag}" >&2
+                if [[ -s "/tmp/imagetools-create-${attempt}.err" ]]; then
+                  cat "/tmp/imagetools-create-${attempt}.err" >&2
+                fi
+                exit 1
+              fi
+              sleep_secs=$((attempt * 3))
+              echo "[manifest] retry in ${sleep_secs}s (${attempt}/5): ${tag}" >&2
+              sleep "${sleep_secs}"
+            done
+          done
+
+      - name: Verify pushed manifest platforms
+        shell: bash
+        env:
+          TAGS_CSV: ${{ needs.release-meta.outputs.tags_csv }}
+          REQUIRED_PLATFORMS: ${{ env.PLATFORMS }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -r -a tags <<< "${TAGS_CSV}"
+          for tag in "${tags[@]}"; do
+            [[ -z "${tag}" ]] && continue
+            echo "[verify] ${tag}"
+            for attempt in 1 2 3 4 5; do
+              if raw_json="$(docker buildx imagetools inspect "${tag}" --raw 2>"/tmp/imagetools-${attempt}.err")"; then
+                if RAW_JSON="${raw_json}" python3 ./.github/scripts/verify_manifest_platforms.py "${tag}"; then
+                  break
+                fi
+              fi
+
+              if [[ "${attempt}" == "5" ]]; then
+                echo "[verify] failed after ${attempt} attempts for ${tag}" >&2
+                if [[ -s "/tmp/imagetools-${attempt}.err" ]]; then
+                  cat "/tmp/imagetools-${attempt}.err" >&2
+                fi
+                exit 1
+              fi
+
+              sleep_secs=$((attempt * 3))
+              echo "[verify] retry in ${sleep_secs}s (${attempt}/5): ${tag}" >&2
+              sleep "${sleep_secs}"
+            done
+          done
+
+      - name: Create and push git tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          tag="${RELEASE_TAG}"
+          sha="${TARGET_SHA}"
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            existing="$(git rev-list -n 1 "${tag}")"
+            if [[ "${existing}" != "${sha}" ]]; then
+              echo "Tag ${tag} already exists but points to ${existing} (expected ${sha})" >&2
+              exit 1
+            fi
+            echo "Tag ${tag} already exists and points to ${sha}."
+          else
+            git tag -a "${tag}" "${sha}" -m "release ${APP_EFFECTIVE_VERSION}"
+          fi
+
+          git push origin "${tag}"
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        env:
+          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
+          RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
+          RELEASE_PRERELEASE: ${{ needs.release-meta.outputs.release_prerelease }}
+          RELEASE_PR_NUMBER: ${{ needs.release-meta.outputs.pr_number }}
+          RELEASE_PR_TITLE: ${{ needs.release-meta.outputs.pr_title }}
+          RELEASE_BUMP: ${{ needs.release-meta.outputs.release_bump }}
+          RELEASE_CHANNEL: ${{ needs.release-meta.outputs.release_channel }}
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const tag = process.env.RELEASE_TAG
+            const prerelease = process.env.RELEASE_PRERELEASE === 'true'
+            const prNumber = process.env.RELEASE_PR_NUMBER
+            const prTitle = process.env.RELEASE_PR_TITLE
+            const bump = process.env.RELEASE_BUMP
+            const channel = process.env.RELEASE_CHANNEL
+            const targetSha = process.env.TARGET_SHA
+
+            if (!tag) {
+              core.setFailed('Missing RELEASE_TAG')
+              return
+            }
+
+            let existing = null
+            try {
+              existing = await github.rest.repos.getReleaseByTag({ owner, repo, tag })
+            } catch (err) {
+              if (err.status !== 404) throw err
+            }
+
+            if (existing) {
+              core.notice(`GitHub Release already exists for tag ${tag}, skipping.`)
+              return
+            }
+
+            const bodyLines = [
+              prNumber ? `PR: #${prNumber} ${prTitle || ''}`.trim() : 'PR: (unknown)',
+              `Channel: ${channel || '(unknown)'}`,
+              `Bump: ${bump || '(unknown)'}`,
+              `Commit: ${targetSha || '(unknown)'}`,
+            ]
+
+            await github.rest.repos.createRelease({
+              owner,
+              repo,
+              tag_name: tag,
+              name: tag,
+              prerelease,
+              body: bodyLines.join('\n'),
+            })
+
+            core.notice(`Created GitHub Release for tag ${tag}`)
+
+      - name: Resolve next pending release target
+        if: github.event_name != 'workflow_dispatch'
+        id: next-pending
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git fetch --tags origin
+          git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}" || true
+          python3 .github/scripts/release_snapshot.py next-pending \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --main-ref "origin/main" \
+            --upper-bound "$(git rev-parse origin/main)" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Continue release queue
+        if: github.event_name != 'workflow_dispatch' && steps.next-pending.outputs.target_sha != ''
+        uses: actions/github-script@v7
+        env:
+          NEXT_TARGET_SHA: ${{ steps.next-pending.outputs.target_sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const nextSha = process.env.NEXT_TARGET_SHA
+            if (!nextSha) {
+              core.notice('Release queue is empty.')
+              return
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'release.yml',
+              ref: 'main',
+              inputs: { commit_sha: nextSha },
+            })
+            core.notice(`Queued next release target ${nextSha}`)

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -47,6 +47,14 @@ python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root
 bash "$repo_root/.github/scripts/test-inline-metadata-workflows.sh"
 probe_release_intent_rollout "$baseline_repo"
 
+simplified_topology_repo="$tmp_dir/simplified-topology-repo"
+cp -R "$baseline_repo/." "$simplified_topology_repo"
+for workflow in ci-main.yml release.yml label-gate.yml; do
+  git -C "$repo_root" show th/simplify-serial-release:.github/workflows/$workflow > "$simplified_topology_repo/.github/workflows/$workflow"
+done
+
+python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$simplified_topology_repo" --profile final
+
 rollout_probe_repo="$tmp_dir/rollout-probe-repo"
 cp -R "$baseline_repo/." "$rollout_probe_repo"
 python3 - <<'PY' "$rollout_probe_repo"

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -50,7 +50,7 @@ probe_release_intent_rollout "$baseline_repo"
 simplified_topology_repo="$tmp_dir/simplified-topology-repo"
 cp -R "$baseline_repo/." "$simplified_topology_repo"
 for workflow in ci-main.yml release.yml label-gate.yml; do
-  git -C "$repo_root" show th/simplify-serial-release:.github/workflows/$workflow > "$simplified_topology_repo/.github/workflows/$workflow"
+  cp "$fixtures_root/simplified/$workflow" "$simplified_topology_repo/.github/workflows/$workflow"
 done
 
 python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$simplified_topology_repo" --profile final


### PR DESCRIPTION
## What changed
- update the trusted quality-gates contract checker to accept both the current rollout topology and the new simplified serial-release topology
- add a regression that rewrites the baseline workflow fixtures into the simplified topology and verifies the contract checker accepts it

## Why
The simplified serial-release PR is currently blocked by the trusted checker on `main`, not by the release logic itself. This bootstrap PR upgrades the trusted gate first so the follow-up topology PR can pass without reintroducing the old artifact-based runtime path.

## Validation
- `python3 -m py_compile .github/scripts/check_quality_gates_contract.py`
- `bash .github/scripts/test-quality-gates-contract.sh`
