### PR TITLE
fix: restore oauth /v1/responses header forwarding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6688,6 +6688,7 @@ async fn read_pool_upstream_first_chunk_with_timeout(
 pub(crate) struct PoolUpstreamResponse {
     pub(crate) account: PoolResolvedAccount,
     pub(crate) response: ProxyUpstreamResponseBody,
+    pub(crate) oauth_responses_debug: Option<oauth_bridge::OauthResponsesDebugInfo>,
     pub(crate) connect_latency_ms: f64,
     pub(crate) first_byte_latency_ms: f64,
     pub(crate) first_chunk: Option<Bytes>,
@@ -6703,6 +6704,7 @@ pub(crate) struct PoolUpstreamError {
     pub(crate) upstream_error_code: Option<String>,
     pub(crate) upstream_error_message: Option<String>,
     pub(crate) upstream_request_id: Option<String>,
+    pub(crate) oauth_responses_debug: Option<oauth_bridge::OauthResponsesDebugInfo>,
 }
 
 #[derive(Debug)]
@@ -7062,6 +7064,7 @@ async fn send_pool_request_with_failover(
                         upstream_error_code: None,
                         upstream_error_message: None,
                         upstream_request_id: None,
+                        oauth_responses_debug: None,
                     }));
                 }
                 Ok(PoolAccountResolution::BlockedByPolicy(message)) => {
@@ -7074,6 +7077,7 @@ async fn send_pool_request_with_failover(
                         upstream_error_code: None,
                         upstream_error_message: None,
                         upstream_request_id: None,
+                        oauth_responses_debug: None,
                     });
                 }
                 Err(err) => {
@@ -7086,6 +7090,7 @@ async fn send_pool_request_with_failover(
                         upstream_error_code: None,
                         upstream_error_message: None,
                         upstream_request_id: None,
+                        oauth_responses_debug: None,
                     });
                 }
             }
@@ -7106,6 +7111,7 @@ async fn send_pool_request_with_failover(
                             upstream_error_code: None,
                             upstream_error_message: None,
                             upstream_request_id: None,
+                            oauth_responses_debug: None,
                         });
                     }
                 }
@@ -7116,7 +7122,7 @@ async fn send_pool_request_with_failover(
 
         for same_account_attempt in 0..same_account_attempts {
             let connect_started = Instant::now();
-            let response = match &account.auth {
+            let (response, oauth_responses_debug) = match &account.auth {
                 PoolResolvedAuth::ApiKey { authorization } => {
                     let mut request = client.request(
                         method.clone(),
@@ -7147,7 +7153,7 @@ async fn send_pool_request_with_failover(
                     }
 
                     match timeout(handshake_timeout, request.send()).await {
-                        Ok(Ok(response)) => ProxyUpstreamResponseBody::Reqwest(response),
+                        Ok(Ok(response)) => (ProxyUpstreamResponseBody::Reqwest(response), None),
                         Ok(Err(err)) => {
                             let message = format!("failed to contact upstream: {err}");
                             let has_retry_budget = same_account_attempt + 1 < same_account_attempts;
@@ -7184,6 +7190,7 @@ async fn send_pool_request_with_failover(
                                 upstream_error_code: None,
                                 upstream_error_message: None,
                                 upstream_request_id: None,
+                                oauth_responses_debug: None,
                             });
                             if excluded_ids.len() >= 64 {
                                 return Err(
@@ -7231,6 +7238,7 @@ async fn send_pool_request_with_failover(
                                 upstream_error_code: None,
                                 upstream_error_message: None,
                                 upstream_request_id: None,
+                                oauth_responses_debug: None,
                             });
                             if excluded_ids.len() >= 64 {
                                 return Err(
@@ -7262,6 +7270,7 @@ async fn send_pool_request_with_failover(
                                 upstream_error_code: None,
                                 upstream_error_message: None,
                                 upstream_request_id: None,
+                                oauth_responses_debug: None,
                             });
                             if excluded_ids.len() >= 64 {
                                 return Err(last_error
@@ -7280,6 +7289,7 @@ async fn send_pool_request_with_failover(
                                     upstream_error_code: None,
                                     upstream_error_message: None,
                                     upstream_request_id: None,
+                                    oauth_responses_debug: None,
                                 })?,
                             )
                         }
@@ -7297,8 +7307,8 @@ async fn send_pool_request_with_failover(
                             "failed to record selected pool account"
                         );
                     }
-                    ProxyUpstreamResponseBody::Axum(
-                        oauth_bridge::send_oauth_upstream_request(
+                    {
+                        let oauth_response = oauth_bridge::send_oauth_upstream_request(
                             &client,
                             method.clone(),
                             original_uri,
@@ -7306,11 +7316,16 @@ async fn send_pool_request_with_failover(
                             oauth_body,
                             handshake_timeout,
                             state.config.request_timeout,
+                            Some(account.account_id),
                             access_token,
                             chatgpt_account_id.as_deref(),
                         )
-                        .await,
-                    )
+                        .await;
+                        (
+                            ProxyUpstreamResponseBody::Axum(oauth_response.response),
+                            oauth_response.responses_debug,
+                        )
+                    }
                 }
             };
 
@@ -7404,6 +7419,7 @@ async fn send_pool_request_with_failover(
                     upstream_error_code,
                     upstream_error_message,
                     upstream_request_id,
+                    oauth_responses_debug: oauth_responses_debug.clone(),
                 });
                 if excluded_ids.len() >= 64 {
                     return Err(last_error.expect("pool http failure should be recorded"));
@@ -7455,6 +7471,7 @@ async fn send_pool_request_with_failover(
                         upstream_error_code: None,
                         upstream_error_message: None,
                         upstream_request_id: None,
+                        oauth_responses_debug: oauth_responses_debug.clone(),
                     });
                     if excluded_ids.len() >= 64 {
                         return Err(
@@ -7468,6 +7485,7 @@ async fn send_pool_request_with_failover(
             return Ok(PoolUpstreamResponse {
                 account: account.clone(),
                 response,
+                oauth_responses_debug,
                 connect_latency_ms,
                 first_byte_latency_ms: elapsed_ms(first_byte_started),
                 first_chunk,
@@ -7555,6 +7573,7 @@ async fn continue_or_retry_pool_live_request(
             upstream_error_code: None,
             upstream_error_message: None,
             upstream_request_id: None,
+            oauth_responses_debug: None,
         }),
         PoolReplayBodyStatus::InternalError(message) => Err(PoolUpstreamError {
             account: Some(initial_account),
@@ -7565,6 +7584,7 @@ async fn continue_or_retry_pool_live_request(
             upstream_error_code: None,
             upstream_error_message: None,
             upstream_request_id: None,
+            oauth_responses_debug: None,
         }),
         PoolReplayBodyStatus::Reading | PoolReplayBodyStatus::Incomplete => {
             replay_cancel.cancel();
@@ -7724,20 +7744,21 @@ async fn proxy_openai_v1_via_pool(
                     let replay_status_rx = replayable.status_rx.clone();
                     let replay_cancel = replayable.cancel.clone();
                     let connect_started = Instant::now();
-                    let response = ProxyUpstreamResponseBody::Axum(
-                        oauth_bridge::send_oauth_upstream_request(
-                            &state.http_clients.client_for_pool_upstream(),
-                            method.clone(),
-                            original_uri,
-                            &headers,
-                            oauth_bridge::OauthUpstreamRequestBody::Stream(replayable.body),
-                            handshake_timeout,
-                            state.config.request_timeout,
-                            access_token,
-                            chatgpt_account_id.as_deref(),
-                        )
-                        .await,
-                    );
+                    let oauth_response = oauth_bridge::send_oauth_upstream_request(
+                        &state.http_clients.client_for_pool_upstream(),
+                        method.clone(),
+                        original_uri,
+                        &headers,
+                        oauth_bridge::OauthUpstreamRequestBody::Stream(replayable.body),
+                        handshake_timeout,
+                        state.config.request_timeout,
+                        Some(initial_account.account_id),
+                        access_token,
+                        chatgpt_account_id.as_deref(),
+                    )
+                    .await;
+                    let response = ProxyUpstreamResponseBody::Axum(oauth_response.response);
+                    let oauth_responses_debug = oauth_response.responses_debug;
                     let connect_latency_ms = elapsed_ms(connect_started);
                     let status = response.status();
                     let upstream = if status == StatusCode::TOO_MANY_REQUESTS
@@ -7795,6 +7816,7 @@ async fn proxy_openai_v1_via_pool(
                             upstream_error_code,
                             upstream_error_message,
                             upstream_request_id,
+                            oauth_responses_debug: oauth_responses_debug.clone(),
                         };
                         continue_or_retry_pool_live_request(
                             state.clone(),
@@ -7822,6 +7844,7 @@ async fn proxy_openai_v1_via_pool(
                             Ok((response, first_chunk)) => PoolUpstreamResponse {
                                 account: initial_account,
                                 response,
+                                oauth_responses_debug,
                                 connect_latency_ms,
                                 first_byte_latency_ms: elapsed_ms(first_byte_started),
                                 first_chunk,
@@ -7838,6 +7861,7 @@ async fn proxy_openai_v1_via_pool(
                                     upstream_error_code: None,
                                     upstream_error_message: None,
                                     upstream_request_id: None,
+                                    oauth_responses_debug: oauth_responses_debug.clone(),
                                 };
                                 continue_or_retry_pool_live_request(
                                     state.clone(),
@@ -7965,6 +7989,7 @@ async fn proxy_openai_v1_via_pool(
                                 upstream_error_code,
                                 upstream_error_message,
                                 upstream_request_id,
+                                oauth_responses_debug: None,
                             };
                             continue_or_retry_pool_live_request(
                                 state.clone(),
@@ -7992,6 +8017,7 @@ async fn proxy_openai_v1_via_pool(
                                 Ok((response, first_chunk)) => PoolUpstreamResponse {
                                     account: initial_account,
                                     response,
+                                    oauth_responses_debug: None,
                                     connect_latency_ms,
                                     first_byte_latency_ms: elapsed_ms(first_byte_started),
                                     first_chunk,
@@ -8008,6 +8034,7 @@ async fn proxy_openai_v1_via_pool(
                                         upstream_error_code: None,
                                         upstream_error_message: None,
                                         upstream_request_id: None,
+                                        oauth_responses_debug: None,
                                     };
                                     continue_or_retry_pool_live_request(
                                         state.clone(),
@@ -8037,6 +8064,7 @@ async fn proxy_openai_v1_via_pool(
                             upstream_error_code: None,
                             upstream_error_message: None,
                             upstream_request_id: None,
+                            oauth_responses_debug: None,
                         };
                         continue_or_retry_pool_live_request(
                             state.clone(),
@@ -8066,6 +8094,7 @@ async fn proxy_openai_v1_via_pool(
                             upstream_error_code: None,
                             upstream_error_message: None,
                             upstream_request_id: None,
+                            oauth_responses_debug: None,
                         };
                         continue_or_retry_pool_live_request(
                             state.clone(),
@@ -8993,6 +9022,10 @@ async fn proxy_openai_v1_capture_target(
                     upstream_account_name: None,
                     oauth_account_header_attached: None,
                     oauth_account_id_shape: None,
+                    oauth_forwarded_header_count: None,
+                    oauth_forwarded_header_names: None,
+                    oauth_prompt_cache_header_forwarded: None,
+                    oauth_responses_rewrite: None,
                     service_tier: None,
                     stream_terminal_event: None,
                     upstream_error_code: None,
@@ -9087,6 +9120,7 @@ async fn proxy_openai_v1_capture_target(
         t_upstream_connect_ms,
         prefetched_first_chunk,
         prefetched_ttfb_ms,
+        oauth_responses_debug,
         attempt_already_recorded,
         final_attempt_update,
         upstream_response,
@@ -9110,6 +9144,7 @@ async fn proxy_openai_v1_capture_target(
                 response.connect_latency_ms,
                 response.first_chunk,
                 response.first_byte_latency_ms,
+                response.oauth_responses_debug,
                 true,
                 None,
                 response.response,
@@ -9167,6 +9202,22 @@ async fn proxy_openai_v1_capture_target(
                         oauth_account_id_shape: oauth_account_id_shape_for_account(
                             err.account.as_ref(),
                         ),
+                        oauth_forwarded_header_count: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .map(|debug| debug.forwarded_header_names.len()),
+                        oauth_forwarded_header_names: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .map(|debug| debug.forwarded_header_names.as_slice()),
+                        oauth_prompt_cache_header_forwarded: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .map(|debug| debug.prompt_cache_header_forwarded),
+                        oauth_responses_rewrite: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .map(|debug| &debug.rewrite),
                         service_tier: None,
                         stream_terminal_event: None,
                         upstream_error_code: err.upstream_error_code.as_deref(),
@@ -9217,6 +9268,7 @@ async fn proxy_openai_v1_capture_target(
                 response.connect_latency_ms,
                 None,
                 0.0,
+                None,
                 response.attempt_recorded,
                 response.attempt_update,
                 response.response,
@@ -9275,6 +9327,10 @@ async fn proxy_openai_v1_capture_target(
                         upstream_account_name: None,
                         oauth_account_header_attached: None,
                         oauth_account_id_shape: None,
+                        oauth_forwarded_header_count: None,
+                        oauth_forwarded_header_names: None,
+                        oauth_prompt_cache_header_forwarded: None,
+                        oauth_responses_rewrite: None,
                         service_tier: None,
                         stream_terminal_event: None,
                         upstream_error_code: None,
@@ -9388,6 +9444,10 @@ async fn proxy_openai_v1_capture_target(
                     oauth_account_id_shape: oauth_account_id_shape_for_account(
                         pool_account.as_ref(),
                     ),
+                    oauth_forwarded_header_count: None,
+                    oauth_forwarded_header_names: None,
+                    oauth_prompt_cache_header_forwarded: None,
+                    oauth_responses_rewrite: None,
                     service_tier: None,
                     stream_terminal_event: None,
                     upstream_error_code: None,
@@ -9496,6 +9556,7 @@ async fn proxy_openai_v1_capture_target(
     let selected_proxy_for_task = selected_proxy.clone();
     let selected_proxy_display_name_for_task = selected_proxy_display_name.clone();
     let pool_account_for_task = pool_account.clone();
+    let oauth_responses_debug_for_task = oauth_responses_debug.clone();
     let attempt_already_recorded_for_task = attempt_already_recorded;
     let final_attempt_update_for_task = final_attempt_update;
     let prefetched_first_chunk_for_task = prefetched_first_chunk;
@@ -9782,6 +9843,18 @@ async fn proxy_openai_v1_capture_target(
             oauth_account_id_shape: oauth_account_id_shape_for_account(
                 pool_account_for_task.as_ref(),
             ),
+            oauth_forwarded_header_count: oauth_responses_debug_for_task
+                .as_ref()
+                .map(|debug| debug.forwarded_header_names.len()),
+            oauth_forwarded_header_names: oauth_responses_debug_for_task
+                .as_ref()
+                .map(|debug| debug.forwarded_header_names.as_slice()),
+            oauth_prompt_cache_header_forwarded: oauth_responses_debug_for_task
+                .as_ref()
+                .map(|debug| debug.prompt_cache_header_forwarded),
+            oauth_responses_rewrite: oauth_responses_debug_for_task
+                .as_ref()
+                .map(|debug| &debug.rewrite),
             service_tier: response_info.service_tier.as_deref(),
             stream_terminal_event: response_info.stream_terminal_event.as_deref(),
             upstream_error_code: response_info.upstream_error_code.as_deref(),
@@ -10839,6 +10912,10 @@ struct ProxyPayloadSummary<'a> {
     upstream_account_name: Option<&'a str>,
     oauth_account_header_attached: Option<bool>,
     oauth_account_id_shape: Option<&'a str>,
+    oauth_forwarded_header_count: Option<usize>,
+    oauth_forwarded_header_names: Option<&'a [String]>,
+    oauth_prompt_cache_header_forwarded: Option<bool>,
+    oauth_responses_rewrite: Option<&'a oauth_bridge::OauthResponsesRewriteSummary>,
     service_tier: Option<&'a str>,
     stream_terminal_event: Option<&'a str>,
     upstream_error_code: Option<&'a str>,
@@ -10870,6 +10947,10 @@ fn build_proxy_payload_summary(summary: ProxyPayloadSummary<'_>) -> String {
         upstream_account_name,
         oauth_account_header_attached,
         oauth_account_id_shape,
+        oauth_forwarded_header_count,
+        oauth_forwarded_header_names,
+        oauth_prompt_cache_header_forwarded,
+        oauth_responses_rewrite,
         service_tier,
         stream_terminal_event,
         upstream_error_code,
@@ -10899,6 +10980,10 @@ fn build_proxy_payload_summary(summary: ProxyPayloadSummary<'_>) -> String {
         "upstreamAccountName": upstream_account_name,
         "oauthAccountHeaderAttached": oauth_account_header_attached,
         "oauthAccountIdShape": oauth_account_id_shape,
+        "oauthForwardedHeaderCount": oauth_forwarded_header_count,
+        "oauthForwardedHeaderNames": oauth_forwarded_header_names,
+        "oauthPromptCacheHeaderForwarded": oauth_prompt_cache_header_forwarded,
+        "oauthResponsesRewrite": oauth_responses_rewrite,
         "serviceTier": service_tier,
         "streamTerminalEvent": stream_terminal_event,
         "upstreamErrorCode": upstream_error_code,
@@ -11122,6 +11207,10 @@ fn build_running_proxy_capture_record(
             upstream_account_name,
             oauth_account_header_attached: None,
             oauth_account_id_shape: None,
+            oauth_forwarded_header_count: None,
+            oauth_forwarded_header_names: None,
+            oauth_prompt_cache_header_forwarded: None,
+            oauth_responses_rewrite: None,
             service_tier: None,
             stream_terminal_event: None,
             upstream_error_code: None,

--- a/src/oauth_bridge.rs
+++ b/src/oauth_bridge.rs
@@ -7,9 +7,12 @@ use axum::{
 };
 use futures_util::TryStreamExt;
 use reqwest::{Body as ReqwestBody, Client, Url};
+use serde::Serialize;
 use serde_json::{Value, json};
+use std::collections::BTreeSet;
 use std::time::Duration;
 use tokio::time::{Instant, timeout};
+use tracing::info;
 
 #[cfg(test)]
 use once_cell::sync::Lazy;
@@ -18,6 +21,17 @@ use std::sync::Mutex as StdMutex;
 
 const OAUTH_CODEX_UPSTREAM_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const OAUTH_CODEX_MODELS_CLIENT_VERSION: &str = "0.111.0";
+const OAUTH_RESPONSES_EXCLUDED_HEADER_NAMES: &[&str] = &[
+    "content-type",
+    "content-length",
+    "openai-beta",
+    "chatgpt-account-id",
+];
+const PROMPT_CACHE_HEADER_NAMES: &[&str] = &[
+    "x-prompt-cache-key",
+    "prompt-cache-key",
+    "x-openai-prompt-cache-key",
+];
 
 #[cfg(test)]
 static TEST_OAUTH_CODEX_UPSTREAM_BASE_URL: Lazy<StdMutex<Option<Url>>> =
@@ -61,6 +75,41 @@ pub(crate) enum OauthUpstreamRequestBody {
     Stream(ReqwestBody),
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OauthResponsesRewriteSummary {
+    pub(crate) applied: bool,
+    pub(crate) added_instructions: bool,
+    pub(crate) added_store: bool,
+    pub(crate) forced_stream_true: bool,
+    pub(crate) removed_max_output_tokens: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct OauthForwardedHeaderSummary {
+    pub(crate) names: Vec<String>,
+    pub(crate) prompt_cache_header_forwarded: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OauthResponsesDebugInfo {
+    pub(crate) forwarded_header_names: Vec<String>,
+    pub(crate) prompt_cache_header_forwarded: bool,
+    pub(crate) rewrite: OauthResponsesRewriteSummary,
+}
+
+pub(crate) struct OauthUpstreamResponse {
+    pub(crate) response: Response,
+    pub(crate) responses_debug: Option<OauthResponsesDebugInfo>,
+}
+
+struct PreparedResponsesRequestBody {
+    wants_stream: bool,
+    body: Vec<u8>,
+    rewrite: OauthResponsesRewriteSummary,
+}
+
 pub(crate) async fn send_oauth_upstream_request(
     client: &Client,
     method: Method,
@@ -69,9 +118,10 @@ pub(crate) async fn send_oauth_upstream_request(
     body: OauthUpstreamRequestBody,
     handshake_timeout: Duration,
     response_timeout: Duration,
+    account_id: Option<i64>,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
-) -> Response {
+) -> OauthUpstreamResponse {
     match original_uri.path() {
         "/v1/models" => {
             oauth_models(
@@ -86,19 +136,24 @@ pub(crate) async fn send_oauth_upstream_request(
         "/v1/responses" => {
             oauth_responses(
                 client,
+                headers,
                 handshake_timeout,
                 response_timeout,
+                account_id,
                 access_token,
                 chatgpt_account_id,
                 match body {
                     OauthUpstreamRequestBody::Empty => Bytes::new(),
                     OauthUpstreamRequestBody::Bytes(bytes) => bytes,
                     OauthUpstreamRequestBody::Stream(_) => {
-                        return error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "streamed request bodies are not supported for /v1/responses",
-                            "server_error",
-                        );
+                        return OauthUpstreamResponse {
+                            response: error_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "streamed request bodies are not supported for /v1/responses",
+                                "server_error",
+                            ),
+                            responses_debug: None,
+                        };
                     }
                 },
             )
@@ -121,14 +176,17 @@ pub(crate) async fn send_oauth_upstream_request(
             )
             .await
         }
-        _ => error_response(
-            StatusCode::NOT_FOUND,
-            &format!(
-                "oauth upstream route is not supported: {}",
-                original_uri.path()
+        _ => OauthUpstreamResponse {
+            response: error_response(
+                StatusCode::NOT_FOUND,
+                &format!(
+                    "oauth upstream route is not supported: {}",
+                    original_uri.path()
+                ),
+                "oauth_unsupported_route",
             ),
-            "oauth_unsupported_route",
-        ),
+            responses_debug: None,
+        },
     }
 }
 
@@ -142,15 +200,18 @@ async fn oauth_models(
     response_timeout: Duration,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
-) -> Response {
+) -> OauthUpstreamResponse {
     let mut upstream_url = match oauth_codex_upstream_base_url() {
         Ok(url) => url,
         Err(err) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("invalid oauth codex models url: {err}"),
-                "server_error",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("invalid oauth codex models url: {err}"),
+                    "server_error",
+                ),
+                responses_debug: None,
+            };
         }
     };
     upstream_url.set_path(&format!(
@@ -170,21 +231,27 @@ async fn oauth_models(
     let upstream = match timeout(handshake_timeout, request.send()).await {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!("failed to contact oauth codex upstream: {err}"),
-                "oauth_upstream_unavailable",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!("failed to contact oauth codex upstream: {err}"),
+                    "oauth_upstream_unavailable",
+                ),
+                responses_debug: None,
+            };
         }
         Err(_) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!(
-                    "oauth codex upstream handshake timed out after {}ms",
-                    handshake_timeout.as_millis()
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!(
+                        "oauth codex upstream handshake timed out after {}ms",
+                        handshake_timeout.as_millis()
+                    ),
+                    "oauth_upstream_handshake_timeout",
                 ),
-                "oauth_upstream_handshake_timeout",
-            );
+                responses_debug: None,
+            };
         }
     };
     let status = upstream.status();
@@ -198,80 +265,132 @@ async fn oauth_models(
     {
         Ok(bytes) => bytes,
         Err(err) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!("failed to read oauth codex models response: {err}"),
-                "oauth_upstream_read_failed",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!("failed to read oauth codex models response: {err}"),
+                    "oauth_upstream_read_failed",
+                ),
+                responses_debug: None,
+            };
         }
     };
     if !status.is_success() {
-        return json_or_plain_error_response(status, &bytes, "oauth_upstream_rejected_request");
+        return OauthUpstreamResponse {
+            response: json_or_plain_error_response(
+                status,
+                &bytes,
+                "oauth_upstream_rejected_request",
+            ),
+            responses_debug: None,
+        };
     }
     match transform_models_payload(&bytes) {
-        Ok(value) => (status, Json(value)).into_response(),
-        Err(err) => error_response(
-            StatusCode::BAD_GATEWAY,
-            &format!("oauth codex returned malformed models payload: {err}"),
-            "oauth_upstream_invalid_models",
-        ),
+        Ok(value) => OauthUpstreamResponse {
+            response: (status, Json(value)).into_response(),
+            responses_debug: None,
+        },
+        Err(err) => OauthUpstreamResponse {
+            response: error_response(
+                StatusCode::BAD_GATEWAY,
+                &format!("oauth codex returned malformed models payload: {err}"),
+                "oauth_upstream_invalid_models",
+            ),
+            responses_debug: None,
+        },
     }
 }
 
 async fn oauth_responses(
     client: &Client,
+    headers: &HeaderMap,
     handshake_timeout: Duration,
     response_timeout: Duration,
+    account_id: Option<i64>,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
     body: Bytes,
-) -> Response {
-    let (wants_stream, upstream_body) = match prepare_responses_request_body(&body) {
+) -> OauthUpstreamResponse {
+    let prepared = match prepare_responses_request_body(&body) {
         Ok(value) => value,
         Err(err) => {
-            return error_response(
-                StatusCode::BAD_REQUEST,
-                &err.to_string(),
-                "invalid_request_error",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_REQUEST,
+                    &err.to_string(),
+                    "invalid_request_error",
+                ),
+                responses_debug: None,
+            };
         }
     };
     let upstream_url = match build_oauth_upstream_url("/responses", None) {
         Ok(url) => url,
         Err(err) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("invalid oauth codex responses url: {err}"),
-                "server_error",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("invalid oauth codex responses url: {err}"),
+                    "server_error",
+                ),
+                responses_debug: None,
+            };
         }
     };
-    let request = client
-        .post(upstream_url)
+    let (request, forwarded_headers) = copy_forwardable_headers(
+        client.post(upstream_url),
+        headers,
+        OAUTH_RESPONSES_EXCLUDED_HEADER_NAMES,
+    );
+    let request = request
         .header(header::CONTENT_TYPE, "application/json")
         .bearer_auth(access_token)
         .header("OpenAI-Beta", "responses=experimental")
-        .body(upstream_body);
+        .body(prepared.body);
     let request = attach_account_header(request, chatgpt_account_id);
+    let responses_debug = OauthResponsesDebugInfo {
+        forwarded_header_names: forwarded_headers.names.clone(),
+        prompt_cache_header_forwarded: forwarded_headers.prompt_cache_header_forwarded,
+        rewrite: prepared.rewrite.clone(),
+    };
+    info!(
+        account_id,
+        path = "/v1/responses",
+        forwarded_header_count = responses_debug.forwarded_header_names.len(),
+        forwarded_header_names = ?responses_debug.forwarded_header_names,
+        prompt_cache_header_forwarded = responses_debug.prompt_cache_header_forwarded,
+        rewrite_applied = responses_debug.rewrite.applied,
+        rewrite_added_instructions = responses_debug.rewrite.added_instructions,
+        rewrite_added_store = responses_debug.rewrite.added_store,
+        rewrite_forced_stream_true = responses_debug.rewrite.forced_stream_true,
+        rewrite_removed_max_output_tokens = responses_debug.rewrite.removed_max_output_tokens,
+        "forwarding oauth responses request"
+    );
     let request_started = Instant::now();
     let upstream = match timeout(handshake_timeout, request.send()).await {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!("failed to contact oauth codex upstream: {err}"),
-                "oauth_upstream_unavailable",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!("failed to contact oauth codex upstream: {err}"),
+                    "oauth_upstream_unavailable",
+                ),
+                responses_debug: Some(responses_debug),
+            };
         }
         Err(_) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!(
-                    "oauth codex upstream handshake timed out after {}ms",
-                    handshake_timeout.as_millis()
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!(
+                        "oauth codex upstream handshake timed out after {}ms",
+                        handshake_timeout.as_millis()
+                    ),
+                    "oauth_upstream_handshake_timeout",
                 ),
-                "oauth_upstream_handshake_timeout",
-            );
+                responses_debug: Some(responses_debug),
+            };
         }
     };
     if !upstream.status().is_success() {
@@ -286,17 +405,30 @@ async fn oauth_responses(
         {
             Ok(bytes) => bytes,
             Err(err) => {
-                return error_response(
-                    StatusCode::BAD_GATEWAY,
-                    &format!("failed to read oauth codex error response: {err}"),
-                    "oauth_upstream_read_failed",
-                );
+                return OauthUpstreamResponse {
+                    response: error_response(
+                        StatusCode::BAD_GATEWAY,
+                        &format!("failed to read oauth codex error response: {err}"),
+                        "oauth_upstream_read_failed",
+                    ),
+                    responses_debug: Some(responses_debug),
+                };
             }
         };
-        return json_or_plain_error_response(status, &bytes, "oauth_upstream_rejected_request");
+        return OauthUpstreamResponse {
+            response: json_or_plain_error_response(
+                status,
+                &bytes,
+                "oauth_upstream_rejected_request",
+            ),
+            responses_debug: Some(responses_debug),
+        };
     }
-    if wants_stream {
-        return reqwest_response_to_axum_response(upstream);
+    if prepared.wants_stream {
+        return OauthUpstreamResponse {
+            response: reqwest_response_to_axum_response(upstream),
+            responses_debug: Some(responses_debug),
+        };
     }
     let bytes = match read_oauth_upstream_bytes_with_timeout(
         upstream,
@@ -308,20 +440,29 @@ async fn oauth_responses(
     {
         Ok(bytes) => bytes,
         Err(err) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!("failed to read oauth codex responses stream: {err}"),
-                "oauth_upstream_read_failed",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!("failed to read oauth codex responses stream: {err}"),
+                    "oauth_upstream_read_failed",
+                ),
+                responses_debug: Some(responses_debug),
+            };
         }
     };
     match extract_completed_response_from_sse(&bytes) {
-        Ok(response_value) => (StatusCode::OK, Json(response_value)).into_response(),
-        Err(err) => error_response(
-            StatusCode::BAD_GATEWAY,
-            &format!("failed to decode oauth codex response stream: {err}"),
-            "oauth_upstream_invalid_response",
-        ),
+        Ok(response_value) => OauthUpstreamResponse {
+            response: (StatusCode::OK, Json(response_value)).into_response(),
+            responses_debug: Some(responses_debug),
+        },
+        Err(err) => OauthUpstreamResponse {
+            response: error_response(
+                StatusCode::BAD_GATEWAY,
+                &format!("failed to decode oauth codex response stream: {err}"),
+                "oauth_upstream_invalid_response",
+            ),
+            responses_debug: Some(responses_debug),
+        },
     }
 }
 
@@ -334,7 +475,7 @@ async fn oauth_passthrough(
     handshake_timeout: Duration,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
-) -> Response {
+) -> OauthUpstreamResponse {
     let suffix = original_uri
         .path()
         .strip_prefix("/v1")
@@ -342,11 +483,14 @@ async fn oauth_passthrough(
     let upstream_url = match build_oauth_upstream_url(suffix, original_uri.query()) {
         Ok(url) => url,
         Err(err) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("invalid oauth codex upstream url: {err}"),
-                "server_error",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("invalid oauth codex upstream url: {err}"),
+                    "server_error",
+                ),
+                responses_debug: None,
+            };
         }
     };
     let mut builder = client
@@ -354,28 +498,37 @@ async fn oauth_passthrough(
         .bearer_auth(access_token)
         .header("OpenAI-Beta", "responses=experimental");
     builder = attach_account_header(builder, chatgpt_account_id);
-    builder = copy_forwardable_headers(builder, headers);
+    let (builder, _) = copy_forwardable_headers(builder, headers, &[]);
     let upstream = match timeout(handshake_timeout, builder.body(body).send()).await {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!("failed to contact oauth codex upstream: {err}"),
-                "oauth_upstream_unavailable",
-            );
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!("failed to contact oauth codex upstream: {err}"),
+                    "oauth_upstream_unavailable",
+                ),
+                responses_debug: None,
+            };
         }
         Err(_) => {
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                &format!(
-                    "oauth codex upstream handshake timed out after {}ms",
-                    handshake_timeout.as_millis()
+            return OauthUpstreamResponse {
+                response: error_response(
+                    StatusCode::BAD_GATEWAY,
+                    &format!(
+                        "oauth codex upstream handshake timed out after {}ms",
+                        handshake_timeout.as_millis()
+                    ),
+                    "oauth_upstream_handshake_timeout",
                 ),
-                "oauth_upstream_handshake_timeout",
-            );
+                responses_debug: None,
+            };
         }
     };
-    reqwest_response_to_axum_response(upstream)
+    OauthUpstreamResponse {
+        response: reqwest_response_to_axum_response(upstream),
+        responses_debug: None,
+    }
 }
 
 fn build_oauth_upstream_url(path_suffix: &str, query: Option<&str>) -> Result<Url> {
@@ -395,29 +548,44 @@ fn build_oauth_upstream_url(path_suffix: &str, query: Option<&str>) -> Result<Ur
 fn copy_forwardable_headers(
     mut builder: reqwest::RequestBuilder,
     headers: &HeaderMap,
-) -> reqwest::RequestBuilder {
+    excluded_names: &[&str],
+) -> (reqwest::RequestBuilder, OauthForwardedHeaderSummary) {
     let connection_scoped = crate::connection_scoped_header_names(headers);
+    let mut forwarded_names = BTreeSet::new();
     for (name, value) in headers {
         if *name == header::AUTHORIZATION
+            || excluded_names
+                .iter()
+                .any(|candidate| name.as_str().eq_ignore_ascii_case(candidate))
             || !crate::should_forward_proxy_header(name, &connection_scoped)
             || is_internal_proxy_metadata_header(name)
         {
             continue;
         }
         builder = builder.header(name, value);
+        forwarded_names.insert(name.as_str().to_ascii_lowercase());
     }
-    builder
+    let names = forwarded_names.into_iter().collect::<Vec<_>>();
+    let prompt_cache_header_forwarded = names
+        .iter()
+        .any(|name| is_prompt_cache_header_name(name.as_str()));
+    (
+        builder,
+        OauthForwardedHeaderSummary {
+            names,
+            prompt_cache_header_forwarded,
+        },
+    )
 }
 
 fn is_internal_proxy_metadata_header(name: &header::HeaderName) -> bool {
-    matches!(
-        name.as_str(),
-        "x-sticky-key"
-            | "sticky-key"
-            | "x-prompt-cache-key"
-            | "prompt-cache-key"
-            | "x-openai-prompt-cache-key"
-    )
+    matches!(name.as_str(), "x-sticky-key" | "sticky-key")
+}
+
+fn is_prompt_cache_header_name(name: &str) -> bool {
+    PROMPT_CACHE_HEADER_NAMES
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
 }
 
 fn attach_account_header(
@@ -481,22 +649,34 @@ fn reqwest_response_to_axum_response(response: reqwest::Response) -> Response {
         })
 }
 
-fn prepare_responses_request_body(body: &[u8]) -> Result<(bool, Vec<u8>)> {
+fn prepare_responses_request_body(body: &[u8]) -> Result<PreparedResponsesRequestBody> {
     let mut value: Value =
         serde_json::from_slice(body).context("request body must be valid JSON")?;
     let Value::Object(ref mut map) = value else {
         bail!("request body must be a JSON object");
     };
     let wants_stream = map.get("stream").and_then(Value::as_bool).unwrap_or(false);
+    let mut rewrite = OauthResponsesRewriteSummary::default();
     if !map.contains_key("instructions") {
         map.insert("instructions".to_string(), Value::String(String::new()));
+        rewrite.added_instructions = true;
     }
     if !map.contains_key("store") {
         map.insert("store".to_string(), Value::Bool(false));
+        rewrite.added_store = true;
     }
+    rewrite.forced_stream_true = map.get("stream").and_then(Value::as_bool) != Some(true);
     map.insert("stream".to_string(), Value::Bool(true));
-    map.remove("max_output_tokens");
-    Ok((wants_stream, serde_json::to_vec(&value)?))
+    rewrite.removed_max_output_tokens = map.remove("max_output_tokens").is_some();
+    rewrite.applied = rewrite.added_instructions
+        || rewrite.added_store
+        || rewrite.forced_stream_true
+        || rewrite.removed_max_output_tokens;
+    Ok(PreparedResponsesRequestBody {
+        wants_stream,
+        body: serde_json::to_vec(&value)?,
+        rewrite,
+    })
 }
 
 fn extract_completed_response_from_sse(bytes: &[u8]) -> Result<Value> {
@@ -701,17 +881,158 @@ mod tests {
 
     #[test]
     fn prepare_responses_request_body_preserves_previous_response_id() {
-        let (wants_stream, rewritten) = prepare_responses_request_body(
+        let prepared = prepare_responses_request_body(
             br#"{"model":"gpt-5.4","stream":false,"max_output_tokens":256,"previous_response_id":"resp_prev_001"}"#,
         )
         .expect("rewrite responses request");
 
-        assert!(!wants_stream);
-        let payload: Value = serde_json::from_slice(&rewritten).expect("decode rewritten body");
+        assert!(!prepared.wants_stream);
+        let payload: Value = serde_json::from_slice(&prepared.body).expect("decode rewritten body");
         assert_eq!(payload["previous_response_id"], "resp_prev_001");
         assert_eq!(payload["instructions"], "");
         assert_eq!(payload["store"], false);
         assert_eq!(payload["stream"], true);
         assert!(payload.get("max_output_tokens").is_none());
+        assert_eq!(
+            prepared.rewrite,
+            OauthResponsesRewriteSummary {
+                applied: true,
+                added_instructions: true,
+                added_store: true,
+                forced_stream_true: true,
+                removed_max_output_tokens: true,
+            }
+        );
+    }
+
+    #[test]
+    fn copy_forwardable_headers_keeps_prompt_cache_headers_but_strips_sticky_headers() {
+        let client = Client::new();
+        let headers = HeaderMap::from_iter([
+            (
+                header::HeaderName::from_static("x-prompt-cache-key"),
+                "prompt-cache-alpha".parse().expect("x prompt cache value"),
+            ),
+            (
+                header::HeaderName::from_static("x-openai-prompt-cache-key"),
+                "prompt-cache-beta"
+                    .parse()
+                    .expect("openai prompt cache value"),
+            ),
+            (
+                header::HeaderName::from_static("x-client-trace-id"),
+                "trace-123".parse().expect("client trace id"),
+            ),
+            (
+                header::HeaderName::from_static("x-sticky-key"),
+                "sticky-should-not-forward".parse().expect("sticky key"),
+            ),
+        ]);
+
+        let (builder, summary) =
+            copy_forwardable_headers(client.get("https://example.com"), &headers, &[]);
+        let request = builder.build().expect("build request");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("x-prompt-cache-key")
+                .and_then(|value| value.to_str().ok()),
+            Some("prompt-cache-alpha")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("x-openai-prompt-cache-key")
+                .and_then(|value| value.to_str().ok()),
+            Some("prompt-cache-beta")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("x-client-trace-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("trace-123")
+        );
+        assert!(request.headers().get("x-sticky-key").is_none());
+        assert!(summary.prompt_cache_header_forwarded);
+        assert_eq!(
+            summary.names,
+            vec![
+                "x-client-trace-id".to_string(),
+                "x-openai-prompt-cache-key".to_string(),
+                "x-prompt-cache-key".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn oauth_responses_request_overrides_security_headers_after_forwarding() {
+        let client = Client::new();
+        let headers = HeaderMap::from_iter([
+            (
+                header::AUTHORIZATION,
+                "Bearer client-token".parse().expect("authorization"),
+            ),
+            (
+                header::CONTENT_TYPE,
+                "application/custom+json".parse().expect("content type"),
+            ),
+            (
+                header::CONTENT_LENGTH,
+                "999".parse().expect("content length"),
+            ),
+            (
+                header::HeaderName::from_static("chatgpt-account-id"),
+                "client-account".parse().expect("chatgpt account id"),
+            ),
+            (
+                header::HeaderName::from_static("x-openai-prompt-cache-key"),
+                "prompt-cache-gamma".parse().expect("prompt cache key"),
+            ),
+        ]);
+
+        let builder = client.post("https://example.com");
+        let (builder, _) =
+            copy_forwardable_headers(builder, &headers, OAUTH_RESPONSES_EXCLUDED_HEADER_NAMES);
+        let request = attach_account_header(
+            builder
+                .bearer_auth("oauth-upstream-token")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header("OpenAI-Beta", "responses=experimental"),
+            Some("server-account"),
+        )
+        .build()
+        .expect("build oauth responses request");
+
+        assert_eq!(
+            request
+                .headers()
+                .get(header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer oauth-upstream-token")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json")
+        );
+        assert!(request.headers().get(header::CONTENT_LENGTH).is_none());
+        assert_eq!(
+            request
+                .headers()
+                .get("ChatGPT-Account-Id")
+                .and_then(|value| value.to_str().ok()),
+            Some("server-account")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("x-openai-prompt-cache-key")
+                .and_then(|value| value.to_str().ok()),
+            Some("prompt-cache-gamma")
+        );
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9518,6 +9518,12 @@ async fn spawn_oauth_codex_http_failure(
 
 async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Response {
     let path = request.uri().path().to_string();
+    let mut forwarded_header_names = request
+        .headers()
+        .keys()
+        .map(|name| name.as_str().to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    forwarded_header_names.sort();
     let authorization = request
         .headers()
         .get(http_header::AUTHORIZATION)
@@ -9538,6 +9544,16 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
         .get("x-prompt-cache-key")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
+    let x_openai_prompt_cache_key_header = request
+        .headers()
+        .get("x-openai-prompt-cache-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let client_trace_id = request
+        .headers()
+        .get("x-client-trace-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     let forwarded_for = request
         .headers()
         .get("x-forwarded-for")
@@ -9554,7 +9570,10 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
             "chatgptAccountId": chatgpt_account_id,
             "stickyKeyHeader": sticky_key_header,
             "promptCacheKeyHeader": prompt_cache_key_header,
+            "xOpenAiPromptCacheKeyHeader": x_openai_prompt_cache_key_header,
+            "clientTraceId": client_trace_id,
             "forwardedFor": forwarded_for,
+            "forwardedHeaderNames": forwarded_header_names,
             "bodyLength": body.len(),
         })),
     )
@@ -9582,6 +9601,12 @@ async fn spawn_oauth_codex_capture_upstream() -> (String, JoinHandle<()>) {
 
 async fn oauth_codex_responses_capture_upstream(request: axum::extract::Request) -> Response {
     let path = request.uri().path().to_string();
+    let mut forwarded_header_names = request
+        .headers()
+        .keys()
+        .map(|name| name.as_str().to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    forwarded_header_names.sort();
     let authorization = request
         .headers()
         .get(http_header::AUTHORIZATION)
@@ -9590,6 +9615,21 @@ async fn oauth_codex_responses_capture_upstream(request: axum::extract::Request)
     let chatgpt_account_id = request
         .headers()
         .get("ChatGPT-Account-Id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let x_openai_prompt_cache_key_header = request
+        .headers()
+        .get("x-openai-prompt-cache-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let prompt_cache_key_header = request
+        .headers()
+        .get("x-prompt-cache-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let client_trace_id = request
+        .headers()
+        .get("x-client-trace-id")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
     let body = to_bytes(request.into_body(), usize::MAX)
@@ -9605,6 +9645,10 @@ async fn oauth_codex_responses_capture_upstream(request: axum::extract::Request)
             "path": path,
             "authorization": authorization,
             "chatgptAccountId": chatgpt_account_id,
+            "xOpenAiPromptCacheKeyHeader": x_openai_prompt_cache_key_header,
+            "promptCacheKeyHeader": prompt_cache_key_header,
+            "clientTraceId": client_trace_id,
+            "forwardedHeaderNames": forwarded_header_names,
             "received": body_value,
             "usage": {
                 "input_tokens": 12,
@@ -10524,10 +10568,24 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
         State(state.clone()),
         OriginalUri("/v1/responses".parse().expect("valid uri")),
         Method::POST,
-        HeaderMap::from_iter([(
-            http_header::AUTHORIZATION,
-            HeaderValue::from_static("Bearer pool-live-key"),
-        )]),
+        HeaderMap::from_iter([
+            (
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            ),
+            (
+                HeaderName::from_static("x-openai-prompt-cache-key"),
+                HeaderValue::from_static("prompt-cache-oauth-responses"),
+            ),
+            (
+                HeaderName::from_static("x-client-trace-id"),
+                HeaderValue::from_static("trace-oauth-responses"),
+            ),
+            (
+                HeaderName::from_static("chatgpt-account-id"),
+                HeaderValue::from_static("client-should-not-win"),
+            ),
+        ]),
         Body::from(
             serde_json::to_vec(&json!({
                 "model": "gpt-5.4",
@@ -10551,6 +10609,30 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
     assert_eq!(
         payload["chatgptAccountId"].as_str(),
         Some("02355c9d-fb23-4517-a96d-35e5f6758e9e")
+    );
+    assert_eq!(
+        payload["xOpenAiPromptCacheKeyHeader"].as_str(),
+        Some("prompt-cache-oauth-responses")
+    );
+    assert_eq!(
+        payload["clientTraceId"].as_str(),
+        Some("trace-oauth-responses")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-openai-prompt-cache-key")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-client-trace-id")
     );
     assert_eq!(payload["received"]["stream"], true);
     assert_eq!(payload["received"]["store"], false);
@@ -10578,6 +10660,43 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
     assert_eq!(payload_json["oauthAccountHeaderAttached"], true);
     assert_eq!(payload_json["oauthAccountIdShape"].as_str(), Some("uuid"));
     assert_eq!(payload_json["endpoint"].as_str(), Some("/v1/responses"));
+    assert_eq!(payload_json["oauthPromptCacheHeaderForwarded"], true);
+    assert!(
+        payload_json["oauthForwardedHeaderCount"]
+            .as_u64()
+            .expect("forwarded header count")
+            >= 2
+    );
+    assert!(
+        payload_json["oauthForwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-openai-prompt-cache-key")
+    );
+    assert!(
+        payload_json["oauthForwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-client-trace-id")
+    );
+    assert_eq!(payload_json["oauthResponsesRewrite"]["applied"], true);
+    assert_eq!(
+        payload_json["oauthResponsesRewrite"]["addedInstructions"],
+        true
+    );
+    assert_eq!(payload_json["oauthResponsesRewrite"]["addedStore"], true);
+    assert_eq!(
+        payload_json["oauthResponsesRewrite"]["forcedStreamTrue"],
+        true
+    );
+    assert_eq!(
+        payload_json["oauthResponsesRewrite"]["removedMaxOutputTokens"],
+        false
+    );
 
     upstream_handle.abort();
     oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
@@ -10635,6 +10754,14 @@ async fn pool_route_oauth_passthrough_streams_without_eager_prebuffering() {
                 HeaderValue::from_static("prompt-cache-oauth-stream"),
             ),
             (
+                HeaderName::from_static("x-openai-prompt-cache-key"),
+                HeaderValue::from_static("prompt-cache-oauth-stream-openai"),
+            ),
+            (
+                HeaderName::from_static("x-client-trace-id"),
+                HeaderValue::from_static("trace-oauth-stream"),
+            ),
+            (
                 HeaderName::from_static("x-forwarded-for"),
                 HeaderValue::from_static("203.0.113.8"),
             ),
@@ -10665,8 +10792,35 @@ async fn pool_route_oauth_passthrough_streams_without_eager_prebuffering() {
         Some("Bearer oauth-streaming")
     );
     assert!(payload["stickyKeyHeader"].is_null());
-    assert!(payload["promptCacheKeyHeader"].is_null());
+    assert_eq!(
+        payload["promptCacheKeyHeader"].as_str(),
+        Some("prompt-cache-oauth-stream")
+    );
+    assert_eq!(
+        payload["xOpenAiPromptCacheKeyHeader"].as_str(),
+        Some("prompt-cache-oauth-stream-openai")
+    );
+    assert_eq!(
+        payload["clientTraceId"].as_str(),
+        Some("trace-oauth-stream")
+    );
     assert!(payload["forwardedFor"].is_null());
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-openai-prompt-cache-key")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-client-trace-id")
+    );
 
     upstream_handle.abort();
     oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
@@ -10755,6 +10909,81 @@ async fn pool_route_oauth_body_sticky_binding_applies_before_first_send() {
     assert!(
         selected_at[1].1.is_some(),
         "sticky-selected oauth account should be marked"
+    );
+
+    upstream_handle.abort();
+    oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
+}
+
+#[tokio::test]
+async fn pool_route_oauth_compact_passthrough_preserves_prompt_cache_headers() {
+    let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
+        .lock()
+        .await;
+
+    let (upstream_base, upstream_handle) = spawn_oauth_codex_capture_upstream().await;
+    oauth_bridge::set_test_oauth_codex_upstream_base_url(
+        Url::parse(&format!("{upstream_base}/backend-api/codex")).expect("valid oauth base url"),
+    )
+    .await;
+
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_oauth_account(&state, "Compact OAuth", "oauth-compact").await;
+
+    let response = proxy_openai_v1(
+        State(state),
+        OriginalUri("/v1/responses/compact".parse().expect("valid compact uri")),
+        Method::POST,
+        HeaderMap::from_iter([
+            (
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            ),
+            (
+                HeaderName::from_static("x-openai-prompt-cache-key"),
+                HeaderValue::from_static("prompt-cache-oauth-compact"),
+            ),
+            (
+                HeaderName::from_static("x-client-trace-id"),
+                HeaderValue::from_static("trace-oauth-compact"),
+            ),
+            (
+                http_header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+        ]),
+        Body::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-5.4",
+                "input": [{"role": "user", "content": "compact me"}]
+            }))
+            .expect("serialize oauth compact body"),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read oauth compact response"),
+    )
+    .expect("decode oauth compact response");
+    assert_eq!(
+        payload["path"].as_str(),
+        Some("/backend-api/codex/responses/compact")
+    );
+    assert_eq!(
+        payload["xOpenAiPromptCacheKeyHeader"].as_str(),
+        Some("prompt-cache-oauth-compact")
+    );
+    assert_eq!(
+        payload["clientTraceId"].as_str(),
+        Some("trace-oauth-compact")
     );
 
     upstream_handle.abort();


### PR DESCRIPTION
## Summary
- forward official client headers for OAuth `/v1/responses` before applying server-enforced auth/account headers
- stop treating prompt-cache headers as internal metadata and persist non-sensitive forwarding/rewrite observability in invocation payloads
- add regression coverage for `/v1/responses`, `/v1/responses/compact`, prompt-cache header forwarding, sticky-key stripping, and rewritten body safeguards

## Root cause
OAuth `/v1/responses` rebuilt the upstream request instead of sharing the passthrough header-forwarding path. That dropped official client headers and swallowed prompt-cache headers, so ChatGPT backend requests lost cache context even when the request prefix was stable.

## Verification
- `cargo fmt`
- `cargo test oauth_bridge::tests -- --nocapture`
- `cargo test pool_route_oauth_ -- --nocapture`
- `cargo check`

## Post-deploy verification
- confirm recent OAuth invocations record `oauthPromptCacheHeaderForwarded=true`
- compare OAuth long-context traffic to ensure it no longer stays in the `97% prefix stable but 2%-4% cache hit` pattern
- verify no new `401/403` or routing regressions for OAuth pool accounts