### PR TITLE
fix: add OAuth fingerprint observability for cache diagnostics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6907,6 +6907,20 @@ impl PoolReplayBodySnapshot {
             Self::File { temp_file, .. } => tokio::fs::read(&temp_file.path).await.map(Bytes::from),
         }
     }
+
+    async fn to_prefix_bytes(&self, limit: usize) -> io::Result<Bytes> {
+        match self {
+            Self::Empty => Ok(Bytes::new()),
+            Self::Memory(bytes) => Ok(bytes.slice(..bytes.len().min(limit))),
+            Self::File { temp_file, .. } => {
+                let mut file = tokio::fs::File::open(&temp_file.path).await?;
+                let mut buf = vec![0_u8; limit];
+                let read_len = file.read(&mut buf).await?;
+                buf.truncate(read_len);
+                Ok(Bytes::from(buf))
+            }
+        }
+    }
 }
 
 fn build_pool_replay_temp_path(proxy_request_id: u64) -> PathBuf {
@@ -7296,9 +7310,29 @@ async fn send_pool_request_with_failover(
                                 })?,
                             )
                         }
-                        Some(snapshot) => oauth_bridge::OauthUpstreamRequestBody::Stream(
-                            snapshot.to_reqwest_body(),
-                        ),
+                        Some(snapshot) => oauth_bridge::OauthUpstreamRequestBody::Stream {
+                            debug_body_prefix: Some(
+                                snapshot
+                                    .to_prefix_bytes(
+                                        oauth_bridge::OAUTH_REQUEST_BODY_PREFIX_FINGERPRINT_MAX_BYTES,
+                                    )
+                                    .await
+                                    .map_err(|err| PoolUpstreamError {
+                                        account: Some(account.clone()),
+                                        status: StatusCode::BAD_GATEWAY,
+                                        message: format!(
+                                            "failed to replay oauth request body prefix: {err}"
+                                        ),
+                                        failure_kind: PROXY_FAILURE_FAILED_CONTACT_UPSTREAM,
+                                        connect_latency_ms: 0.0,
+                                        upstream_error_code: None,
+                                        upstream_error_message: None,
+                                        upstream_request_id: None,
+                                        oauth_responses_debug: None,
+                                    })?,
+                            ),
+                            body: snapshot.to_reqwest_body(),
+                        },
                         None => oauth_bridge::OauthUpstreamRequestBody::Empty,
                     };
                     if let Err(route_err) =
@@ -7322,11 +7356,12 @@ async fn send_pool_request_with_failover(
                             Some(account.account_id),
                             access_token,
                             chatgpt_account_id.as_deref(),
+                            state.upstream_accounts.crypto_key.as_ref(),
                         )
                         .await;
                         (
                             ProxyUpstreamResponseBody::Axum(oauth_response.response),
-                            oauth_response.responses_debug,
+                            oauth_response.request_debug,
                         )
                     }
                 }
@@ -7596,6 +7631,37 @@ async fn continue_or_retry_pool_live_request(
     }
 }
 
+async fn maybe_backfill_oauth_request_debug_from_replay_status(
+    debug: &mut Option<oauth_bridge::OauthResponsesDebugInfo>,
+    original_uri: &Uri,
+    replay_status_rx: &watch::Receiver<PoolReplayBodyStatus>,
+    crypto_key: Option<&[u8; 32]>,
+) {
+    let Some(debug) = debug.as_mut() else {
+        return;
+    };
+    if debug.request_body_prefix_fingerprint.is_some() || crypto_key.is_none() {
+        return;
+    }
+
+    let replay_status = { replay_status_rx.borrow().clone() };
+    let PoolReplayBodyStatus::Complete(snapshot) = replay_status else {
+        return;
+    };
+    let Ok(prefix) = snapshot
+        .to_prefix_bytes(oauth_bridge::OAUTH_REQUEST_BODY_PREFIX_FINGERPRINT_MAX_BYTES)
+        .await
+    else {
+        return;
+    };
+    oauth_bridge::backfill_oauth_request_debug_body_prefix(
+        debug,
+        original_uri.path(),
+        prefix.as_ref(),
+        crypto_key,
+    );
+}
+
 async fn proxy_openai_v1_via_pool(
     state: Arc<AppState>,
     proxy_request_id: u64,
@@ -7752,16 +7818,20 @@ async fn proxy_openai_v1_via_pool(
                         method.clone(),
                         original_uri,
                         &headers,
-                        oauth_bridge::OauthUpstreamRequestBody::Stream(replayable.body),
+                        oauth_bridge::OauthUpstreamRequestBody::Stream {
+                            body: replayable.body,
+                            debug_body_prefix: None,
+                        },
                         handshake_timeout,
                         state.config.request_timeout,
                         Some(initial_account.account_id),
                         access_token,
                         chatgpt_account_id.as_deref(),
+                        state.upstream_accounts.crypto_key.as_ref(),
                     )
                     .await;
                     let response = ProxyUpstreamResponseBody::Axum(oauth_response.response);
-                    let oauth_responses_debug = oauth_response.responses_debug;
+                    let mut oauth_responses_debug = oauth_response.request_debug;
                     let connect_latency_ms = elapsed_ms(connect_started);
                     let status = response.status();
                     let upstream = if status == StatusCode::TOO_MANY_REQUESTS
@@ -7810,6 +7880,13 @@ async fn proxy_openai_v1_via_pool(
                         } else {
                             PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT
                         };
+                        maybe_backfill_oauth_request_debug_from_replay_status(
+                            &mut oauth_responses_debug,
+                            original_uri,
+                            &replay_status_rx,
+                            state.upstream_accounts.crypto_key.as_ref(),
+                        )
+                        .await;
                         let first_error = PoolUpstreamError {
                             account: Some(initial_account.clone()),
                             status,
@@ -7844,15 +7921,31 @@ async fn proxy_openai_v1_via_pool(
                         )
                         .await
                         {
-                            Ok((response, first_chunk)) => PoolUpstreamResponse {
-                                account: initial_account,
-                                response,
-                                oauth_responses_debug,
-                                connect_latency_ms,
-                                first_byte_latency_ms: elapsed_ms(first_byte_started),
-                                first_chunk,
-                            },
+                            Ok((response, first_chunk)) => {
+                                maybe_backfill_oauth_request_debug_from_replay_status(
+                                    &mut oauth_responses_debug,
+                                    original_uri,
+                                    &replay_status_rx,
+                                    state.upstream_accounts.crypto_key.as_ref(),
+                                )
+                                .await;
+                                PoolUpstreamResponse {
+                                    account: initial_account,
+                                    response,
+                                    oauth_responses_debug,
+                                    connect_latency_ms,
+                                    first_byte_latency_ms: elapsed_ms(first_byte_started),
+                                    first_chunk,
+                                }
+                            }
                             Err(err) => {
+                                maybe_backfill_oauth_request_debug_from_replay_status(
+                                    &mut oauth_responses_debug,
+                                    original_uri,
+                                    &replay_status_rx,
+                                    state.upstream_accounts.crypto_key.as_ref(),
+                                )
+                                .await;
                                 let first_error = PoolUpstreamError {
                                     account: Some(initial_account.clone()),
                                     status: StatusCode::BAD_GATEWAY,
@@ -9027,7 +9120,11 @@ async fn proxy_openai_v1_capture_target(
                     oauth_account_id_shape: None,
                     oauth_forwarded_header_count: None,
                     oauth_forwarded_header_names: None,
+                    oauth_fingerprint_version: None,
+                    oauth_forwarded_header_fingerprints: None,
                     oauth_prompt_cache_header_forwarded: None,
+                    oauth_request_body_prefix_fingerprint: None,
+                    oauth_request_body_prefix_bytes: None,
                     oauth_responses_rewrite: None,
                     service_tier: None,
                     stream_terminal_event: None,
@@ -9213,10 +9310,26 @@ async fn proxy_openai_v1_capture_target(
                             .oauth_responses_debug
                             .as_ref()
                             .map(|debug| debug.forwarded_header_names.as_slice()),
+                        oauth_fingerprint_version: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .and_then(|debug| debug.fingerprint_version),
+                        oauth_forwarded_header_fingerprints: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .and_then(|debug| debug.forwarded_header_fingerprints.as_ref()),
                         oauth_prompt_cache_header_forwarded: err
                             .oauth_responses_debug
                             .as_ref()
                             .map(|debug| debug.prompt_cache_header_forwarded),
+                        oauth_request_body_prefix_fingerprint: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .and_then(|debug| debug.request_body_prefix_fingerprint.as_deref()),
+                        oauth_request_body_prefix_bytes: err
+                            .oauth_responses_debug
+                            .as_ref()
+                            .and_then(|debug| debug.request_body_prefix_bytes),
                         oauth_responses_rewrite: err
                             .oauth_responses_debug
                             .as_ref()
@@ -9332,7 +9445,11 @@ async fn proxy_openai_v1_capture_target(
                         oauth_account_id_shape: None,
                         oauth_forwarded_header_count: None,
                         oauth_forwarded_header_names: None,
+                        oauth_fingerprint_version: None,
+                        oauth_forwarded_header_fingerprints: None,
                         oauth_prompt_cache_header_forwarded: None,
+                        oauth_request_body_prefix_fingerprint: None,
+                        oauth_request_body_prefix_bytes: None,
                         oauth_responses_rewrite: None,
                         service_tier: None,
                         stream_terminal_event: None,
@@ -9449,7 +9566,11 @@ async fn proxy_openai_v1_capture_target(
                     ),
                     oauth_forwarded_header_count: None,
                     oauth_forwarded_header_names: None,
+                    oauth_fingerprint_version: None,
+                    oauth_forwarded_header_fingerprints: None,
                     oauth_prompt_cache_header_forwarded: None,
+                    oauth_request_body_prefix_fingerprint: None,
+                    oauth_request_body_prefix_bytes: None,
                     oauth_responses_rewrite: None,
                     service_tier: None,
                     stream_terminal_event: None,
@@ -9852,9 +9973,21 @@ async fn proxy_openai_v1_capture_target(
             oauth_forwarded_header_names: oauth_responses_debug_for_task
                 .as_ref()
                 .map(|debug| debug.forwarded_header_names.as_slice()),
+            oauth_fingerprint_version: oauth_responses_debug_for_task
+                .as_ref()
+                .and_then(|debug| debug.fingerprint_version),
+            oauth_forwarded_header_fingerprints: oauth_responses_debug_for_task
+                .as_ref()
+                .and_then(|debug| debug.forwarded_header_fingerprints.as_ref()),
             oauth_prompt_cache_header_forwarded: oauth_responses_debug_for_task
                 .as_ref()
                 .map(|debug| debug.prompt_cache_header_forwarded),
+            oauth_request_body_prefix_fingerprint: oauth_responses_debug_for_task
+                .as_ref()
+                .and_then(|debug| debug.request_body_prefix_fingerprint.as_deref()),
+            oauth_request_body_prefix_bytes: oauth_responses_debug_for_task
+                .as_ref()
+                .and_then(|debug| debug.request_body_prefix_bytes),
             oauth_responses_rewrite: oauth_responses_debug_for_task
                 .as_ref()
                 .map(|debug| &debug.rewrite),
@@ -10917,7 +11050,11 @@ struct ProxyPayloadSummary<'a> {
     oauth_account_id_shape: Option<&'a str>,
     oauth_forwarded_header_count: Option<usize>,
     oauth_forwarded_header_names: Option<&'a [String]>,
+    oauth_fingerprint_version: Option<&'a str>,
+    oauth_forwarded_header_fingerprints: Option<&'a BTreeMap<String, String>>,
     oauth_prompt_cache_header_forwarded: Option<bool>,
+    oauth_request_body_prefix_fingerprint: Option<&'a str>,
+    oauth_request_body_prefix_bytes: Option<usize>,
     oauth_responses_rewrite: Option<&'a oauth_bridge::OauthResponsesRewriteSummary>,
     service_tier: Option<&'a str>,
     stream_terminal_event: Option<&'a str>,
@@ -10952,7 +11089,11 @@ fn build_proxy_payload_summary(summary: ProxyPayloadSummary<'_>) -> String {
         oauth_account_id_shape,
         oauth_forwarded_header_count,
         oauth_forwarded_header_names,
+        oauth_fingerprint_version,
+        oauth_forwarded_header_fingerprints,
         oauth_prompt_cache_header_forwarded,
+        oauth_request_body_prefix_fingerprint,
+        oauth_request_body_prefix_bytes,
         oauth_responses_rewrite,
         service_tier,
         stream_terminal_event,
@@ -10985,7 +11126,11 @@ fn build_proxy_payload_summary(summary: ProxyPayloadSummary<'_>) -> String {
         "oauthAccountIdShape": oauth_account_id_shape,
         "oauthForwardedHeaderCount": oauth_forwarded_header_count,
         "oauthForwardedHeaderNames": oauth_forwarded_header_names,
+        "oauthFingerprintVersion": oauth_fingerprint_version,
+        "oauthForwardedHeaderFingerprints": oauth_forwarded_header_fingerprints,
         "oauthPromptCacheHeaderForwarded": oauth_prompt_cache_header_forwarded,
+        "oauthRequestBodyPrefixFingerprint": oauth_request_body_prefix_fingerprint,
+        "oauthRequestBodyPrefixBytes": oauth_request_body_prefix_bytes,
         "oauthResponsesRewrite": oauth_responses_rewrite,
         "serviceTier": service_tier,
         "streamTerminalEvent": stream_terminal_event,
@@ -11212,7 +11357,11 @@ fn build_running_proxy_capture_record(
             oauth_account_id_shape: None,
             oauth_forwarded_header_count: None,
             oauth_forwarded_header_names: None,
+            oauth_fingerprint_version: None,
+            oauth_forwarded_header_fingerprints: None,
             oauth_prompt_cache_header_forwarded: None,
+            oauth_request_body_prefix_fingerprint: None,
+            oauth_request_body_prefix_bytes: None,
             oauth_responses_rewrite: None,
             service_tier: None,
             stream_terminal_event: None,

--- a/src/oauth_bridge.rs
+++ b/src/oauth_bridge.rs
@@ -9,7 +9,8 @@ use futures_util::TryStreamExt;
 use reqwest::{Body as ReqwestBody, Client, Url};
 use serde::Serialize;
 use serde_json::{Value, json};
-use std::collections::BTreeSet;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 use tokio::time::{Instant, timeout};
 use tracing::info;
@@ -31,6 +32,15 @@ const PROMPT_CACHE_HEADER_NAMES: &[&str] = &[
     "x-prompt-cache-key",
     "prompt-cache-key",
     "x-openai-prompt-cache-key",
+];
+const OAUTH_FINGERPRINT_VERSION: &str = "v1";
+pub(crate) const OAUTH_REQUEST_BODY_PREFIX_FINGERPRINT_MAX_BYTES: usize = 64 * 1024;
+const OAUTH_FINGERPRINTED_HEADER_NAMES: &[&str] = &[
+    "session_id",
+    "traceparent",
+    "x-client-request-id",
+    "x-codex-turn-metadata",
+    "originator",
 ];
 
 #[cfg(test)]
@@ -72,7 +82,10 @@ pub(crate) async fn reset_test_oauth_codex_upstream_base_url() {
 pub(crate) enum OauthUpstreamRequestBody {
     Empty,
     Bytes(Bytes),
-    Stream(ReqwestBody),
+    Stream {
+        body: ReqwestBody,
+        debug_body_prefix: Option<Bytes>,
+    },
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
@@ -89,19 +102,26 @@ pub(crate) struct OauthResponsesRewriteSummary {
 pub(crate) struct OauthForwardedHeaderSummary {
     pub(crate) names: Vec<String>,
     pub(crate) prompt_cache_header_forwarded: bool,
+    pub(crate) fingerprints: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct OauthResponsesDebugInfo {
+pub(crate) struct OauthRequestDebugInfo {
+    pub(crate) fingerprint_version: Option<&'static str>,
     pub(crate) forwarded_header_names: Vec<String>,
+    pub(crate) forwarded_header_fingerprints: Option<BTreeMap<String, String>>,
     pub(crate) prompt_cache_header_forwarded: bool,
+    pub(crate) request_body_prefix_fingerprint: Option<String>,
+    pub(crate) request_body_prefix_bytes: Option<usize>,
     pub(crate) rewrite: OauthResponsesRewriteSummary,
 }
 
+pub(crate) type OauthResponsesDebugInfo = OauthRequestDebugInfo;
+
 pub(crate) struct OauthUpstreamResponse {
     pub(crate) response: Response,
-    pub(crate) responses_debug: Option<OauthResponsesDebugInfo>,
+    pub(crate) request_debug: Option<OauthRequestDebugInfo>,
 }
 
 struct PreparedResponsesRequestBody {
@@ -121,6 +141,7 @@ pub(crate) async fn send_oauth_upstream_request(
     account_id: Option<i64>,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
+    crypto_key: Option<&[u8; 32]>,
 ) -> OauthUpstreamResponse {
     match original_uri.path() {
         "/v1/models" => {
@@ -145,17 +166,18 @@ pub(crate) async fn send_oauth_upstream_request(
                 match body {
                     OauthUpstreamRequestBody::Empty => Bytes::new(),
                     OauthUpstreamRequestBody::Bytes(bytes) => bytes,
-                    OauthUpstreamRequestBody::Stream(_) => {
+                    OauthUpstreamRequestBody::Stream { .. } => {
                         return OauthUpstreamResponse {
                             response: error_response(
                                 StatusCode::INTERNAL_SERVER_ERROR,
                                 "streamed request bodies are not supported for /v1/responses",
                                 "server_error",
                             ),
-                            responses_debug: None,
+                            request_debug: None,
                         };
                     }
                 },
+                crypto_key,
             )
             .await
         }
@@ -166,13 +188,24 @@ pub(crate) async fn send_oauth_upstream_request(
                 original_uri,
                 headers,
                 match body {
-                    OauthUpstreamRequestBody::Empty => ReqwestBody::from(Bytes::new()),
-                    OauthUpstreamRequestBody::Bytes(bytes) => ReqwestBody::from(bytes),
-                    OauthUpstreamRequestBody::Stream(body) => body,
+                    OauthUpstreamRequestBody::Empty => {
+                        (ReqwestBody::from(Bytes::new()), Some(Bytes::new()))
+                    }
+                    OauthUpstreamRequestBody::Bytes(bytes) => {
+                        let debug_body_prefix =
+                            oauth_request_body_prefix_bytes(Some(bytes.as_ref())).map(Bytes::from);
+                        (ReqwestBody::from(bytes), debug_body_prefix)
+                    }
+                    OauthUpstreamRequestBody::Stream {
+                        body,
+                        debug_body_prefix,
+                    } => (body, debug_body_prefix),
                 },
                 handshake_timeout,
+                account_id,
                 access_token,
                 chatgpt_account_id,
+                crypto_key,
             )
             .await
         }
@@ -185,7 +218,7 @@ pub(crate) async fn send_oauth_upstream_request(
                 ),
                 "oauth_unsupported_route",
             ),
-            responses_debug: None,
+            request_debug: None,
         },
     }
 }
@@ -210,7 +243,7 @@ async fn oauth_models(
                     &format!("invalid oauth codex models url: {err}"),
                     "server_error",
                 ),
-                responses_debug: None,
+                request_debug: None,
             };
         }
     };
@@ -237,7 +270,7 @@ async fn oauth_models(
                     &format!("failed to contact oauth codex upstream: {err}"),
                     "oauth_upstream_unavailable",
                 ),
-                responses_debug: None,
+                request_debug: None,
             };
         }
         Err(_) => {
@@ -250,7 +283,7 @@ async fn oauth_models(
                     ),
                     "oauth_upstream_handshake_timeout",
                 ),
-                responses_debug: None,
+                request_debug: None,
             };
         }
     };
@@ -271,7 +304,7 @@ async fn oauth_models(
                     &format!("failed to read oauth codex models response: {err}"),
                     "oauth_upstream_read_failed",
                 ),
-                responses_debug: None,
+                request_debug: None,
             };
         }
     };
@@ -282,13 +315,13 @@ async fn oauth_models(
                 &bytes,
                 "oauth_upstream_rejected_request",
             ),
-            responses_debug: None,
+            request_debug: None,
         };
     }
     match transform_models_payload(&bytes) {
         Ok(value) => OauthUpstreamResponse {
             response: (status, Json(value)).into_response(),
-            responses_debug: None,
+            request_debug: None,
         },
         Err(err) => OauthUpstreamResponse {
             response: error_response(
@@ -296,7 +329,7 @@ async fn oauth_models(
                 &format!("oauth codex returned malformed models payload: {err}"),
                 "oauth_upstream_invalid_models",
             ),
-            responses_debug: None,
+            request_debug: None,
         },
     }
 }
@@ -310,6 +343,7 @@ async fn oauth_responses(
     access_token: &str,
     chatgpt_account_id: Option<&str>,
     body: Bytes,
+    crypto_key: Option<&[u8; 32]>,
 ) -> OauthUpstreamResponse {
     let prepared = match prepare_responses_request_body(&body) {
         Ok(value) => value,
@@ -320,7 +354,7 @@ async fn oauth_responses(
                     &err.to_string(),
                     "invalid_request_error",
                 ),
-                responses_debug: None,
+                request_debug: None,
             };
         }
     };
@@ -333,7 +367,7 @@ async fn oauth_responses(
                     &format!("invalid oauth codex responses url: {err}"),
                     "server_error",
                 ),
-                responses_debug: None,
+                request_debug: None,
             };
         }
     };
@@ -341,6 +375,14 @@ async fn oauth_responses(
         client.post(upstream_url),
         headers,
         OAUTH_RESPONSES_EXCLUDED_HEADER_NAMES,
+        crypto_key,
+    );
+    let request_debug = build_oauth_request_debug(
+        "/v1/responses",
+        &forwarded_headers,
+        Some(prepared.body.as_slice()),
+        prepared.rewrite.clone(),
+        crypto_key,
     );
     let request = request
         .header(header::CONTENT_TYPE, "application/json")
@@ -348,22 +390,21 @@ async fn oauth_responses(
         .header("OpenAI-Beta", "responses=experimental")
         .body(prepared.body);
     let request = attach_account_header(request, chatgpt_account_id);
-    let responses_debug = OauthResponsesDebugInfo {
-        forwarded_header_names: forwarded_headers.names.clone(),
-        prompt_cache_header_forwarded: forwarded_headers.prompt_cache_header_forwarded,
-        rewrite: prepared.rewrite.clone(),
-    };
     info!(
         account_id,
         path = "/v1/responses",
-        forwarded_header_count = responses_debug.forwarded_header_names.len(),
-        forwarded_header_names = ?responses_debug.forwarded_header_names,
-        prompt_cache_header_forwarded = responses_debug.prompt_cache_header_forwarded,
-        rewrite_applied = responses_debug.rewrite.applied,
-        rewrite_added_instructions = responses_debug.rewrite.added_instructions,
-        rewrite_added_store = responses_debug.rewrite.added_store,
-        rewrite_forced_stream_true = responses_debug.rewrite.forced_stream_true,
-        rewrite_removed_max_output_tokens = responses_debug.rewrite.removed_max_output_tokens,
+        forwarded_header_count = request_debug.forwarded_header_names.len(),
+        forwarded_header_names = ?request_debug.forwarded_header_names,
+        forwarded_header_fingerprints = ?request_debug.forwarded_header_fingerprints,
+        prompt_cache_header_forwarded = request_debug.prompt_cache_header_forwarded,
+        fingerprint_version = request_debug.fingerprint_version,
+        request_body_prefix_bytes = request_debug.request_body_prefix_bytes,
+        request_body_prefix_fingerprint = request_debug.request_body_prefix_fingerprint,
+        rewrite_applied = request_debug.rewrite.applied,
+        rewrite_added_instructions = request_debug.rewrite.added_instructions,
+        rewrite_added_store = request_debug.rewrite.added_store,
+        rewrite_forced_stream_true = request_debug.rewrite.forced_stream_true,
+        rewrite_removed_max_output_tokens = request_debug.rewrite.removed_max_output_tokens,
         "forwarding oauth responses request"
     );
     let request_started = Instant::now();
@@ -376,7 +417,7 @@ async fn oauth_responses(
                     &format!("failed to contact oauth codex upstream: {err}"),
                     "oauth_upstream_unavailable",
                 ),
-                responses_debug: Some(responses_debug),
+                request_debug: Some(request_debug),
             };
         }
         Err(_) => {
@@ -389,7 +430,7 @@ async fn oauth_responses(
                     ),
                     "oauth_upstream_handshake_timeout",
                 ),
-                responses_debug: Some(responses_debug),
+                request_debug: Some(request_debug),
             };
         }
     };
@@ -411,7 +452,7 @@ async fn oauth_responses(
                         &format!("failed to read oauth codex error response: {err}"),
                         "oauth_upstream_read_failed",
                     ),
-                    responses_debug: Some(responses_debug),
+                    request_debug: Some(request_debug),
                 };
             }
         };
@@ -421,13 +462,13 @@ async fn oauth_responses(
                 &bytes,
                 "oauth_upstream_rejected_request",
             ),
-            responses_debug: Some(responses_debug),
+            request_debug: Some(request_debug),
         };
     }
     if prepared.wants_stream {
         return OauthUpstreamResponse {
             response: reqwest_response_to_axum_response(upstream),
-            responses_debug: Some(responses_debug),
+            request_debug: Some(request_debug),
         };
     }
     let bytes = match read_oauth_upstream_bytes_with_timeout(
@@ -446,14 +487,14 @@ async fn oauth_responses(
                     &format!("failed to read oauth codex responses stream: {err}"),
                     "oauth_upstream_read_failed",
                 ),
-                responses_debug: Some(responses_debug),
+                request_debug: Some(request_debug),
             };
         }
     };
     match extract_completed_response_from_sse(&bytes) {
         Ok(response_value) => OauthUpstreamResponse {
             response: (StatusCode::OK, Json(response_value)).into_response(),
-            responses_debug: Some(responses_debug),
+            request_debug: Some(request_debug),
         },
         Err(err) => OauthUpstreamResponse {
             response: error_response(
@@ -461,7 +502,7 @@ async fn oauth_responses(
                 &format!("failed to decode oauth codex response stream: {err}"),
                 "oauth_upstream_invalid_response",
             ),
-            responses_debug: Some(responses_debug),
+            request_debug: Some(request_debug),
         },
     }
 }
@@ -471,10 +512,12 @@ async fn oauth_passthrough(
     method: Method,
     original_uri: &Uri,
     headers: &HeaderMap,
-    body: ReqwestBody,
+    body: (ReqwestBody, Option<Bytes>),
     handshake_timeout: Duration,
+    account_id: Option<i64>,
     access_token: &str,
     chatgpt_account_id: Option<&str>,
+    crypto_key: Option<&[u8; 32]>,
 ) -> OauthUpstreamResponse {
     let suffix = original_uri
         .path()
@@ -489,7 +532,7 @@ async fn oauth_passthrough(
                     &format!("invalid oauth codex upstream url: {err}"),
                     "server_error",
                 ),
-                responses_debug: None,
+                request_debug: None,
             };
         }
     };
@@ -498,8 +541,32 @@ async fn oauth_passthrough(
         .bearer_auth(access_token)
         .header("OpenAI-Beta", "responses=experimental");
     builder = attach_account_header(builder, chatgpt_account_id);
-    let (builder, _) = copy_forwardable_headers(builder, headers, &[]);
-    let upstream = match timeout(handshake_timeout, builder.body(body).send()).await {
+    let (builder, forwarded_headers) = copy_forwardable_headers(builder, headers, &[], crypto_key);
+    let request_debug = build_oauth_request_debug(
+        original_uri.path(),
+        &forwarded_headers,
+        body.1.as_deref(),
+        OauthResponsesRewriteSummary::default(),
+        crypto_key,
+    );
+    info!(
+        account_id,
+        path = original_uri.path(),
+        forwarded_header_count = request_debug.forwarded_header_names.len(),
+        forwarded_header_names = ?request_debug.forwarded_header_names,
+        forwarded_header_fingerprints = ?request_debug.forwarded_header_fingerprints,
+        prompt_cache_header_forwarded = request_debug.prompt_cache_header_forwarded,
+        fingerprint_version = request_debug.fingerprint_version,
+        request_body_prefix_bytes = request_debug.request_body_prefix_bytes,
+        request_body_prefix_fingerprint = request_debug.request_body_prefix_fingerprint,
+        rewrite_applied = request_debug.rewrite.applied,
+        rewrite_added_instructions = request_debug.rewrite.added_instructions,
+        rewrite_added_store = request_debug.rewrite.added_store,
+        rewrite_forced_stream_true = request_debug.rewrite.forced_stream_true,
+        rewrite_removed_max_output_tokens = request_debug.rewrite.removed_max_output_tokens,
+        "forwarding oauth passthrough request"
+    );
+    let upstream = match timeout(handshake_timeout, builder.body(body.0).send()).await {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
             return OauthUpstreamResponse {
@@ -508,7 +575,7 @@ async fn oauth_passthrough(
                     &format!("failed to contact oauth codex upstream: {err}"),
                     "oauth_upstream_unavailable",
                 ),
-                responses_debug: None,
+                request_debug: Some(request_debug),
             };
         }
         Err(_) => {
@@ -521,13 +588,13 @@ async fn oauth_passthrough(
                     ),
                     "oauth_upstream_handshake_timeout",
                 ),
-                responses_debug: None,
+                request_debug: Some(request_debug),
             };
         }
     };
     OauthUpstreamResponse {
         response: reqwest_response_to_axum_response(upstream),
-        responses_debug: None,
+        request_debug: Some(request_debug),
     }
 }
 
@@ -549,9 +616,11 @@ fn copy_forwardable_headers(
     mut builder: reqwest::RequestBuilder,
     headers: &HeaderMap,
     excluded_names: &[&str],
+    crypto_key: Option<&[u8; 32]>,
 ) -> (reqwest::RequestBuilder, OauthForwardedHeaderSummary) {
     let connection_scoped = crate::connection_scoped_header_names(headers);
     let mut forwarded_names = BTreeSet::new();
+    let mut fingerprints = crypto_key.map(|_| BTreeMap::new());
     for (name, value) in headers {
         if *name == header::AUTHORIZATION
             || excluded_names
@@ -563,7 +632,22 @@ fn copy_forwardable_headers(
             continue;
         }
         builder = builder.header(name, value);
-        forwarded_names.insert(name.as_str().to_ascii_lowercase());
+        let lower_name = name.as_str().to_ascii_lowercase();
+        if let (Some(crypto_key), Some(header_fingerprints)) = (crypto_key, fingerprints.as_mut()) {
+            if is_fingerprinted_oauth_header_name(lower_name.as_str())
+                && !value.as_bytes().is_empty()
+            {
+                header_fingerprints.insert(
+                    lower_name.clone(),
+                    oauth_fingerprint_header_value(
+                        crypto_key,
+                        lower_name.as_str(),
+                        value.as_bytes(),
+                    ),
+                );
+            }
+        }
+        forwarded_names.insert(lower_name);
     }
     let names = forwarded_names.into_iter().collect::<Vec<_>>();
     let prompt_cache_header_forwarded = names
@@ -574,6 +658,7 @@ fn copy_forwardable_headers(
         OauthForwardedHeaderSummary {
             names,
             prompt_cache_header_forwarded,
+            fingerprints,
         },
     )
 }
@@ -586,6 +671,114 @@ fn is_prompt_cache_header_name(name: &str) -> bool {
     PROMPT_CACHE_HEADER_NAMES
         .iter()
         .any(|candidate| name.eq_ignore_ascii_case(candidate))
+}
+
+fn is_fingerprinted_oauth_header_name(name: &str) -> bool {
+    OAUTH_FINGERPRINTED_HEADER_NAMES
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+}
+
+fn oauth_request_body_prefix_bytes(body: Option<&[u8]>) -> Option<Vec<u8>> {
+    body.map(|bytes| {
+        bytes[..bytes
+            .len()
+            .min(OAUTH_REQUEST_BODY_PREFIX_FINGERPRINT_MAX_BYTES)]
+            .to_vec()
+    })
+}
+
+fn oauth_fingerprint_header_value(crypto_key: &[u8; 32], name: &str, value: &[u8]) -> String {
+    oauth_fingerprint_debug_value(crypto_key, "header", name.as_bytes(), value)
+}
+
+fn oauth_fingerprint_body_prefix(crypto_key: &[u8; 32], path: &str, prefix: &[u8]) -> String {
+    oauth_fingerprint_debug_value(crypto_key, "body-prefix", path.as_bytes(), prefix)
+}
+
+fn oauth_fingerprint_debug_value(
+    crypto_key: &[u8; 32],
+    namespace: &str,
+    discriminator: &[u8],
+    value: &[u8],
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"oauth-debug");
+    hasher.update([0]);
+    hasher.update(OAUTH_FINGERPRINT_VERSION.as_bytes());
+    hasher.update([0]);
+    hasher.update(namespace.as_bytes());
+    hasher.update([0]);
+    hasher.update(discriminator);
+    hasher.update([0]);
+    hasher.update(crypto_key);
+    hasher.update([0]);
+    hasher.update(value);
+    let digest = hasher.finalize();
+    digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn build_oauth_request_debug(
+    path: &str,
+    forwarded_headers: &OauthForwardedHeaderSummary,
+    body: Option<&[u8]>,
+    rewrite: OauthResponsesRewriteSummary,
+    crypto_key: Option<&[u8; 32]>,
+) -> OauthRequestDebugInfo {
+    let body_prefix = oauth_request_body_prefix_bytes(body);
+    let request_body_prefix_bytes = match (crypto_key, body_prefix.as_ref()) {
+        (Some(_), Some(prefix)) => Some(prefix.len()),
+        _ => None,
+    };
+    let request_body_prefix_fingerprint = match (crypto_key, body_prefix.as_ref()) {
+        (Some(crypto_key), Some(prefix)) => Some(oauth_fingerprint_body_prefix(
+            crypto_key,
+            path,
+            prefix.as_slice(),
+        )),
+        _ => None,
+    };
+
+    OauthRequestDebugInfo {
+        fingerprint_version: crypto_key.map(|_| OAUTH_FINGERPRINT_VERSION),
+        forwarded_header_names: forwarded_headers.names.clone(),
+        forwarded_header_fingerprints: if crypto_key.is_some() {
+            forwarded_headers.fingerprints.clone()
+        } else {
+            None
+        },
+        prompt_cache_header_forwarded: forwarded_headers.prompt_cache_header_forwarded,
+        request_body_prefix_fingerprint,
+        request_body_prefix_bytes,
+        rewrite,
+    }
+}
+
+pub(crate) fn backfill_oauth_request_debug_body_prefix(
+    debug: &mut OauthRequestDebugInfo,
+    path: &str,
+    body: &[u8],
+    crypto_key: Option<&[u8; 32]>,
+) {
+    let body_prefix = oauth_request_body_prefix_bytes(Some(body));
+    debug.request_body_prefix_bytes = match (crypto_key, body_prefix.as_ref()) {
+        (Some(_), Some(prefix)) => Some(prefix.len()),
+        _ => None,
+    };
+    debug.request_body_prefix_fingerprint = match (crypto_key, body_prefix.as_ref()) {
+        (Some(crypto_key), Some(prefix)) => Some(oauth_fingerprint_body_prefix(
+            crypto_key,
+            path,
+            prefix.as_slice(),
+        )),
+        _ => None,
+    };
+    if crypto_key.is_some() {
+        debug.fingerprint_version = Some(OAUTH_FINGERPRINT_VERSION);
+    }
 }
 
 fn attach_account_header(
@@ -908,6 +1101,7 @@ mod tests {
     #[test]
     fn copy_forwardable_headers_keeps_prompt_cache_headers_but_strips_sticky_headers() {
         let client = Client::new();
+        let crypto_key: [u8; 32] = Sha256::digest(b"oauth-debug-test-secret").into();
         let headers = HeaderMap::from_iter([
             (
                 header::HeaderName::from_static("x-prompt-cache-key"),
@@ -929,8 +1123,12 @@ mod tests {
             ),
         ]);
 
-        let (builder, summary) =
-            copy_forwardable_headers(client.get("https://example.com"), &headers, &[]);
+        let (builder, summary) = copy_forwardable_headers(
+            client.get("https://example.com"),
+            &headers,
+            &[],
+            Some(&crypto_key),
+        );
         let request = builder.build().expect("build request");
 
         assert_eq!(
@@ -964,6 +1162,11 @@ mod tests {
                 "x-prompt-cache-key".to_string()
             ]
         );
+        assert_eq!(
+            summary.fingerprints,
+            Some(BTreeMap::new()),
+            "non-allowlisted forwarded headers should not emit fingerprints"
+        );
     }
 
     #[test]
@@ -993,8 +1196,12 @@ mod tests {
         ]);
 
         let builder = client.post("https://example.com");
-        let (builder, _) =
-            copy_forwardable_headers(builder, &headers, OAUTH_RESPONSES_EXCLUDED_HEADER_NAMES);
+        let (builder, _) = copy_forwardable_headers(
+            builder,
+            &headers,
+            OAUTH_RESPONSES_EXCLUDED_HEADER_NAMES,
+            None,
+        );
         let request = attach_account_header(
             builder
                 .bearer_auth("oauth-upstream-token")
@@ -1034,5 +1241,113 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("prompt-cache-gamma")
         );
+    }
+
+    #[test]
+    fn copy_forwardable_headers_fingerprints_allowlisted_header_values() {
+        let client = Client::new();
+        let crypto_key: [u8; 32] = Sha256::digest(b"oauth-debug-test-secret").into();
+        let headers = HeaderMap::from_iter([
+            (
+                header::HeaderName::from_static("session_id"),
+                "session-alpha".parse().expect("session header"),
+            ),
+            (
+                header::HeaderName::from_static("traceparent"),
+                "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+                    .parse()
+                    .expect("traceparent"),
+            ),
+        ]);
+
+        let (_, summary_a) = copy_forwardable_headers(
+            client.get("https://example.com"),
+            &headers,
+            &[],
+            Some(&crypto_key),
+        );
+        let (_, summary_b) = copy_forwardable_headers(
+            client.get("https://example.com"),
+            &headers,
+            &[],
+            Some(&crypto_key),
+        );
+
+        let mut changed_headers = headers.clone();
+        changed_headers.insert(
+            header::HeaderName::from_static("session_id"),
+            "session-beta".parse().expect("updated session header"),
+        );
+        let (_, summary_c) = copy_forwardable_headers(
+            client.get("https://example.com"),
+            &changed_headers,
+            &[],
+            Some(&crypto_key),
+        );
+
+        assert_eq!(summary_a.fingerprints, summary_b.fingerprints);
+        assert_ne!(summary_a.fingerprints, summary_c.fingerprints);
+        assert_eq!(
+            summary_a
+                .fingerprints
+                .as_ref()
+                .and_then(|fingerprints| fingerprints.get("session_id"))
+                .map(String::len),
+            Some(16)
+        );
+        assert_eq!(
+            summary_a
+                .fingerprints
+                .as_ref()
+                .and_then(|fingerprints| fingerprints.get("traceparent"))
+                .map(String::len),
+            Some(16)
+        );
+    }
+
+    #[test]
+    fn build_oauth_request_debug_fingerprints_body_prefix_and_downgrades_without_crypto_key() {
+        let crypto_key: [u8; 32] = Sha256::digest(b"oauth-debug-test-secret").into();
+        let forwarded_headers = OauthForwardedHeaderSummary {
+            names: vec!["session_id".to_string()],
+            prompt_cache_header_forwarded: false,
+            fingerprints: Some(BTreeMap::from([(
+                "session_id".to_string(),
+                "0123456789abcdef".to_string(),
+            )])),
+        };
+        let debug = build_oauth_request_debug(
+            "/v1/responses",
+            &forwarded_headers,
+            Some(br#"{"model":"gpt-5.4","input":"hello"}"#),
+            OauthResponsesRewriteSummary::default(),
+            Some(&crypto_key),
+        );
+        let no_crypto = build_oauth_request_debug(
+            "/v1/responses",
+            &forwarded_headers,
+            Some(br#"{"model":"gpt-5.4","input":"hello"}"#),
+            OauthResponsesRewriteSummary::default(),
+            None,
+        );
+
+        assert_eq!(debug.fingerprint_version, Some("v1"));
+        assert!(
+            debug
+                .request_body_prefix_bytes
+                .expect("body prefix byte count")
+                > 0
+        );
+        assert_eq!(
+            debug
+                .request_body_prefix_fingerprint
+                .as_ref()
+                .map(String::len),
+            Some(16)
+        );
+        assert!(no_crypto.fingerprint_version.is_none());
+        assert!(no_crypto.request_body_prefix_fingerprint.is_none());
+        assert!(no_crypto.request_body_prefix_bytes.is_none());
+        assert!(no_crypto.forwarded_header_fingerprints.is_none());
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9554,6 +9554,31 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
         .get("x-client-trace-id")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
+    let session_id = request
+        .headers()
+        .get("session_id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let traceparent = request
+        .headers()
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let x_client_request_id = request
+        .headers()
+        .get("x-client-request-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let x_codex_turn_metadata = request
+        .headers()
+        .get("x-codex-turn-metadata")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let originator = request
+        .headers()
+        .get("originator")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     let forwarded_for = request
         .headers()
         .get("x-forwarded-for")
@@ -9572,6 +9597,11 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
             "promptCacheKeyHeader": prompt_cache_key_header,
             "xOpenAiPromptCacheKeyHeader": x_openai_prompt_cache_key_header,
             "clientTraceId": client_trace_id,
+            "sessionIdHeader": session_id,
+            "traceparentHeader": traceparent,
+            "xClientRequestIdHeader": x_client_request_id,
+            "xCodexTurnMetadataHeader": x_codex_turn_metadata,
+            "originatorHeader": originator,
             "forwardedFor": forwarded_for,
             "forwardedHeaderNames": forwarded_header_names,
             "bodyLength": body.len(),
@@ -9632,6 +9662,31 @@ async fn oauth_codex_responses_capture_upstream(request: axum::extract::Request)
         .get("x-client-trace-id")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
+    let session_id = request
+        .headers()
+        .get("session_id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let traceparent = request
+        .headers()
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let x_client_request_id = request
+        .headers()
+        .get("x-client-request-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let x_codex_turn_metadata = request
+        .headers()
+        .get("x-codex-turn-metadata")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let originator = request
+        .headers()
+        .get("originator")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     let body = to_bytes(request.into_body(), usize::MAX)
         .await
         .expect("read oauth codex responses capture request body");
@@ -9648,6 +9703,11 @@ async fn oauth_codex_responses_capture_upstream(request: axum::extract::Request)
             "xOpenAiPromptCacheKeyHeader": x_openai_prompt_cache_key_header,
             "promptCacheKeyHeader": prompt_cache_key_header,
             "clientTraceId": client_trace_id,
+            "sessionIdHeader": session_id,
+            "traceparentHeader": traceparent,
+            "xClientRequestIdHeader": x_client_request_id,
+            "xCodexTurnMetadataHeader": x_codex_turn_metadata,
+            "originatorHeader": originator,
             "forwardedHeaderNames": forwarded_header_names,
             "received": body_value,
             "usage": {
@@ -10582,6 +10642,26 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
                 HeaderValue::from_static("trace-oauth-responses"),
             ),
             (
+                HeaderName::from_static("session_id"),
+                HeaderValue::from_static("session-oauth-responses"),
+            ),
+            (
+                HeaderName::from_static("traceparent"),
+                HeaderValue::from_static("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"),
+            ),
+            (
+                HeaderName::from_static("x-client-request-id"),
+                HeaderValue::from_static("client-request-oauth-responses"),
+            ),
+            (
+                HeaderName::from_static("x-codex-turn-metadata"),
+                HeaderValue::from_static("{\"turn\":42}"),
+            ),
+            (
+                HeaderName::from_static("originator"),
+                HeaderValue::from_static("Codex Desktop"),
+            ),
+            (
                 HeaderName::from_static("chatgpt-account-id"),
                 HeaderValue::from_static("client-should-not-win"),
             ),
@@ -10618,6 +10698,23 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
         payload["clientTraceId"].as_str(),
         Some("trace-oauth-responses")
     );
+    assert_eq!(
+        payload["sessionIdHeader"].as_str(),
+        Some("session-oauth-responses")
+    );
+    assert_eq!(
+        payload["traceparentHeader"].as_str(),
+        Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")
+    );
+    assert_eq!(
+        payload["xClientRequestIdHeader"].as_str(),
+        Some("client-request-oauth-responses")
+    );
+    assert_eq!(
+        payload["xCodexTurnMetadataHeader"].as_str(),
+        Some("{\"turn\":42}")
+    );
+    assert_eq!(payload["originatorHeader"].as_str(), Some("Codex Desktop"));
     assert!(
         payload["forwardedHeaderNames"]
             .as_array()
@@ -10633,6 +10730,30 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
             .iter()
             .filter_map(Value::as_str)
             .any(|name| name == "x-client-trace-id")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "session_id")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "traceparent")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-client-request-id")
     );
     assert_eq!(payload["received"]["stream"], true);
     assert_eq!(payload["received"]["store"], false);
@@ -10660,6 +10781,7 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
     assert_eq!(payload_json["oauthAccountHeaderAttached"], true);
     assert_eq!(payload_json["oauthAccountIdShape"].as_str(), Some("uuid"));
     assert_eq!(payload_json["endpoint"].as_str(), Some("/v1/responses"));
+    assert_eq!(payload_json["oauthFingerprintVersion"].as_str(), Some("v1"));
     assert_eq!(payload_json["oauthPromptCacheHeaderForwarded"], true);
     assert!(
         payload_json["oauthForwardedHeaderCount"]
@@ -10682,6 +10804,56 @@ async fn pool_route_oauth_responses_sends_uuid_account_header_and_persists_obser
             .iter()
             .filter_map(Value::as_str)
             .any(|name| name == "x-client-trace-id")
+    );
+    assert!(
+        payload_json["oauthRequestBodyPrefixBytes"]
+            .as_u64()
+            .expect("body prefix byte count")
+            > 0
+    );
+    assert!(
+        payload_json["oauthRequestBodyPrefixFingerprint"]
+            .as_str()
+            .expect("body prefix fingerprint")
+            .len()
+            == 16
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["session_id"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["traceparent"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["x-client-request-id"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["x-codex-turn-metadata"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["originator"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert!(payload_json["oauthForwardedHeaderFingerprints"]["x-client-trace-id"].is_null());
+    assert!(
+        !row.payload
+            .as_deref()
+            .expect("persisted payload text")
+            .contains("session-oauth-responses")
     );
     assert_eq!(payload_json["oauthResponsesRewrite"]["applied"], true);
     assert_eq!(
@@ -10762,6 +10934,26 @@ async fn pool_route_oauth_passthrough_streams_without_eager_prebuffering() {
                 HeaderValue::from_static("trace-oauth-stream"),
             ),
             (
+                HeaderName::from_static("session_id"),
+                HeaderValue::from_static("session-oauth-stream"),
+            ),
+            (
+                HeaderName::from_static("traceparent"),
+                HeaderValue::from_static("00-cccccccccccccccccccccccccccccccc-dddddddddddddddd-01"),
+            ),
+            (
+                HeaderName::from_static("x-client-request-id"),
+                HeaderValue::from_static("client-request-oauth-stream"),
+            ),
+            (
+                HeaderName::from_static("x-codex-turn-metadata"),
+                HeaderValue::from_static("{\"stream\":true}"),
+            ),
+            (
+                HeaderName::from_static("originator"),
+                HeaderValue::from_static("Codex Desktop"),
+            ),
+            (
                 HeaderName::from_static("x-forwarded-for"),
                 HeaderValue::from_static("203.0.113.8"),
             ),
@@ -10821,9 +11013,75 @@ async fn pool_route_oauth_passthrough_streams_without_eager_prebuffering() {
             .filter_map(Value::as_str)
             .any(|name| name == "x-client-trace-id")
     );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "session_id")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-client-request-id")
+    );
 
     upstream_handle.abort();
     oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
+}
+
+#[tokio::test]
+async fn oauth_streaming_passthrough_backfills_body_prefix_from_replay_status() {
+    let crypto_key: [u8; 32] = Sha256::digest(b"test-upstream-account-secret").into();
+    let mut debug = Some(oauth_bridge::OauthResponsesDebugInfo {
+        fingerprint_version: Some("v1"),
+        forwarded_header_names: vec!["session_id".to_string()],
+        forwarded_header_fingerprints: Some(BTreeMap::from([(
+            "session_id".to_string(),
+            "0123456789abcdef".to_string(),
+        )])),
+        prompt_cache_header_forwarded: false,
+        request_body_prefix_fingerprint: None,
+        request_body_prefix_bytes: None,
+        rewrite: oauth_bridge::OauthResponsesRewriteSummary::default(),
+    });
+    let (status_tx, status_rx) = watch::channel(PoolReplayBodyStatus::Reading);
+    status_tx
+        .send(PoolReplayBodyStatus::Complete(
+            PoolReplayBodySnapshot::Memory(Bytes::from_static(
+                br#"{"messages":[{"role":"user","content":"hello"}]}"#,
+            )),
+        ))
+        .expect("send replay completion");
+
+    maybe_backfill_oauth_request_debug_from_replay_status(
+        &mut debug,
+        &"/v1/chat/completions"
+            .parse()
+            .expect("valid chat completions uri"),
+        &status_rx,
+        Some(&crypto_key),
+    )
+    .await;
+
+    let debug = debug.expect("debug should remain present");
+    assert!(
+        debug
+            .request_body_prefix_bytes
+            .expect("body prefix bytes should be backfilled")
+            > 0
+    );
+    assert_eq!(
+        debug
+            .request_body_prefix_fingerprint
+            .as_ref()
+            .map(String::len),
+        Some(16)
+    );
 }
 
 #[tokio::test]
@@ -10917,6 +11175,11 @@ async fn pool_route_oauth_body_sticky_binding_applies_before_first_send() {
 
 #[tokio::test]
 async fn pool_route_oauth_compact_passthrough_preserves_prompt_cache_headers() {
+    #[derive(sqlx::FromRow)]
+    struct PersistedRow {
+        payload: Option<String>,
+    }
+
     let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
         .lock()
         .await;
@@ -10932,10 +11195,10 @@ async fn pool_route_oauth_compact_passthrough_preserves_prompt_cache_headers() {
     )
     .await;
     seed_pool_routing_api_key(&state, "pool-live-key").await;
-    insert_test_pool_oauth_account(&state, "Compact OAuth", "oauth-compact").await;
+    let account_id = insert_test_pool_oauth_account(&state, "Compact OAuth", "oauth-compact").await;
 
     let response = proxy_openai_v1(
-        State(state),
+        State(state.clone()),
         OriginalUri("/v1/responses/compact".parse().expect("valid compact uri")),
         Method::POST,
         HeaderMap::from_iter([
@@ -10950,6 +11213,26 @@ async fn pool_route_oauth_compact_passthrough_preserves_prompt_cache_headers() {
             (
                 HeaderName::from_static("x-client-trace-id"),
                 HeaderValue::from_static("trace-oauth-compact"),
+            ),
+            (
+                HeaderName::from_static("session_id"),
+                HeaderValue::from_static("session-oauth-compact"),
+            ),
+            (
+                HeaderName::from_static("traceparent"),
+                HeaderValue::from_static("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"),
+            ),
+            (
+                HeaderName::from_static("x-client-request-id"),
+                HeaderValue::from_static("client-request-oauth-compact"),
+            ),
+            (
+                HeaderName::from_static("x-codex-turn-metadata"),
+                HeaderValue::from_static("{\"compact\":true}"),
+            ),
+            (
+                HeaderName::from_static("originator"),
+                HeaderValue::from_static("Codex Desktop"),
             ),
             (
                 http_header::CONTENT_TYPE,
@@ -10984,6 +11267,178 @@ async fn pool_route_oauth_compact_passthrough_preserves_prompt_cache_headers() {
     assert_eq!(
         payload["clientTraceId"].as_str(),
         Some("trace-oauth-compact")
+    );
+    assert_eq!(
+        payload["sessionIdHeader"].as_str(),
+        Some("session-oauth-compact")
+    );
+    assert_eq!(
+        payload["traceparentHeader"].as_str(),
+        Some("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
+    );
+    assert_eq!(
+        payload["xClientRequestIdHeader"].as_str(),
+        Some("client-request-oauth-compact")
+    );
+    assert_eq!(
+        payload["xCodexTurnMetadataHeader"].as_str(),
+        Some("{\"compact\":true}")
+    );
+    assert_eq!(payload["originatorHeader"].as_str(), Some("Codex Desktop"));
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "session_id")
+    );
+    assert!(
+        payload["forwardedHeaderNames"]
+            .as_array()
+            .expect("forwarded header names")
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| name == "x-client-request-id")
+    );
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let row = sqlx::query_as::<_, PersistedRow>(
+        r#"
+        SELECT payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load persisted invocation payload");
+    let payload_json: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("payload should be persisted for oauth compact"),
+    )
+    .expect("decode persisted invocation payload");
+    assert_eq!(payload_json["upstreamAccountId"].as_i64(), Some(account_id));
+    assert_eq!(
+        payload_json["endpoint"].as_str(),
+        Some("/v1/responses/compact")
+    );
+    assert_eq!(payload_json["oauthFingerprintVersion"].as_str(), Some("v1"));
+    assert_eq!(payload_json["oauthPromptCacheHeaderForwarded"], true);
+    assert_eq!(payload_json["oauthResponsesRewrite"]["applied"], false);
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["session_id"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["traceparent"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["x-client-request-id"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["x-codex-turn-metadata"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert_eq!(
+        payload_json["oauthForwardedHeaderFingerprints"]["originator"]
+            .as_str()
+            .map(str::len),
+        Some(16)
+    );
+    assert!(
+        payload_json["oauthRequestBodyPrefixBytes"]
+            .as_u64()
+            .expect("compact body prefix byte count")
+            > 0
+    );
+    assert!(
+        payload_json["oauthRequestBodyPrefixFingerprint"]
+            .as_str()
+            .expect("compact body fingerprint")
+            .len()
+            == 16
+    );
+
+    upstream_handle.abort();
+    oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
+}
+
+#[tokio::test]
+async fn pool_route_oauth_observability_omits_fingerprints_without_crypto_key() {
+    let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
+        .lock()
+        .await;
+
+    let (upstream_base, upstream_handle) = spawn_oauth_codex_responses_capture_upstream().await;
+    oauth_bridge::set_test_oauth_codex_upstream_base_url(
+        Url::parse(&format!("{upstream_base}/backend-api/codex")).expect("valid oauth base url"),
+    )
+    .await;
+
+    let oauth_response = oauth_bridge::send_oauth_upstream_request(
+        &reqwest::Client::new(),
+        Method::POST,
+        &"/v1/responses".parse().expect("valid uri"),
+        &HeaderMap::from_iter([
+            (
+                HeaderName::from_static("session_id"),
+                HeaderValue::from_static("session-no-crypto"),
+            ),
+            (
+                HeaderName::from_static("traceparent"),
+                HeaderValue::from_static("00-11111111111111111111111111111111-2222222222222222-01"),
+            ),
+        ]),
+        oauth_bridge::OauthUpstreamRequestBody::Bytes(Bytes::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-5.4",
+                "input": "hello"
+            }))
+            .expect("serialize oauth responses body"),
+        )),
+        Duration::from_secs(5),
+        Duration::from_secs(5),
+        Some(7),
+        "oauth-no-crypto",
+        Some("02355c9d-fb23-4517-a96d-35e5f6758e9e"),
+        None,
+    )
+    .await;
+
+    assert_eq!(oauth_response.response.status(), StatusCode::OK);
+    let body = to_bytes(oauth_response.response.into_body(), usize::MAX)
+        .await
+        .expect("read oauth response body");
+    let payload_json: Value = serde_json::from_slice(&body).expect("decode oauth response body");
+    assert_eq!(
+        payload_json["path"].as_str(),
+        Some("/backend-api/codex/responses")
+    );
+
+    let request_debug = oauth_response
+        .request_debug
+        .expect("oauth request debug should be present");
+    assert!(request_debug.fingerprint_version.is_none());
+    assert!(request_debug.forwarded_header_fingerprints.is_none());
+    assert!(request_debug.request_body_prefix_fingerprint.is_none());
+    assert!(request_debug.request_body_prefix_bytes.is_none());
+    let serialized_debug = serde_json::to_string(&request_debug).expect("serialize request debug");
+    assert!(
+        !serialized_debug.contains("session-no-crypto"),
+        "request debug should not leak raw header values"
     );
 
     upstream_handle.abort();


### PR DESCRIPTION
## Summary
- extend OAuth request debug data so both `/v1/responses` and passthrough routes emit the same safe observability fields
- record keyed fingerprints for selected forwarded header values plus the outbound request body prefix without storing any raw secrets or prompt/cache payloads
- backfill body-prefix fingerprints for direct streamed OAuth passthrough requests once replay capture completes, so diagnostics stay consistent across routing paths

## Root Cause
OAuth low-cache spike analysis still had a blind spot after header-forwarding fixes landed. We only persisted forwarded header names and rewrite flags, so we could not compare whether header values or outbound body prefixes drifted across adjacent low-cache spikes. The direct streamed OAuth passthrough path also dropped body-prefix observability entirely.

## What Changed
- generalized OAuth request debug info inside `src/oauth_bridge.rs`
- added `oauthFingerprintVersion`, `oauthForwardedHeaderFingerprints`, `oauthRequestBodyPrefixFingerprint`, and `oauthRequestBodyPrefixBytes` to invocation payloads
- fingerprinted only the allowlisted forwarded headers: `session_id`, `traceparent`, `x-client-request-id`, `x-codex-turn-metadata`, and `originator`
- used the existing `UPSTREAM_ACCOUNTS_ENCRYPTION_SECRET` derived crypto key for domain-separated keyed SHA-256 fingerprints, truncated to 16 hex chars
- kept `/v1/responses` rewrite behavior unchanged while adding the same observability to `/v1/responses/compact` and `/v1/chat/completions`
- backfilled body-prefix fingerprints for streamed passthrough requests after replay capture finishes

## Validation
- `cargo test pool_route_oauth_ -- --nocapture`
- `cargo test oauth_streaming_passthrough_backfills_body_prefix_from_replay_status -- --nocapture`
- `cargo test oauth_bridge::tests -- --nocapture`
- `cargo check`
- `codex review --base origin/main` on the final head completed with no actionable findings

## Post-Deploy Verification
After the release lands on 101, query recent OAuth traffic and compare adjacent low-cache spikes against neighboring high-cache requests:
- confirm `oauthFingerprintVersion = "v1"`
- confirm `oauthForwardedHeaderFingerprints` is present when crypto is configured and absent only for no-crypto test paths
- confirm `oauthRequestBodyPrefixFingerprint` is present for `/v1/responses`, `/v1/responses/compact`, and streamed `/v1/chat/completions`
- for account `7` and `sticky_key = 019cffad-c9ad-7fa3-80c0-9c48e171b3a3`, compare low-cache spikes against adjacent high-cache requests to classify the cause as header-value drift, body-prefix drift, or upstream instability
