### PR TITLE
fix(docs): remove stale storybook guide nav link

### DIFF
--- a/docs-site/rspress.config.ts
+++ b/docs-site/rspress.config.ts
@@ -54,7 +54,6 @@ export default defineConfig({
           text: '预览与源码',
           items: [
             { text: 'Storybook 入口', link: '/storybook.html' },
-            { text: 'Storybook 导览', link: '/storybook-guide.html' },
             { text: 'GitHub 仓库', link: 'https://github.com/IvanLi-CN/codex-vibe-monitor' },
           ],
         },

--- a/web/README.md
+++ b/web/README.md
@@ -34,7 +34,7 @@ bun run storybook
 bun run storybook:build
 ```
 
-静态产物会写入 `web/storybook-static/`。GitHub Pages 发布时，该目录会被装配到 public docs 站点的 `/storybook/` 子路径下；主入口通过 `/storybook.html` 跳转，导览页固定在 `/storybook-guide.html`。
+静态产物会写入 `web/storybook-static/`。GitHub Pages 发布时，该目录会被装配到 public docs 站点的 `/storybook/` 子路径下；公共入口统一通过 `/storybook.html` 跳转。
 
 ## Storybook 范围
 


### PR DESCRIPTION
## Summary
- remove the stale `Storybook 导览` sidebar entry from the public docs navigation
- align the `web/README.md` Storybook publishing note with the single public `/storybook.html` entry

## Validation
- `cd docs-site && bun install`
- `cd docs-site && DOCS_BASE=/codex-vibe-monitor/ bun run build`
- `rg -n "storybook-guide|Storybook 导览" docs-site/doc_build`