### PR TITLE
fix: send oauth chatgpt account header consistently

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8983,6 +8983,8 @@ async fn proxy_openai_v1_capture_target(
                     prompt_cache_key: header_prompt_cache_key.as_deref(),
                     upstream_account_id: None,
                     upstream_account_name: None,
+                    oauth_account_header_attached: None,
+                    oauth_account_id_shape: None,
                     service_tier: None,
                     stream_terminal_event: None,
                     upstream_error_code: None,
@@ -9151,6 +9153,12 @@ async fn proxy_openai_v1_capture_target(
                             .account
                             .as_ref()
                             .map(|account| account.display_name.as_str()),
+                        oauth_account_header_attached: oauth_account_header_attached_for_account(
+                            err.account.as_ref(),
+                        ),
+                        oauth_account_id_shape: oauth_account_id_shape_for_account(
+                            err.account.as_ref(),
+                        ),
                         service_tier: None,
                         stream_terminal_event: None,
                         upstream_error_code: err.upstream_error_code.as_deref(),
@@ -9257,6 +9265,8 @@ async fn proxy_openai_v1_capture_target(
                         prompt_cache_key: prompt_cache_key.as_deref(),
                         upstream_account_id: None,
                         upstream_account_name: None,
+                        oauth_account_header_attached: None,
+                        oauth_account_id_shape: None,
                         service_tier: None,
                         stream_terminal_event: None,
                         upstream_error_code: None,
@@ -9364,6 +9374,12 @@ async fn proxy_openai_v1_capture_target(
                     upstream_account_name: pool_account
                         .as_ref()
                         .map(|account| account.display_name.as_str()),
+                    oauth_account_header_attached: oauth_account_header_attached_for_account(
+                        pool_account.as_ref(),
+                    ),
+                    oauth_account_id_shape: oauth_account_id_shape_for_account(
+                        pool_account.as_ref(),
+                    ),
                     service_tier: None,
                     stream_terminal_event: None,
                     upstream_error_code: None,
@@ -9752,6 +9768,12 @@ async fn proxy_openai_v1_capture_target(
             upstream_account_name: pool_account_for_task
                 .as_ref()
                 .map(|account| account.display_name.as_str()),
+            oauth_account_header_attached: oauth_account_header_attached_for_account(
+                pool_account_for_task.as_ref(),
+            ),
+            oauth_account_id_shape: oauth_account_id_shape_for_account(
+                pool_account_for_task.as_ref(),
+            ),
             service_tier: response_info.service_tier.as_deref(),
             stream_terminal_event: response_info.stream_terminal_event.as_deref(),
             upstream_error_code: response_info.upstream_error_code.as_deref(),
@@ -10732,6 +10754,63 @@ fn upstream_account_id_from_payload(payload: Option<&str>) -> Option<i64> {
     value.get("upstreamAccountId").and_then(json_value_to_i64)
 }
 
+fn normalized_oauth_account_id(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn looks_like_uuid_shape(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 36 {
+        return false;
+    }
+    for (idx, byte) in bytes.iter().enumerate() {
+        let is_hyphen = matches!(idx, 8 | 13 | 18 | 23);
+        if is_hyphen {
+            if *byte != b'-' {
+                return false;
+            }
+        } else if !byte.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    true
+}
+
+fn oauth_account_id_shape(value: Option<&str>) -> &'static str {
+    match normalized_oauth_account_id(value) {
+        None => "empty",
+        Some(value) if value.starts_with("org_") => "org",
+        Some(value) if looks_like_uuid_shape(value) => "uuid",
+        Some(_) => "other",
+    }
+}
+
+fn oauth_account_header_attached_for_account(
+    account: Option<&PoolResolvedAccount>,
+) -> Option<bool> {
+    let PoolResolvedAuth::Oauth {
+        chatgpt_account_id, ..
+    } = &account?.auth
+    else {
+        return None;
+    };
+
+    Some(normalized_oauth_account_id(chatgpt_account_id.as_deref()).is_some())
+}
+
+fn oauth_account_id_shape_for_account(
+    account: Option<&PoolResolvedAccount>,
+) -> Option<&'static str> {
+    let PoolResolvedAuth::Oauth {
+        chatgpt_account_id, ..
+    } = &account?.auth
+    else {
+        return None;
+    };
+
+    Some(oauth_account_id_shape(chatgpt_account_id.as_deref()))
+}
+
 struct ProxyPayloadSummary<'a> {
     target: ProxyCaptureTarget,
     status: StatusCode,
@@ -10750,6 +10829,8 @@ struct ProxyPayloadSummary<'a> {
     prompt_cache_key: Option<&'a str>,
     upstream_account_id: Option<i64>,
     upstream_account_name: Option<&'a str>,
+    oauth_account_header_attached: Option<bool>,
+    oauth_account_id_shape: Option<&'a str>,
     service_tier: Option<&'a str>,
     stream_terminal_event: Option<&'a str>,
     upstream_error_code: Option<&'a str>,
@@ -10779,6 +10860,8 @@ fn build_proxy_payload_summary(summary: ProxyPayloadSummary<'_>) -> String {
         prompt_cache_key,
         upstream_account_id,
         upstream_account_name,
+        oauth_account_header_attached,
+        oauth_account_id_shape,
         service_tier,
         stream_terminal_event,
         upstream_error_code,
@@ -10806,6 +10889,8 @@ fn build_proxy_payload_summary(summary: ProxyPayloadSummary<'_>) -> String {
         "promptCacheKey": prompt_cache_key,
         "upstreamAccountId": upstream_account_id,
         "upstreamAccountName": upstream_account_name,
+        "oauthAccountHeaderAttached": oauth_account_header_attached,
+        "oauthAccountIdShape": oauth_account_id_shape,
         "serviceTier": service_tier,
         "streamTerminalEvent": stream_terminal_event,
         "upstreamErrorCode": upstream_error_code,
@@ -11027,6 +11112,8 @@ fn build_running_proxy_capture_record(
             prompt_cache_key,
             upstream_account_id,
             upstream_account_name,
+            oauth_account_header_attached: None,
+            oauth_account_id_shape: None,
             service_tier: None,
             stream_terminal_event: None,
             upstream_error_code: None,

--- a/src/oauth_bridge.rs
+++ b/src/oauth_bridge.rs
@@ -424,8 +424,11 @@ fn attach_account_header(
     builder: reqwest::RequestBuilder,
     chatgpt_account_id: Option<&str>,
 ) -> reqwest::RequestBuilder {
-    if chatgpt_account_id.is_some_and(|value| value.starts_with("org_")) {
-        builder.header("ChatGPT-Account-Id", chatgpt_account_id.unwrap_or_default())
+    if let Some(account_id) = chatgpt_account_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        builder.header("ChatGPT-Account-Id", account_id)
     } else {
         builder
     }
@@ -667,5 +670,48 @@ mod tests {
             "/v1/responses/compact"
         ));
         assert!(is_supported_oauth_passthrough_route("/v1/chat/completions"));
+    }
+
+    #[test]
+    fn attach_account_header_accepts_uuid_style_account_ids() {
+        let request = attach_account_header(
+            Client::new().get("https://example.com"),
+            Some(" 02355c9d-fb23-4517-a96d-35e5f6758e9e "),
+        )
+        .build()
+        .expect("build request");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("ChatGPT-Account-Id")
+                .and_then(|value| value.to_str().ok()),
+            Some("02355c9d-fb23-4517-a96d-35e5f6758e9e")
+        );
+    }
+
+    #[test]
+    fn attach_account_header_skips_blank_account_ids() {
+        let request = attach_account_header(Client::new().get("https://example.com"), Some("   "))
+            .build()
+            .expect("build request");
+
+        assert!(request.headers().get("ChatGPT-Account-Id").is_none());
+    }
+
+    #[test]
+    fn prepare_responses_request_body_preserves_previous_response_id() {
+        let (wants_stream, rewritten) = prepare_responses_request_body(
+            br#"{"model":"gpt-5.4","stream":false,"max_output_tokens":256,"previous_response_id":"resp_prev_001"}"#,
+        )
+        .expect("rewrite responses request");
+
+        assert!(!wants_stream);
+        let payload: Value = serde_json::from_slice(&rewritten).expect("decode rewritten body");
+        assert_eq!(payload["previous_response_id"], "resp_prev_001");
+        assert_eq!(payload["instructions"], "");
+        assert_eq!(payload["store"], false);
+        assert_eq!(payload["stream"], true);
+        assert!(payload.get("max_output_tokens").is_none());
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2779,6 +2779,21 @@ async fn insert_test_pool_oauth_account(
     display_name: &str,
     access_token: &str,
 ) -> i64 {
+    insert_test_pool_oauth_account_with_chatgpt_account_id(
+        state,
+        display_name,
+        access_token,
+        "org_test",
+    )
+    .await
+}
+
+async fn insert_test_pool_oauth_account_with_chatgpt_account_id(
+    state: &Arc<AppState>,
+    display_name: &str,
+    access_token: &str,
+    chatgpt_account_id: &str,
+) -> i64 {
     ensure_upstream_accounts_schema(&state.pool)
         .await
         .expect("ensure upstream account schema");
@@ -2806,7 +2821,7 @@ async fn insert_test_pool_oauth_account(
     .bind(display_name)
     .bind("active")
     .bind("oauth@example.com")
-    .bind("org_test")
+    .bind(chatgpt_account_id)
     .bind("user_test")
     .bind("team")
     .bind(encrypted_credentials)
@@ -9376,6 +9391,11 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
         .get(http_header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
+    let chatgpt_account_id = request
+        .headers()
+        .get("ChatGPT-Account-Id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     let sticky_key_header = request
         .headers()
         .get("x-sticky-key")
@@ -9399,6 +9419,7 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
         Json(json!({
             "path": path,
             "authorization": authorization,
+            "chatgptAccountId": chatgpt_account_id,
             "stickyKeyHeader": sticky_key_header,
             "promptCacheKeyHeader": prompt_cache_key_header,
             "forwardedFor": forwarded_for,
@@ -9423,6 +9444,75 @@ async fn spawn_oauth_codex_capture_upstream() -> (String, JoinHandle<()>) {
         axum::serve(listener, app)
             .await
             .expect("oauth codex capture upstream should run");
+    });
+    (format!("http://{addr}"), handle)
+}
+
+async fn oauth_codex_responses_capture_upstream(request: axum::extract::Request) -> Response {
+    let path = request.uri().path().to_string();
+    let authorization = request
+        .headers()
+        .get(http_header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let chatgpt_account_id = request
+        .headers()
+        .get("ChatGPT-Account-Id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = to_bytes(request.into_body(), usize::MAX)
+        .await
+        .expect("read oauth codex responses capture request body");
+    let body_value: Value = serde_json::from_slice(&body).expect("decode oauth capture body");
+    let completed_event = serde_json::json!({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_oauth_capture",
+            "model": "gpt-5.4",
+            "status": "completed",
+            "path": path,
+            "authorization": authorization,
+            "chatgptAccountId": chatgpt_account_id,
+            "received": body_value,
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "total_tokens": 15,
+            }
+        }
+    });
+
+    (
+        StatusCode::OK,
+        [(
+            http_header::CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream"),
+        )],
+        [
+            "event: response.completed".to_string(),
+            format!("data: {}", completed_event),
+            String::new(),
+        ]
+        .join("\n"),
+    )
+        .into_response()
+}
+
+async fn spawn_oauth_codex_responses_capture_upstream() -> (String, JoinHandle<()>) {
+    let app = Router::new().route(
+        "/backend-api/codex/responses",
+        post(oauth_codex_responses_capture_upstream),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind oauth codex responses capture upstream");
+    let addr = listener
+        .local_addr()
+        .expect("oauth codex responses capture upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("oauth codex responses capture upstream should run");
     });
     (format!("http://{addr}"), handle)
 }
@@ -10261,7 +10351,101 @@ async fn pool_route_oauth_passthrough_replays_large_file_backed_body() {
         payload["authorization"].as_str(),
         Some("Bearer oauth-large")
     );
+    assert_eq!(payload["chatgptAccountId"].as_str(), Some("org_test"));
     assert_eq!(payload["bodyLength"].as_u64(), Some(body.len() as u64));
+
+    upstream_handle.abort();
+    oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
+}
+
+#[tokio::test]
+async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_observability() {
+    #[derive(sqlx::FromRow)]
+    struct PersistedRow {
+        payload: Option<String>,
+    }
+
+    let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
+        .lock()
+        .await;
+
+    let (upstream_base, upstream_handle) = spawn_oauth_codex_responses_capture_upstream().await;
+    oauth_bridge::set_test_oauth_codex_upstream_base_url(
+        Url::parse(&format!("{upstream_base}/backend-api/codex")).expect("valid oauth base url"),
+    )
+    .await;
+
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let account_id = insert_test_pool_oauth_account_with_chatgpt_account_id(
+        &state,
+        "UUID OAuth",
+        "oauth-uuid",
+        "02355c9d-fb23-4517-a96d-35e5f6758e9e",
+    )
+    .await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-5.4",
+                "input": "hello"
+            }))
+            .expect("serialize oauth responses body"),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read oauth response body");
+    let payload: Value = serde_json::from_slice(&body).expect("decode oauth response body");
+    assert_eq!(
+        payload["path"].as_str(),
+        Some("/backend-api/codex/responses")
+    );
+    assert_eq!(payload["authorization"].as_str(), Some("Bearer oauth-uuid"));
+    assert_eq!(
+        payload["chatgptAccountId"].as_str(),
+        Some("02355c9d-fb23-4517-a96d-35e5f6758e9e")
+    );
+    assert_eq!(payload["received"]["stream"], true);
+    assert_eq!(payload["received"]["store"], false);
+    assert_eq!(payload["received"]["instructions"], "");
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let row = sqlx::query_as::<_, PersistedRow>(
+        r#"
+        SELECT payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load persisted invocation payload");
+    let payload_json: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("payload should be persisted for oauth responses"),
+    )
+    .expect("decode persisted invocation payload");
+    assert_eq!(payload_json["upstreamAccountId"].as_i64(), Some(account_id));
+    assert_eq!(payload_json["oauthAccountHeaderAttached"], true);
+    assert_eq!(payload_json["oauthAccountIdShape"].as_str(), Some("uuid"));
+    assert_eq!(payload_json["endpoint"].as_str(), Some("/v1/responses"));
 
     upstream_handle.abort();
     oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;


### PR DESCRIPTION
## Summary
- send `ChatGPT-Account-Id` for any non-empty OAuth account id instead of only `org_` values
- persist minimal OAuth account-header observability in proxy invocation payloads without exposing raw account ids
- add regression coverage for UUID/team OAuth accounts and preserve existing `/v1/responses` vs `/v1/responses/compact` behavior

## Root Cause
OAuth Codex requests were routed to `chatgpt.com/backend-api/codex` correctly, but the bridge suppressed `ChatGPT-Account-Id` unless the account id started with `org_`. Our production team accounts use UUID-shaped ids, so the header was omitted for the whole OAuth pool.

## Validation
- `cargo test oauth_bridge::tests -- --nocapture`
- `cargo test pool_route_oauth_ -- --nocapture`
- `cargo check`

## Production Follow-up
After merge/deploy, verify OAuth account `id=4` and the same UUID-backed pool accounts no longer stay stuck at `3456/5504` cached tokens on long `gpt-5.4` chains, and compare `/v1/responses` cache ratio against the March 18, 2026 baseline.