### PR TITLE
fix(ci): restore release snapshot catch-up window

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -502,10 +502,44 @@ def first_parent_commits(target_sha: str) -> list[str]:
     return [commit for commit in commits.splitlines() if commit]
 
 
+def tagged_release_commits(target_sha: str) -> set[str]:
+    commits: set[str] = set()
+    for tag in git_output("tag", "--merged", target_sha, "-l", "v*").splitlines():
+        tag_name = tag.strip()
+        if not tag_name:
+            continue
+        commit = git_output("rev-list", "-n", "1", tag_name).strip()
+        if commit:
+            commits.add(commit)
+    return commits
+
+
 def commits_to_materialize(notes_ref: str, target_sha: str, *, target_only: bool) -> list[str]:
     if target_only:
         return [target_sha]
-    return first_parent_commits(target_sha)
+
+    commits = first_parent_commits(target_sha)
+    tagged_commits = tagged_release_commits(target_sha)
+    anchor_index = -1
+    for index, commit in enumerate(commits):
+        if commit in tagged_commits:
+            anchor_index = index
+
+    earliest_snapshot_after_anchor = -1
+    for index in range(anchor_index + 1, len(commits)):
+        if read_snapshot(notes_ref, commits[index]) is not None:
+            earliest_snapshot_after_anchor = index
+            break
+
+    if earliest_snapshot_after_anchor >= 0:
+        return commits[earliest_snapshot_after_anchor + 1 :]
+    if anchor_index >= 0:
+        return commits[anchor_index + 1 :]
+
+    for index, commit in enumerate(commits):
+        if read_snapshot(notes_ref, commit) is not None:
+            return commits[index + 1 :]
+    return [target_sha]
 
 
 def export_key_values(values: dict[str, Any], github_output: str) -> None:

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -636,5 +636,142 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-sparse-history-") as t
         module.git = original_git
         os.chdir(original_cwd)
 
+
+with tempfile.TemporaryDirectory(prefix="release-snapshot-catch-up-window-") as tmp:
+    repo = Path(tmp)
+    run("init", cwd=repo)
+    run("config", "user.name", "Test User", cwd=repo)
+    run("config", "user.email", "test@example.com", cwd=repo)
+    run("checkout", "-b", "main", cwd=repo)
+    (repo / "Cargo.toml").write_text('[package]\nname = "demo"\nversion = "0.1.0"\n')
+    (repo / "README.md").write_text("base\n")
+    run("add", "Cargo.toml", "README.md", cwd=repo)
+    run("commit", "-m", "base", cwd=repo)
+    run("tag", "v0.1.0", cwd=repo)
+
+    (repo / "README.md").write_text("legacy unlabeled\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "legacy unlabeled", cwd=repo)
+    legacy_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    (repo / "README.md").write_text("existing snapshot\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "existing snapshot", cwd=repo)
+    existing_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    (repo / "README.md").write_text("mid pending\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "mid pending", cwd=repo)
+    mid_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    (repo / "README.md").write_text("target pending\n")
+    run("add", "README.md", cwd=repo)
+    run("commit", "-m", "target pending", cwd=repo)
+    target_sha = run("rev-parse", "HEAD", cwd=repo)
+
+    existing_snapshot = {
+        "schema_version": module.SNAPSHOT_SCHEMA_VERSION,
+        "target_sha": existing_sha,
+        "pr_number": 601,
+        "pr_title": "Existing snapshot",
+        "registry": "ghcr.io",
+        "pr_head_sha": existing_sha,
+        "type_label": "type:patch",
+        "channel_label": "channel:stable",
+        "release_bump": "patch",
+        "release_channel": "stable",
+        "release_enabled": True,
+        "release_prerelease": False,
+        "image_name_lower": "ivanli-cn/codex-vibe-monitor",
+        "base_stable_version": "0.1.0",
+        "next_stable_version": "0.1.1",
+        "app_effective_version": "0.1.1",
+        "release_tag": "v0.1.1",
+        "tags_csv": "ghcr.io/ivanli-cn/codex-vibe-monitor:v0.1.1,ghcr.io/ivanli-cn/codex-vibe-monitor:latest",
+        "notes_ref": module.DEFAULT_NOTES_REF,
+        "snapshot_source": "ci-main",
+        "created_at": "2026-03-15T00:00:00Z",
+    }
+    run("notes", f"--ref={module.DEFAULT_NOTES_REF}", "add", "-f", "-m", json.dumps(existing_snapshot), existing_sha, cwd=repo)
+
+    original_cwd = Path.cwd()
+    original_load_pr = module.load_pr_for_commit
+    original_build_snapshot = module.build_snapshot
+    original_git = module.git
+    calls: list[str] = []
+
+    def fake_build_snapshot(*, target_sha: str, **kwargs: object):
+        calls.append(target_sha)
+        version_map = {
+            mid_sha: ("0.1.1", "0.1.2", "v0.1.2"),
+            target_sha: ("0.1.2", "0.1.3", "v0.1.3"),
+        }
+        if target_sha not in version_map:
+            raise AssertionError(f"unexpected snapshot build for {target_sha}")
+        base_version, next_version, release_tag = version_map[target_sha]
+        return {
+            "schema_version": module.SNAPSHOT_SCHEMA_VERSION,
+            "target_sha": target_sha,
+            "pr_number": 602 if target_sha == mid_sha else 603,
+            "pr_title": "Pending snapshot",
+            "registry": "ghcr.io",
+            "pr_head_sha": target_sha,
+            "type_label": "type:patch",
+            "channel_label": "channel:stable",
+            "release_bump": "patch",
+            "release_channel": "stable",
+            "release_enabled": True,
+            "release_prerelease": False,
+            "image_name_lower": "ivanli-cn/codex-vibe-monitor",
+            "base_stable_version": base_version,
+            "next_stable_version": next_version,
+            "app_effective_version": next_version,
+            "release_tag": release_tag,
+            "tags_csv": f"ghcr.io/ivanli-cn/codex-vibe-monitor:{release_tag},ghcr.io/ivanli-cn/codex-vibe-monitor:latest",
+            "notes_ref": module.DEFAULT_NOTES_REF,
+            "snapshot_source": "ci-main",
+            "created_at": "2026-03-15T00:00:00Z",
+        }
+
+    os.chdir(repo)
+    try:
+        def fake_git(*args: str, **kwargs: object):
+            if args == ("push", "origin", module.DEFAULT_NOTES_REF):
+                return subprocess.CompletedProcess(["git", *args], 0, "", "")
+            return original_git(*args, **kwargs)
+
+        def fake_load_pr(api_root, repository, token, commit_sha, **kwargs):
+            if commit_sha == legacy_sha:
+                raise AssertionError("catch-up must not walk older unlabeled history once a snapshot ancestor exists")
+            return {
+                mid_sha: make_pr(602, "Mid pending", mid_sha, ["type:patch", "channel:stable"]),
+                target_sha: make_pr(603, "Target pending", target_sha, ["type:patch", "channel:stable"]),
+            }.get(commit_sha)
+
+        module.load_pr_for_commit = fake_load_pr
+        module.build_snapshot = fake_build_snapshot
+        module.git = fake_git
+        exit_code = module.ensure_snapshot(
+            argparse.Namespace(
+                target_sha=target_sha,
+                github_repository="IvanLi-CN/codex-vibe-monitor",
+                github_token="token",
+                notes_ref=module.DEFAULT_NOTES_REF,
+                registry="ghcr.io",
+                api_root="https://api.github.com",
+                output=str(repo / "catch-up-window.json"),
+                max_attempts=1,
+                target_only=False,
+            )
+        )
+        assert exit_code == 0
+        assert calls == [mid_sha, target_sha]
+        assert module.read_snapshot(module.DEFAULT_NOTES_REF, legacy_sha) is None
+    finally:
+        module.load_pr_for_commit = original_load_pr
+        module.build_snapshot = original_build_snapshot
+        module.git = original_git
+        os.chdir(original_cwd)
+
 print("test-release-snapshot: all checks passed")
 PY


### PR DESCRIPTION
## What
- restore the release snapshot catch-up window so `CI Main` only materializes commits after the latest safe anchor instead of replaying the entire first-parent history
- use existing release tags and immutable snapshot notes as anchors before deciding which `main` commits still need snapshots
- add a regression that proves older unlabeled history no longer breaks newer release snapshot backfill

## Why
Recent merges for PR #155 and PR #154 both failed in `CI Main` at `Release Snapshot` with `Expected exactly 1 type:* label, got 0: (none)`. The root cause was a regression that reverted the narrowed catch-up window and made snapshot generation walk back into older unlabeled commits on `main`.

## Validation
- `python3 -m py_compile .github/scripts/release_snapshot.py`
- `bash .github/scripts/test-release-snapshot.sh`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-inline-metadata-workflows.sh`
- `bash .github/scripts/test-live-quality-gates.sh`

## Rollout
1. Merge this PR.
2. Re-run `CI Main` for commit `622ce0e3b3518475f34eaee567aabab12c4691a8` (PR #155).
3. Re-run `CI Main` for commit `20a644ee5d6ab86ac66eab77d9d910f385604be7` (PR #154).
4. Confirm `Release` publishes the queued stable versions in order.