### PR TITLE
fix: avoid pool stream timeout truncation

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,6 +7,7 @@
 ## Index
 
 | ID    | Title                                                                         | Status          | Spec                                                     | Last       | Notes                                                                                          |
+| ynr8z | 号池流式上游误用整请求超时 | 进行中 | `ynr8z-pool-stream-total-timeout/SPEC.md` | 2026-03-17 | fast-track / pool streaming / shared client timeout / no replay semantic change |
 | q1m9k | Release PR 评论权限补齐 | 进行中 | `q1m9k-release-pr-comment-permission/SPEC.md` | 2026-03-17 | fast-track / release workflow / pull-requests write / comment permission fix |
 | sq8gw | Release 工作流 PR 版本评论                                               | 进行中         | `sq8gw-release-pr-version-comment/SPEC.md`           | 2026-03-17 | fast-track / release publish / PR version comment upsert / review convergence |
 | 3n287 | OAuth 临时邮箱自动化与验证码/邀请态集成                                   | 进行中         | `3n287-oauth-temp-mail-automation/SPEC.md`           | 2026-03-16 | fast-track / MoeMail mailbox sessions / oauth mailbox gating / parsing pending |

--- a/docs/specs/ynr8z-pool-stream-total-timeout/SPEC.md
+++ b/docs/specs/ynr8z-pool-stream-total-timeout/SPEC.md
@@ -1,0 +1,116 @@
+# 号池流式上游误用整请求超时（#ynr8z）
+
+## 状态
+
+- Status: 进行中
+- Created: 2026-03-17
+- Last: 2026-03-17
+
+## 背景 / 问题陈述
+
+- `#154` 已经把代理编码协商改为透明透传，但 101 线上在 `2026-03-17 10:00 +08:00` 之后仍持续出现 `routeMode=pool` 的 `upstream_stream_error`。
+- 线上失败样本的 `t_total_ms` 大量集中在约 `60024ms`，与部署环境的 `REQUEST_TIMEOUT_SECS=60` 精确对齐，说明失败不是随机网络抖动，而是服务自身在大约 `60s` 处把长流式响应截断。
+- 当前实现中，号池上游请求复用了带 `.timeout(config.request_timeout)` 的 shared `reqwest::Client`；对于 `/v1/responses*` 这类先快速返回首字节、随后长时间流式输出的请求，这个整请求总超时会在 body 传输阶段把流切断。
+- `gzip unexpected end of file` 只是截断后的诊断结果：服务先把流中途切断，随后原始响应落盘与 usage 解析才看到半截 gzip；根因仍然是我们自己的客户端超时策略，而不是新增号池重放逻辑缺失。
+
+## 目标 / 非目标
+
+### Goals
+
+- 让号池上游的流式请求不再复用整请求总超时 client，避免在 body 传输阶段被 `REQUEST_TIMEOUT_SECS` 硬切断。
+- 保持现有握手超时、请求体读取超时、429 重试与号池请求重放语义不变。
+- 补齐自动化回归，覆盖“短 `request_timeout` 配置下，号池流式响应仍可完整透传”的场景。
+
+### Non-goals
+
+- 不新增“号池路径对上游错误自动重放恢复服务”的新能力。
+- 不修改外部 relay、NSNGC、Traefik、Caddy 或部署网络拓扑。
+- 不调整非号池后台轮询任务对 `request_timeout` 的既有依赖。
+
+## 范围（Scope）
+
+### In scope
+
+- `src/main.rs` 中 `HttpClients` 的 client 分工，以及号池上游发送路径对 client 的选择。
+- `src/tests/mod.rs` 中覆盖号池流式透传的后端回归测试。
+- `docs/specs/README.md` 与当前 spec 的状态同步。
+
+### Out of scope
+
+- 上游账号路由策略、熔断策略或重试策略设计变更。
+- 新的失败分类口径与数据库 schema 改动。
+
+## 需求（Requirements）
+
+### MUST
+
+- 号池上游发送路径不得继续复用带整请求总超时的 shared `reqwest::Client`。
+- 号池 API key 与 OAuth 的 live upstream 请求都必须使用“无整请求总超时”的 client。
+- 非号池后台轮询/抓取路径继续保留 shared client 的 `request_timeout` 行为，不得把后台任务的超时保护一并移除。
+- 号池路径已有的 `handshake_timeout` 包装、`request_read_timeout`、429/5xx/401/403 分支与 sticky/replay 语义必须保持不变。
+- 当 `config.request_timeout=200ms` 且上游首字节后延迟 `400ms` 再返回下一块数据时，号池 `/v1/slow-stream` 仍必须成功返回完整 body，而不是在约 `200ms` 后报 `upstream_stream_error`。
+- 当 `config.request_timeout=200ms` 且号池 `/v1/responses` 返回慢速成功 SSE 时，代理仍必须完整返回 `response.completed` 事件。
+
+### SHOULD
+
+- client 命名与职责应明确区分“后台抓取总超时”与“号池流式上游无总超时”，避免未来再次误用。
+- 至少保留一条直接映射线上现象的 `/v1/responses` 回归测试，避免只验证通用 `/v1/slow-stream` 而漏掉真实路径。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- `HttpClients::build` 继续构建：
+  - 带整请求总超时的 shared client，用于后台轮询与非流式抓取；
+  - 不带整请求总超时的号池上游 client，用于 pool live upstream；
+  - 现有 forward proxy client 继续保留原职责。
+- `send_pool_request_with_failover`、号池 OAuth live upstream、号池 API key live upstream 都改为使用号池专用 client。
+- 号池 live upstream 仍然只在握手阶段受 `handshake_timeout` 保护；一旦首字节已到达，后续 body 传输不得再被 `request_timeout` 截断。
+
+### Edge cases / errors
+
+- 若号池上游在首字节前超过握手预算，仍按既有 `upstream_handshake_timeout` / `failed_contact_upstream` 逻辑返回。
+- 若请求体读取阶段超时，仍按现有 `request_body_read_timeout` 路径失败；本次修复不能改变上传读体语义。
+- 若后台轮询或普通抓取超过 `request_timeout`，仍应保持既有失败行为；本次修复不能把 shared client 的保护全局移除。
+
+## 验收标准（Acceptance Criteria）
+
+- Given `config.request_timeout=200ms`，When 号池 GET `/v1/slow-stream` 命中上游 `chunk-a` 后等待 `400ms` 才收到 `chunk-b`，Then 响应仍为 `200 OK` 且 body 为 `chunk-achunk-b`。
+- Given 同样的 `config.request_timeout=200ms`，When 号池 POST `/v1/responses?mode=slow-success` 命中慢速成功 SSE，Then 响应仍为 `200 OK` 且包含 `response.completed`。
+- Given 同样的配置，When 非号池后台任务仍使用 shared client，Then 其 `request_timeout` 行为不变。
+- Given 线上样本全文检索 `routeMode=pool` 的 `upstream_stream_error`，When 修复发布并部署后复核，Then 不应再出现稳定集中在约 `60000ms` 的同类截断模式。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- `cargo test pool_openai_v1_e2e_stream_survives_short_request_timeout`
+- `cargo test pool_openai_v1_responses_stream_survives_short_request_timeout`
+- `cargo test proxy_openai_v1_e2e_stream_survives_short_request_timeout`
+
+### Quality checks
+
+- `cargo fmt --check`
+- `cargo test`
+
+## 文档更新（Docs to Update）
+
+- `docs/specs/README.md`：新增规格索引，并在流程推进后同步状态。
+- `docs/specs/ynr8z-pool-stream-total-timeout/SPEC.md`：记录实现进展、验证与 PR/发布状态。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 为号池上游引入无整请求总超时 client，并只在 pool 发送路径上使用。
+- [x] M2: 增加 `/v1/slow-stream` 与 `/v1/responses` 的短超时慢流成功回归测试。
+- [ ] M3: 完成 fast-track 交付（提交、push、PR、checks、review-loop、merge、release、deploy、verify）。
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：若误把 shared client 的超时保护全部移除，后台轮询可能失去既有超时收敛；本次必须严格限定变更范围。
+- 风险：若直接复用 forward proxy client，可能意外改变 redirect/connect 语义；实现应尽量保持 pool 既有行为，只去掉整请求总超时。
+- 假设：线上稳定落在约 `60s` 的 `upstream_stream_error` 峰值主要由 shared client 的 `.timeout(config.request_timeout)` 触发，修复后应显著消失。
+
+## 变更记录（Change log）
+
+- 2026-03-17: 创建 spec，冻结根因、边界与回归标准。
+- 2026-03-17: 完成 `HttpClients` 分工修复；号池 live upstream 改走无整请求总超时 client，并为“首 chunk 超时 / OAuth 非流式读体超时”补回显式预算，`cargo test` 全量 395 项通过。

--- a/src/main.rs
+++ b/src/main.rs
@@ -6235,6 +6235,50 @@ impl ProxyUpstreamResponseBody {
     }
 }
 
+fn pool_upstream_timeout_message(total_timeout: Duration, phase: &str) -> String {
+    format!(
+        "request timed out after {}ms while {phase}",
+        total_timeout.as_millis()
+    )
+}
+
+async fn read_pool_upstream_bytes_with_timeout(
+    response: ProxyUpstreamResponseBody,
+    total_timeout: Duration,
+    started: Instant,
+    phase: &str,
+) -> Result<Bytes, String> {
+    let Some(timeout_budget) = remaining_timeout_budget(total_timeout, started.elapsed()) else {
+        return Err(pool_upstream_timeout_message(total_timeout, phase));
+    };
+
+    match timeout(timeout_budget, response.into_bytes()).await {
+        Ok(result) => result,
+        Err(_) => Err(pool_upstream_timeout_message(total_timeout, phase)),
+    }
+}
+
+async fn read_pool_upstream_first_chunk_with_timeout(
+    response: ProxyUpstreamResponseBody,
+    total_timeout: Duration,
+    started: Instant,
+) -> Result<(ProxyUpstreamResponseBody, Option<Bytes>), String> {
+    let Some(timeout_budget) = remaining_timeout_budget(total_timeout, started.elapsed()) else {
+        return Err(pool_upstream_timeout_message(
+            total_timeout,
+            "waiting for first upstream chunk",
+        ));
+    };
+
+    match timeout(timeout_budget, response.into_first_chunk()).await {
+        Ok(result) => result,
+        Err(_) => Err(pool_upstream_timeout_message(
+            total_timeout,
+            "waiting for first upstream chunk",
+        )),
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct PoolUpstreamResponse {
     pub(crate) account: PoolResolvedAccount,
@@ -6661,21 +6705,7 @@ async fn send_pool_request_with_failover(
             }
             PoolResolvedAuth::Oauth { .. } => None,
         };
-        let client = match state.http_clients.client_for_parallelism(false) {
-            Ok(client) => client,
-            Err(err) => {
-                return Err(PoolUpstreamError {
-                    account: Some(account),
-                    status: StatusCode::BAD_GATEWAY,
-                    message: format!("failed to initialize upstream client: {err}"),
-                    failure_kind: PROXY_FAILURE_FAILED_CONTACT_UPSTREAM,
-                    connect_latency_ms: 0.0,
-                    upstream_error_code: None,
-                    upstream_error_message: None,
-                    upstream_request_id: None,
-                });
-            }
-        };
+        let client = state.http_clients.client_for_pool_upstream();
 
         for same_account_attempt in 0..same_account_attempts {
             let connect_started = Instant::now();
@@ -6868,6 +6898,7 @@ async fn send_pool_request_with_failover(
                             headers,
                             oauth_body,
                             handshake_timeout,
+                            state.config.request_timeout,
                             access_token,
                             chatgpt_account_id.as_deref(),
                         )
@@ -6912,7 +6943,14 @@ async fn send_pool_request_with_failover(
                     .filter(|value| !value.is_empty())
                     .map(|value| value.to_string());
                 let (upstream_error_code, upstream_error_message, upstream_request_id, message) =
-                    match response.into_bytes().await {
+                    match read_pool_upstream_bytes_with_timeout(
+                        response,
+                        state.config.request_timeout,
+                        connect_started,
+                        "reading upstream error body",
+                    )
+                    .await
+                    {
                         Ok(body_bytes) => summarize_pool_upstream_http_failure(
                             status,
                             upstream_request_id_header.as_deref(),
@@ -6967,7 +7005,13 @@ async fn send_pool_request_with_failover(
             }
 
             let first_byte_started = Instant::now();
-            let (response, first_chunk) = match response.into_first_chunk().await {
+            let (response, first_chunk) = match read_pool_upstream_first_chunk_with_timeout(
+                response,
+                state.config.request_timeout,
+                connect_started,
+            )
+            .await
+            {
                 Ok(value) => value,
                 Err(err) => {
                     let message = format!("upstream stream error before first chunk: {err}");
@@ -7270,20 +7314,13 @@ async fn proxy_openai_v1_via_pool(
                     let connect_started = Instant::now();
                     let response = ProxyUpstreamResponseBody::Axum(
                         oauth_bridge::send_oauth_upstream_request(
-                            &state
-                                .http_clients
-                                .client_for_parallelism(false)
-                                .map_err(|err| {
-                                    (
-                                        StatusCode::BAD_GATEWAY,
-                                        format!("failed to initialize upstream client: {err}"),
-                                    )
-                                })?,
+                            &state.http_clients.client_for_pool_upstream(),
                             method.clone(),
                             original_uri,
                             &headers,
                             oauth_bridge::OauthUpstreamRequestBody::Stream(replayable.body),
                             handshake_timeout,
+                            state.config.request_timeout,
                             access_token,
                             chatgpt_account_id.as_deref(),
                         )
@@ -7307,7 +7344,14 @@ async fn proxy_openai_v1_via_pool(
                             upstream_error_message,
                             upstream_request_id,
                             message,
-                        ) = match response.into_bytes().await {
+                        ) = match read_pool_upstream_bytes_with_timeout(
+                            response,
+                            state.config.request_timeout,
+                            connect_started,
+                            "reading upstream error body",
+                        )
+                        .await
+                        {
                             Ok(body_bytes) => summarize_pool_upstream_http_failure(
                                 status,
                                 upstream_request_id_header.as_deref(),
@@ -7356,7 +7400,13 @@ async fn proxy_openai_v1_via_pool(
                         .map_err(|err| (err.status, err.message))?
                     } else {
                         let first_byte_started = Instant::now();
-                        match response.into_first_chunk().await {
+                        match read_pool_upstream_first_chunk_with_timeout(
+                            response,
+                            state.config.request_timeout,
+                            connect_started,
+                        )
+                        .await
+                        {
                             Ok((response, first_chunk)) => PoolUpstreamResponse {
                                 account: initial_account,
                                 response,
@@ -7405,15 +7455,7 @@ async fn proxy_openai_v1_via_pool(
                                 format!("failed to build pool upstream url: {err}"),
                             )
                         })?;
-                let client = state
-                    .http_clients
-                    .client_for_parallelism(false)
-                    .map_err(|err| {
-                        (
-                            StatusCode::BAD_GATEWAY,
-                            format!("failed to initialize upstream client: {err}"),
-                        )
-                    })?;
+                let client = state.http_clients.client_for_pool_upstream();
                 let request_connection_scoped = connection_scoped_header_names(&headers);
                 let replayable = spawn_pool_replayable_request_body(
                     body,
@@ -7472,7 +7514,14 @@ async fn proxy_openai_v1_via_pool(
                                 upstream_error_message,
                                 upstream_request_id,
                                 message,
-                            ) = match response.into_bytes().await {
+                            ) = match read_pool_upstream_bytes_with_timeout(
+                                response,
+                                state.config.request_timeout,
+                                connect_started,
+                                "reading upstream error body",
+                            )
+                            .await
+                            {
                                 Ok(body_bytes) => summarize_pool_upstream_http_failure(
                                     status,
                                     upstream_request_id_header.as_deref(),
@@ -7521,7 +7570,13 @@ async fn proxy_openai_v1_via_pool(
                             .map_err(|err| (err.status, err.message))?
                         } else {
                             let first_byte_started = Instant::now();
-                            match response.into_first_chunk().await {
+                            match read_pool_upstream_first_chunk_with_timeout(
+                                response,
+                                state.config.request_timeout,
+                                connect_started,
+                            )
+                            .await
+                            {
                                 Ok((response, first_chunk)) => PoolUpstreamResponse {
                                     account: initial_account,
                                     response,
@@ -14239,6 +14294,7 @@ fn normalize_pricing_source(raw: String) -> String {
 #[derive(Debug, Clone)]
 struct HttpClients {
     shared: Client,
+    pool_upstream: Client,
     proxy: Client,
     timeout: Duration,
     user_agent: String,
@@ -14254,6 +14310,13 @@ impl HttpClients {
             .build()
             .context("failed to construct shared HTTP client")?;
 
+        // Pool live upstream traffic can legitimately stream well past REQUEST_TIMEOUT_SECS.
+        // Handshake and upload budgets are enforced by route-specific timeout wrappers instead.
+        let pool_upstream = Self::builder(None, &user_agent)
+            .pool_max_idle_per_host(config.shared_connection_parallelism)
+            .build()
+            .context("failed to construct pool upstream HTTP client")?;
+
         let proxy = Self::builder(None, &user_agent)
             .pool_max_idle_per_host(config.shared_connection_parallelism)
             .connect_timeout(timeout)
@@ -14263,6 +14326,7 @@ impl HttpClients {
 
         Ok(Self {
             shared,
+            pool_upstream,
             proxy,
             timeout,
             user_agent,
@@ -14279,6 +14343,10 @@ impl HttpClients {
         } else {
             Ok(self.shared.clone())
         }
+    }
+
+    fn client_for_pool_upstream(&self) -> Client {
+        self.pool_upstream.clone()
     }
 
     fn client_for_forward_proxy(&self, endpoint_url: Option<&Url>) -> Result<Client> {

--- a/src/oauth_bridge.rs
+++ b/src/oauth_bridge.rs
@@ -9,7 +9,7 @@ use futures_util::TryStreamExt;
 use reqwest::{Body as ReqwestBody, Client, Url};
 use serde_json::{Value, json};
 use std::time::Duration;
-use tokio::time::timeout;
+use tokio::time::{Instant, timeout};
 
 #[cfg(test)]
 use once_cell::sync::Lazy;
@@ -68,17 +68,26 @@ pub(crate) async fn send_oauth_upstream_request(
     headers: &HeaderMap,
     body: OauthUpstreamRequestBody,
     handshake_timeout: Duration,
+    response_timeout: Duration,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
 ) -> Response {
     match original_uri.path() {
         "/v1/models" => {
-            oauth_models(client, handshake_timeout, access_token, chatgpt_account_id).await
+            oauth_models(
+                client,
+                handshake_timeout,
+                response_timeout,
+                access_token,
+                chatgpt_account_id,
+            )
+            .await
         }
         "/v1/responses" => {
             oauth_responses(
                 client,
                 handshake_timeout,
+                response_timeout,
                 access_token,
                 chatgpt_account_id,
                 match body {
@@ -130,6 +139,7 @@ fn is_supported_oauth_passthrough_route(path: &str) -> bool {
 async fn oauth_models(
     client: &Client,
     handshake_timeout: Duration,
+    response_timeout: Duration,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
 ) -> Response {
@@ -156,6 +166,7 @@ async fn oauth_models(
         .bearer_auth(access_token)
         .header("OpenAI-Beta", "responses=experimental");
     let request = attach_account_header(request, chatgpt_account_id);
+    let request_started = Instant::now();
     let upstream = match timeout(handshake_timeout, request.send()).await {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
@@ -177,7 +188,14 @@ async fn oauth_models(
         }
     };
     let status = upstream.status();
-    let bytes = match upstream.bytes().await {
+    let bytes = match read_oauth_upstream_bytes_with_timeout(
+        upstream,
+        response_timeout,
+        request_started,
+        "reading oauth codex models response",
+    )
+    .await
+    {
         Ok(bytes) => bytes,
         Err(err) => {
             return error_response(
@@ -203,6 +221,7 @@ async fn oauth_models(
 async fn oauth_responses(
     client: &Client,
     handshake_timeout: Duration,
+    response_timeout: Duration,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
     body: Bytes,
@@ -234,6 +253,7 @@ async fn oauth_responses(
         .header("OpenAI-Beta", "responses=experimental")
         .body(upstream_body);
     let request = attach_account_header(request, chatgpt_account_id);
+    let request_started = Instant::now();
     let upstream = match timeout(handshake_timeout, request.send()).await {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
@@ -256,7 +276,14 @@ async fn oauth_responses(
     };
     if !upstream.status().is_success() {
         let status = upstream.status();
-        let bytes = match upstream.bytes().await {
+        let bytes = match read_oauth_upstream_bytes_with_timeout(
+            upstream,
+            response_timeout,
+            request_started,
+            "reading oauth codex error response",
+        )
+        .await
+        {
             Ok(bytes) => bytes,
             Err(err) => {
                 return error_response(
@@ -271,7 +298,14 @@ async fn oauth_responses(
     if wants_stream {
         return reqwest_response_to_axum_response(upstream);
     }
-    let bytes = match upstream.bytes().await {
+    let bytes = match read_oauth_upstream_bytes_with_timeout(
+        upstream,
+        response_timeout,
+        request_started,
+        "reading oauth codex responses stream",
+    )
+    .await
+    {
         Ok(bytes) => bytes,
         Err(err) => {
             return error_response(
@@ -394,6 +428,30 @@ fn attach_account_header(
         builder.header("ChatGPT-Account-Id", chatgpt_account_id.unwrap_or_default())
     } else {
         builder
+    }
+}
+
+fn oauth_upstream_timeout_message(total_timeout: Duration, phase: &str) -> String {
+    format!(
+        "request timed out after {}ms while {phase}",
+        total_timeout.as_millis()
+    )
+}
+
+async fn read_oauth_upstream_bytes_with_timeout(
+    upstream: reqwest::Response,
+    total_timeout: Duration,
+    started: Instant,
+    phase: &str,
+) -> Result<Bytes, String> {
+    let Some(timeout_budget) = crate::remaining_timeout_budget(total_timeout, started.elapsed())
+    else {
+        return Err(oauth_upstream_timeout_message(total_timeout, phase));
+    };
+
+    match timeout(timeout_budget, upstream.bytes()).await {
+        Ok(result) => result.map_err(|err| err.to_string()),
+        Err(_) => Err(oauth_upstream_timeout_message(total_timeout, phase)),
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4073,6 +4073,26 @@ async fn test_upstream_slow_stream() -> impl IntoResponse {
     )
 }
 
+async fn test_upstream_slow_first_chunk() -> impl IntoResponse {
+    let chunks = stream::unfold(0usize, |state| async move {
+        match state {
+            0 => {
+                tokio::time::sleep(Duration::from_millis(400)).await;
+                Some((Ok::<_, Infallible>(Bytes::from_static(b"chunk-a")), 1))
+            }
+            _ => None,
+        }
+    });
+    (
+        StatusCode::OK,
+        [(
+            http_header::CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream"),
+        )],
+        Body::from_stream(chunks),
+    )
+}
+
 async fn test_upstream_hang() -> impl IntoResponse {
     tokio::time::sleep(Duration::from_secs(2)).await;
     StatusCode::NO_CONTENT
@@ -4142,6 +4162,39 @@ async fn test_upstream_responses_gzip_stream() -> impl IntoResponse {
     )
 }
 
+async fn test_upstream_responses_slow_success_stream() -> impl IntoResponse {
+    let first = concat!(
+        "event: response.created\n",
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_slow_test\",\"model\":\"gpt-5.4\",\"status\":\"in_progress\"}}\n\n",
+    );
+    let second = concat!(
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_slow_test\",\"model\":\"gpt-5.4\",\"status\":\"completed\",\"usage\":{\"input_tokens\":12,\"output_tokens\":3,\"total_tokens\":15}}}\n\n",
+    );
+    let chunks = stream::unfold(0usize, move |state| async move {
+        match state {
+            0 => Some((Ok::<_, Infallible>(Bytes::from_static(first.as_bytes())), 1)),
+            1 => {
+                tokio::time::sleep(Duration::from_millis(400)).await;
+                Some((
+                    Ok::<_, Infallible>(Bytes::from_static(second.as_bytes())),
+                    2,
+                ))
+            }
+            _ => None,
+        }
+    });
+
+    (
+        StatusCode::OK,
+        [(
+            http_header::CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream"),
+        )],
+        Body::from_stream(chunks),
+    )
+}
+
 async fn test_upstream_responses_failed_stream() -> impl IntoResponse {
     let payload = [
         "event: response.created
@@ -4179,6 +4232,13 @@ async fn test_upstream_responses(uri: Uri) -> Response {
         .is_some_and(|query| query.contains("mode=response_failed"))
     {
         test_upstream_responses_failed_stream()
+            .await
+            .into_response()
+    } else if uri
+        .query()
+        .is_some_and(|query| query.contains("mode=slow-success"))
+    {
+        test_upstream_responses_slow_success_stream()
             .await
             .into_response()
     } else if uri.query().is_some_and(|query| query.contains("mode=gzip")) {
@@ -4323,6 +4383,7 @@ async fn spawn_test_upstream() -> (String, JoinHandle<()>) {
         .route("/v1/stream-mid-error", any(test_upstream_stream_mid_error))
         .route("/v1/429-mid-error", any(test_upstream_429_mid_error))
         .route("/v1/slow-stream", any(test_upstream_slow_stream))
+        .route("/v1/slow-first-chunk", any(test_upstream_slow_first_chunk))
         .route("/v1/hang", any(test_upstream_hang))
         .route("/v1/models", get(test_upstream_models))
         .route("/v1/redirect", any(test_upstream_redirect))
@@ -9048,6 +9109,50 @@ async fn spawn_oauth_codex_capture_upstream() -> (String, JoinHandle<()>) {
     (format!("http://{addr}"), handle)
 }
 
+async fn oauth_codex_slow_models_upstream() -> impl IntoResponse {
+    let chunks = stream::unfold(0usize, |state| async move {
+        match state {
+            0 => {
+                tokio::time::sleep(Duration::from_millis(400)).await;
+                Some((
+                    Ok::<_, Infallible>(Bytes::from_static(
+                        br#"{"data":[{"id":"slow-model","object":"model"}]}"#,
+                    )),
+                    1,
+                ))
+            }
+            _ => None,
+        }
+    });
+    (
+        StatusCode::OK,
+        [(
+            http_header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        Body::from_stream(chunks),
+    )
+}
+
+async fn spawn_oauth_codex_slow_models_upstream() -> (String, JoinHandle<()>) {
+    let app = Router::new().route(
+        "/backend-api/codex/models",
+        get(oauth_codex_slow_models_upstream),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind oauth codex slow models upstream");
+    let addr = listener
+        .local_addr()
+        .expect("oauth codex slow models upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("oauth codex slow models upstream should run");
+    });
+    (format!("http://{addr}"), handle)
+}
+
 async fn spawn_pool_retry_upstream(
     fail_before_success: &[(&str, usize)],
 ) -> (
@@ -10535,6 +10640,184 @@ async fn proxy_openai_v1_e2e_stream_survives_short_request_timeout() {
 
     server_handle.abort();
     upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_openai_v1_e2e_stream_survives_short_request_timeout() {
+    let (upstream_base, upstream_handle) = spawn_test_upstream().await;
+    let mut config = test_config();
+    config.openai_upstream_base_url = Url::parse(&upstream_base).expect("valid upstream base url");
+    config.request_timeout = Duration::from_millis(200);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+
+    let app = Router::new()
+        .route("/v1/*path", any(proxy_openai_v1))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy test server");
+    let addr = listener.local_addr().expect("proxy test server addr");
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("proxy test server should run");
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{addr}/v1/slow-stream"))
+        .header(http_header::AUTHORIZATION, "Bearer pool-live-key")
+        .send()
+        .await
+        .expect("send pool proxy stream request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.bytes().await.expect("read proxied stream");
+    assert_eq!(&body[..], b"chunk-achunk-b");
+
+    server_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_openai_v1_times_out_before_first_chunk_with_short_request_timeout() {
+    let (upstream_base, upstream_handle) = spawn_test_upstream().await;
+    let mut config = test_config();
+    config.openai_upstream_base_url = Url::parse(&upstream_base).expect("valid upstream base url");
+    config.request_timeout = Duration::from_millis(200);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+
+    let app = Router::new()
+        .route("/v1/*path", any(proxy_openai_v1))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy test server");
+    let addr = listener.local_addr().expect("proxy test server addr");
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("proxy test server should run");
+    });
+
+    let client = reqwest::Client::new();
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        client
+            .get(format!("http://{addr}/v1/slow-first-chunk"))
+            .header(http_header::AUTHORIZATION, "Bearer pool-live-key")
+            .send(),
+    )
+    .await
+    .expect("pool request should not hang")
+    .expect("send pool proxy request");
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body = response.bytes().await.expect("read pool error body");
+    let payload = String::from_utf8_lossy(&body);
+    assert!(payload.contains("first upstream chunk"));
+
+    server_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_openai_v1_responses_stream_survives_short_request_timeout() {
+    let (upstream_base, upstream_handle) = spawn_test_upstream().await;
+    let mut config = test_config();
+    config.openai_upstream_base_url = Url::parse(&upstream_base).expect("valid upstream base url");
+    config.request_timeout = Duration::from_millis(200);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+
+    let app = Router::new()
+        .route("/v1/*path", any(proxy_openai_v1))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy test server");
+    let addr = listener.local_addr().expect("proxy test server addr");
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("proxy test server should run");
+    });
+
+    let request_body = serde_json::to_vec(&json!({
+        "model": "gpt-5.4",
+        "stream": true,
+        "input": "hello",
+    }))
+    .expect("serialize request body");
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://{addr}/v1/responses?mode=slow-success"))
+        .header(http_header::AUTHORIZATION, "Bearer pool-live-key")
+        .header(http_header::CONTENT_TYPE, "application/json")
+        .body(request_body)
+        .send()
+        .await
+        .expect("send pool responses request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.bytes().await.expect("read pool responses body");
+    let payload = String::from_utf8_lossy(&body);
+    assert!(payload.contains("response.created"));
+    assert!(payload.contains("response.completed"));
+    assert!(payload.contains("resp_slow_test"));
+
+    server_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_route_oauth_models_preserve_response_timeout_after_headers() {
+    let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
+        .lock()
+        .await;
+
+    let (upstream_base, upstream_handle) = spawn_oauth_codex_slow_models_upstream().await;
+    oauth_bridge::set_test_oauth_codex_upstream_base_url(
+        Url::parse(&format!("{upstream_base}/backend-api/codex")).expect("valid oauth base url"),
+    )
+    .await;
+
+    let mut config = test_config();
+    config.request_timeout = Duration::from_millis(200);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_oauth_account(&state, "Primary OAuth", "oauth-primary").await;
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        proxy_openai_v1(
+            State(state),
+            OriginalUri("/v1/models".parse().expect("valid uri")),
+            Method::GET,
+            HeaderMap::from_iter([(
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            )]),
+            Body::empty(),
+        ),
+    )
+    .await
+    .expect("oauth pool request should not hang");
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read oauth pool error body");
+    let payload = String::from_utf8_lossy(&body);
+    assert!(payload.contains("timed out"));
+
+    upstream_handle.abort();
+    oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What
- stop pool live upstream traffic from reusing the shared reqwest client with a total request timeout
- keep explicit timeout budgets until the first upstream chunk or buffered OAuth body is available
- add regressions for pool slow-stream success, first-chunk timeout, responses slow SSE, and OAuth models body stall
- sync the new spec entry for `ynr8z-pool-stream-total-timeout`

## Why
Pool-routed streaming requests were being cut off by our own `REQUEST_TIMEOUT_SECS` total deadline. That truncated long-lived `/v1/responses*` bodies around 60s and surfaced as `upstream_stream_error` / partial gzip diagnostics.

## Validation
- `cargo fmt --all --check`
- `cargo test`
- `cargo test pool_openai_v1_e2e_stream_survives_short_request_timeout`
- `cargo test pool_openai_v1_times_out_before_first_chunk_with_short_request_timeout`
- `cargo test pool_openai_v1_responses_stream_survives_short_request_timeout`
- `cargo test pool_route_oauth_models_preserve_response_timeout_after_headers`