### PR TITLE
fix(ci): narrow release snapshot catch-up

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -502,6 +502,21 @@ def first_parent_commits(target_sha: str) -> list[str]:
     return [commit for commit in commits.splitlines() if commit]
 
 
+def commits_to_materialize(notes_ref: str, target_sha: str, *, target_only: bool) -> list[str]:
+    if target_only:
+        return [target_sha]
+
+    commits = first_parent_commits(target_sha)
+    latest_existing_index = -1
+    for index, commit in enumerate(commits):
+        if read_snapshot(notes_ref, commit) is not None:
+            latest_existing_index = index
+
+    if latest_existing_index < 0:
+        return [target_sha]
+    return commits[latest_existing_index + 1 :]
+
+
 def export_key_values(values: dict[str, Any], github_output: str) -> None:
     lines = []
     for key, value in values.items():
@@ -564,7 +579,6 @@ def export_snapshot(snapshot: dict[str, Any], github_output: str) -> None:
 def ensure_snapshot(args: argparse.Namespace) -> int:
     target_sha = normalize_sha(args.target_sha)
     output_path = Path(args.output)
-    commits_to_materialize = [target_sha] if args.target_only else first_parent_commits(target_sha)
 
     for attempt in range(1, args.max_attempts + 1):
         fetch_notes_ref(args.notes_ref)
@@ -573,10 +587,11 @@ def ensure_snapshot(args: argparse.Namespace) -> int:
             write_json(output_path, existing)
             return 0
 
+        commits_to_fill = commits_to_materialize(args.notes_ref, target_sha, target_only=args.target_only)
         target_snapshot: dict[str, Any] | None = None
         with tempfile.TemporaryDirectory(prefix="release-snapshot-notes-") as tmp:
             temp_note = Path(tmp) / "snapshot.json"
-            for commit in commits_to_materialize:
+            for commit in commits_to_fill:
                 snapshot = read_snapshot(args.notes_ref, commit)
                 if snapshot is not None:
                     if commit == target_sha:

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -270,5 +270,147 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-target-only-") as tmp:
         module.git = original_git
         os.chdir(original_cwd)
 
+
+with tempfile.TemporaryDirectory(prefix="release-snapshot-catch-up-") as tmp:
+    repo = Path(tmp)
+    run("init", cwd=repo)
+    run("config", "user.name", "Test User", cwd=repo)
+    run("config", "user.email", "test@example.com", cwd=repo)
+    run("checkout", "-b", "main", cwd=repo)
+    (repo / "Cargo.toml").write_text('[package]\nname = "demo"\nversion = "0.1.0"\n')
+    (repo / "README.md").write_text("base\n")
+    run("add", "Cargo.toml", "README.md", cwd=repo)
+    run("commit", "-m", "base", cwd=repo)
+    run("tag", "v0.1.0", cwd=repo)
+
+    (repo / "README.md").write_text("legacy unlabeled\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "legacy unlabeled", cwd=repo)
+    legacy_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    (repo / "README.md").write_text("existing snapshot\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "existing snapshot", cwd=repo)
+    snap_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    (repo / "README.md").write_text("mid pending\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "mid pending", cwd=repo)
+    mid_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    (repo / "README.md").write_text("target pending\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "target pending", cwd=repo)
+    target_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    existing_snapshot = {
+        "schema_version": module.SNAPSHOT_SCHEMA_VERSION,
+        "target_sha": snap_sha,
+        "pr_number": 301,
+        "pr_title": "Existing snapshot",
+        "registry": "ghcr.io",
+        "pr_head_sha": snap_sha,
+        "type_label": "type:patch",
+        "channel_label": "channel:stable",
+        "release_bump": "patch",
+        "release_channel": "stable",
+        "release_enabled": True,
+        "release_prerelease": False,
+        "image_name_lower": "ivanli-cn/codex-vibe-monitor",
+        "base_stable_version": "0.1.0",
+        "next_stable_version": "0.1.1",
+        "app_effective_version": "0.1.1",
+        "release_tag": "v0.1.1",
+        "tags_csv": "ghcr.io/ivanli-cn/codex-vibe-monitor:v0.1.1,ghcr.io/ivanli-cn/codex-vibe-monitor:latest",
+        "notes_ref": module.DEFAULT_NOTES_REF,
+        "snapshot_source": "ci-main",
+        "created_at": "2026-03-15T00:00:00Z",
+    }
+    run("notes", f"--ref={module.DEFAULT_NOTES_REF}", "add", "-f", "-m", json.dumps(existing_snapshot), snap_sha, cwd=repo)
+
+    original_cwd = Path.cwd()
+    original_load_pr = module.load_pr_for_commit
+    original_build_snapshot = module.build_snapshot
+    original_git = module.git
+    calls: list[str] = []
+
+    def fake_build_snapshot(*, target_sha: str, **kwargs: object):
+        calls.append(target_sha)
+        version_map = {
+            mid_sha: ("0.1.1", "0.1.2", "v0.1.2"),
+            target_sha: ("0.1.2", "0.1.3", "v0.1.3"),
+        }
+        if target_sha not in version_map:
+            raise AssertionError(f"unexpected snapshot build for {target_sha}")
+        base_version, next_version, release_tag = version_map[target_sha]
+        return {
+            "schema_version": module.SNAPSHOT_SCHEMA_VERSION,
+            "target_sha": target_sha,
+            "pr_number": 302 if target_sha == mid_sha else 303,
+            "pr_title": "Pending snapshot",
+            "registry": "ghcr.io",
+            "pr_head_sha": target_sha,
+            "type_label": "type:patch",
+            "channel_label": "channel:stable",
+            "release_bump": "patch",
+            "release_channel": "stable",
+            "release_enabled": True,
+            "release_prerelease": False,
+            "image_name_lower": "ivanli-cn/codex-vibe-monitor",
+            "base_stable_version": base_version,
+            "next_stable_version": next_version,
+            "app_effective_version": next_version,
+            "release_tag": release_tag,
+            "tags_csv": f"ghcr.io/ivanli-cn/codex-vibe-monitor:{release_tag},ghcr.io/ivanli-cn/codex-vibe-monitor:latest",
+            "notes_ref": module.DEFAULT_NOTES_REF,
+            "snapshot_source": "ci-main",
+            "created_at": "2026-03-15T00:00:00Z",
+        }
+
+    os.chdir(repo)
+    try:
+        def fake_git(*args: str, **kwargs: object):
+            if args == ("push", "origin", module.DEFAULT_NOTES_REF):
+                return subprocess.CompletedProcess(["git", *args], 0, "", "")
+            return original_git(*args, **kwargs)
+
+        def fake_load_pr(api_root, repository, token, commit_sha, **kwargs):
+            if commit_sha == legacy_sha:
+                raise AssertionError("catch-up must not walk older unlabeled history once a snapshot ancestor exists")
+            return {
+                mid_sha: make_pr(302, "Mid pending", mid_sha, ["type:patch", "channel:stable"]),
+                target_sha: make_pr(303, "Target pending", target_sha, ["type:patch", "channel:stable"]),
+            }.get(commit_sha)
+
+        module.load_pr_for_commit = fake_load_pr
+        module.build_snapshot = fake_build_snapshot
+        module.git = fake_git
+        exit_code = module.ensure_snapshot(
+            argparse.Namespace(
+                target_sha=target_sha,
+                github_repository="IvanLi-CN/codex-vibe-monitor",
+                github_token="token",
+                notes_ref=module.DEFAULT_NOTES_REF,
+                registry="ghcr.io",
+                api_root="https://api.github.com",
+                output=str(repo / "catch-up.json"),
+                max_attempts=1,
+                target_only=False,
+            )
+        )
+        assert exit_code == 0
+        assert calls == [mid_sha, target_sha]
+        assert module.read_snapshot(module.DEFAULT_NOTES_REF, legacy_sha) is None
+        assert module.read_snapshot(module.DEFAULT_NOTES_REF, snap_sha) is not None
+        assert module.read_snapshot(module.DEFAULT_NOTES_REF, mid_sha) is not None
+        stored = module.read_snapshot(module.DEFAULT_NOTES_REF, target_sha)
+        assert stored is not None
+        assert stored["release_tag"] == "v0.1.3"
+    finally:
+        module.load_pr_for_commit = original_load_pr
+        module.build_snapshot = original_build_snapshot
+        module.git = original_git
+        os.chdir(original_cwd)
+
 print("test-release-snapshot: all checks passed")
 PY


### PR DESCRIPTION
## What changed
- start automatic catch-up from the newest commit that already has an immutable snapshot note instead of replaying the entire `main` first-parent history
- keep manual `workflow_dispatch(commit_sha)` target-only behavior unchanged
- add a regression that proves older unlabeled history no longer blocks newer snapshot backfill

## Why
The simplified serial pipeline on `main` was still failing because `CI Main` tried to rebuild snapshot notes for ancient pre-policy commits that do not have release labels. This narrows catch-up to the missing window after the latest existing snapshot so pending-run replacement still recovers missing releases without dragging old unlabeled history back into the automatic path.

## Validation
- `python3 -m py_compile .github/scripts/release_snapshot.py`
- `bash .github/scripts/test-release-snapshot.sh`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-inline-metadata-workflows.sh`
- `bash .github/scripts/test-live-quality-gates.sh`
