### PR TITLE
fix: restore invocation proxy display names

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -8,6 +8,7 @@
 
 | ID    | Title                                                                         | Status          | Spec                                                     | Last       | Notes                                                                                          |
 | q1m9k | Release PR 评论权限补齐 | 进行中 | `q1m9k-release-pr-comment-permission/SPEC.md` | 2026-03-17 | fast-track / release workflow / pull-requests write / comment permission fix |
+| f7nqn | InvocationTable 代理节点展示恢复热修 | 进行中 | `f7nqn-invocation-proxy-display-restore-hotfix/SPEC.md` | 2026-03-17 | fast-track / hotfix / restore proxyDisplayName for future invocations |
 | sq8gw | Release 工作流 PR 版本评论                                               | 进行中         | `sq8gw-release-pr-version-comment/SPEC.md`           | 2026-03-17 | fast-track / release publish / PR version comment upsert / review convergence |
 | 3n287 | OAuth 临时邮箱自动化与验证码/邀请态集成                                   | 进行中         | `3n287-oauth-temp-mail-automation/SPEC.md`           | 2026-03-16 | fast-track / MoeMail mailbox sessions / oauth mailbox gating / parsing pending |
 | f6f6e | GH Actions 防取消发布链路全面对齐                                              | 部分完成（3/4） | `f6f6e-gh-actions-release-anti-cancel/SPEC.md`           | 2026-03-15 | strict anti-cancel / global serial CI Main+Release / current PR labels / contract refresh |

--- a/docs/specs/f7nqn-invocation-proxy-display-restore-hotfix/SPEC.md
+++ b/docs/specs/f7nqn-invocation-proxy-display-restore-hotfix/SPEC.md
@@ -1,0 +1,85 @@
+# InvocationTable 代理节点展示恢复热修（#f7nqn)
+
+## 状态
+
+- Status: 进行中
+- Created: 2026-03-17
+- Last: 2026-03-17
+
+## 背景 / 问题陈述
+
+- 生产 `Dashboard / Live` 的 InvocationTable 已经切成“账号 / 代理”双行摘要，但 2026-03-17 的新请求里 `proxyDisplayName` 持续为空，导致列表第二行与详情里的“代理”字段都显示 `—`。
+- 同一时间生产 `/api/settings` 里的 `forwardProxy.nodes[].displayName` 正常存在，说明不是代理节点配置丢失，而是 invocation 采集链路没有稳定写入展示值。
+- 对 `routeMode=pool` 的新记录，当前成功路径没有真正的 `SelectedForwardProxy`，但仍然需要给前端一个可读的“代理节点”展示值，否则账号列改造后会把空洞直接暴露出来。
+
+## 目标 / 非目标
+
+### Goals
+
+- 恢复未来新产生 invocation 的 `proxyDisplayName`，让列表摘要与详情重新显示可读代理节点信息。
+- 保持 `/api/invocations` 与前端 `ApiInvocation` 契约不变，只修 payload 填充逻辑。
+- 为 pool 路由与 forward proxy 路由都补齐回归保护，避免长位置参数再次错位。
+
+### Non-goals
+
+- 不回填历史空值记录；旧数据仍允许显示 `—`。
+- 不回滚账号列、时延列或当前页账号抽屉功能。
+- 不新增新的公开 API 字段或数据库迁移。
+
+## 范围（Scope）
+
+### In scope
+
+- `src/main.rs` 的 invocation payload 构造与 `proxyDisplayName` 解析策略。
+- `src/tests/mod.rs` 的后端回归测试。
+- `web/src/components/InvocationTable.test.tsx` 的前端展示断言。
+- `docs/specs/README.md` 与本热修 spec 的同步。
+
+### Out of scope
+
+- 历史记录 backfill。
+- 其它业务表格与号池页面布局调整。
+- 生产代理配置本身的修改。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- forward proxy 路由继续优先使用 `SelectedForwardProxy.display_name` 作为 `proxyDisplayName`。
+- pool 路由在没有 `SelectedForwardProxy` 时，改为从 `PoolResolvedAccount.upstream_base_url` 派生展示值：优先显示 host，存在端口时显示 `host:port`。
+- invocation payload 构造改成具名 `ProxyPayloadSummary`，把 `routeMode`、`upstreamAccount*`、`responseContentEncoding`、`proxyDisplayName` 统一集中写入，避免再被长位置参数错位污染。
+- 前端继续沿用现有回退：新记录应展示非空代理节点名，历史空值仍显示 `—`。
+
+### Edge cases / errors
+
+- OAuth 号池账号的上游地址默认会落到 `https://chatgpt.com/backend-api/codex`，列表展示值应归一成 `chatgpt.com`。
+- API key 号池账号若上游地址包含端口，展示值必须保留端口，便于区分测试/内网 relay。
+- 在请求读取阶段尚未选中账号或代理时，`proxyDisplayName` 仍可为空，不伪造值。
+
+## 验收标准（Acceptance Criteria）
+
+- Given 一条新的 `routeMode=pool` invocation，When 它被写入并从 `/api/invocations` 读回，Then `proxyDisplayName` 为非空且等于该账号 `upstream_base_url` 的 host 或 `host:port`。
+- Given 一条新的 `routeMode=forward_proxy` invocation，When 它被写入并从 `/api/invocations` 读回，Then `proxyDisplayName` 保持选中 forward proxy 的 display name。
+- Given 前端收到非空 `proxyDisplayName`，When 渲染摘要与展开详情，Then 两处都展示相同代理名。
+- Given 生产发布完成后新产生一条 invocation，When 在生产容器内查询 `/api/invocations?limit=20`，Then 最新记录的 `proxyDisplayName` 不再为 `null`。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- `cargo check`
+- `cargo test resolve_invocation_proxy_display_name`
+- `cargo test pool_route_switches_accounts_after_first_chunk_failures_are_exhausted`
+- `cargo test list_invocations_projects_payload_context_fields`
+- `cd web && bun run test -- --run src/components/InvocationTable.test.tsx`
+- `cd web && bun run build`
+
+## 文档更新（Docs to Update）
+
+- `docs/specs/README.md`
+- `docs/specs/f7nqn-invocation-proxy-display-restore-hotfix/SPEC.md`
+
+## 风险 / 假设
+
+- 风险：pool 路由的“代理”展示值本质上是上游 host，而不是真实前置 relay 节点名；这是当前生产链路里唯一稳定可得的非空代理上下文。
+- 假设：主人接受“只修未来，不回填历史”的 hotfix 边界。

--- a/src/main.rs
+++ b/src/main.rs
@@ -8498,41 +8498,41 @@ async fn proxy_openai_v1_capture_target(
                 },
                 error_message: Some(error_message),
                 failure_kind: Some(read_err.failure_kind.to_string()),
-                payload: Some(build_proxy_payload_summary(
-                    capture_target,
-                    read_err.status,
-                    request_info.is_stream,
-                    None,
-                    request_info.requested_service_tier.as_deref(),
-                    request_info.reasoning_effort.as_deref(),
-                    None,
-                    None,
-                    request_info.parse_error.as_deref(),
-                    Some(read_err.failure_kind),
-                    requester_ip.as_deref(),
-                    if pool_route_active {
+                payload: Some(build_proxy_payload_summary(ProxyPayloadSummary {
+                    target: capture_target,
+                    status: read_err.status,
+                    is_stream: request_info.is_stream,
+                    request_model: None,
+                    requested_service_tier: request_info.requested_service_tier.as_deref(),
+                    reasoning_effort: request_info.reasoning_effort.as_deref(),
+                    response_model: None,
+                    usage_missing_reason: None,
+                    request_parse_error: request_info.parse_error.as_deref(),
+                    failure_kind: Some(read_err.failure_kind),
+                    requester_ip: requester_ip.as_deref(),
+                    upstream_scope: if pool_route_active {
                         INVOCATION_UPSTREAM_SCOPE_INTERNAL
                     } else {
                         INVOCATION_UPSTREAM_SCOPE_EXTERNAL
                     },
-                    if pool_route_active {
+                    route_mode: if pool_route_active {
                         INVOCATION_ROUTE_MODE_POOL
                     } else {
                         INVOCATION_ROUTE_MODE_FORWARD_PROXY
                     },
-                    header_sticky_key.as_deref(),
-                    header_prompt_cache_key.as_deref(),
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                )),
+                    sticky_key: header_sticky_key.as_deref(),
+                    prompt_cache_key: header_prompt_cache_key.as_deref(),
+                    upstream_account_id: None,
+                    upstream_account_name: None,
+                    service_tier: None,
+                    stream_terminal_event: None,
+                    upstream_error_code: None,
+                    upstream_error_message: None,
+                    upstream_request_id: None,
+                    response_content_encoding: None,
+                    proxy_display_name: None,
+                    proxy_weight_delta: None,
+                })),
                 raw_response: "{}".to_string(),
                 req_raw,
                 resp_raw: RawPayloadMeta::default(),
@@ -8627,6 +8627,8 @@ async fn proxy_openai_v1_capture_target(
                     )
                     .await;
                 let error_message = format!("[{}] {}", err.failure_kind, err.message);
+                let pool_proxy_display_name =
+                    resolve_invocation_proxy_display_name(None, err.account.as_ref());
                 let record = ProxyCaptureRecord {
                     invoke_id,
                     occurred_at,
@@ -8642,35 +8644,36 @@ async fn proxy_openai_v1_capture_target(
                     },
                     error_message: Some(error_message),
                     failure_kind: Some(err.failure_kind.to_string()),
-                    payload: Some(build_proxy_payload_summary(
-                        capture_target,
-                        err.status,
-                        request_info.is_stream,
-                        None,
-                        request_info.requested_service_tier.as_deref(),
-                        request_info.reasoning_effort.as_deref(),
-                        None,
-                        None,
-                        request_info.parse_error.as_deref(),
-                        Some(err.failure_kind),
-                        requester_ip.as_deref(),
-                        INVOCATION_UPSTREAM_SCOPE_INTERNAL,
-                        INVOCATION_ROUTE_MODE_POOL,
-                        sticky_key.as_deref(),
-                        prompt_cache_key.as_deref(),
-                        err.account.as_ref().map(|account| account.account_id),
-                        err.account
+                    payload: Some(build_proxy_payload_summary(ProxyPayloadSummary {
+                        target: capture_target,
+                        status: err.status,
+                        is_stream: request_info.is_stream,
+                        request_model: None,
+                        requested_service_tier: request_info.requested_service_tier.as_deref(),
+                        reasoning_effort: request_info.reasoning_effort.as_deref(),
+                        response_model: None,
+                        usage_missing_reason: None,
+                        request_parse_error: request_info.parse_error.as_deref(),
+                        failure_kind: Some(err.failure_kind),
+                        requester_ip: requester_ip.as_deref(),
+                        upstream_scope: INVOCATION_UPSTREAM_SCOPE_INTERNAL,
+                        route_mode: INVOCATION_ROUTE_MODE_POOL,
+                        sticky_key: sticky_key.as_deref(),
+                        prompt_cache_key: prompt_cache_key.as_deref(),
+                        upstream_account_id: err.account.as_ref().map(|account| account.account_id),
+                        upstream_account_name: err
+                            .account
                             .as_ref()
                             .map(|account| account.display_name.as_str()),
-                        None,
-                        None,
-                        err.upstream_error_code.as_deref(),
-                        err.upstream_error_message.as_deref(),
-                        err.upstream_request_id.as_deref(),
-                        None,
-                        None,
-                        None,
-                    )),
+                        service_tier: None,
+                        stream_terminal_event: None,
+                        upstream_error_code: err.upstream_error_code.as_deref(),
+                        upstream_error_message: err.upstream_error_message.as_deref(),
+                        upstream_request_id: err.upstream_request_id.as_deref(),
+                        response_content_encoding: None,
+                        proxy_display_name: pool_proxy_display_name.as_deref(),
+                        proxy_weight_delta: None,
+                    })),
                     raw_response: "{}".to_string(),
                     req_raw,
                     resp_raw: RawPayloadMeta::default(),
@@ -8750,33 +8753,33 @@ async fn proxy_openai_v1_capture_target(
                     },
                     error_message: Some(error_message),
                     failure_kind: Some(err.failure_kind.to_string()),
-                    payload: Some(build_proxy_payload_summary(
-                        capture_target,
-                        err.status,
-                        request_info.is_stream,
-                        None,
-                        request_info.requested_service_tier.as_deref(),
-                        request_info.reasoning_effort.as_deref(),
-                        None,
-                        None,
-                        request_info.parse_error.as_deref(),
-                        Some(err.failure_kind),
-                        requester_ip.as_deref(),
-                        INVOCATION_UPSTREAM_SCOPE_EXTERNAL,
-                        INVOCATION_ROUTE_MODE_FORWARD_PROXY,
-                        sticky_key.as_deref(),
-                        prompt_cache_key.as_deref(),
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        Some(err.selected_proxy.display_name.as_str()),
-                        proxy_attempt_update.delta(),
-                    )),
+                    payload: Some(build_proxy_payload_summary(ProxyPayloadSummary {
+                        target: capture_target,
+                        status: err.status,
+                        is_stream: request_info.is_stream,
+                        request_model: None,
+                        requested_service_tier: request_info.requested_service_tier.as_deref(),
+                        reasoning_effort: request_info.reasoning_effort.as_deref(),
+                        response_model: None,
+                        usage_missing_reason: None,
+                        request_parse_error: request_info.parse_error.as_deref(),
+                        failure_kind: Some(err.failure_kind),
+                        requester_ip: requester_ip.as_deref(),
+                        upstream_scope: INVOCATION_UPSTREAM_SCOPE_EXTERNAL,
+                        route_mode: INVOCATION_ROUTE_MODE_FORWARD_PROXY,
+                        sticky_key: sticky_key.as_deref(),
+                        prompt_cache_key: prompt_cache_key.as_deref(),
+                        upstream_account_id: None,
+                        upstream_account_name: None,
+                        service_tier: None,
+                        stream_terminal_event: None,
+                        upstream_error_code: None,
+                        upstream_error_message: None,
+                        upstream_request_id: None,
+                        response_content_encoding: None,
+                        proxy_display_name: Some(err.selected_proxy.display_name.as_str()),
+                        proxy_weight_delta: proxy_attempt_update.delta(),
+                    })),
                     raw_response: "{}".to_string(),
                     req_raw,
                     resp_raw: RawPayloadMeta::default(),
@@ -8835,6 +8838,10 @@ async fn proxy_openai_v1_capture_target(
                 &usage,
             )
             .await;
+            let proxy_display_name = resolve_invocation_proxy_display_name(
+                selected_proxy.as_ref(),
+                pool_account.as_ref(),
+            );
             let record = ProxyCaptureRecord {
                 invoke_id,
                 occurred_at,
@@ -8846,40 +8853,40 @@ async fn proxy_openai_v1_capture_target(
                 status: "http_502".to_string(),
                 error_message: Some(message.clone()),
                 failure_kind: None,
-                payload: Some(build_proxy_payload_summary(
-                    capture_target,
-                    StatusCode::BAD_GATEWAY,
-                    request_info.is_stream,
-                    None,
-                    request_info.requested_service_tier.as_deref(),
-                    request_info.reasoning_effort.as_deref(),
-                    None,
-                    None,
-                    request_info.parse_error.as_deref(),
-                    None,
-                    requester_ip.as_deref(),
-                    if pool_route_active {
+                payload: Some(build_proxy_payload_summary(ProxyPayloadSummary {
+                    target: capture_target,
+                    status: StatusCode::BAD_GATEWAY,
+                    is_stream: request_info.is_stream,
+                    request_model: None,
+                    requested_service_tier: request_info.requested_service_tier.as_deref(),
+                    reasoning_effort: request_info.reasoning_effort.as_deref(),
+                    response_model: None,
+                    usage_missing_reason: None,
+                    request_parse_error: request_info.parse_error.as_deref(),
+                    failure_kind: None,
+                    requester_ip: requester_ip.as_deref(),
+                    upstream_scope: if pool_route_active {
                         INVOCATION_UPSTREAM_SCOPE_INTERNAL
                     } else {
                         INVOCATION_UPSTREAM_SCOPE_EXTERNAL
                     },
-                    if pool_route_active {
+                    route_mode: if pool_route_active {
                         INVOCATION_ROUTE_MODE_POOL
                     } else {
                         INVOCATION_ROUTE_MODE_FORWARD_PROXY
                     },
-                    sticky_key.as_deref(),
-                    prompt_cache_key.as_deref(),
-                    pool_account.as_ref().map(|account| account.account_id),
-                    pool_account
+                    sticky_key: sticky_key.as_deref(),
+                    prompt_cache_key: prompt_cache_key.as_deref(),
+                    upstream_account_id: pool_account.as_ref().map(|account| account.account_id),
+                    upstream_account_name: pool_account
                         .as_ref()
                         .map(|account| account.display_name.as_str()),
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some(
+                    service_tier: None,
+                    stream_terminal_event: None,
+                    upstream_error_code: None,
+                    upstream_error_message: None,
+                    upstream_request_id: None,
+                    response_content_encoding: Some(
                         summarize_response_content_encoding(
                             upstream_response
                                 .headers()
@@ -8888,15 +8895,13 @@ async fn proxy_openai_v1_capture_target(
                         )
                         .as_str(),
                     ),
-                    selected_proxy
-                        .as_ref()
-                        .map(|proxy| proxy.display_name.as_str()),
-                    if selected_proxy.is_some() {
+                    proxy_display_name: proxy_display_name.as_deref(),
+                    proxy_weight_delta: if selected_proxy.is_some() {
                         proxy_attempt_update.delta()
                     } else {
                         None
                     },
-                )),
+                })),
                 raw_response: "{}".to_string(),
                 req_raw,
                 resp_raw: RawPayloadMeta::default(),
@@ -9086,9 +9091,10 @@ async fn proxy_openai_v1_capture_target(
         } else {
             format!("http_{}", upstream_status.as_u16())
         };
-        let selected_proxy_display_name = selected_proxy_for_task
-            .as_ref()
-            .map(|proxy| proxy.display_name.clone());
+        let selected_proxy_display_name = resolve_invocation_proxy_display_name(
+            selected_proxy_for_task.as_ref(),
+            pool_account_for_task.as_ref(),
+        );
         let proxy_attempt_update = if let Some(selected_proxy) = selected_proxy_for_task.as_ref() {
             let forward_proxy_success = proxy_capture_response_status_is_success(
                 upstream_status,
@@ -9171,49 +9177,49 @@ async fn proxy_openai_v1_capture_target(
             "response",
             &response_bytes,
         );
-        let payload = build_proxy_payload_summary(
-            capture_target,
-            upstream_status,
-            request_info_for_task.is_stream,
-            request_info_for_task.model.as_deref(),
-            request_info_for_task.requested_service_tier.as_deref(),
-            request_info_for_task.reasoning_effort.as_deref(),
-            response_info.model.as_deref(),
-            response_info.usage_missing_reason.as_deref(),
-            request_info_for_task.parse_error.as_deref(),
+        let payload = build_proxy_payload_summary(ProxyPayloadSummary {
+            target: capture_target,
+            status: upstream_status,
+            is_stream: request_info_for_task.is_stream,
+            request_model: request_info_for_task.model.as_deref(),
+            requested_service_tier: request_info_for_task.requested_service_tier.as_deref(),
+            reasoning_effort: request_info_for_task.reasoning_effort.as_deref(),
+            response_model: response_info.model.as_deref(),
+            usage_missing_reason: response_info.usage_missing_reason.as_deref(),
+            request_parse_error: request_info_for_task.parse_error.as_deref(),
             failure_kind,
-            requester_ip_for_task.as_deref(),
-            if pool_account_for_task.is_some() {
+            requester_ip: requester_ip_for_task.as_deref(),
+            upstream_scope: if pool_account_for_task.is_some() {
                 INVOCATION_UPSTREAM_SCOPE_INTERNAL
             } else {
                 INVOCATION_UPSTREAM_SCOPE_EXTERNAL
             },
-            if pool_account_for_task.is_some() {
+            route_mode: if pool_account_for_task.is_some() {
                 INVOCATION_ROUTE_MODE_POOL
             } else {
                 INVOCATION_ROUTE_MODE_FORWARD_PROXY
             },
-            sticky_key_for_task.as_deref(),
-            prompt_cache_key_for_task.as_deref(),
-            pool_account_for_task
+            sticky_key: sticky_key_for_task.as_deref(),
+            prompt_cache_key: prompt_cache_key_for_task.as_deref(),
+            upstream_account_id: pool_account_for_task
                 .as_ref()
                 .map(|account| account.account_id),
-            pool_account_for_task
+            upstream_account_name: pool_account_for_task
                 .as_ref()
                 .map(|account| account.display_name.as_str()),
-            response_info.service_tier.as_deref(),
-            response_info.stream_terminal_event.as_deref(),
-            response_info.upstream_error_code.as_deref(),
-            response_info.upstream_error_message.as_deref(),
-            response_info.upstream_request_id.as_deref(),
-            Some(response_content_encoding.as_str()),
-            selected_proxy_display_name.as_deref(),
-            if selected_proxy_display_name.is_some() {
+            service_tier: response_info.service_tier.as_deref(),
+            stream_terminal_event: response_info.stream_terminal_event.as_deref(),
+            upstream_error_code: response_info.upstream_error_code.as_deref(),
+            upstream_error_message: response_info.upstream_error_message.as_deref(),
+            upstream_request_id: response_info.upstream_request_id.as_deref(),
+            response_content_encoding: Some(response_content_encoding.as_str()),
+            proxy_display_name: selected_proxy_display_name.as_deref(),
+            proxy_weight_delta: if selected_proxy_for_task.is_some() {
                 proxy_attempt_update.delta()
             } else {
                 None
             },
-        );
+        });
 
         let record = ProxyCaptureRecord {
             invoke_id: invoke_id_for_task,
@@ -10160,34 +10166,62 @@ fn json_value_to_i64(value: &Value) -> Option<i64> {
     value.as_str().and_then(|v| v.parse::<i64>().ok())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn build_proxy_payload_summary(
+struct ProxyPayloadSummary<'a> {
     target: ProxyCaptureTarget,
     status: StatusCode,
     is_stream: bool,
-    request_model: Option<&str>,
-    requested_service_tier: Option<&str>,
-    reasoning_effort: Option<&str>,
-    response_model: Option<&str>,
-    usage_missing_reason: Option<&str>,
-    request_parse_error: Option<&str>,
-    failure_kind: Option<&str>,
-    requester_ip: Option<&str>,
-    upstream_scope: &str,
-    route_mode: &str,
-    sticky_key: Option<&str>,
-    prompt_cache_key: Option<&str>,
+    request_model: Option<&'a str>,
+    requested_service_tier: Option<&'a str>,
+    reasoning_effort: Option<&'a str>,
+    response_model: Option<&'a str>,
+    usage_missing_reason: Option<&'a str>,
+    request_parse_error: Option<&'a str>,
+    failure_kind: Option<&'a str>,
+    requester_ip: Option<&'a str>,
+    upstream_scope: &'a str,
+    route_mode: &'a str,
+    sticky_key: Option<&'a str>,
+    prompt_cache_key: Option<&'a str>,
     upstream_account_id: Option<i64>,
-    upstream_account_name: Option<&str>,
-    service_tier: Option<&str>,
-    stream_terminal_event: Option<&str>,
-    upstream_error_code: Option<&str>,
-    upstream_error_message: Option<&str>,
-    upstream_request_id: Option<&str>,
-    response_content_encoding: Option<&str>,
-    proxy_display_name: Option<&str>,
+    upstream_account_name: Option<&'a str>,
+    service_tier: Option<&'a str>,
+    stream_terminal_event: Option<&'a str>,
+    upstream_error_code: Option<&'a str>,
+    upstream_error_message: Option<&'a str>,
+    upstream_request_id: Option<&'a str>,
+    response_content_encoding: Option<&'a str>,
+    proxy_display_name: Option<&'a str>,
     proxy_weight_delta: Option<f64>,
-) -> String {
+}
+
+fn build_proxy_payload_summary(summary: ProxyPayloadSummary<'_>) -> String {
+    let ProxyPayloadSummary {
+        target,
+        status,
+        is_stream,
+        request_model,
+        requested_service_tier,
+        reasoning_effort,
+        response_model,
+        usage_missing_reason,
+        request_parse_error,
+        failure_kind,
+        requester_ip,
+        upstream_scope,
+        route_mode,
+        sticky_key,
+        prompt_cache_key,
+        upstream_account_id,
+        upstream_account_name,
+        service_tier,
+        stream_terminal_event,
+        upstream_error_code,
+        upstream_error_message,
+        upstream_request_id,
+        response_content_encoding,
+        proxy_display_name,
+        proxy_weight_delta,
+    } = summary;
     let payload = json!({
         "endpoint": target.endpoint(),
         "statusCode": status.as_u16(),
@@ -10216,6 +10250,26 @@ fn build_proxy_payload_summary(
         "proxyWeightDelta": proxy_weight_delta,
     });
     serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn format_pool_proxy_display_name(upstream_base_url: &Url) -> String {
+    let host = upstream_base_url
+        .host_str()
+        .unwrap_or_else(|| upstream_base_url.as_str());
+    match upstream_base_url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    }
+}
+
+fn resolve_invocation_proxy_display_name(
+    selected_proxy: Option<&SelectedForwardProxy>,
+    pool_account: Option<&PoolResolvedAccount>,
+) -> Option<String> {
+    if let Some(selected_proxy) = selected_proxy {
+        return Some(selected_proxy.display_name.clone());
+    }
+    pool_account.map(|account| format_pool_proxy_display_name(&account.upstream_base_url))
 }
 
 fn summarize_response_content_encoding(content_encoding: Option<&str>) -> String {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -156,6 +156,71 @@ fn local_naive_to_utc_does_not_fall_back_to_and_utc_on_dst_gap() {
 }
 
 #[test]
+fn resolve_invocation_proxy_display_name_prefers_selected_forward_proxy() {
+    let selected_proxy = SelectedForwardProxy {
+        key: "proxy-a".to_string(),
+        source: "manual".to_string(),
+        display_name: "Tokyo-Edge-1".to_string(),
+        endpoint_url: Some(Url::parse("http://127.0.0.1:7890").expect("valid proxy url")),
+        endpoint_url_raw: Some("http://127.0.0.1:7890".to_string()),
+    };
+    let pool_account = PoolResolvedAccount {
+        account_id: 7,
+        display_name: "Pool Alpha".to_string(),
+        kind: "api_key".to_string(),
+        auth: PoolResolvedAuth::ApiKey {
+            authorization: "Bearer pool-alpha".to_string(),
+        },
+        upstream_base_url: Url::parse("https://claude-relay-service.nsngc.org/openai")
+            .expect("valid upstream url"),
+    };
+
+    assert_eq!(
+        resolve_invocation_proxy_display_name(Some(&selected_proxy), Some(&pool_account))
+            .as_deref(),
+        Some("Tokyo-Edge-1")
+    );
+}
+
+#[test]
+fn resolve_invocation_proxy_display_name_uses_pool_upstream_host_and_port() {
+    let pool_account = PoolResolvedAccount {
+        account_id: 17,
+        display_name: "Pool Beta".to_string(),
+        kind: "api_key".to_string(),
+        auth: PoolResolvedAuth::ApiKey {
+            authorization: "Bearer pool-beta".to_string(),
+        },
+        upstream_base_url: Url::parse("http://127.0.0.1:43121/openai").expect("valid upstream url"),
+    };
+
+    assert_eq!(
+        resolve_invocation_proxy_display_name(None, Some(&pool_account)).as_deref(),
+        Some("127.0.0.1:43121")
+    );
+}
+
+#[test]
+fn resolve_invocation_proxy_display_name_uses_oauth_upstream_host() {
+    let pool_account = PoolResolvedAccount {
+        account_id: 23,
+        display_name: "OAuth Pool".to_string(),
+        kind: "oauth_codex".to_string(),
+        auth: PoolResolvedAuth::Oauth {
+            access_token: "oauth-token".to_string(),
+            chatgpt_account_id: Some("org_test".to_string()),
+        },
+        upstream_base_url: Url::parse("https://chatgpt.com/backend-api/codex")
+            .expect("valid oauth upstream url"),
+    };
+
+    assert_eq!(
+        resolve_invocation_proxy_display_name(None, Some(&pool_account)).as_deref(),
+        Some("chatgpt.com")
+    );
+}
+
+#[test]
 fn normalize_single_proxy_url_supports_scheme_less_host_port() {
     assert_eq!(
         normalize_single_proxy_url("127.0.0.1:7890"),
@@ -9485,6 +9550,24 @@ async fn capture_target_pool_route_retries_first_chunk_failure_and_persists_sing
     assert_eq!(
         payload_json["upstreamAccountName"].as_str(),
         Some("Primary")
+    );
+    let expected_proxy_display_name = {
+        let upstream_url = Url::parse(&upstream_base).expect("valid upstream base url");
+        match upstream_url.port() {
+            Some(port) => format!(
+                "{}:{}",
+                upstream_url.host_str().expect("upstream host should exist"),
+                port
+            ),
+            None => upstream_url
+                .host_str()
+                .expect("upstream host should exist")
+                .to_string(),
+        }
+    };
+    assert_eq!(
+        payload_json["proxyDisplayName"].as_str(),
+        Some(expected_proxy_display_name.as_str())
     );
     assert_eq!(
         wait_for_test_sticky_route_account_id(&state.pool, "sticky-cap-001").await,

--- a/web/src/components/InvocationTable.test.tsx
+++ b/web/src/components/InvocationTable.test.tsx
@@ -287,6 +287,47 @@ describe('InvocationTable', () => {
     expect(html).toContain('data-testid="invocation-account-name"')
   })
 
+  it('shows proxyDisplayName in both summary and expanded details when present', async () => {
+    await renderInteractiveTable([
+      {
+        id: 33,
+        invokeId: 'invocation-proxy-detail-visible',
+        occurredAt: '2026-03-07T03:13:51Z',
+        createdAt: '2026-03-07T03:13:51Z',
+        source: 'proxy',
+        routeMode: 'pool',
+        upstreamAccountId: 7,
+        upstreamAccountName: 'pool-account-a',
+        proxyDisplayName: 'codex-relay-01',
+        responseContentEncoding: 'gzip, br',
+        endpoint: '/v1/responses',
+        model: 'gpt-5.4',
+        status: 'success',
+        totalTokens: 2048,
+        cost: 0.0042,
+        tUpstreamTtfbMs: 118.2,
+        tTotalMs: 910.4,
+      },
+    ])
+
+    const beforeExpandMatches = document.body.textContent?.match(/codex-relay-01/g) ?? []
+    expect(beforeExpandMatches.length).toBeGreaterThanOrEqual(1)
+
+    const toggle = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.getAttribute('aria-expanded') === 'false',
+    )
+    expect(toggle).toBeTruthy()
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('请求详情')
+    const afterExpandMatches = document.body.textContent?.match(/codex-relay-01/g) ?? []
+    expect(afterExpandMatches.length).toBeGreaterThanOrEqual(2)
+  })
+
   it('colors compact endpoint paths without adding extra summary badges', () => {
     const html = renderTable([
       {


### PR DESCRIPTION
## Summary
- restore non-empty `proxyDisplayName` values for future invocation records
- derive pool-route proxy labels from the resolved upstream account host when no forward proxy node exists
- refactor payload construction to use a named summary struct and add regression coverage for Rust + InvocationTable rendering

## Validation
- `cargo check`
- `cargo test --manifest-path /Users/ivan/Projects/Ivan/codex-vibe-monitor-wt-proxy-display-hotfix/Cargo.toml resolve_invocation_proxy_display_name -- --nocapture`
- `cargo test --manifest-path /Users/ivan/Projects/Ivan/codex-vibe-monitor-wt-proxy-display-hotfix/Cargo.toml pool_route_switches_accounts_after_first_chunk_failures_are_exhausted -- --nocapture`
- `cargo test --manifest-path /Users/ivan/Projects/Ivan/codex-vibe-monitor-wt-proxy-display-hotfix/Cargo.toml list_invocations_projects_payload_context_fields -- --nocapture`
- `cd /Users/ivan/Projects/Ivan/codex-vibe-monitor-wt-proxy-display-hotfix/web && bun run test -- --run src/components/InvocationTable.test.tsx`
- `cd /Users/ivan/Projects/Ivan/codex-vibe-monitor-wt-proxy-display-hotfix/web && bun run build`

## Spec Sync
- Spec: `/Users/ivan/Projects/Ivan/codex-vibe-monitor-wt-proxy-display-hotfix/docs/specs/f7nqn-invocation-proxy-display-restore-hotfix/SPEC.md`
- README index updated in `docs/specs/README.md`