### PR TITLE
fix(ci): allow release PR comments

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -797,6 +797,7 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     require(publish_permissions.get("contents") == "write", "release.yml.jobs.release-publish.permissions.contents must stay write")
     require(publish_permissions.get("issues") == "write", "release.yml.jobs.release-publish.permissions.issues must stay write")
     require(publish_permissions.get("packages") == "write", "release.yml.jobs.release-publish.permissions.packages must stay write")
+    require(publish_permissions.get("pull-requests") == "write", "release.yml.jobs.release-publish.permissions.pull-requests must stay write")
     publish_checkout = checkout_step(publish, "Checkout code", "release.yml.jobs.release-publish")
     require(publish_checkout.get("ref") == "${{ needs.release-meta.outputs.target_sha }}", "release.yml.jobs.release-publish checkout ref drifted")
     tag_step = step_config(publish, "Create and push git tag", "release.yml.jobs.release-publish")

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -611,7 +611,11 @@ jobs:
               })
               core.notice(`Created PR #${issueNumber} release version comment for ${releaseTag}`)
             } catch (error) {
-              core.warning(`Failed to upsert PR release version comment: ${error.message}`)
+              const acceptedPermissions = error.response?.headers?.['x-accepted-github-permissions'] || '(not provided)'
+              const status = error.status || error.response?.status || '(unknown)'
+              core.warning(
+                `Failed to upsert PR release version comment: ${error.message} (status=${status}, accepted_permissions=${acceptedPermissions})`
+              )
             }
 
       - name: Resolve next pending release target

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -363,6 +363,7 @@ jobs:
       contents: write
       issues: write
       packages: write
+      pull-requests: write
     timeout-minutes: 45
     steps:
       - name: Checkout code

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -611,7 +611,11 @@ jobs:
               })
               core.notice(`Created PR #${issueNumber} release version comment for ${releaseTag}`)
             } catch (error) {
-              core.warning(`Failed to upsert PR release version comment: ${error.message}`)
+              const acceptedPermissions = error.response?.headers?.['x-accepted-github-permissions'] || '(not provided)'
+              const status = error.status || error.response?.status || '(unknown)'
+              core.warning(
+                `Failed to upsert PR release version comment: ${error.message} (status=${status}, accepted_permissions=${acceptedPermissions})`
+              )
             }
 
       - name: Resolve next pending release target

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -363,6 +363,7 @@ jobs:
       contents: write
       issues: write
       packages: write
+      pull-requests: write
     timeout-minutes: 45
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -611,7 +611,11 @@ jobs:
               })
               core.notice(`Created PR #${issueNumber} release version comment for ${releaseTag}`)
             } catch (error) {
-              core.warning(`Failed to upsert PR release version comment: ${error.message}`)
+              const acceptedPermissions = error.response?.headers?.['x-accepted-github-permissions'] || '(not provided)'
+              const status = error.status || error.response?.status || '(unknown)'
+              core.warning(
+                `Failed to upsert PR release version comment: ${error.message} (status=${status}, accepted_permissions=${acceptedPermissions})`
+              )
             }
 
       - name: Resolve next pending release target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,7 @@ jobs:
       contents: write
       issues: write
       packages: write
+      pull-requests: write
     timeout-minutes: 45
     steps:
       - name: Checkout code

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,6 +7,7 @@
 ## Index
 
 | ID    | Title                                                                         | Status          | Spec                                                     | Last       | Notes                                                                                          |
+| q1m9k | Release PR 评论权限补齐 | 进行中 | `q1m9k-release-pr-comment-permission/SPEC.md` | 2026-03-17 | fast-track / release workflow / pull-requests write / comment permission fix |
 | sq8gw | Release 工作流 PR 版本评论                                               | 进行中         | `sq8gw-release-pr-version-comment/SPEC.md`           | 2026-03-17 | fast-track / release publish / PR version comment upsert / review convergence |
 | 3n287 | OAuth 临时邮箱自动化与验证码/邀请态集成                                   | 进行中         | `3n287-oauth-temp-mail-automation/SPEC.md`           | 2026-03-16 | fast-track / MoeMail mailbox sessions / oauth mailbox gating / parsing pending |
 | f6f6e | GH Actions 防取消发布链路全面对齐                                              | 部分完成（3/4） | `f6f6e-gh-actions-release-anti-cancel/SPEC.md`           | 2026-03-15 | strict anti-cancel / global serial CI Main+Release / current PR labels / contract refresh |

--- a/docs/specs/q1m9k-release-pr-comment-permission/SPEC.md
+++ b/docs/specs/q1m9k-release-pr-comment-permission/SPEC.md
@@ -1,0 +1,69 @@
+# Release PR 评论权限补齐（#q1m9k）
+
+## 状态
+
+- Status: 进行中
+- Created: 2026-03-17
+- Last: 2026-03-17
+
+## 背景 / 问题陈述
+
+- `Release` workflow 已经执行到 `Upsert PR release version comment`，但线上真实 run 对 `PR #161` 返回 `Resource not accessible by integration`。
+- 同一个 job 内 tag、GitHub Release 与镜像发布均成功，说明故障集中在 PR 评论所需的权限声明。
+
+## 目标 / 非目标
+
+### Goals
+
+- 补齐 release 评论步骤的 GitHub token 权限，使已完成的 release 能把版本评论写回对应 PR。
+- 用 contract / fixture 锁定新增权限，避免后续漂移。
+
+### Non-goals
+
+- 不改变 release 版本计算、tag / GitHub Release 创建或 release queue 串行逻辑。
+- 不把 PR 评论失败升级为发布失败。
+
+## 范围（Scope）
+
+### In scope
+
+- 更新 `.github/workflows/release.yml` 的 `release-publish.permissions`。
+- 更新 quality-gates contract 与 fixtures。
+
+### Out of scope
+
+- 重新设计评论正文。
+- 修改 branch protection 或仓库级 Actions policy。
+
+## 需求（Requirements）
+
+### MUST
+
+- `release-publish` 必须显式声明足够的 PR 评论权限。
+- contract checker 必须校验新增权限。
+- 本地 contract/self-test 必须通过。
+
+## 验收标准（Acceptance Criteria）
+
+- Given 一个 `type:{patch|minor|major}` 的 release
+  When `Release Publish` 执行 PR 评论步骤
+  Then workflow 不再因权限不足返回 `Resource not accessible by integration`。
+- Given 运行 `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final` 与 `bash .github/scripts/test-quality-gates-contract.sh`
+  When 本地校验执行
+  Then 二者都通过。
+
+## 质量门槛（Quality Gates）
+
+- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
+- `bash .github/scripts/test-quality-gates-contract.sh`
+
+## 里程碑（Milestones）
+
+- [ ] M1: 为 release-publish 补齐 PR 评论权限
+- [ ] M2: 更新 contract / fixture 并完成本地验证
+- [ ] M3: fast-flow 推进到 PR checks 收敛
+
+## 参考（References）
+
+- `.github/workflows/release.yml`
+- `docs/specs/sq8gw-release-pr-version-comment/SPEC.md`


### PR DESCRIPTION
## Summary
- add `pull-requests: write` to `release-publish` so the release workflow can write back to merged PRs under `workflow_run`
- lock the new permission into the release quality-gates contract and fixtures
- add follow-up spec `q1m9k-release-pr-comment-permission` for the production permission fix

## Verification
- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
- `bash .github/scripts/test-quality-gates-contract.sh`

## Why patch
- this PR intentionally uses a release-enabled label so the merged run can self-verify that PR release comments now work end-to-end

## Spec
- `docs/specs/q1m9k-release-pr-comment-permission/SPEC.md`