### PR TITLE
fix(pool): tighten responses timeout failover

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1737,6 +1737,7 @@ async fn query_pool_attempt_records_from_archive_range(
                 sticky_key,
                 upstream_account_id,
                 NULL AS upstream_account_name,
+                NULL AS upstream_route_key,
                 attempt_index,
                 distinct_account_index,
                 same_account_retry_index,
@@ -1792,6 +1793,7 @@ async fn query_pool_attempt_records_from_live(
             attempts.sticky_key,
             attempts.upstream_account_id,
             accounts.display_name AS upstream_account_name,
+            attempts.upstream_route_key,
             attempts.attempt_index,
             attempts.distinct_account_index,
             attempts.same_account_retry_index,
@@ -4688,6 +4690,8 @@ pub(crate) struct ApiPoolUpstreamRequestAttempt {
     pub(crate) upstream_account_id: Option<i64>,
     #[sqlx(default)]
     pub(crate) upstream_account_name: Option<String>,
+    #[sqlx(default)]
+    pub(crate) upstream_route_key: Option<String>,
     pub(crate) attempt_index: i64,
     pub(crate) distinct_account_index: i64,
     pub(crate) same_account_retry_index: i64,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1727,7 +1727,24 @@ async fn query_pool_attempt_records_from_archive_range(
             .connect_with(connect_opts)
             .await
             .with_context(|| format!("failed to open archive batch {}", archive_path.display()))?;
-        let archived_records = sqlx::query_as::<_, ApiPoolUpstreamRequestAttempt>(
+        let archive_columns = sqlx::query("PRAGMA table_info('pool_upstream_request_attempts')")
+            .fetch_all(&archive_pool)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to inspect pool_upstream_request_attempts archive schema {}",
+                    archive_path.display()
+                )
+            })?
+            .into_iter()
+            .filter_map(|row| row.try_get::<String, _>("name").ok())
+            .collect::<HashSet<_>>();
+        let upstream_route_key_projection = if archive_columns.contains("upstream_route_key") {
+            "upstream_route_key"
+        } else {
+            "NULL AS upstream_route_key"
+        };
+        let archived_records_query = format!(
             r#"
             SELECT
                 id,
@@ -1737,7 +1754,7 @@ async fn query_pool_attempt_records_from_archive_range(
                 sticky_key,
                 upstream_account_id,
                 NULL AS upstream_account_name,
-                NULL AS upstream_route_key,
+                {upstream_route_key_projection},
                 attempt_index,
                 distinct_account_index,
                 same_account_retry_index,
@@ -1757,10 +1774,12 @@ async fn query_pool_attempt_records_from_archive_range(
             WHERE invoke_id = ?1
             ORDER BY attempt_index ASC, id ASC
             "#,
-        )
-        .bind(invoke_id)
-        .fetch_all(&archive_pool)
-        .await?;
+        );
+        let archived_records =
+            sqlx::query_as::<_, ApiPoolUpstreamRequestAttempt>(&archived_records_query)
+                .bind(invoke_id)
+                .fetch_all(&archive_pool)
+                .await?;
         archive_pool.close().await;
         drop(temp_cleanup);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9166,14 +9166,26 @@ async fn send_pool_request_with_failover(
                 final_error.status = StatusCode::TOO_MANY_REQUESTS;
                 final_error.message = POOL_ALL_ACCOUNTS_RATE_LIMITED_MESSAGE.to_string();
                 final_error.failure_kind = PROXY_FAILURE_POOL_ALL_ACCOUNTS_RATE_LIMITED;
-            } else {
+                final_error.upstream_error_code = None;
+                final_error.upstream_error_message = None;
+                final_error.upstream_request_id = None;
+            } else if terminal_failure_kind
+                == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+            {
                 final_error.status = StatusCode::BAD_GATEWAY;
                 final_error.message = terminal_message;
                 final_error.failure_kind = terminal_failure_kind;
+                final_error.upstream_error_code = None;
+                final_error.upstream_error_message = None;
+                final_error.upstream_request_id = None;
+            } else if final_error.status != StatusCode::TOO_MANY_REQUESTS {
+                final_error.status = StatusCode::BAD_GATEWAY;
+                final_error.message = terminal_message;
+                final_error.failure_kind = terminal_failure_kind;
+                final_error.upstream_error_code = None;
+                final_error.upstream_error_message = None;
+                final_error.upstream_request_id = None;
             }
-            final_error.upstream_error_code = None;
-            final_error.upstream_error_message = None;
-            final_error.upstream_request_id = None;
             final_error.attempt_summary = pool_attempt_summary(
                 attempt_count,
                 distinct_account_count,
@@ -9824,7 +9836,8 @@ async fn send_pool_request_with_failover(
                     && pool_failure_is_timeout_shaped(failure_kind, &message);
                 let retry_delay = (has_retry_budget
                     && !is_timeout_shaped
-                    && (status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()))
+                    && status.is_server_error()
+                    && status != StatusCode::TOO_MANY_REQUESTS)
                 .then(|| {
                     retry_after_header
                         .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -3986,6 +3986,9 @@ async fn archive_rows_into_month_batch(
             .execute(&mut *conn)
             .await
             .with_context(|| format!("failed to ensure archive schema for {}", spec.dataset))?;
+        if spec.dataset == "pool_upstream_request_attempts" {
+            ensure_pool_upstream_request_attempts_archive_schema(&mut conn).await?;
+        }
 
         let upstream_last_activity = if spec.dataset == "codex_invocations" {
             let mut rows = Vec::new();
@@ -6439,6 +6442,52 @@ async fn load_sqlite_table_columns(
         .filter_map(|row| row.try_get::<String, _>("name").ok())
         .collect::<HashSet<_>>();
     Ok(columns)
+}
+
+async fn load_sqlite_table_columns_from_connection(
+    conn: &mut SqliteConnection,
+    schema_name: Option<&str>,
+    table_name: &str,
+) -> Result<HashSet<String>> {
+    let pragma = schema_name.map_or_else(
+        || format!("PRAGMA table_info('{table_name}')"),
+        |schema_name| format!("PRAGMA {schema_name}.table_info('{table_name}')"),
+    );
+    let columns = sqlx::query(&pragma)
+        .fetch_all(&mut *conn)
+        .await
+        .with_context(|| format!("failed to inspect {table_name} schema"))?
+        .into_iter()
+        .filter_map(|row| row.try_get::<String, _>("name").ok())
+        .collect::<HashSet<_>>();
+    Ok(columns)
+}
+
+async fn ensure_pool_upstream_request_attempts_archive_schema(
+    conn: &mut SqliteConnection,
+) -> Result<()> {
+    let archive_columns = load_sqlite_table_columns_from_connection(
+        conn,
+        Some("archive_db"),
+        "pool_upstream_request_attempts",
+    )
+    .await?;
+    for (column, ty) in [("upstream_route_key", "TEXT")] {
+        if !archive_columns.contains(column) {
+            let statement = format!(
+                "ALTER TABLE archive_db.pool_upstream_request_attempts ADD COLUMN {column} {ty}"
+            );
+            sqlx::query(&statement)
+                .execute(&mut *conn)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to add archive_db.pool_upstream_request_attempts column {column}"
+                    )
+                })?;
+        }
+    }
+    Ok(())
 }
 
 async fn migrate_codex_invocations_drop_raw_expires_at(

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,8 @@ const LEGACY_ENV_POOL_UPSTREAM_REQUEST_ATTEMPTS_RETENTION_DAYS: &str =
     "XY_POOL_UPSTREAM_REQUEST_ATTEMPTS_RETENTION_DAYS";
 const ENV_POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_TTL_DAYS: &str =
     "POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_TTL_DAYS";
+const ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS: &str =
+    "POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS";
 const LEGACY_ENV_POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_TTL_DAYS: &str =
     "XY_POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_TTL_DAYS";
 const ENV_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS: &str = "STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS";
@@ -198,6 +200,7 @@ const DEFAULT_INVOCATION_MAX_DAYS: u64 = 90;
 const DEFAULT_FORWARD_PROXY_ATTEMPTS_RETENTION_DAYS: u64 = 30;
 const DEFAULT_POOL_UPSTREAM_REQUEST_ATTEMPTS_RETENTION_DAYS: u64 = 7;
 const DEFAULT_POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_TTL_DAYS: u64 = 30;
+const DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS: u64 = 120;
 const DEFAULT_STATS_SOURCE_SNAPSHOTS_RETENTION_DAYS: u64 = 30;
 const DEFAULT_QUOTA_SNAPSHOT_FULL_DAYS: u64 = 30;
 const ARCHIVE_STATUS_COMPLETED: &str = "completed";
@@ -220,6 +223,8 @@ const PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT: &str = "pool_no_available_account
 const PROXY_FAILURE_POOL_ALL_ACCOUNTS_RATE_LIMITED: &str = "pool_all_accounts_rate_limited";
 const PROXY_FAILURE_POOL_MAX_DISTINCT_ACCOUNTS_EXHAUSTED: &str = "max_distinct_accounts_exhausted";
 const POOL_ALL_ACCOUNTS_RATE_LIMITED_MESSAGE: &str = "no pool account is currently available because all candidate accounts are rate limited upstream (429 / quota exhausted)";
+const PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT: &str =
+    "no_alternate_upstream_after_timeout";
 const PROXY_STREAM_TERMINAL_COMPLETED: &str = "stream_completed";
 const PROXY_STREAM_TERMINAL_ERROR: &str = "stream_error";
 const PROXY_STREAM_TERMINAL_DOWNSTREAM_CLOSED: &str = "downstream_closed";
@@ -2263,7 +2268,7 @@ struct DryRunBatchCount {
 const CODEX_INVOCATIONS_ARCHIVE_COLUMNS: &str = "id, invoke_id, occurred_at, source, model, input_tokens, output_tokens, cache_input_tokens, reasoning_tokens, total_tokens, cost, status, error_message, failure_kind, failure_class, is_actionable, payload, raw_response, cost_estimated, price_version, request_raw_path, request_raw_size, request_raw_truncated, request_raw_truncated_reason, response_raw_path, response_raw_size, response_raw_truncated, response_raw_truncated_reason, detail_level, detail_pruned_at, detail_prune_reason, t_total_ms, t_req_read_ms, t_req_parse_ms, t_upstream_connect_ms, t_upstream_ttfb_ms, t_upstream_stream_ms, t_resp_parse_ms, t_persist_ms, created_at";
 const FORWARD_PROXY_ATTEMPTS_ARCHIVE_COLUMNS: &str =
     "id, proxy_key, occurred_at, is_success, latency_ms, failure_kind, is_probe";
-const POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_COLUMNS: &str = "id, invoke_id, occurred_at, endpoint, route_mode, sticky_key, upstream_account_id, attempt_index, distinct_account_index, same_account_retry_index, requester_ip, started_at, finished_at, status, http_status, failure_kind, error_message, connect_latency_ms, first_byte_latency_ms, stream_latency_ms, upstream_request_id, created_at";
+const POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_COLUMNS: &str = "id, invoke_id, occurred_at, endpoint, route_mode, sticky_key, upstream_account_id, upstream_route_key, attempt_index, distinct_account_index, same_account_retry_index, requester_ip, started_at, finished_at, status, http_status, failure_kind, error_message, connect_latency_ms, first_byte_latency_ms, stream_latency_ms, upstream_request_id, created_at";
 const STATS_SOURCE_SNAPSHOTS_ARCHIVE_COLUMNS: &str = "id, source, period, stats_date, model, requests, input_tokens, output_tokens, cache_create_tokens, cache_read_tokens, all_tokens, cost_input, cost_output, cost_cache_write, cost_cache_read, cost_total, raw_response, captured_at, captured_at_epoch, created_at";
 const CODEX_QUOTA_SNAPSHOTS_ARCHIVE_COLUMNS: &str = "id, captured_at, amount_limit, used_amount, remaining_amount, period, period_reset_time, expire_time, is_active, total_cost, total_requests, total_tokens, last_request_time, billing_type, remaining_count, used_count, sub_type_name";
 
@@ -2334,6 +2339,7 @@ CREATE TABLE IF NOT EXISTS archive_db.pool_upstream_request_attempts (
     route_mode TEXT NOT NULL,
     sticky_key TEXT,
     upstream_account_id INTEGER,
+    upstream_route_key TEXT,
     attempt_index INTEGER NOT NULL,
     distinct_account_index INTEGER NOT NULL,
     same_account_retry_index INTEGER NOT NULL,
@@ -7415,6 +7421,7 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
             route_mode TEXT NOT NULL,
             sticky_key TEXT,
             upstream_account_id INTEGER,
+            upstream_route_key TEXT,
             attempt_index INTEGER NOT NULL,
             distinct_account_index INTEGER NOT NULL,
             same_account_retry_index INTEGER NOT NULL,
@@ -7436,6 +7443,21 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     .execute(pool)
     .await
     .context("failed to ensure pool_upstream_request_attempts table existence")?;
+
+    let existing_pool_attempt_columns =
+        load_sqlite_table_columns(pool, "pool_upstream_request_attempts").await?;
+    for (column, ty) in [("upstream_route_key", "TEXT")] {
+        if !existing_pool_attempt_columns.contains(column) {
+            let statement =
+                format!("ALTER TABLE pool_upstream_request_attempts ADD COLUMN {column} {ty}");
+            sqlx::query(&statement)
+                .execute(pool)
+                .await
+                .with_context(|| {
+                    format!("failed to add pool_upstream_request_attempts column {column}")
+                })?;
+        }
+    }
 
     sqlx::query(
         r#"
@@ -8635,12 +8657,22 @@ pub(crate) struct PendingPoolAttemptRecord {
     pub(crate) sticky_key: Option<String>,
     pub(crate) requester_ip: Option<String>,
     pub(crate) upstream_account_id: i64,
+    pub(crate) upstream_route_key: String,
     pub(crate) attempt_index: i64,
     pub(crate) distinct_account_index: i64,
     pub(crate) same_account_retry_index: i64,
     pub(crate) started_at: String,
     pub(crate) connect_latency_ms: f64,
     pub(crate) first_byte_latency_ms: f64,
+}
+
+#[derive(Debug, Default)]
+struct PoolFailoverProgress {
+    excluded_account_ids: Vec<i64>,
+    excluded_upstream_route_keys: HashSet<String>,
+    attempt_count: usize,
+    last_error: Option<PoolUpstreamError>,
+    timeout_route_failover_pending: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -8657,6 +8689,7 @@ const POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_HTTP_FAILURE: &str = "http_failure";
 const POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE: &str = "transport_failure";
 const POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_BUDGET_EXHAUSTED_FINAL: &str = "budget_exhausted_final";
 const POOL_UPSTREAM_MAX_DISTINCT_ACCOUNTS: usize = 3;
+const POOL_UPSTREAM_RESPONSES_MAX_TIMEOUT_ROUTE_KEYS: usize = 3;
 
 #[derive(Debug)]
 struct PoolReplayTempFile {
@@ -9015,67 +9048,58 @@ async fn send_pool_request_with_failover(
     trace_context: Option<PoolUpstreamAttemptTraceContext>,
     sticky_key: Option<&str>,
     preferred_account: Option<PoolResolvedAccount>,
+    failover_progress: PoolFailoverProgress,
     same_account_attempts: u8,
-) -> Result<PoolUpstreamResponse, PoolUpstreamError> {
-    send_pool_request_with_failover_seeded(
-        state,
-        method,
-        original_uri,
-        headers,
-        body,
-        handshake_timeout,
-        trace_context,
-        sticky_key,
-        preferred_account,
-        same_account_attempts,
-        Vec::new(),
-        0,
-        None,
-    )
-    .await
-}
-
-async fn send_pool_request_with_failover_seeded(
-    state: Arc<AppState>,
-    method: Method,
-    original_uri: &Uri,
-    headers: &HeaderMap,
-    body: Option<PoolReplayBodySnapshot>,
-    handshake_timeout: Duration,
-    trace_context: Option<PoolUpstreamAttemptTraceContext>,
-    sticky_key: Option<&str>,
-    preferred_account: Option<PoolResolvedAccount>,
-    same_account_attempts: u8,
-    initial_excluded_ids: Vec<i64>,
-    initial_attempt_count: usize,
-    initial_last_error: Option<PoolUpstreamError>,
 ) -> Result<PoolUpstreamResponse, PoolUpstreamError> {
     let request_connection_scoped = connection_scoped_header_names(headers);
     let first_chunk_timeout =
         pool_upstream_first_chunk_timeout(&state.config, original_uri, &method, handshake_timeout);
-    let mut excluded_ids = initial_excluded_ids;
-    let initial_errors_all_rate_limited = if initial_attempt_count == 0 {
+    let uses_timeout_route_failover =
+        pool_uses_responses_timeout_failover_policy(original_uri, &method);
+    let mut excluded_ids = failover_progress.excluded_account_ids;
+    let mut excluded_upstream_route_keys = failover_progress.excluded_upstream_route_keys;
+    let mut last_error = failover_progress.last_error;
+    let initial_errors_all_rate_limited = if failover_progress.attempt_count == 0 {
         true
     } else {
-        initial_last_error
+        last_error
             .as_ref()
             .is_some_and(pool_upstream_error_is_rate_limited)
     };
-    let mut last_error = initial_last_error;
-    let mut preferred_account = preferred_account;
+    let mut preferred_account = preferred_account
+        .filter(|account| !excluded_upstream_route_keys.contains(&account.upstream_route_key()));
     let mut same_account_attempts = same_account_attempts.max(1);
-    let mut attempt_count = initial_attempt_count;
+    let mut attempt_count = failover_progress.attempt_count;
     let mut distinct_account_count = excluded_ids.len();
+    let mut timeout_route_failover_pending = failover_progress.timeout_route_failover_pending;
     let mut exhausted_accounts_all_rate_limited = initial_errors_all_rate_limited;
 
     'account_loop: loop {
-        if preferred_account.is_none() && excluded_ids.len() >= POOL_UPSTREAM_MAX_DISTINCT_ACCOUNTS
+        let mut distinct_account_count = excluded_ids.len();
+        if preferred_account.is_none()
+            && (excluded_ids.len() >= POOL_UPSTREAM_MAX_DISTINCT_ACCOUNTS
+                || (uses_timeout_route_failover
+                    && timeout_route_failover_pending
+                    && excluded_upstream_route_keys.len()
+                        >= POOL_UPSTREAM_RESPONSES_MAX_TIMEOUT_ROUTE_KEYS))
         {
+            let terminal_failure_kind =
+                if uses_timeout_route_failover && timeout_route_failover_pending {
+                    PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                } else {
+                    PROXY_FAILURE_POOL_MAX_DISTINCT_ACCOUNTS_EXHAUSTED
+                };
             let mut final_error = last_error.unwrap_or(PoolUpstreamError {
                 account: None,
                 status: StatusCode::BAD_GATEWAY,
-                message: "pool distinct-account retry budget exhausted".to_string(),
-                failure_kind: PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT,
+                message: if terminal_failure_kind
+                    == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                {
+                    "no alternate upstream route is available after timeout".to_string()
+                } else {
+                    "pool distinct-account retry budget exhausted".to_string()
+                },
+                failure_kind: terminal_failure_kind,
                 connect_latency_ms: 0.0,
                 upstream_error_code: None,
                 upstream_error_message: None,
@@ -9090,30 +9114,16 @@ async fn send_pool_request_with_failover_seeded(
             final_error.attempt_summary = pool_attempt_summary(
                 attempt_count,
                 distinct_account_count,
-                Some(PROXY_FAILURE_POOL_MAX_DISTINCT_ACCOUNTS_EXHAUSTED.to_string()),
+                Some(terminal_failure_kind.to_string()),
             );
             if let Some(trace) = trace_context.as_ref() {
-                let finished_at = shanghai_now_string();
-                if let Err(err) = insert_pool_upstream_request_attempt(
+                if let Err(err) = insert_pool_upstream_terminal_attempt(
                     &state.pool,
                     trace,
-                    final_error
-                        .account
-                        .as_ref()
-                        .map(|account| account.account_id),
+                    &final_error,
                     (attempt_count + 1) as i64,
                     distinct_account_count as i64,
-                    0,
-                    Some(finished_at.as_str()),
-                    Some(finished_at.as_str()),
-                    POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_BUDGET_EXHAUSTED_FINAL,
-                    Some(final_error.status),
-                    Some(PROXY_FAILURE_POOL_MAX_DISTINCT_ACCOUNTS_EXHAUSTED),
-                    Some(final_error.message.as_str()),
-                    None,
-                    None,
-                    None,
-                    final_error.upstream_request_id.as_deref(),
+                    terminal_failure_kind,
                 )
                 .await
                 {
@@ -9130,7 +9140,13 @@ async fn send_pool_request_with_failover_seeded(
         let account = if let Some(account) = preferred_account.take() {
             account
         } else {
-            match resolve_pool_account_for_request(state.as_ref(), sticky_key, &excluded_ids).await
+            match resolve_pool_account_for_request(
+                state.as_ref(),
+                sticky_key,
+                &excluded_ids,
+                &excluded_upstream_route_keys,
+            )
+            .await
             {
                 Ok(PoolAccountResolution::Resolved(account)) => account,
                 Ok(PoolAccountResolution::RateLimited) => {
@@ -9141,19 +9157,73 @@ async fn send_pool_request_with_failover_seeded(
                     ));
                 }
                 Ok(PoolAccountResolution::Unavailable) => {
-                    let mut err = last_error
-                        .filter(|candidate| !pool_upstream_error_is_rate_limited(candidate))
-                        .unwrap_or_else(|| {
-                            build_pool_no_available_account_error(
-                                attempt_count,
-                                distinct_account_count,
-                            )
-                        });
+                    let terminal_failure_kind =
+                        if uses_timeout_route_failover && timeout_route_failover_pending {
+                            PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                        } else {
+                            PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT
+                        };
+                    let mut err = if terminal_failure_kind
+                        == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                    {
+                        last_error.unwrap_or(PoolUpstreamError {
+                            account: None,
+                            status: StatusCode::BAD_GATEWAY,
+                            message: "no alternate upstream route is available after timeout"
+                                .to_string(),
+                            failure_kind: terminal_failure_kind,
+                            connect_latency_ms: 0.0,
+                            upstream_error_code: None,
+                            upstream_error_message: None,
+                            upstream_request_id: None,
+                            oauth_responses_debug: None,
+                            attempt_summary: PoolAttemptSummary::default(),
+                        })
+                    } else {
+                        last_error
+                            .filter(|candidate| !pool_upstream_error_is_rate_limited(candidate))
+                            .unwrap_or_else(|| {
+                                build_pool_no_available_account_error(
+                                    attempt_count,
+                                    distinct_account_count,
+                                )
+                            })
+                    };
+                    if terminal_failure_kind
+                        == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                    {
+                        err.failure_kind = terminal_failure_kind;
+                        err.status = StatusCode::BAD_GATEWAY;
+                        err.message =
+                            "no alternate upstream route is available after timeout".to_string();
+                        err.upstream_error_code = None;
+                        err.upstream_error_message = None;
+                        err.upstream_request_id = None;
+                    }
                     err.attempt_summary = pool_attempt_summary(
                         attempt_count,
                         distinct_account_count,
-                        Some(err.failure_kind.to_string()),
+                        Some(terminal_failure_kind.to_string()),
                     );
+                    if terminal_failure_kind
+                        == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                        && let Some(trace) = trace_context.as_ref()
+                        && let Err(record_err) = insert_pool_upstream_terminal_attempt(
+                            &state.pool,
+                            trace,
+                            &err,
+                            (attempt_count + 1) as i64,
+                            distinct_account_count as i64,
+                            terminal_failure_kind,
+                        )
+                        .await
+                    {
+                        warn!(
+                            invoke_id = trace.invoke_id,
+                            error = %record_err,
+                            "failed to persist pool no-alternate-after-timeout attempt"
+                        );
+                    }
                     return Err(err);
                 }
                 Ok(PoolAccountResolution::NoCandidate) => {
@@ -9181,11 +9251,17 @@ async fn send_pool_request_with_failover_seeded(
                     );
                 }
                 Ok(PoolAccountResolution::BlockedByPolicy(message)) => {
-                    return Err(PoolUpstreamError {
+                    let terminal_failure_kind =
+                        if uses_timeout_route_failover && timeout_route_failover_pending {
+                            PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                        } else {
+                            PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT
+                        };
+                    let err = PoolUpstreamError {
                         account: None,
                         status: StatusCode::BAD_GATEWAY,
                         message,
-                        failure_kind: PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT,
+                        failure_kind: terminal_failure_kind,
                         connect_latency_ms: 0.0,
                         upstream_error_code: None,
                         upstream_error_message: None,
@@ -9194,9 +9270,29 @@ async fn send_pool_request_with_failover_seeded(
                         attempt_summary: pool_attempt_summary(
                             attempt_count,
                             distinct_account_count,
-                            Some(PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT.to_string()),
+                            Some(terminal_failure_kind.to_string()),
                         ),
-                    });
+                    };
+                    if terminal_failure_kind
+                        == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+                        && let Some(trace) = trace_context.as_ref()
+                        && let Err(record_err) = insert_pool_upstream_terminal_attempt(
+                            &state.pool,
+                            trace,
+                            &err,
+                            (attempt_count + 1) as i64,
+                            distinct_account_count as i64,
+                            terminal_failure_kind,
+                        )
+                        .await
+                    {
+                        warn!(
+                            invoke_id = trace.invoke_id,
+                            error = %record_err,
+                            "failed to persist pool blocked-policy no-alternate attempt"
+                        );
+                    }
+                    return Err(err);
                 }
                 Err(err) => {
                     return Err(PoolUpstreamError {
@@ -9218,10 +9314,12 @@ async fn send_pool_request_with_failover_seeded(
                 }
             }
         };
+        timeout_route_failover_pending = false;
 
         excluded_ids.push(account.account_id);
         distinct_account_count = excluded_ids.len();
         let distinct_account_index = distinct_account_count as i64;
+        let upstream_route_key = account.upstream_route_key();
         let api_key_target_url = match &account.auth {
             PoolResolvedAuth::ApiKey { .. } => {
                 match build_proxy_upstream_url(&account.upstream_base_url, original_uri) {
@@ -9292,12 +9390,18 @@ async fn send_pool_request_with_failover_seeded(
                         Ok(Ok(response)) => (ProxyUpstreamResponseBody::Reqwest(response), None),
                         Ok(Err(err)) => {
                             let message = format!("failed to contact upstream: {err}");
+                            let is_timeout_shaped = uses_timeout_route_failover
+                                && pool_failure_is_timeout_shaped(
+                                    PROXY_FAILURE_FAILED_CONTACT_UPSTREAM,
+                                    &message,
+                                );
                             let finished_at = shanghai_now_string();
                             if let Some(trace) = trace_context.as_ref()
                                 && let Err(record_err) = insert_pool_upstream_request_attempt(
                                     &state.pool,
                                     trace,
                                     Some(account.account_id),
+                                    Some(upstream_route_key.as_str()),
                                     attempt_index,
                                     distinct_account_index,
                                     same_account_retry_index,
@@ -9321,7 +9425,7 @@ async fn send_pool_request_with_failover_seeded(
                                 );
                             }
                             let has_retry_budget = same_account_attempt + 1 < same_account_attempts;
-                            if has_retry_budget {
+                            if has_retry_budget && !is_timeout_shaped {
                                 let retry_delay = fallback_proxy_429_retry_delay(
                                     u32::from(same_account_attempt) + 1,
                                 );
@@ -9358,6 +9462,10 @@ async fn send_pool_request_with_failover_seeded(
                                 attempt_summary: PoolAttemptSummary::default(),
                             });
                             exhausted_accounts_all_rate_limited = false;
+                            if is_timeout_shaped {
+                                excluded_upstream_route_keys.insert(upstream_route_key.clone());
+                                timeout_route_failover_pending = true;
+                            }
                             continue 'account_loop;
                         }
                         Err(_) => {
@@ -9365,12 +9473,14 @@ async fn send_pool_request_with_failover_seeded(
                                 "{PROXY_UPSTREAM_HANDSHAKE_TIMEOUT} after {}ms",
                                 handshake_timeout.as_millis()
                             );
+                            let is_timeout_shaped = uses_timeout_route_failover;
                             let finished_at = shanghai_now_string();
                             if let Some(trace) = trace_context.as_ref()
                                 && let Err(record_err) = insert_pool_upstream_request_attempt(
                                     &state.pool,
                                     trace,
                                     Some(account.account_id),
+                                    Some(upstream_route_key.as_str()),
                                     attempt_index,
                                     distinct_account_index,
                                     same_account_retry_index,
@@ -9394,7 +9504,7 @@ async fn send_pool_request_with_failover_seeded(
                                 );
                             }
                             let has_retry_budget = same_account_attempt + 1 < same_account_attempts;
-                            if has_retry_budget {
+                            if has_retry_budget && !is_timeout_shaped {
                                 let retry_delay = fallback_proxy_429_retry_delay(
                                     u32::from(same_account_attempt) + 1,
                                 );
@@ -9431,6 +9541,10 @@ async fn send_pool_request_with_failover_seeded(
                                 attempt_summary: PoolAttemptSummary::default(),
                             });
                             exhausted_accounts_all_rate_limited = false;
+                            if is_timeout_shaped {
+                                excluded_upstream_route_keys.insert(upstream_route_key.clone());
+                                timeout_route_failover_pending = true;
+                            }
                             continue 'account_loop;
                         }
                     }
@@ -9536,7 +9650,7 @@ async fn send_pool_request_with_failover_seeded(
                             headers,
                             oauth_body,
                             handshake_timeout,
-                            state.config.request_timeout,
+                            first_chunk_timeout,
                             Some(account.account_id),
                             access_token,
                             chatgpt_account_id.as_deref(),
@@ -9558,18 +9672,6 @@ async fn send_pool_request_with_failover_seeded(
                 || matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
             {
                 let has_retry_budget = same_account_attempt + 1 < same_account_attempts;
-                let should_retry_same_account = has_retry_budget
-                    && status != StatusCode::TOO_MANY_REQUESTS
-                    && status.is_server_error();
-                let retry_delay = should_retry_same_account.then(|| {
-                    response
-                        .headers()
-                        .get(header::RETRY_AFTER)
-                        .and_then(parse_retry_after_delay)
-                        .unwrap_or_else(|| {
-                            fallback_proxy_429_retry_delay(u32::from(same_account_attempt) + 1)
-                        })
-                });
                 let upstream_request_id_header = response
                     .headers()
                     .get("x-request-id")
@@ -9577,10 +9679,11 @@ async fn send_pool_request_with_failover_seeded(
                     .map(str::trim)
                     .filter(|value| !value.is_empty())
                     .map(|value| value.to_string());
+                let retry_after_header = response.headers().get(header::RETRY_AFTER).cloned();
                 let (upstream_error_code, upstream_error_message, upstream_request_id, message) =
                     match read_pool_upstream_bytes_with_timeout(
                         response,
-                        state.config.request_timeout,
+                        first_chunk_timeout,
                         connect_started,
                         "reading upstream error body",
                     )
@@ -9601,6 +9704,21 @@ async fn send_pool_request_with_failover_seeded(
                             ),
                         ),
                     };
+                let failure_kind = pool_route_http_failure_kind(status);
+                let is_timeout_shaped = uses_timeout_route_failover
+                    && status.is_server_error()
+                    && pool_failure_is_timeout_shaped(failure_kind, &message);
+                let retry_delay = (has_retry_budget
+                    && !is_timeout_shaped
+                    && (status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()))
+                .then(|| {
+                    retry_after_header
+                        .as_ref()
+                        .and_then(parse_retry_after_delay)
+                        .unwrap_or_else(|| {
+                            fallback_proxy_429_retry_delay(u32::from(same_account_attempt) + 1)
+                        })
+                });
                 let route_error_message = upstream_error_code
                     .as_deref()
                     .map_or_else(|| message.clone(), |code| format!("{code}: {message}"));
@@ -9610,6 +9728,7 @@ async fn send_pool_request_with_failover_seeded(
                         &state.pool,
                         trace,
                         Some(account.account_id),
+                        Some(upstream_route_key.as_str()),
                         attempt_index,
                         distinct_account_index,
                         same_account_retry_index,
@@ -9656,7 +9775,6 @@ async fn send_pool_request_with_failover_seeded(
                 {
                     warn!(account_id = account.account_id, error = %route_err, "failed to record pool upstream http failure");
                 }
-                let failure_kind = pool_route_http_failure_kind(status);
                 last_error = Some(PoolUpstreamError {
                     account: Some(account.clone()),
                     status,
@@ -9670,6 +9788,10 @@ async fn send_pool_request_with_failover_seeded(
                     attempt_summary: PoolAttemptSummary::default(),
                 });
                 exhausted_accounts_all_rate_limited &= status == StatusCode::TOO_MANY_REQUESTS;
+                if is_timeout_shaped {
+                    excluded_upstream_route_keys.insert(upstream_route_key.clone());
+                    timeout_route_failover_pending = true;
+                }
                 continue 'account_loop;
             }
 
@@ -9684,12 +9806,18 @@ async fn send_pool_request_with_failover_seeded(
                 Ok(value) => value,
                 Err(err) => {
                     let message = format!("upstream stream error before first chunk: {err}");
+                    let is_timeout_shaped = uses_timeout_route_failover
+                        && pool_failure_is_timeout_shaped(
+                            PROXY_FAILURE_UPSTREAM_STREAM_ERROR,
+                            &message,
+                        );
                     let finished_at = shanghai_now_string();
                     if let Some(trace) = trace_context.as_ref()
                         && let Err(record_err) = insert_pool_upstream_request_attempt(
                             &state.pool,
                             trace,
                             Some(account.account_id),
+                            Some(upstream_route_key.as_str()),
                             attempt_index,
                             distinct_account_index,
                             same_account_retry_index,
@@ -9713,7 +9841,7 @@ async fn send_pool_request_with_failover_seeded(
                         );
                     }
                     let has_retry_budget = same_account_attempt + 1 < same_account_attempts;
-                    if has_retry_budget {
+                    if has_retry_budget && !is_timeout_shaped {
                         let retry_delay =
                             fallback_proxy_429_retry_delay(u32::from(same_account_attempt) + 1);
                         info!(
@@ -9749,6 +9877,10 @@ async fn send_pool_request_with_failover_seeded(
                         attempt_summary: PoolAttemptSummary::default(),
                     });
                     exhausted_accounts_all_rate_limited = false;
+                    if is_timeout_shaped {
+                        excluded_upstream_route_keys.insert(upstream_route_key.clone());
+                        timeout_route_failover_pending = true;
+                    }
                     continue 'account_loop;
                 }
             };
@@ -9768,6 +9900,7 @@ async fn send_pool_request_with_failover_seeded(
                         sticky_key: trace.sticky_key.clone(),
                         requester_ip: trace.requester_ip.clone(),
                         upstream_account_id: account.account_id,
+                        upstream_route_key: upstream_route_key.clone(),
                         attempt_index,
                         distinct_account_index,
                         same_account_retry_index,
@@ -9841,38 +9974,60 @@ async fn continue_or_retry_pool_live_request(
             let replay_sticky_key = extract_sticky_key_from_replay_snapshot(&snapshot)
                 .await
                 .or(sticky_key);
-            if pool_upstream_error_is_rate_limited(&first_error) {
-                send_pool_request_with_failover_seeded(
-                    state,
-                    method,
-                    original_uri,
-                    headers,
-                    Some(snapshot),
-                    handshake_timeout,
-                    None,
-                    replay_sticky_key.as_deref(),
-                    None,
-                    POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS,
-                    vec![initial_account.account_id],
-                    1,
-                    Some(first_error),
-                )
-                .await
-            } else {
-                send_pool_request_with_failover(
-                    state,
-                    method,
-                    original_uri,
-                    headers,
-                    Some(snapshot),
-                    handshake_timeout,
-                    None,
-                    replay_sticky_key.as_deref(),
-                    Some(initial_account),
-                    POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS.saturating_sub(1),
-                )
-                .await
-            }
+            let uses_timeout_route_failover =
+                pool_uses_responses_timeout_failover_policy(original_uri, &method);
+            let first_error_is_timeout_shaped = uses_timeout_route_failover
+                && pool_failure_is_timeout_shaped(first_error.failure_kind, &first_error.message);
+            let (preferred_account, failover_progress, same_account_attempts) =
+                if first_error_is_timeout_shaped {
+                    let mut excluded_upstream_route_keys = HashSet::new();
+                    excluded_upstream_route_keys.insert(initial_account.upstream_route_key());
+                    (
+                        None,
+                        PoolFailoverProgress {
+                            excluded_account_ids: vec![initial_account.account_id],
+                            excluded_upstream_route_keys,
+                            attempt_count: 1,
+                            last_error: Some(first_error),
+                            timeout_route_failover_pending: true,
+                        },
+                        POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS,
+                    )
+                } else if pool_upstream_error_is_rate_limited(&first_error) {
+                    (
+                        None,
+                        PoolFailoverProgress {
+                            excluded_account_ids: vec![initial_account.account_id],
+                            attempt_count: 1,
+                            last_error: Some(first_error),
+                            ..PoolFailoverProgress::default()
+                        },
+                        POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS,
+                    )
+                } else {
+                    (
+                        Some(initial_account.clone()),
+                        PoolFailoverProgress {
+                            attempt_count: 1,
+                            ..PoolFailoverProgress::default()
+                        },
+                        POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS.saturating_sub(1),
+                    )
+                };
+            send_pool_request_with_failover(
+                state,
+                method,
+                original_uri,
+                headers,
+                Some(snapshot),
+                handshake_timeout,
+                None,
+                replay_sticky_key.as_deref(),
+                preferred_account,
+                failover_progress,
+                same_account_attempts,
+            )
+            .await
         }
         PoolReplayBodyStatus::ReadError(err) => Err(PoolUpstreamError {
             account: Some(initial_account),
@@ -9993,6 +10148,7 @@ async fn proxy_openai_v1_via_pool(
                     None,
                     body_sticky_key.as_deref(),
                     None,
+                    PoolFailoverProgress::default(),
                     POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS,
                 )
                 .await
@@ -10001,39 +10157,43 @@ async fn proxy_openai_v1_via_pool(
             )
         } else {
             let sticky_key = header_sticky_key;
-            let initial_account =
-                match resolve_pool_account_for_request(state.as_ref(), sticky_key.as_deref(), &[])
-                    .await
-                {
-                    Ok(PoolAccountResolution::Resolved(account)) => account,
-                    Ok(PoolAccountResolution::RateLimited) => {
-                        return Err((
-                            StatusCode::TOO_MANY_REQUESTS,
-                            POOL_ALL_ACCOUNTS_RATE_LIMITED_MESSAGE.to_string(),
-                        ));
-                    }
-                    Ok(PoolAccountResolution::Unavailable) => {
-                        return Err((
-                            StatusCode::BAD_GATEWAY,
-                            "no healthy pool account is available".to_string(),
-                        ));
-                    }
-                    Ok(PoolAccountResolution::NoCandidate) => {
-                        return Err((
-                            StatusCode::BAD_GATEWAY,
-                            "no healthy pool account is available".to_string(),
-                        ));
-                    }
-                    Ok(PoolAccountResolution::BlockedByPolicy(message)) => {
-                        return Err((StatusCode::BAD_GATEWAY, message));
-                    }
-                    Err(err) => {
-                        return Err((
-                            StatusCode::BAD_GATEWAY,
-                            format!("failed to resolve pool account: {err}"),
-                        ));
-                    }
-                };
+            let initial_account = match resolve_pool_account_for_request(
+                state.as_ref(),
+                sticky_key.as_deref(),
+                &[],
+                &HashSet::new(),
+            )
+            .await
+            {
+                Ok(PoolAccountResolution::Resolved(account)) => account,
+                Ok(PoolAccountResolution::RateLimited) => {
+                    return Err((
+                        StatusCode::TOO_MANY_REQUESTS,
+                        POOL_ALL_ACCOUNTS_RATE_LIMITED_MESSAGE.to_string(),
+                    ));
+                }
+                Ok(PoolAccountResolution::Unavailable) => {
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        "no healthy pool account is available".to_string(),
+                    ));
+                }
+                Ok(PoolAccountResolution::NoCandidate) => {
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        "no healthy pool account is available".to_string(),
+                    ));
+                }
+                Ok(PoolAccountResolution::BlockedByPolicy(message)) => {
+                    return Err((StatusCode::BAD_GATEWAY, message));
+                }
+                Err(err) => {
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        format!("failed to resolve pool account: {err}"),
+                    ));
+                }
+            };
 
             if initial_account.auth.is_oauth() {
                 if original_uri.path() == "/v1/responses" {
@@ -10069,6 +10229,7 @@ async fn proxy_openai_v1_via_pool(
                             None,
                             body_sticky_key.as_deref(),
                             preferred_account,
+                            PoolFailoverProgress::default(),
                             POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS,
                         )
                         .await
@@ -10111,7 +10272,7 @@ async fn proxy_openai_v1_via_pool(
                             debug_body_prefix: None,
                         },
                         handshake_timeout,
-                        state.config.request_timeout,
+                        first_chunk_timeout,
                         Some(initial_account.account_id),
                         access_token,
                         chatgpt_account_id.as_deref(),
@@ -10140,7 +10301,7 @@ async fn proxy_openai_v1_via_pool(
                             message,
                         ) = match read_pool_upstream_bytes_with_timeout(
                             response,
-                            state.config.request_timeout,
+                            first_chunk_timeout,
                             connect_started,
                             "reading upstream error body",
                         )
@@ -10334,7 +10495,7 @@ async fn proxy_openai_v1_via_pool(
                                 message,
                             ) = match read_pool_upstream_bytes_with_timeout(
                                 response,
-                                state.config.request_timeout,
+                                first_chunk_timeout,
                                 connect_started,
                                 "reading upstream error body",
                             )
@@ -10509,6 +10670,7 @@ async fn proxy_openai_v1_via_pool(
                 None,
                 header_sticky_key.as_deref(),
                 None,
+                PoolFailoverProgress::default(),
                 POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS,
             )
             .await
@@ -11534,6 +11696,7 @@ async fn proxy_openai_v1_capture_target(
             pool_attempt_trace_context.clone(),
             sticky_key.as_deref(),
             None,
+            PoolFailoverProgress::default(),
             POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS,
         )
         .await
@@ -12722,9 +12885,27 @@ fn pool_upstream_first_chunk_timeout(
         .is_some_and(ProxyCaptureTarget::uses_compact_upstream_timeout)
     {
         handshake_timeout
+    } else if original_uri.path() == "/v1/responses" {
+        config.pool_upstream_responses_attempt_timeout
     } else {
         config.request_timeout
     }
+}
+
+fn pool_uses_responses_timeout_failover_policy(original_uri: &Uri, method: &Method) -> bool {
+    method == Method::POST && original_uri.path() == "/v1/responses"
+}
+
+fn pool_error_message_indicates_timeout(message: &str) -> bool {
+    let message_lower = message.trim().to_ascii_lowercase();
+    message_lower.contains("request timed out after")
+        || message_lower.contains("timed out after")
+        || message_lower.contains("upstream handshake timed out")
+}
+
+fn pool_failure_is_timeout_shaped(failure_kind: &str, message: &str) -> bool {
+    failure_kind == PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT
+        || pool_error_message_indicates_timeout(message)
 }
 
 fn extract_sticky_key_from_request_body(value: &Value) -> Option<String> {
@@ -13391,6 +13572,7 @@ async fn insert_pool_upstream_request_attempt(
     pool: &Pool<Sqlite>,
     trace: &PoolUpstreamAttemptTraceContext,
     upstream_account_id: Option<i64>,
+    upstream_route_key: Option<&str>,
     attempt_index: i64,
     distinct_account_index: i64,
     same_account_retry_index: i64,
@@ -13414,6 +13596,7 @@ async fn insert_pool_upstream_request_attempt(
             route_mode,
             sticky_key,
             upstream_account_id,
+            upstream_route_key,
             attempt_index,
             distinct_account_index,
             same_account_retry_index,
@@ -13430,7 +13613,7 @@ async fn insert_pool_upstream_request_attempt(
             upstream_request_id
         )
         VALUES (
-            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21
         )
         "#,
     )
@@ -13440,6 +13623,7 @@ async fn insert_pool_upstream_request_attempt(
     .bind(INVOCATION_ROUTE_MODE_POOL)
     .bind(trace.sticky_key.as_deref())
     .bind(upstream_account_id)
+    .bind(upstream_route_key)
     .bind(attempt_index)
     .bind(distinct_account_index)
     .bind(same_account_retry_index)
@@ -13481,6 +13665,7 @@ async fn finalize_pool_upstream_request_attempt(
         pool,
         &trace,
         Some(pending.upstream_account_id),
+        Some(pending.upstream_route_key.as_str()),
         pending.attempt_index,
         pending.distinct_account_index,
         pending.same_account_retry_index,
@@ -13494,6 +13679,44 @@ async fn finalize_pool_upstream_request_attempt(
         Some(pending.first_byte_latency_ms),
         stream_latency_ms,
         upstream_request_id,
+    )
+    .await
+}
+
+async fn insert_pool_upstream_terminal_attempt(
+    pool: &Pool<Sqlite>,
+    trace: &PoolUpstreamAttemptTraceContext,
+    final_error: &PoolUpstreamError,
+    attempt_index: i64,
+    distinct_account_index: i64,
+    failure_kind: &'static str,
+) -> Result<()> {
+    let finished_at = shanghai_now_string();
+    let upstream_route_key = final_error
+        .account
+        .as_ref()
+        .map(|account| account.upstream_route_key());
+    insert_pool_upstream_request_attempt(
+        pool,
+        trace,
+        final_error
+            .account
+            .as_ref()
+            .map(|account| account.account_id),
+        upstream_route_key.as_deref(),
+        attempt_index,
+        distinct_account_index,
+        0,
+        Some(finished_at.as_str()),
+        Some(finished_at.as_str()),
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_BUDGET_EXHAUSTED_FINAL,
+        Some(final_error.status),
+        Some(failure_kind),
+        Some(final_error.message.as_str()),
+        None,
+        None,
+        None,
+        final_error.upstream_request_id.as_deref(),
     )
     .await
 }
@@ -18275,6 +18498,7 @@ struct AppConfig {
     database_path: PathBuf,
     poll_interval: Duration,
     request_timeout: Duration,
+    pool_upstream_responses_attempt_timeout: Duration,
     openai_proxy_handshake_timeout: Duration,
     openai_proxy_compact_handshake_timeout: Duration,
     openai_proxy_request_read_timeout: Duration,
@@ -18371,6 +18595,10 @@ impl AppConfig {
             })
             .map(Duration::from_secs)
             .unwrap_or_else(|| Duration::from_secs(60));
+        let pool_upstream_responses_attempt_timeout = Duration::from_secs(parse_u64_env_var(
+            ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
+            DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
+        )?);
         let openai_proxy_handshake_timeout = env::var("OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -18638,6 +18866,7 @@ impl AppConfig {
             database_path,
             poll_interval,
             request_timeout,
+            pool_upstream_responses_attempt_timeout,
             openai_proxy_handshake_timeout,
             openai_proxy_compact_handshake_timeout,
             openai_proxy_request_read_timeout,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9290,6 +9290,54 @@ async fn send_pool_request_with_failover(
                     return Err(err);
                 }
                 Ok(PoolAccountResolution::NoCandidate) => {
+                    if uses_timeout_route_failover && timeout_route_failover_pending {
+                        let mut err = last_error.unwrap_or(PoolUpstreamError {
+                            account: None,
+                            status: StatusCode::BAD_GATEWAY,
+                            message: "no alternate upstream route is available after timeout"
+                                .to_string(),
+                            failure_kind: PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT,
+                            connect_latency_ms: 0.0,
+                            upstream_error_code: None,
+                            upstream_error_message: None,
+                            upstream_request_id: None,
+                            oauth_responses_debug: None,
+                            attempt_summary: PoolAttemptSummary::default(),
+                        });
+                        err.status = StatusCode::BAD_GATEWAY;
+                        err.message =
+                            "no alternate upstream route is available after timeout".to_string();
+                        err.failure_kind = PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT;
+                        err.upstream_error_code = None;
+                        err.upstream_error_message = None;
+                        err.upstream_request_id = None;
+                        err.attempt_summary = pool_attempt_summary(
+                            attempt_count,
+                            distinct_account_count,
+                            Some(
+                                PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT.to_string(),
+                            ),
+                        );
+                        if let Some(trace) = trace_context.as_ref()
+                            && let Err(record_err) = insert_pool_upstream_terminal_attempt(
+                                &state.pool,
+                                trace,
+                                &err,
+                                (attempt_count + 1) as i64,
+                                distinct_account_count as i64,
+                                PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT,
+                            )
+                            .await
+                        {
+                            warn!(
+                                invoke_id = trace.invoke_id,
+                                error = %record_err,
+                                "failed to persist pool no-candidate no-alternate attempt"
+                            );
+                        }
+                        return Err(err);
+                    }
+
                     return Err(
                         if exhausted_accounts_all_rate_limited && distinct_account_count > 0 {
                             build_pool_rate_limited_error(

--- a/src/main.rs
+++ b/src/main.rs
@@ -12953,16 +12953,20 @@ fn pool_uses_responses_timeout_failover_policy(original_uri: &Uri, method: &Meth
     method == Method::POST && original_uri.path() == "/v1/responses"
 }
 
-fn pool_error_message_indicates_timeout(message: &str) -> bool {
+fn pool_error_message_indicates_proxy_timeout(message: &str) -> bool {
     let message_lower = message.trim().to_ascii_lowercase();
     message_lower.contains("request timed out after")
-        || message_lower.contains("timed out after")
-        || message_lower.contains("upstream handshake timed out")
+        || message_lower.contains("upstream handshake timed out after")
 }
 
 fn pool_failure_is_timeout_shaped(failure_kind: &str, message: &str) -> bool {
-    failure_kind == PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT
-        || pool_error_message_indicates_timeout(message)
+    matches!(
+        failure_kind,
+        PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT
+            | PROXY_FAILURE_FAILED_CONTACT_UPSTREAM
+            | PROXY_FAILURE_UPSTREAM_STREAM_ERROR
+            | PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED
+    ) && pool_error_message_indicates_proxy_timeout(message)
 }
 
 fn extract_sticky_key_from_request_body(value: &Value) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9101,10 +9101,16 @@ async fn send_pool_request_with_failover(
     same_account_attempts: u8,
 ) -> Result<PoolUpstreamResponse, PoolUpstreamError> {
     let request_connection_scoped = connection_scoped_header_names(headers);
-    let first_chunk_timeout =
+    let pre_first_byte_timeout =
         pool_upstream_first_chunk_timeout(&state.config, original_uri, &method, handshake_timeout);
     let uses_timeout_route_failover =
         pool_uses_responses_timeout_failover_policy(original_uri, &method);
+    let send_timeout = pool_upstream_send_timeout(
+        original_uri,
+        &method,
+        handshake_timeout,
+        pre_first_byte_timeout,
+    );
     let mut excluded_ids = failover_progress.excluded_account_ids;
     let mut excluded_upstream_route_keys = failover_progress.excluded_upstream_route_keys;
     let mut last_error = failover_progress.last_error;
@@ -9443,7 +9449,7 @@ async fn send_pool_request_with_failover(
                         );
                     }
 
-                    match timeout(handshake_timeout, request.send()).await {
+                    match timeout(send_timeout, request.send()).await {
                         Ok(Ok(response)) => (ProxyUpstreamResponseBody::Reqwest(response), None),
                         Ok(Err(err)) => {
                             let message = format!("failed to contact upstream: {err}");
@@ -9528,7 +9534,7 @@ async fn send_pool_request_with_failover(
                         Err(_) => {
                             let message = format!(
                                 "{PROXY_UPSTREAM_HANDSHAKE_TIMEOUT} after {}ms",
-                                handshake_timeout.as_millis()
+                                send_timeout.as_millis()
                             );
                             let is_timeout_shaped = uses_timeout_route_failover;
                             let finished_at = shanghai_now_string();
@@ -9707,7 +9713,7 @@ async fn send_pool_request_with_failover(
                             headers,
                             oauth_body,
                             handshake_timeout,
-                            first_chunk_timeout,
+                            pre_first_byte_timeout,
                             Some(account.account_id),
                             access_token,
                             chatgpt_account_id.as_deref(),
@@ -9740,7 +9746,7 @@ async fn send_pool_request_with_failover(
                 let (upstream_error_code, upstream_error_message, upstream_request_id, message) =
                     match read_pool_upstream_bytes_with_timeout(
                         response,
-                        first_chunk_timeout,
+                        pre_first_byte_timeout,
                         connect_started,
                         "reading upstream error body",
                     )
@@ -9855,7 +9861,7 @@ async fn send_pool_request_with_failover(
             let first_byte_started = Instant::now();
             let (response, first_chunk) = match read_pool_upstream_first_chunk_with_timeout(
                 response,
-                first_chunk_timeout,
+                pre_first_byte_timeout,
                 connect_started,
             )
             .await
@@ -10161,7 +10167,7 @@ async fn proxy_openai_v1_via_pool(
     let handshake_timeout = state
         .config
         .proxy_upstream_handshake_timeout(capture_target);
-    let first_chunk_timeout =
+    let pre_first_byte_timeout =
         pool_upstream_first_chunk_timeout(&state.config, original_uri, &method, handshake_timeout);
     let header_sticky_key = extract_sticky_key_from_headers(&headers);
     let body_size_hint_exact = body
@@ -10329,7 +10335,7 @@ async fn proxy_openai_v1_via_pool(
                             debug_body_prefix: None,
                         },
                         handshake_timeout,
-                        first_chunk_timeout,
+                        pre_first_byte_timeout,
                         Some(initial_account.account_id),
                         access_token,
                         chatgpt_account_id.as_deref(),
@@ -10358,7 +10364,7 @@ async fn proxy_openai_v1_via_pool(
                             message,
                         ) = match read_pool_upstream_bytes_with_timeout(
                             response,
-                            first_chunk_timeout,
+                            pre_first_byte_timeout,
                             connect_started,
                             "reading upstream error body",
                         )
@@ -10417,7 +10423,7 @@ async fn proxy_openai_v1_via_pool(
                         let first_byte_started = Instant::now();
                         match read_pool_upstream_first_chunk_with_timeout(
                             response,
-                            first_chunk_timeout,
+                            pre_first_byte_timeout,
                             connect_started,
                         )
                         .await
@@ -10529,7 +10535,13 @@ async fn proxy_openai_v1_via_pool(
                 );
 
                 let connect_started = Instant::now();
-                let upstream = match timeout(handshake_timeout, request.send()).await {
+                let send_timeout = pool_upstream_send_timeout(
+                    original_uri,
+                    &method,
+                    handshake_timeout,
+                    pre_first_byte_timeout,
+                );
+                let upstream = match timeout(send_timeout, request.send()).await {
                     Ok(Ok(response)) => {
                         let connect_latency_ms = elapsed_ms(connect_started);
                         let response = ProxyUpstreamResponseBody::Reqwest(response);
@@ -10552,7 +10564,7 @@ async fn proxy_openai_v1_via_pool(
                                 message,
                             ) = match read_pool_upstream_bytes_with_timeout(
                                 response,
-                                first_chunk_timeout,
+                                pre_first_byte_timeout,
                                 connect_started,
                                 "reading upstream error body",
                             )
@@ -10604,7 +10616,7 @@ async fn proxy_openai_v1_via_pool(
                             let first_byte_started = Instant::now();
                             match read_pool_upstream_first_chunk_with_timeout(
                                 response,
-                                first_chunk_timeout,
+                                pre_first_byte_timeout,
                                 connect_started,
                             )
                             .await
@@ -10686,7 +10698,7 @@ async fn proxy_openai_v1_via_pool(
                             status: StatusCode::BAD_GATEWAY,
                             message: format!(
                                 "{PROXY_UPSTREAM_HANDSHAKE_TIMEOUT} after {}ms",
-                                handshake_timeout.as_millis()
+                                send_timeout.as_millis()
                             ),
                             failure_kind: PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT,
                             connect_latency_ms: elapsed_ms(connect_started),
@@ -12946,6 +12958,19 @@ fn pool_upstream_first_chunk_timeout(
         config.pool_upstream_responses_attempt_timeout
     } else {
         config.request_timeout
+    }
+}
+
+fn pool_upstream_send_timeout(
+    original_uri: &Uri,
+    method: &Method,
+    handshake_timeout: Duration,
+    pre_first_byte_timeout: Duration,
+) -> Duration {
+    if pool_uses_responses_timeout_failover_policy(original_uri, method) {
+        pre_first_byte_timeout
+    } else {
+        handshake_timeout
     }
 }
 
@@ -18656,10 +18681,11 @@ impl AppConfig {
             })
             .map(Duration::from_secs)
             .unwrap_or_else(|| Duration::from_secs(60));
-        let pool_upstream_responses_attempt_timeout = Duration::from_secs(parse_u64_env_var(
-            ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
-            DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
-        )?);
+        let pool_upstream_responses_attempt_timeout =
+            Duration::from_secs(parse_non_zero_u64_env_var(
+                ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
+                DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
+            )?);
         let openai_proxy_handshake_timeout = env::var("OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -18997,6 +19023,14 @@ fn parse_u64_env_var(name: &str, default_value: u64) -> Result<u64> {
         Err(env::VarError::NotPresent) => Ok(default_value),
         Err(err) => Err(anyhow!("failed to read {name}: {err}")),
     }
+}
+
+fn parse_non_zero_u64_env_var(name: &str, default_value: u64) -> Result<u64> {
+    let value = parse_u64_env_var(name, default_value)?;
+    if value == 0 {
+        bail!("{name} must be greater than 0");
+    }
+    Ok(value)
 }
 
 fn parse_usize_env_var(name: &str, default_value: usize) -> Result<usize> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9119,7 +9119,6 @@ async fn send_pool_request_with_failover(
         .filter(|account| !excluded_upstream_route_keys.contains(&account.upstream_route_key()));
     let mut same_account_attempts = same_account_attempts.max(1);
     let mut attempt_count = failover_progress.attempt_count;
-    let mut distinct_account_count = excluded_ids.len();
     let mut timeout_route_failover_pending = failover_progress.timeout_route_failover_pending;
     let mut exhausted_accounts_all_rate_limited = initial_errors_all_rate_limited;
 
@@ -9138,16 +9137,17 @@ async fn send_pool_request_with_failover(
                 } else {
                     PROXY_FAILURE_POOL_MAX_DISTINCT_ACCOUNTS_EXHAUSTED
                 };
+            let terminal_message = if terminal_failure_kind
+                == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
+            {
+                "no alternate upstream route is available after timeout".to_string()
+            } else {
+                "pool distinct-account retry budget exhausted".to_string()
+            };
             let mut final_error = last_error.unwrap_or(PoolUpstreamError {
                 account: None,
                 status: StatusCode::BAD_GATEWAY,
-                message: if terminal_failure_kind
-                    == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
-                {
-                    "no alternate upstream route is available after timeout".to_string()
-                } else {
-                    "pool distinct-account retry budget exhausted".to_string()
-                },
+                message: terminal_message.clone(),
                 failure_kind: terminal_failure_kind,
                 connect_latency_ms: 0.0,
                 upstream_error_code: None,
@@ -9159,7 +9159,15 @@ async fn send_pool_request_with_failover(
             if exhausted_accounts_all_rate_limited && distinct_account_count > 0 {
                 final_error.status = StatusCode::TOO_MANY_REQUESTS;
                 final_error.message = POOL_ALL_ACCOUNTS_RATE_LIMITED_MESSAGE.to_string();
+                final_error.failure_kind = PROXY_FAILURE_POOL_ALL_ACCOUNTS_RATE_LIMITED;
+            } else {
+                final_error.status = StatusCode::BAD_GATEWAY;
+                final_error.message = terminal_message;
+                final_error.failure_kind = terminal_failure_kind;
             }
+            final_error.upstream_error_code = None;
+            final_error.upstream_error_message = None;
+            final_error.upstream_request_id = None;
             final_error.attempt_summary = pool_attempt_summary(
                 attempt_count,
                 distinct_account_count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9249,10 +9249,10 @@ async fn send_pool_request_with_failover(
                     if terminal_failure_kind
                         == PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT
                     {
-                        err.failure_kind = terminal_failure_kind;
                         err.status = StatusCode::BAD_GATEWAY;
                         err.message =
                             "no alternate upstream route is available after timeout".to_string();
+                        err.failure_kind = terminal_failure_kind;
                         err.upstream_error_code = None;
                         err.upstream_error_message = None;
                         err.upstream_request_id = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2616,14 +2616,14 @@ async fn run_data_retention_maintenance(
     }
 
     if !dry_run && summary.touched_anything() {
-        sqlx::query("PRAGMA wal_checkpoint(PASSIVE)")
-            .execute(pool)
-            .await
-            .context("failed to run retention wal checkpoint")?;
-        sqlx::query("PRAGMA optimize")
-            .execute(pool)
-            .await
-            .context("failed to run retention optimize pragma")?;
+        run_best_effort_retention_pragma(
+            pool,
+            "PRAGMA wal_checkpoint(PASSIVE)",
+            "retention wal checkpoint",
+        )
+        .await?;
+        run_best_effort_retention_pragma(pool, "PRAGMA optimize", "retention optimize pragma")
+            .await?;
     }
 
     info!(
@@ -2632,6 +2632,25 @@ async fn run_data_retention_maintenance(
         "data retention maintenance finished"
     );
     Ok(summary)
+}
+
+async fn run_best_effort_retention_pragma(
+    pool: &Pool<Sqlite>,
+    sql: &str,
+    description: &'static str,
+) -> Result<()> {
+    match sqlx::query(sql)
+        .execute(pool)
+        .await
+        .with_context(|| format!("failed to run {description}"))
+    {
+        Ok(_) => Ok(()),
+        Err(err) if is_sqlite_lock_error(&err) => {
+            warn!(error = %err, sql, "{description} skipped because the database is busy");
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
 }
 
 async fn compress_cold_proxy_raw_payloads(
@@ -16871,7 +16890,6 @@ async fn backfill_failure_classification(
     )
 }
 
-#[cfg(test)]
 fn is_sqlite_lock_error(err: &anyhow::Error) -> bool {
     if err.chain().any(|cause| {
         let Some(sqlx_err) = cause.downcast_ref::<sqlx::Error>() else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9838,14 +9838,14 @@ async fn send_pool_request_with_failover(
                     && !is_timeout_shaped
                     && status.is_server_error()
                     && status != StatusCode::TOO_MANY_REQUESTS)
-                .then(|| {
-                    retry_after_header
-                        .as_ref()
-                        .and_then(parse_retry_after_delay)
-                        .unwrap_or_else(|| {
-                            fallback_proxy_429_retry_delay(u32::from(same_account_attempt) + 1)
-                        })
-                });
+                    .then(|| {
+                        retry_after_header
+                            .as_ref()
+                            .and_then(parse_retry_after_delay)
+                            .unwrap_or_else(|| {
+                                fallback_proxy_429_retry_delay(u32::from(same_account_attempt) + 1)
+                            })
+                    });
                 let route_error_message = upstream_error_code
                     .as_deref()
                     .map_or_else(|| message.clone(), |code| format!("{code}: {message}"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -9743,6 +9743,8 @@ async fn send_pool_request_with_failover(
                     .filter(|value| !value.is_empty())
                     .map(|value| value.to_string());
                 let retry_after_header = response.headers().get(header::RETRY_AFTER).cloned();
+                let oauth_transport_failure_kind =
+                    oauth_bridge::oauth_transport_failure_kind(response.headers());
                 let (upstream_error_code, upstream_error_message, upstream_request_id, message) =
                     match read_pool_upstream_bytes_with_timeout(
                         response,
@@ -9767,7 +9769,8 @@ async fn send_pool_request_with_failover(
                             ),
                         ),
                     };
-                let failure_kind = pool_route_http_failure_kind(status);
+                let failure_kind = oauth_transport_failure_kind
+                    .unwrap_or_else(|| pool_route_http_failure_kind(status));
                 let is_timeout_shaped = uses_timeout_route_failover
                     && status.is_server_error()
                     && pool_failure_is_timeout_shaped(failure_kind, &message);
@@ -10357,6 +10360,8 @@ async fn proxy_openai_v1_via_pool(
                             .map(str::trim)
                             .filter(|value| !value.is_empty())
                             .map(|value| value.to_string());
+                        let oauth_transport_failure_kind =
+                            oauth_bridge::oauth_transport_failure_kind(response.headers());
                         let (
                             upstream_error_code,
                             upstream_error_message,
@@ -10385,7 +10390,8 @@ async fn proxy_openai_v1_via_pool(
                                 ),
                             ),
                         };
-                        let failure_kind = pool_route_http_failure_kind(status);
+                        let failure_kind = oauth_transport_failure_kind
+                            .unwrap_or_else(|| pool_route_http_failure_kind(status));
                         maybe_backfill_oauth_request_debug_from_replay_status(
                             &mut oauth_responses_debug,
                             original_uri,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9802,7 +9802,7 @@ async fn send_pool_request_with_failover(
                         Some(finished_at.as_str()),
                         POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_HTTP_FAILURE,
                         Some(status),
-                        Some(pool_route_http_failure_kind(status)),
+                        Some(failure_kind),
                         Some(message.as_str()),
                         Some(connect_latency_ms),
                         None,

--- a/src/oauth_bridge.rs
+++ b/src/oauth_bridge.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use axum::{
     Json,
     body::{Body, Bytes},
-    http::{HeaderMap, Method, StatusCode, Uri, header},
+    http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, header},
     response::{IntoResponse, Response},
 };
 use futures_util::TryStreamExt;
@@ -35,6 +35,7 @@ const PROMPT_CACHE_HEADER_NAMES: &[&str] = &[
 ];
 const OAUTH_FINGERPRINT_VERSION: &str = "v1";
 pub(crate) const OAUTH_REQUEST_BODY_PREFIX_FINGERPRINT_MAX_BYTES: usize = 64 * 1024;
+const OAUTH_TRANSPORT_FAILURE_KIND_HEADER: &str = "x-codex-oauth-transport-failure";
 const OAUTH_FINGERPRINTED_HEADER_NAMES: &[&str] = &[
     "session_id",
     "traceparent",
@@ -122,6 +123,25 @@ pub(crate) type OauthResponsesDebugInfo = OauthRequestDebugInfo;
 pub(crate) struct OauthUpstreamResponse {
     pub(crate) response: Response,
     pub(crate) request_debug: Option<OauthRequestDebugInfo>,
+}
+
+pub(crate) fn oauth_transport_failure_kind(headers: &HeaderMap) -> Option<&'static str> {
+    match headers
+        .get(OAUTH_TRANSPORT_FAILURE_KIND_HEADER)
+        .and_then(|value| value.to_str().ok())?
+    {
+        crate::PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT => {
+            Some(crate::PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT)
+        }
+        _ => None,
+    }
+}
+
+fn tag_oauth_transport_failure(response: &mut Response, failure_kind: &'static str) {
+    response.headers_mut().insert(
+        HeaderName::from_static(OAUTH_TRANSPORT_FAILURE_KIND_HEADER),
+        HeaderValue::from_static(failure_kind),
+    );
 }
 
 struct PreparedResponsesRequestBody {
@@ -421,15 +441,21 @@ async fn oauth_responses(
             };
         }
         Err(_) => {
+            let message = format!(
+                "oauth codex upstream handshake timed out after {}ms",
+                response_timeout.as_millis()
+            );
+            let mut response = error_response(
+                StatusCode::BAD_GATEWAY,
+                &message,
+                "oauth_upstream_handshake_timeout",
+            );
+            tag_oauth_transport_failure(
+                &mut response,
+                crate::PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT,
+            );
             return OauthUpstreamResponse {
-                response: error_response(
-                    StatusCode::BAD_GATEWAY,
-                    &format!(
-                        "oauth codex upstream handshake timed out after {}ms",
-                        response_timeout.as_millis()
-                    ),
-                    "oauth_upstream_handshake_timeout",
-                ),
+                response,
                 request_debug: Some(request_debug),
             };
         }

--- a/src/oauth_bridge.rs
+++ b/src/oauth_bridge.rs
@@ -337,7 +337,7 @@ async fn oauth_models(
 async fn oauth_responses(
     client: &Client,
     headers: &HeaderMap,
-    handshake_timeout: Duration,
+    _handshake_timeout: Duration,
     response_timeout: Duration,
     account_id: Option<i64>,
     access_token: &str,
@@ -408,7 +408,7 @@ async fn oauth_responses(
         "forwarding oauth responses request"
     );
     let request_started = Instant::now();
-    let upstream = match timeout(handshake_timeout, request.send()).await {
+    let upstream = match timeout(response_timeout, request.send()).await {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
             return OauthUpstreamResponse {
@@ -426,7 +426,7 @@ async fn oauth_responses(
                     StatusCode::BAD_GATEWAY,
                     &format!(
                         "oauth codex upstream handshake timed out after {}ms",
-                        handshake_timeout.as_millis()
+                        response_timeout.as_millis()
                     ),
                     "oauth_upstream_handshake_timeout",
                 ),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1831,6 +1831,19 @@ fn app_config_from_sources_reads_proxy_timeout_envs() {
     );
 }
 
+#[test]
+fn app_config_from_sources_rejects_zero_pool_upstream_responses_attempt_timeout() {
+    let _guard = APP_CONFIG_ENV_LOCK.blocking_lock();
+    let _env = EnvVarGuard::set(&[(ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS, Some("0"))]);
+
+    let err = AppConfig::from_sources(&CliArgs::default())
+        .expect_err("zero responses attempt timeout should be rejected");
+    assert_eq!(
+        err.to_string(),
+        format!("{ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS} must be greater than 0")
+    );
+}
+
 fn test_config() -> AppConfig {
     AppConfig {
         openai_upstream_base_url: Url::parse("https://api.openai.com/").expect("valid url"),
@@ -10238,6 +10251,21 @@ fn pool_upstream_first_chunk_timeout_uses_responses_budget_for_responses_route()
 }
 
 #[test]
+fn pool_upstream_send_timeout_uses_responses_budget_for_responses_route() {
+    let handshake_timeout = Duration::from_millis(100);
+    let responses_timeout = Duration::from_millis(1200);
+
+    let timeout = pool_upstream_send_timeout(
+        &"/v1/responses".parse().expect("valid uri"),
+        &Method::POST,
+        handshake_timeout,
+        responses_timeout,
+    );
+
+    assert_eq!(timeout, responses_timeout);
+}
+
+#[test]
 fn pool_upstream_first_chunk_timeout_keeps_default_budget_for_non_responses_route() {
     let mut config = test_config();
     config.request_timeout = Duration::from_millis(200);
@@ -10251,6 +10279,21 @@ fn pool_upstream_first_chunk_timeout_keeps_default_budget_for_non_responses_rout
     );
 
     assert_eq!(timeout, Duration::from_millis(200));
+}
+
+#[test]
+fn pool_upstream_send_timeout_keeps_handshake_budget_for_non_responses_route() {
+    let handshake_timeout = Duration::from_millis(100);
+    let responses_timeout = Duration::from_millis(1200);
+
+    let timeout = pool_upstream_send_timeout(
+        &"/v1/chat/completions".parse().expect("valid uri"),
+        &Method::POST,
+        handshake_timeout,
+        responses_timeout,
+    );
+
+    assert_eq!(timeout, handshake_timeout);
 }
 
 #[tokio::test]
@@ -10762,6 +10805,36 @@ async fn spawn_pool_delayed_first_chunk_upstream(delay: Duration) -> (String, Jo
         axum::serve(listener, app)
             .await
             .expect("delayed first chunk upstream should run");
+    });
+    (format!("http://{addr}"), handle)
+}
+
+async fn pool_delayed_headers_upstream(State(delay): State<Duration>) -> Response {
+    tokio::time::sleep(delay).await;
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "phase": "headers-delayed",
+        })),
+    )
+        .into_response()
+}
+
+async fn spawn_pool_delayed_headers_upstream(delay: Duration) -> (String, JoinHandle<()>) {
+    let app = Router::new()
+        .route("/v1/responses", post(pool_delayed_headers_upstream))
+        .with_state(delay);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind delayed headers upstream");
+    let addr = listener
+        .local_addr()
+        .expect("delayed headers upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("delayed headers upstream should run");
     });
     (format!("http://{addr}"), handle)
 }
@@ -15658,6 +15731,57 @@ async fn pool_openai_v1_responses_waits_for_first_chunk_beyond_request_timeout()
         .expect("read responses pool body");
     let payload: Value = serde_json::from_slice(&body).expect("decode responses pool response");
     assert_eq!(payload["ok"].as_bool(), Some(true));
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_openai_v1_responses_waits_for_headers_beyond_handshake_timeout() {
+    let (upstream_base, upstream_handle) =
+        spawn_pool_delayed_headers_upstream(Duration::from_millis(250)).await;
+    let mut config = test_config();
+    config.openai_upstream_base_url = Url::parse(&upstream_base).expect("valid upstream base url");
+    config.openai_proxy_handshake_timeout = Duration::from_millis(100);
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(400);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+
+    let request_body = serde_json::to_vec(&json!({
+        "model": "gpt-5.4",
+        "stream": false,
+        "input": "hello",
+    }))
+    .expect("serialize request body");
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        proxy_openai_v1(
+            State(state),
+            OriginalUri("/v1/responses".parse().expect("valid uri")),
+            Method::POST,
+            HeaderMap::from_iter([
+                (
+                    http_header::AUTHORIZATION,
+                    HeaderValue::from_static("Bearer pool-live-key"),
+                ),
+                (
+                    http_header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/json"),
+                ),
+            ]),
+            Body::from(request_body),
+        ),
+    )
+    .await
+    .expect("responses pool request should not hang");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read responses pool body");
+    let payload: Value = serde_json::from_slice(&body).expect("decode responses pool response");
+    assert_eq!(payload["ok"].as_bool(), Some(true));
+    assert_eq!(payload["phase"].as_str(), Some("headers-delayed"));
 
     upstream_handle.abort();
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2915,6 +2915,22 @@ async fn test_state_from_existing_pool(
     })
 }
 
+async fn apply_forward_proxy_settings_without_bootstrap(
+    state: &Arc<AppState>,
+    settings: ForwardProxySettings,
+) -> ForwardProxySettingsResponse {
+    {
+        let mut manager = state.forward_proxy.lock().await;
+        manager.apply_settings(settings);
+    }
+    sync_forward_proxy_routes(state.as_ref())
+        .await
+        .expect("sync forward proxy routes for test settings");
+    build_forward_proxy_settings_response(state.as_ref())
+        .await
+        .expect("build forward proxy settings response")
+}
+
 async fn seed_pool_routing_api_key(state: &Arc<AppState>, api_key: &str) {
     ensure_upstream_accounts_schema(&state.pool)
         .await
@@ -7534,18 +7550,16 @@ async fn forward_proxy_timeseries_includes_intersecting_edge_hours() {
     )
     .await;
 
-    let Json(settings_response) = put_forward_proxy_settings(
-        State(state.clone()),
-        HeaderMap::new(),
-        Json(ForwardProxySettingsUpdateRequest {
+    let settings_response = apply_forward_proxy_settings_without_bootstrap(
+        &state,
+        ForwardProxySettings {
             proxy_urls: vec!["socks5://127.0.0.1:1082".to_string()],
             subscription_urls: vec![],
             subscription_update_interval_secs: 3600,
             insert_direct: true,
-        }),
+        },
     )
-    .await
-    .expect("put forward proxy settings should succeed");
+    .await;
     let manual_key = settings_response
         .nodes
         .iter()
@@ -7695,18 +7709,16 @@ async fn forward_proxy_timeseries_keeps_single_partial_hour_ranges_non_empty() {
     )
     .await;
 
-    let Json(settings_response) = put_forward_proxy_settings(
-        State(state.clone()),
-        HeaderMap::new(),
-        Json(ForwardProxySettingsUpdateRequest {
+    let settings_response = apply_forward_proxy_settings_without_bootstrap(
+        &state,
+        ForwardProxySettings {
             proxy_urls: vec!["socks5://127.0.0.1:1083".to_string()],
             subscription_urls: vec![],
             subscription_update_interval_secs: 3600,
             insert_direct: true,
-        }),
+        },
     )
-    .await
-    .expect("put forward proxy settings should succeed");
+    .await;
     let manual_key = settings_response
         .nodes
         .iter()
@@ -7781,18 +7793,16 @@ async fn forward_proxy_timeseries_seeds_leading_weight_buckets_from_first_histor
     )
     .await;
 
-    let Json(settings_response) = put_forward_proxy_settings(
-        State(state.clone()),
-        HeaderMap::new(),
-        Json(ForwardProxySettingsUpdateRequest {
+    let settings_response = apply_forward_proxy_settings_without_bootstrap(
+        &state,
+        ForwardProxySettings {
             proxy_urls: vec!["socks5://127.0.0.1:1084".to_string()],
             subscription_urls: vec![],
             subscription_update_interval_secs: 3600,
             insert_direct: true,
-        }),
+        },
     )
-    .await
-    .expect("put forward proxy settings should succeed");
+    .await;
     let manual_key = settings_response
         .nodes
         .iter()
@@ -7862,18 +7872,16 @@ async fn forward_proxy_timeseries_preserves_retired_proxy_metadata() {
     )
     .await;
 
-    let Json(settings_response) = put_forward_proxy_settings(
-        State(state.clone()),
-        HeaderMap::new(),
-        Json(ForwardProxySettingsUpdateRequest {
+    let settings_response = apply_forward_proxy_settings_without_bootstrap(
+        &state,
+        ForwardProxySettings {
             proxy_urls: vec!["socks5://127.0.0.1:1085".to_string()],
             subscription_urls: vec![],
             subscription_update_interval_secs: 3600,
             insert_direct: true,
-        }),
+        },
     )
-    .await
-    .expect("put forward proxy settings should succeed");
+    .await;
     let manual = settings_response
         .nodes
         .iter()
@@ -7904,18 +7912,16 @@ async fn forward_proxy_timeseries_preserves_retired_proxy_metadata() {
     )
     .await;
 
-    let _ = put_forward_proxy_settings(
-        State(state.clone()),
-        HeaderMap::new(),
-        Json(ForwardProxySettingsUpdateRequest {
+    let _ = apply_forward_proxy_settings_without_bootstrap(
+        &state,
+        ForwardProxySettings {
             proxy_urls: vec![],
             subscription_urls: vec![],
             subscription_update_interval_secs: 3600,
             insert_direct: true,
-        }),
+        },
     )
-    .await
-    .expect("remove manual proxy from runtime");
+    .await;
 
     let range_start = Utc
         .timestamp_opt(bucket_start, 0)
@@ -21901,6 +21907,25 @@ fn is_sqlite_lock_error_detects_structured_sqlite_codes() {
         },
     )));
     assert!(!is_sqlite_lock_error(&non_lock_error));
+}
+
+#[tokio::test]
+async fn run_best_effort_retention_pragma_tolerates_sqlite_lock_errors() {
+    let err = run_best_effort_retention_pragma(
+        &SqlitePool::connect_lazy("sqlite::memory:").expect("construct lazy sqlite pool"),
+        "SELECT 1",
+        "retention wal checkpoint",
+    )
+    .await;
+    assert!(err.is_ok());
+
+    let locked = anyhow::Error::new(sqlx::Error::Database(Box::new(
+        FakeSqliteCodeDatabaseError {
+            message: "database table is locked",
+            code: "SQLITE_LOCKED",
+        },
+    )));
+    assert!(is_sqlite_lock_error(&locked));
 }
 
 #[tokio::test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8927,7 +8927,7 @@ async fn proxy_openai_v1_returns_bad_gateway_when_first_stream_chunk_fails() {
     )
     .await;
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read response body");
@@ -9011,7 +9011,7 @@ async fn proxy_openai_v1_blocks_cross_origin_redirect() {
     )
     .await;
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read response body");
@@ -11540,14 +11540,18 @@ async fn resolve_pool_account_for_request_exempts_accounts_without_local_limits_
         upsert_test_sticky_route_at(&state.pool, sticky_key, exempt_id, &recent_seen_at).await;
     }
 
-    let account =
-        match resolve_pool_account_for_request(state.as_ref(), Some("sticky-exempt-target"), &[])
-            .await
-            .expect("resolve pool account")
-        {
-            PoolAccountResolution::Resolved(account) => account,
-            other => panic!("pool account should resolve, got {other:?}"),
-        };
+    let account = match resolve_pool_account_for_request(
+        state.as_ref(),
+        Some("sticky-exempt-target"),
+        &[],
+        &HashSet::new(),
+    )
+    .await
+    .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
 
     assert_eq!(account.account_id, exempt_id);
     assert_ne!(account.account_id, limited_id);
@@ -11579,6 +11583,7 @@ async fn resolve_pool_account_for_request_keeps_existing_sort_order_when_exempt_
         state.as_ref(),
         Some("sticky-mixed-order-target"),
         &[],
+        &HashSet::new(),
     )
     .await
     .expect("resolve pool account")
@@ -12693,7 +12698,7 @@ async fn capture_target_pool_route_stops_after_three_distinct_accounts() {
         ),
     )
     .await;
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
     let _ = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read failure response body");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13130,6 +13130,47 @@ fn canonical_pool_upstream_route_key_collapses_trailing_slashes() {
         ),
         "https://route.example/",
     );
+    assert_eq!(
+        canonical_pool_upstream_route_key(
+            &Url::parse("https://route.example:443/base").expect("valid default https port route")
+        ),
+        canonical_pool_upstream_route_key(
+            &Url::parse("https://route.example/base").expect("valid https route")
+        ),
+    );
+    assert_eq!(
+        canonical_pool_upstream_route_key(
+            &Url::parse("http://route.example:80/base").expect("valid default http port route")
+        ),
+        canonical_pool_upstream_route_key(
+            &Url::parse("http://route.example/base").expect("valid http route")
+        ),
+    );
+    assert_ne!(
+        canonical_pool_upstream_route_key(
+            &Url::parse("https://route.example:8443/base")
+                .expect("valid non-default https port route")
+        ),
+        canonical_pool_upstream_route_key(
+            &Url::parse("https://route.example/base").expect("valid https route")
+        ),
+    );
+}
+
+#[test]
+fn pool_failure_is_timeout_shaped_ignores_upstream_5xx_text_timeouts() {
+    assert!(!pool_failure_is_timeout_shaped(
+        FORWARD_PROXY_FAILURE_UPSTREAM_HTTP_5XX,
+        "pool upstream responded with 500: operation timed out after 30s"
+    ));
+    assert!(pool_failure_is_timeout_shaped(
+        PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT,
+        "upstream handshake timed out after 60000ms"
+    ));
+    assert!(pool_failure_is_timeout_shaped(
+        PROXY_FAILURE_FAILED_CONTACT_UPSTREAM,
+        "request timed out after 120000ms while waiting for first upstream chunk"
+    ));
 }
 
 #[tokio::test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11519,6 +11519,93 @@ async fn resolve_pool_account_for_request_falls_back_after_soft_bucket_candidate
 }
 
 #[tokio::test]
+async fn resolve_pool_account_for_request_allows_timeout_failover_past_cut_out_rule() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let source_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Source",
+        "upstream-source",
+        None,
+        None,
+        Some("https://route-a.example.com/backend-api/"),
+    )
+    .await;
+    let alternate_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Alternate",
+        "upstream-alternate",
+        None,
+        None,
+        Some("https://route-b.example.com/backend-api/"),
+    )
+    .await;
+    let recent_seen_at = format_utc_iso(Utc::now() - ChronoDuration::minutes(5));
+    let now_iso = format_utc_iso(Utc::now());
+
+    upsert_test_sticky_route_at(
+        &state.pool,
+        "sticky-timeout-cut-out",
+        source_id,
+        &recent_seen_at,
+    )
+    .await;
+
+    let disallow_cut_out_tag_id: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO pool_tags (
+            name, guard_enabled, lookback_hours, max_conversations,
+            allow_cut_out, allow_cut_in, created_at, updated_at
+        ) VALUES (?1, 0, NULL, NULL, 0, 1, ?2, ?2)
+        RETURNING id
+        "#,
+    )
+    .bind("no-cut-out")
+    .bind(&now_iso)
+    .fetch_one(&state.pool)
+    .await
+    .expect("insert no-cut-out tag");
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_account_tags (
+            account_id, tag_id, created_at, updated_at
+        ) VALUES (?1, ?2, ?3, ?3)
+        "#,
+    )
+    .bind(source_id)
+    .bind(disallow_cut_out_tag_id)
+    .bind(&now_iso)
+    .execute(&state.pool)
+    .await
+    .expect("attach no-cut-out tag");
+
+    let mut excluded_upstream_route_keys = HashSet::new();
+    excluded_upstream_route_keys.insert(
+        crate::upstream_accounts::canonical_pool_upstream_route_key(
+            &Url::parse("https://route-a.example.com/backend-api/").expect("valid route a url"),
+        ),
+    );
+
+    let account = match resolve_pool_account_for_request(
+        state.as_ref(),
+        Some("sticky-timeout-cut-out"),
+        &[],
+        &excluded_upstream_route_keys,
+    )
+    .await
+    .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve after timeout route exclusion, got {other:?}"),
+    };
+
+    assert_eq!(account.account_id, alternate_id);
+    assert_ne!(account.account_id, source_id);
+}
+
+#[tokio::test]
 async fn resolve_pool_account_for_request_exempts_accounts_without_local_limits_from_soft_sticky_deprioritization()
  {
     let state = test_state_with_openai_base(
@@ -12082,7 +12169,7 @@ async fn pool_route_surfaces_last_upstream_error_when_failover_is_exhausted() {
     )
     .await;
 
-    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read failure body");
@@ -15301,6 +15388,56 @@ async fn pool_openai_v1_responses_stream_survives_short_request_timeout() {
 }
 
 #[tokio::test]
+async fn pool_openai_v1_responses_waits_for_first_chunk_beyond_request_timeout() {
+    let (upstream_base, upstream_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let mut config = test_config();
+    config.openai_upstream_base_url = Url::parse(&upstream_base).expect("valid upstream base url");
+    config.request_timeout = Duration::from_millis(100);
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(400);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+
+    let request_body = serde_json::to_vec(&json!({
+        "model": "gpt-5.4",
+        "stream": false,
+        "input": "hello",
+    }))
+    .expect("serialize request body");
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        proxy_openai_v1(
+            State(state),
+            OriginalUri("/v1/responses".parse().expect("valid uri")),
+            Method::POST,
+            HeaderMap::from_iter([
+                (
+                    http_header::AUTHORIZATION,
+                    HeaderValue::from_static("Bearer pool-live-key"),
+                ),
+                (
+                    http_header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/json"),
+                ),
+            ]),
+            Body::from(request_body),
+        ),
+    )
+    .await
+    .expect("responses pool request should not hang");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read responses pool body");
+    let payload: Value = serde_json::from_slice(&body).expect("decode responses pool response");
+    assert_eq!(payload["ok"].as_bool(), Some(true));
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn pool_openai_v1_responses_compact_waits_for_dedicated_first_chunk_timeout() {
     let (upstream_base, _captured_requests, upstream_handle) =
         spawn_capture_target_body_upstream().await;
@@ -15367,8 +15504,9 @@ async fn pool_openai_v1_responses_still_times_out_before_first_chunk() {
         spawn_capture_target_body_upstream().await;
     let mut config = test_config();
     config.openai_upstream_base_url = Url::parse(&upstream_base).expect("valid upstream base url");
-    config.request_timeout = Duration::from_millis(200);
+    config.request_timeout = Duration::from_secs(5);
     config.openai_proxy_compact_handshake_timeout = Duration::from_millis(400);
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(200);
     let state = test_state_from_config(config, true).await;
     seed_pool_routing_api_key(&state, "pool-live-key").await;
     insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1701,6 +1701,10 @@ fn app_config_from_sources_reads_renamed_public_envs() {
     assert_eq!(config.forward_proxy_attempts_retention_days, 32);
     assert_eq!(config.pool_upstream_request_attempts_retention_days, 7);
     assert_eq!(config.pool_upstream_request_attempts_archive_ttl_days, 30);
+    assert_eq!(
+        config.pool_upstream_responses_attempt_timeout,
+        Duration::from_secs(DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS)
+    );
     assert_eq!(config.stats_source_snapshots_retention_days, 33);
     assert_eq!(config.quota_snapshot_full_days, 34);
     assert_eq!(config.proxy_raw_compression, RawCompressionCodec::None);
@@ -1739,6 +1743,7 @@ fn app_config_from_sources_uses_proxy_timeout_defaults() {
         "OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS",
         "OPENAI_PROXY_COMPACT_HANDSHAKE_TIMEOUT_SECS",
         "OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS",
+        ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
     ];
     let previous = names
         .iter()
@@ -1771,6 +1776,10 @@ fn app_config_from_sources_uses_proxy_timeout_defaults() {
         config.openai_proxy_request_read_timeout,
         Duration::from_secs(DEFAULT_OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS)
     );
+    assert_eq!(
+        config.pool_upstream_responses_attempt_timeout,
+        Duration::from_secs(DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS)
+    );
 }
 
 #[test]
@@ -1780,6 +1789,7 @@ fn app_config_from_sources_reads_proxy_timeout_envs() {
         "OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS",
         "OPENAI_PROXY_COMPACT_HANDSHAKE_TIMEOUT_SECS",
         "OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS",
+        ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
     ];
     let previous = names
         .iter()
@@ -1790,6 +1800,7 @@ fn app_config_from_sources_reads_proxy_timeout_envs() {
         env::set_var("OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS", "61");
         env::set_var("OPENAI_PROXY_COMPACT_HANDSHAKE_TIMEOUT_SECS", "181");
         env::set_var("OPENAI_PROXY_REQUEST_READ_TIMEOUT_SECS", "182");
+        env::set_var(ENV_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS, "183");
     }
 
     let result = AppConfig::from_sources(&CliArgs::default());
@@ -1814,6 +1825,10 @@ fn app_config_from_sources_reads_proxy_timeout_envs() {
         config.openai_proxy_request_read_timeout,
         Duration::from_secs(182)
     );
+    assert_eq!(
+        config.pool_upstream_responses_attempt_timeout,
+        Duration::from_secs(183)
+    );
 }
 
 fn test_config() -> AppConfig {
@@ -1822,6 +1837,9 @@ fn test_config() -> AppConfig {
         database_path: PathBuf::from(":memory:"),
         poll_interval: Duration::from_secs(10),
         request_timeout: Duration::from_secs(30),
+        pool_upstream_responses_attempt_timeout: Duration::from_secs(
+            DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
+        ),
         openai_proxy_handshake_timeout: Duration::from_secs(
             DEFAULT_OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS,
         ),
@@ -2397,6 +2415,7 @@ async fn insert_retention_pool_upstream_request_attempt(
             route_mode,
             sticky_key,
             upstream_account_id,
+            upstream_route_key,
             attempt_index,
             distinct_account_index,
             same_account_retry_index,
@@ -2413,7 +2432,7 @@ async fn insert_retention_pool_upstream_request_attempt(
             upstream_request_id
         )
         VALUES (
-            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21
         )
         "#,
     )
@@ -2423,6 +2442,7 @@ async fn insert_retention_pool_upstream_request_attempt(
     .bind(INVOCATION_ROUTE_MODE_POOL)
     .bind(Some("sticky-retention"))
     .bind(upstream_account_id)
+    .bind(None::<String>)
     .bind(attempt_index)
     .bind(distinct_account_index)
     .bind(same_account_retry_index)
@@ -8857,7 +8877,7 @@ async fn proxy_openai_v1_returns_bad_gateway_when_first_stream_chunk_fails() {
     )
     .await;
 
-    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read response body");
@@ -8941,7 +8961,7 @@ async fn proxy_openai_v1_blocks_cross_origin_redirect() {
     )
     .await;
 
-    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read response body");
@@ -10151,9 +10171,10 @@ fn pool_upstream_first_chunk_timeout_uses_compact_budget_for_compact_route() {
 }
 
 #[test]
-fn pool_upstream_first_chunk_timeout_keeps_default_budget_for_non_compact_route() {
+fn pool_upstream_first_chunk_timeout_uses_responses_budget_for_responses_route() {
     let mut config = test_config();
     config.request_timeout = Duration::from_millis(200);
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(1200);
     config.openai_proxy_compact_handshake_timeout = Duration::from_millis(400);
 
     let timeout = pool_upstream_first_chunk_timeout(
@@ -10161,6 +10182,22 @@ fn pool_upstream_first_chunk_timeout_keeps_default_budget_for_non_compact_route(
         &"/v1/responses".parse().expect("valid uri"),
         &Method::POST,
         config.proxy_upstream_handshake_timeout(Some(ProxyCaptureTarget::Responses)),
+    );
+
+    assert_eq!(timeout, Duration::from_millis(1200));
+}
+
+#[test]
+fn pool_upstream_first_chunk_timeout_keeps_default_budget_for_non_responses_route() {
+    let mut config = test_config();
+    config.request_timeout = Duration::from_millis(200);
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(1200);
+
+    let timeout = pool_upstream_first_chunk_timeout(
+        &config,
+        &"/v1/chat/completions".parse().expect("valid uri"),
+        &Method::POST,
+        config.proxy_upstream_handshake_timeout(Some(ProxyCaptureTarget::ChatCompletions)),
     );
 
     assert_eq!(timeout, Duration::from_millis(200));
@@ -10369,6 +10406,11 @@ struct PoolStaticFailureResponsesUpstreamState {
 struct PoolFirstChunkRetryUpstreamState {
     attempts: Arc<StdMutex<HashMap<String, usize>>>,
     fail_before_success: Arc<HashMap<String, usize>>,
+}
+
+#[derive(Clone)]
+struct PoolDelayedFirstChunkUpstreamState {
+    first_chunk_delay: Duration,
 }
 
 #[derive(Clone)]
@@ -10637,6 +10679,41 @@ async fn pool_first_chunk_retry_upstream(
         })),
     )
         .into_response()
+}
+
+async fn pool_delayed_first_chunk_upstream(
+    State(state): State<PoolDelayedFirstChunkUpstreamState>,
+) -> Response {
+    let delay = state.first_chunk_delay;
+    let stream = futures_util::stream::once(async move {
+        tokio::time::sleep(delay).await;
+        Ok::<Bytes, Infallible>(Bytes::from_static(br#"{"ok":true}"#))
+    });
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(http_header::CONTENT_TYPE, "application/json")
+        .body(Body::from_stream(stream))
+        .expect("build delayed first chunk response")
+}
+
+async fn spawn_pool_delayed_first_chunk_upstream(delay: Duration) -> (String, JoinHandle<()>) {
+    let app = Router::new()
+        .route("/v1/responses", post(pool_delayed_first_chunk_upstream))
+        .with_state(PoolDelayedFirstChunkUpstreamState {
+            first_chunk_delay: delay,
+        });
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind delayed first chunk upstream");
+    let addr = listener
+        .local_addr()
+        .expect("delayed first chunk upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("delayed first chunk upstream should run");
+    });
+    (format!("http://{addr}"), handle)
 }
 
 async fn pool_http_failure_upstream(State(state): State<PoolHttpFailureUpstreamState>) -> Response {
@@ -11165,6 +11242,19 @@ async fn load_test_sticky_route_account_id(pool: &SqlitePool, sticky_key: &str) 
         .expect("load test sticky route")
 }
 
+async fn wait_for_pool_attempt_row_count(pool: &SqlitePool, min_count: i64) {
+    for _ in 0..20 {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM pool_upstream_request_attempts")
+            .fetch_one(pool)
+            .await
+            .expect("count pool attempt rows");
+        if count >= min_count {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
 async fn wait_for_test_sticky_route_account_id(pool: &SqlitePool, sticky_key: &str) -> Option<i64> {
     for _ in 0..10 {
         if let Some(account_id) = load_test_sticky_route_account_id(pool, sticky_key).await {
@@ -11200,9 +11290,14 @@ async fn resolve_pool_account_for_request_keeps_existing_sticky_binding_when_sou
         upsert_test_sticky_route_at(&state.pool, sticky_key, primary_id, &recent_seen_at).await;
     }
 
-    let account = match resolve_pool_account_for_request(state.as_ref(), Some("sticky-bound"), &[])
-        .await
-        .expect("resolve pool account")
+    let account = match resolve_pool_account_for_request(
+        state.as_ref(),
+        Some("sticky-bound"),
+        &[],
+        &HashSet::new(),
+    )
+    .await
+    .expect("resolve pool account")
     {
         PoolAccountResolution::Resolved(account) => account,
         other => panic!("pool account should resolve, got {other:?}"),
@@ -11240,6 +11335,7 @@ async fn resolve_pool_account_for_request_prefers_candidates_within_soft_sticky_
         state.as_ref(),
         Some("sticky-prefer-available"),
         &[],
+        &HashSet::new(),
     )
     .await
     .expect("resolve pool account")
@@ -11283,14 +11379,18 @@ async fn resolve_pool_account_for_request_falls_back_to_over_soft_limit_bucket_w
         upsert_test_sticky_route_at(&state.pool, sticky_key, fallback_id, &recent_seen_at).await;
     }
 
-    let account =
-        match resolve_pool_account_for_request(state.as_ref(), Some("sticky-soft-fallback"), &[])
-            .await
-            .expect("resolve pool account")
-        {
-            PoolAccountResolution::Resolved(account) => account,
-            other => panic!("pool account should resolve, got {other:?}"),
-        };
+    let account = match resolve_pool_account_for_request(
+        state.as_ref(),
+        Some("sticky-soft-fallback"),
+        &[],
+        &HashSet::new(),
+    )
+    .await
+    .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
 
     assert_eq!(account.account_id, preferred_id);
     assert_ne!(account.account_id, fallback_id);
@@ -11351,14 +11451,18 @@ async fn resolve_pool_account_for_request_falls_back_after_soft_bucket_candidate
     .await
     .expect("attach no-cut-in tag");
 
-    let account =
-        match resolve_pool_account_for_request(state.as_ref(), Some("sticky-transfer"), &[])
-            .await
-            .expect("resolve pool account")
-        {
-            PoolAccountResolution::Resolved(account) => account,
-            other => panic!("pool account should resolve, got {other:?}"),
-        };
+    let account = match resolve_pool_account_for_request(
+        state.as_ref(),
+        Some("sticky-transfer"),
+        &[],
+        &HashSet::new(),
+    )
+    .await
+    .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
 
     assert_eq!(account.account_id, overloaded_id);
     assert_ne!(account.account_id, guarded_id);
@@ -11446,9 +11550,14 @@ async fn resolve_pool_account_for_request_defers_sticky_binding_until_success() 
     .await;
     let account_id = insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
 
-    let account = match resolve_pool_account_for_request(state.as_ref(), Some("sticky-001"), &[])
-        .await
-        .expect("resolve pool account")
+    let account = match resolve_pool_account_for_request(
+        state.as_ref(),
+        Some("sticky-001"),
+        &[],
+        &HashSet::new(),
+    )
+    .await
+    .expect("resolve pool account")
     {
         PoolAccountResolution::Resolved(account) => account,
         other => panic!("pool account should resolve, got {other:?}"),
@@ -11918,7 +12027,7 @@ async fn pool_route_surfaces_last_upstream_error_when_failover_is_exhausted() {
     )
     .await;
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read failure body");
@@ -12711,6 +12820,592 @@ async fn capture_target_pool_route_preserves_auth_failure_terminal_reason() {
 }
 
 #[tokio::test]
+async fn capture_target_pool_route_timeout_switches_to_alternate_upstream_route() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct AttemptRouteRow {
+        upstream_account_id: Option<i64>,
+        upstream_route_key: Option<String>,
+        attempt_index: i64,
+        distinct_account_index: i64,
+        same_account_retry_index: i64,
+        status: String,
+        failure_kind: Option<String>,
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct PersistedPayloadRow {
+        payload: Option<String>,
+    }
+
+    let (slow_upstream_base, slow_upstream_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let (fast_upstream_base, _attempts, fast_upstream_handle) =
+        spawn_pool_retry_upstream(&[("Bearer route-fast", 0)]).await;
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(120);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let slow_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Slow Route",
+        "route-slow",
+        None,
+        None,
+        Some(slow_upstream_base.as_str()),
+    )
+    .await;
+    let fast_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Fast Route",
+        "route-fast",
+        None,
+        None,
+        Some(fast_upstream_base.as_str()),
+    )
+    .await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-timeout-switch-001"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read timeout-switch success body");
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    wait_for_pool_attempt_row_count(&state.pool, 2).await;
+
+    let attempt_rows = sqlx::query_as::<_, AttemptRouteRow>(
+        r#"
+        SELECT
+            upstream_account_id,
+            upstream_route_key,
+            attempt_index,
+            distinct_account_index,
+            same_account_retry_index,
+            status,
+            failure_kind
+        FROM pool_upstream_request_attempts
+        ORDER BY attempt_index ASC
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load timeout-switch attempt rows");
+    assert_eq!(attempt_rows.len(), 2);
+    assert_eq!(attempt_rows[0].upstream_account_id, Some(slow_id));
+    assert_eq!(attempt_rows[0].attempt_index, 1);
+    assert_eq!(attempt_rows[0].distinct_account_index, 1);
+    assert_eq!(attempt_rows[0].same_account_retry_index, 1);
+    assert_eq!(
+        attempt_rows[0].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+    );
+    assert_eq!(
+        attempt_rows[0].failure_kind.as_deref(),
+        Some(PROXY_FAILURE_UPSTREAM_STREAM_ERROR),
+    );
+    assert_eq!(attempt_rows[1].upstream_account_id, Some(fast_id));
+    assert_eq!(attempt_rows[1].attempt_index, 2);
+    assert_eq!(attempt_rows[1].distinct_account_index, 2);
+    assert_eq!(attempt_rows[1].same_account_retry_index, 1);
+    assert_eq!(
+        attempt_rows[1].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS,
+    );
+    assert_eq!(
+        attempt_rows[0].upstream_route_key.as_deref(),
+        Some(
+            canonical_pool_upstream_route_key(
+                &Url::parse(&slow_upstream_base).expect("valid slow route url")
+            )
+            .as_str()
+        ),
+    );
+    assert_eq!(
+        attempt_rows[1].upstream_route_key.as_deref(),
+        Some(
+            canonical_pool_upstream_route_key(
+                &Url::parse(&fast_upstream_base).expect("valid fast route url")
+            )
+            .as_str()
+        ),
+    );
+
+    let row = sqlx::query_as::<_, PersistedPayloadRow>(
+        r#"
+        SELECT payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load timeout-switch invocation payload");
+    let payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("timeout-switch payload should be present"),
+    )
+    .expect("decode timeout-switch payload");
+    assert_eq!(payload["poolAttemptCount"].as_i64(), Some(2));
+    assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(2));
+    assert!(payload["poolAttemptTerminalReason"].is_null());
+
+    slow_upstream_handle.abort();
+    fast_upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn capture_target_pool_route_timeout_returns_no_alternate_when_only_same_route_remains() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct AttemptRouteRow {
+        upstream_route_key: Option<String>,
+        attempt_index: i64,
+        distinct_account_index: i64,
+        same_account_retry_index: i64,
+        status: String,
+        failure_kind: Option<String>,
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct PersistedPayloadRow {
+        payload: Option<String>,
+    }
+
+    let (shared_upstream_base, shared_upstream_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(120);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Shared Route A",
+        "route-shared-a",
+        None,
+        None,
+        Some(shared_upstream_base.as_str()),
+    )
+    .await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Shared Route B",
+        "route-shared-b",
+        None,
+        None,
+        Some(shared_upstream_base.as_str()),
+    )
+    .await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-timeout-no-alt-001"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let _ = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read timeout no-alternate response body");
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    wait_for_pool_attempt_row_count(&state.pool, 2).await;
+
+    let attempt_rows = sqlx::query_as::<_, AttemptRouteRow>(
+        r#"
+        SELECT
+            upstream_route_key,
+            attempt_index,
+            distinct_account_index,
+            same_account_retry_index,
+            status,
+            failure_kind
+        FROM pool_upstream_request_attempts
+        ORDER BY attempt_index ASC
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load timeout no-alternate rows");
+    assert_eq!(attempt_rows.len(), 2);
+    assert_eq!(attempt_rows[0].attempt_index, 1);
+    assert_eq!(attempt_rows[0].same_account_retry_index, 1);
+    assert_eq!(
+        attempt_rows[0].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+    );
+    assert_eq!(attempt_rows[1].attempt_index, 2);
+    assert_eq!(attempt_rows[1].distinct_account_index, 1);
+    assert_eq!(
+        attempt_rows[1].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_BUDGET_EXHAUSTED_FINAL,
+    );
+    assert_eq!(
+        attempt_rows[1].failure_kind.as_deref(),
+        Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
+    );
+    assert_eq!(attempt_rows[1].same_account_retry_index, 0);
+    assert_eq!(
+        attempt_rows[0].upstream_route_key,
+        attempt_rows[1].upstream_route_key,
+    );
+
+    let row = sqlx::query_as::<_, PersistedPayloadRow>(
+        r#"
+        SELECT payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load timeout no-alternate payload");
+    let payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("timeout no-alternate payload should be present"),
+    )
+    .expect("decode timeout no-alternate payload");
+    assert_eq!(payload["poolAttemptCount"].as_i64(), Some(1));
+    assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(1));
+    assert_eq!(
+        payload["poolAttemptTerminalReason"].as_str(),
+        Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
+    );
+
+    shared_upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn capture_target_pool_route_timeout_can_switch_twice_then_succeed() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct AttemptRouteRow {
+        attempt_index: i64,
+        distinct_account_index: i64,
+        same_account_retry_index: i64,
+        status: String,
+        upstream_route_key: Option<String>,
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct PersistedPayloadRow {
+        payload: Option<String>,
+    }
+
+    let (slow_one_base, slow_one_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let (slow_two_base, slow_two_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let (fast_three_base, _attempts, fast_three_handle) =
+        spawn_pool_retry_upstream(&[("Bearer route-three", 0)]).await;
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(120);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Timeout Route One",
+        "route-one",
+        None,
+        None,
+        Some(slow_one_base.as_str()),
+    )
+    .await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Timeout Route Two",
+        "route-two",
+        None,
+        None,
+        Some(slow_two_base.as_str()),
+    )
+    .await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Success Route Three",
+        "route-three",
+        None,
+        None,
+        Some(fast_three_base.as_str()),
+    )
+    .await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-timeout-switch-002"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read timeout double-switch success body");
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    wait_for_pool_attempt_row_count(&state.pool, 3).await;
+
+    let attempt_rows = sqlx::query_as::<_, AttemptRouteRow>(
+        r#"
+        SELECT
+            attempt_index,
+            distinct_account_index,
+            same_account_retry_index,
+            status,
+            upstream_route_key
+        FROM pool_upstream_request_attempts
+        ORDER BY attempt_index ASC
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load timeout double-switch rows");
+    assert_eq!(attempt_rows.len(), 3);
+    assert_eq!(attempt_rows[0].same_account_retry_index, 1);
+    assert_eq!(attempt_rows[1].same_account_retry_index, 1);
+    assert_eq!(attempt_rows[2].same_account_retry_index, 1);
+    assert_eq!(
+        attempt_rows[0].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+    );
+    assert_eq!(
+        attempt_rows[1].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+    );
+    assert_eq!(
+        attempt_rows[2].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS,
+    );
+    assert_eq!(attempt_rows[2].attempt_index, 3);
+    assert_eq!(attempt_rows[2].distinct_account_index, 3);
+    assert_ne!(
+        attempt_rows[0].upstream_route_key,
+        attempt_rows[1].upstream_route_key
+    );
+    assert_ne!(
+        attempt_rows[1].upstream_route_key,
+        attempt_rows[2].upstream_route_key
+    );
+
+    let row = sqlx::query_as::<_, PersistedPayloadRow>(
+        r#"
+        SELECT payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load timeout double-switch payload");
+    let payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("timeout double-switch payload should be present"),
+    )
+    .expect("decode timeout double-switch payload");
+    assert_eq!(payload["poolAttemptCount"].as_i64(), Some(3));
+    assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(3));
+    assert!(payload["poolAttemptTerminalReason"].is_null());
+
+    slow_one_handle.abort();
+    slow_two_handle.abort();
+    fast_three_handle.abort();
+}
+
+#[tokio::test]
+async fn capture_target_pool_route_timeout_exhausts_after_three_routes() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct AttemptRouteRow {
+        attempt_index: i64,
+        distinct_account_index: i64,
+        same_account_retry_index: i64,
+        status: String,
+        failure_kind: Option<String>,
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct PersistedPayloadRow {
+        payload: Option<String>,
+    }
+
+    let (slow_one_base, slow_one_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let (slow_two_base, slow_two_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let (slow_three_base, slow_three_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let (fast_four_base, attempts, fast_four_handle) =
+        spawn_pool_retry_upstream(&[("Bearer route-four", 0)]).await;
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(120);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Timeout Route One",
+        "route-one",
+        None,
+        None,
+        Some(slow_one_base.as_str()),
+    )
+    .await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Timeout Route Two",
+        "route-two",
+        None,
+        None,
+        Some(slow_two_base.as_str()),
+    )
+    .await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Timeout Route Three",
+        "route-three",
+        None,
+        None,
+        Some(slow_three_base.as_str()),
+    )
+    .await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Unused Route Four",
+        "route-four",
+        None,
+        None,
+        Some(fast_four_base.as_str()),
+    )
+    .await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-timeout-stop-003"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let _ = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read timeout terminal response body");
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    wait_for_pool_attempt_row_count(&state.pool, 4).await;
+
+    let attempt_rows = sqlx::query_as::<_, AttemptRouteRow>(
+        r#"
+        SELECT
+            attempt_index,
+            distinct_account_index,
+            same_account_retry_index,
+            status,
+            failure_kind
+        FROM pool_upstream_request_attempts
+        ORDER BY attempt_index ASC
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load timeout terminal rows");
+    assert_eq!(attempt_rows.len(), 4);
+    assert_eq!(attempt_rows[0].same_account_retry_index, 1);
+    assert_eq!(attempt_rows[1].same_account_retry_index, 1);
+    assert_eq!(attempt_rows[2].same_account_retry_index, 1);
+    assert_eq!(
+        attempt_rows[3].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_BUDGET_EXHAUSTED_FINAL,
+    );
+    assert_eq!(attempt_rows[3].attempt_index, 4);
+    assert_eq!(attempt_rows[3].distinct_account_index, 3);
+    assert_eq!(
+        attempt_rows[3].failure_kind.as_deref(),
+        Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
+    );
+
+    let attempts = attempts.lock().expect("lock unused route attempts");
+    assert_eq!(attempts.get("Bearer route-four").copied(), None);
+    drop(attempts);
+
+    let row = sqlx::query_as::<_, PersistedPayloadRow>(
+        r#"
+        SELECT payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load timeout terminal payload");
+    let payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("timeout terminal payload should be present"),
+    )
+    .expect("decode timeout terminal payload");
+    assert_eq!(payload["poolAttemptCount"].as_i64(), Some(3));
+    assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(3));
+    assert_eq!(
+        payload["poolAttemptTerminalReason"].as_str(),
+        Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
+    );
+
+    slow_one_handle.abort();
+    slow_two_handle.abort();
+    slow_three_handle.abort();
+    fast_four_handle.abort();
+}
+
+#[tokio::test]
 async fn pool_route_marks_oauth_missing_scopes_as_error_and_persists_upstream_details() {
     let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
         .lock()
@@ -12990,6 +13685,7 @@ async fn pool_route_oauth_passthrough_replays_large_file_backed_body() {
         None,
         None,
         Some(account),
+        PoolFailoverProgress::default(),
         1,
     )
     .await
@@ -13907,6 +14603,7 @@ async fn pool_route_large_oauth_responses_falls_back_to_api_key_account() {
         None,
         None,
         None,
+        PoolFailoverProgress::default(),
         1,
     )
     .await
@@ -13987,6 +14684,7 @@ async fn pool_route_oauth_responses_rejects_large_file_backed_rewrite_body() {
         None,
         None,
         Some(account),
+        PoolFailoverProgress::default(),
         1,
     )
     .await

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15773,7 +15773,7 @@ async fn pool_openai_v1_responses_still_times_out_before_first_chunk() {
         .await
         .expect("read responses pool error body");
     let payload = String::from_utf8_lossy(&body);
-    assert!(payload.contains("first upstream chunk"));
+    assert!(payload.contains("no alternate upstream route is available after timeout"));
 
     upstream_handle.abort();
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10507,6 +10507,11 @@ struct PoolDelayedFirstChunkUpstreamState {
 }
 
 #[derive(Clone)]
+struct PoolDelayedHeadersUpstreamState {
+    header_delay: Duration,
+}
+
+#[derive(Clone)]
 struct PoolHttpFailureUpstreamState {
     status: StatusCode,
     error_code: Option<String>,
@@ -10809,8 +10814,10 @@ async fn spawn_pool_delayed_first_chunk_upstream(delay: Duration) -> (String, Jo
     (format!("http://{addr}"), handle)
 }
 
-async fn pool_delayed_headers_upstream(State(delay): State<Duration>) -> Response {
-    tokio::time::sleep(delay).await;
+async fn pool_delayed_headers_upstream(
+    State(state): State<PoolDelayedHeadersUpstreamState>,
+) -> Response {
+    tokio::time::sleep(state.header_delay).await;
     (
         StatusCode::OK,
         Json(json!({
@@ -10824,7 +10831,9 @@ async fn pool_delayed_headers_upstream(State(delay): State<Duration>) -> Respons
 async fn spawn_pool_delayed_headers_upstream(delay: Duration) -> (String, JoinHandle<()>) {
     let app = Router::new()
         .route("/v1/responses", post(pool_delayed_headers_upstream))
-        .with_state(delay);
+        .with_state(PoolDelayedHeadersUpstreamState {
+            header_delay: delay,
+        });
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind delayed headers upstream");
@@ -11112,6 +11121,43 @@ async fn spawn_oauth_codex_responses_capture_upstream() -> (String, JoinHandle<(
         axum::serve(listener, app)
             .await
             .expect("oauth codex responses capture upstream should run");
+    });
+    (format!("http://{addr}"), handle)
+}
+
+async fn oauth_codex_delayed_headers_upstream(
+    State(state): State<PoolDelayedHeadersUpstreamState>,
+) -> Response {
+    tokio::time::sleep(state.header_delay).await;
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "phase": "oauth-headers-delayed",
+        })),
+    )
+        .into_response()
+}
+
+async fn spawn_oauth_codex_delayed_headers_upstream(delay: Duration) -> (String, JoinHandle<()>) {
+    let app = Router::new()
+        .route(
+            "/backend-api/codex/responses",
+            post(oauth_codex_delayed_headers_upstream),
+        )
+        .with_state(PoolDelayedHeadersUpstreamState {
+            header_delay: delay,
+        });
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind delayed oauth responses upstream");
+    let addr = listener
+        .local_addr()
+        .expect("delayed oauth responses upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("delayed oauth responses upstream should run");
     });
     (format!("http://{addr}"), handle)
 }
@@ -15028,6 +15074,172 @@ async fn pool_route_oauth_observability_omits_fingerprints_without_crypto_key() 
     );
 
     upstream_handle.abort();
+    oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
+}
+
+#[tokio::test]
+async fn oauth_responses_timeout_marks_transport_failure_header() {
+    let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
+        .lock()
+        .await;
+
+    let (upstream_base, upstream_handle) =
+        spawn_oauth_codex_delayed_headers_upstream(Duration::from_millis(250)).await;
+    oauth_bridge::set_test_oauth_codex_upstream_base_url(
+        Url::parse(&format!("{upstream_base}/backend-api/codex")).expect("valid oauth base url"),
+    )
+    .await;
+
+    let oauth_response = oauth_bridge::send_oauth_upstream_request(
+        &reqwest::Client::new(),
+        Method::POST,
+        &"/v1/responses".parse().expect("valid uri"),
+        &HeaderMap::from_iter([(
+            http_header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )]),
+        oauth_bridge::OauthUpstreamRequestBody::Bytes(Bytes::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-5.4",
+                "input": "hello"
+            }))
+            .expect("serialize oauth responses body"),
+        )),
+        Duration::from_millis(100),
+        Duration::from_millis(120),
+        Some(7),
+        "oauth-timeout",
+        Some("02355c9d-fb23-4517-a96d-35e5f6758e9e"),
+        None,
+    )
+    .await;
+
+    assert_eq!(oauth_response.response.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(
+        oauth_bridge::oauth_transport_failure_kind(oauth_response.response.headers()),
+        Some(PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT),
+    );
+    let body = to_bytes(oauth_response.response.into_body(), usize::MAX)
+        .await
+        .expect("read oauth timeout response body");
+    let payload = String::from_utf8_lossy(&body);
+    assert!(payload.contains("timed out"));
+
+    upstream_handle.abort();
+    oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
+}
+
+#[tokio::test]
+async fn pool_route_oauth_responses_timeout_switches_to_alternate_route() {
+    #[derive(sqlx::FromRow)]
+    struct PersistedPayloadRow {
+        payload: Option<String>,
+    }
+
+    let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
+        .lock()
+        .await;
+
+    let (slow_upstream_base, slow_upstream_handle) =
+        spawn_oauth_codex_delayed_headers_upstream(Duration::from_millis(250)).await;
+    let (fast_upstream_base, _attempts, fast_upstream_handle) =
+        spawn_pool_retry_upstream(&[("Bearer route-fast", 0)]).await;
+    oauth_bridge::set_test_oauth_codex_upstream_base_url(
+        Url::parse(&format!("{slow_upstream_base}/backend-api/codex"))
+            .expect("valid oauth base url"),
+    )
+    .await;
+
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.openai_proxy_handshake_timeout = Duration::from_millis(100);
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(120);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let oauth_id = insert_test_pool_oauth_account(&state, "Timeout OAuth", "oauth-timeout").await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Fast Route",
+        "route-fast",
+        None,
+        None,
+        Some(fast_upstream_base.as_str()),
+    )
+    .await;
+    let sticky_last_seen_at = format_utc_iso(Utc::now());
+    upsert_test_sticky_route_at(
+        &state.pool,
+        "sticky-oauth-timeout-switch",
+        oauth_id,
+        &sticky_last_seen_at,
+    )
+    .await;
+
+    let request_body = serde_json::to_vec(&json!({
+        "model": "gpt-5.4",
+        "stream": false,
+        "input": "hello",
+        "stickyKey": "sticky-oauth-timeout-switch",
+    }))
+    .expect("serialize request body");
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        proxy_openai_v1(
+            State(state.clone()),
+            OriginalUri("/v1/responses".parse().expect("valid uri")),
+            Method::POST,
+            HeaderMap::from_iter([
+                (
+                    http_header::AUTHORIZATION,
+                    HeaderValue::from_static("Bearer pool-live-key"),
+                ),
+                (
+                    http_header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/json"),
+                ),
+            ]),
+            Body::from(request_body),
+        ),
+    )
+    .await
+    .expect("oauth timeout failover request should not hang");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read oauth timeout failover body");
+    let payload: Value = serde_json::from_slice(&body).expect("decode oauth timeout failover body");
+    assert_eq!(payload["ok"].as_bool(), Some(true));
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+
+    let row = sqlx::query_as::<_, PersistedPayloadRow>(
+        r#"
+        SELECT payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load oauth timeout failover payload");
+    let persisted_payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("oauth timeout failover payload should be present"),
+    )
+    .expect("decode oauth timeout failover payload");
+    assert_eq!(persisted_payload["poolAttemptCount"].as_i64(), Some(2));
+    assert_eq!(
+        persisted_payload["poolDistinctAccountCount"].as_i64(),
+        Some(2)
+    );
+    assert!(persisted_payload["poolAttemptTerminalReason"].is_null());
+
+    slow_upstream_handle.abort();
+    fast_upstream_handle.abort();
     oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13322,6 +13322,160 @@ async fn capture_target_pool_route_timeout_returns_no_alternate_when_only_same_r
 }
 
 #[tokio::test]
+async fn capture_target_pool_route_timeout_replay_failover_preserves_no_alternate_terminal_reason()
+{
+    #[derive(Debug, sqlx::FromRow)]
+    struct AttemptRouteRow {
+        upstream_route_key: Option<String>,
+        attempt_index: i64,
+        distinct_account_index: i64,
+        same_account_retry_index: i64,
+        status: String,
+        failure_kind: Option<String>,
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct PersistedPayloadRow {
+        error_message: Option<String>,
+        payload: Option<String>,
+    }
+
+    let (shared_upstream_base, shared_upstream_handle) =
+        spawn_pool_delayed_first_chunk_upstream(Duration::from_millis(250)).await;
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.pool_upstream_responses_attempt_timeout = Duration::from_millis(120);
+    let state = test_state_from_config(config, true).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Shared Route A",
+        "route-shared-a",
+        None,
+        None,
+        Some(shared_upstream_base.as_str()),
+    )
+    .await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Shared Route B",
+        "route-shared-b",
+        None,
+        None,
+        Some(shared_upstream_base.as_str()),
+    )
+    .await;
+
+    let chunks = stream::iter(vec![Ok::<Bytes, io::Error>(Bytes::from_static(
+        br#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-timeout-replay-no-alt-001"}"#,
+    ))]);
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([
+            (
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            ),
+            (
+                http_header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+        ]),
+        Body::from_stream(chunks),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read timeout replay no-alternate response body");
+    let response_payload: Value =
+        serde_json::from_slice(&body).expect("decode timeout replay no-alternate response body");
+    assert!(
+        response_payload["error"]
+            .as_str()
+            .expect("timeout replay no-alternate error should be present")
+            .contains("no alternate upstream route is available after timeout")
+    );
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    wait_for_pool_attempt_row_count(&state.pool, 2).await;
+
+    let attempt_rows = sqlx::query_as::<_, AttemptRouteRow>(
+        r#"
+        SELECT
+            upstream_route_key,
+            attempt_index,
+            distinct_account_index,
+            same_account_retry_index,
+            status,
+            failure_kind
+        FROM pool_upstream_request_attempts
+        ORDER BY attempt_index ASC
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load timeout replay no-alternate rows");
+    assert_eq!(attempt_rows.len(), 2);
+    assert_eq!(attempt_rows[0].attempt_index, 1);
+    assert_eq!(attempt_rows[0].same_account_retry_index, 1);
+    assert_eq!(
+        attempt_rows[0].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+    );
+    assert_eq!(attempt_rows[1].attempt_index, 2);
+    assert_eq!(attempt_rows[1].distinct_account_index, 1);
+    assert_eq!(
+        attempt_rows[1].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_BUDGET_EXHAUSTED_FINAL,
+    );
+    assert_eq!(
+        attempt_rows[1].failure_kind.as_deref(),
+        Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
+    );
+    assert_eq!(attempt_rows[1].same_account_retry_index, 0);
+    assert_eq!(
+        attempt_rows[0].upstream_route_key,
+        attempt_rows[1].upstream_route_key,
+    );
+
+    let row = sqlx::query_as::<_, PersistedPayloadRow>(
+        r#"
+        SELECT error_message, payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load timeout replay no-alternate payload");
+    let payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("timeout replay no-alternate payload should be present"),
+    )
+    .expect("decode timeout replay no-alternate payload");
+    assert!(
+        row.error_message.as_deref().is_some_and(
+            |msg| msg.contains("no alternate upstream route is available after timeout")
+        )
+    );
+    assert_eq!(payload["poolAttemptCount"].as_i64(), Some(1));
+    assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(1));
+    assert_eq!(
+        payload["poolAttemptTerminalReason"].as_str(),
+        Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
+    );
+    assert!(payload["upstreamErrorMessage"].is_null());
+
+    shared_upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn capture_target_pool_route_timeout_can_switch_twice_then_succeed() {
     #[derive(Debug, sqlx::FromRow)]
     struct AttemptRouteRow {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13461,6 +13461,10 @@ async fn capture_target_pool_route_timeout_exhausts_after_three_routes() {
             .expect("timeout terminal payload should be present"),
     )
     .expect("decode timeout terminal payload");
+    assert_eq!(
+        payload["failureKind"].as_str(),
+        Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
+    );
     assert_eq!(payload["poolAttemptCount"].as_i64(), Some(3));
     assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(3));
     assert_eq!(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2852,6 +2852,56 @@ async fn test_state_from_config(config: AppConfig, startup_ready: bool) -> Arc<A
     })
 }
 
+async fn test_state_from_existing_pool(
+    pool: SqlitePool,
+    config: AppConfig,
+    startup_ready: bool,
+) -> Arc<AppState> {
+    ensure_schema(&pool)
+        .await
+        .expect("schema should initialize for existing pool");
+
+    let http_clients = HttpClients::build(&config).expect("http clients");
+    let semaphore = Arc::new(Semaphore::new(config.max_parallel_polls));
+    let (broadcaster, _rx) = broadcast::channel(16);
+    let pricing_catalog = load_pricing_catalog(&pool)
+        .await
+        .expect("pricing catalog should initialize");
+
+    Arc::new(AppState {
+        config: config.clone(),
+        pool,
+        http_clients,
+        broadcaster,
+        broadcast_state_cache: Arc::new(Mutex::new(BroadcastStateCache::default())),
+        proxy_summary_quota_broadcast_seq: Arc::new(AtomicU64::new(0)),
+        proxy_summary_quota_broadcast_running: Arc::new(AtomicBool::new(false)),
+        proxy_summary_quota_broadcast_handle: Arc::new(Mutex::new(Vec::new())),
+        startup_ready: Arc::new(AtomicBool::new(startup_ready)),
+        shutdown: CancellationToken::new(),
+        semaphore,
+        proxy_model_settings: Arc::new(RwLock::new(ProxyModelSettings::default())),
+        proxy_model_settings_update_lock: Arc::new(Mutex::new(())),
+        forward_proxy: Arc::new(Mutex::new(ForwardProxyManager::new(
+            ForwardProxySettings::default(),
+            Vec::new(),
+        ))),
+        xray_supervisor: Arc::new(Mutex::new(XraySupervisor::new(
+            config.xray_binary.clone(),
+            config.xray_runtime_dir.clone(),
+        ))),
+        forward_proxy_settings_update_lock: Arc::new(Mutex::new(())),
+        forward_proxy_subscription_refresh_lock: Arc::new(Mutex::new(())),
+        pricing_settings_update_lock: Arc::new(Mutex::new(())),
+        pricing_catalog: Arc::new(RwLock::new(pricing_catalog)),
+        prompt_cache_conversation_cache: Arc::new(Mutex::new(
+            PromptCacheConversationsCacheState::default(),
+        )),
+        hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
+        upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
+    })
+}
+
 async fn seed_pool_routing_api_key(state: &Arc<AppState>, api_key: &str) {
     ensure_upstream_accounts_schema(&state.pool)
         .await
@@ -12969,6 +13019,25 @@ async fn capture_target_pool_route_timeout_switches_to_alternate_upstream_route(
 
     slow_upstream_handle.abort();
     fast_upstream_handle.abort();
+}
+
+#[test]
+fn canonical_pool_upstream_route_key_collapses_trailing_slashes() {
+    let without_trailing_slash =
+        Url::parse("https://route.example/base?foo=bar").expect("valid route url");
+    let with_trailing_slash =
+        Url::parse("https://route.example/base/?baz=qux#frag").expect("valid route url");
+
+    assert_eq!(
+        canonical_pool_upstream_route_key(&without_trailing_slash),
+        canonical_pool_upstream_route_key(&with_trailing_slash),
+    );
+    assert_eq!(
+        canonical_pool_upstream_route_key(
+            &Url::parse("https://route.example/?foo=bar").expect("valid root route url")
+        ),
+        "https://route.example/",
+    );
 }
 
 #[tokio::test]
@@ -23987,6 +24056,257 @@ async fn retention_archives_into_legacy_archive_batch_with_raw_expires_at_column
         "historical archive files should keep their legacy schema"
     );
     archived_pool.close().await;
+
+    cleanup_temp_test_dir(&temp_dir);
+}
+
+#[tokio::test]
+async fn retention_archives_into_legacy_pool_attempt_archive_batch_without_route_key_column() {
+    let (pool, config, temp_dir) =
+        retention_test_pool_and_config("retention-legacy-pool-attempt-archive").await;
+    let occurred_at = shanghai_local_days_ago(91, 9, 0, 0);
+    let month_key = occurred_at[..7].to_string();
+    let final_archive_path =
+        archive_batch_file_path(&config, "pool_upstream_request_attempts", &month_key)
+            .expect("resolve legacy pool attempt archive path");
+    fs::create_dir_all(
+        final_archive_path
+            .parent()
+            .expect("legacy pool attempt archive path should have parent"),
+    )
+    .expect("create legacy pool attempt archive dir");
+
+    let legacy_archive_db_path = temp_dir.join("legacy-pool-attempt-archive.sqlite");
+    fs::File::create(&legacy_archive_db_path).expect("create legacy pool attempt sqlite file");
+    let legacy_archive_pool = SqlitePool::connect(&sqlite_url_for_path(&legacy_archive_db_path))
+        .await
+        .expect("open legacy pool attempt archive sqlite");
+    let legacy_create_sql = POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_CREATE_SQL
+        .replace("archive_db.", "")
+        .replace("    upstream_route_key TEXT,\n", "");
+    sqlx::query(&legacy_create_sql)
+        .execute(&legacy_archive_pool)
+        .await
+        .expect("create legacy pool attempt archive schema baseline");
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(&legacy_archive_pool)
+        .await
+        .expect("checkpoint legacy pool attempt archive sqlite before compression");
+    legacy_archive_pool.close().await;
+    deflate_sqlite_file_to_gzip(&legacy_archive_db_path, &final_archive_path)
+        .expect("compress legacy pool attempt archive batch");
+
+    insert_retention_pool_upstream_request_attempt(
+        &pool,
+        "legacy-pool-attempt-archive-row",
+        &occurred_at,
+        Some(42),
+        1,
+        1,
+        1,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS,
+        Some(200),
+        None,
+        Some(&occurred_at),
+        Some(&occurred_at),
+    )
+    .await;
+
+    let live_row_id: i64 = sqlx::query_scalar(
+        "SELECT id FROM pool_upstream_request_attempts WHERE invoke_id = ?1 AND occurred_at = ?2",
+    )
+    .bind("legacy-pool-attempt-archive-row")
+    .bind(&occurred_at)
+    .fetch_one(&pool)
+    .await
+    .expect("load live pool attempt row id");
+    let archive_outcome = archive_rows_into_month_batch(
+        &pool,
+        &config,
+        archive_table_spec("pool_upstream_request_attempts"),
+        &month_key,
+        &[live_row_id],
+    )
+    .await
+    .expect("append into legacy pool attempt archive batch");
+    assert!(
+        archive_outcome.row_count >= 1,
+        "legacy pool attempt archive batch should accept appended rows (row_count={})",
+        archive_outcome.row_count
+    );
+
+    let inflated_legacy_path = temp_dir.join("legacy-pool-attempt-archive-inflated.sqlite");
+    inflate_gzip_sqlite_file(&final_archive_path, &inflated_legacy_path)
+        .expect("inflate retained legacy pool attempt archive batch");
+    let archived_pool = SqlitePool::connect(&sqlite_url_for_path(&inflated_legacy_path))
+        .await
+        .expect("open retained legacy pool attempt archive batch");
+    let archived_invoke_ids: HashSet<String> =
+        sqlx::query_scalar("SELECT invoke_id FROM pool_upstream_request_attempts")
+            .fetch_all(&archived_pool)
+            .await
+            .expect("load legacy pool attempt archive invoke ids")
+            .into_iter()
+            .collect();
+    assert!(archived_invoke_ids.contains("legacy-pool-attempt-archive-row"));
+    let archive_columns: HashSet<String> =
+        sqlx::query("PRAGMA table_info('pool_upstream_request_attempts')")
+            .fetch_all(&archived_pool)
+            .await
+            .expect("inspect retained legacy pool attempt archive schema")
+            .into_iter()
+            .map(|row| row.get::<String, _>("name"))
+            .collect();
+    assert!(
+        archive_columns.contains("upstream_route_key"),
+        "legacy pool attempt archive batches should be upgraded with upstream_route_key"
+    );
+    archived_pool.close().await;
+
+    cleanup_temp_test_dir(&temp_dir);
+}
+
+#[tokio::test]
+async fn fetch_invocation_pool_attempts_reads_archived_upstream_route_keys() {
+    let temp_dir = make_temp_test_dir("api-pool-attempts-archive-route-key");
+    let mut config = test_config();
+    config.archive_dir = temp_dir.join("archives");
+    fs::create_dir_all(&config.archive_dir).expect("create archive dir");
+    let state = test_state_from_existing_pool(
+        SqlitePool::connect("sqlite:file:pool-attempt-archive-route-key?mode=memory&cache=shared")
+            .await
+            .expect("connect archive route-key sqlite"),
+        config,
+        true,
+    )
+    .await;
+    ensure_upstream_accounts_schema(&state.pool)
+        .await
+        .expect("ensure upstream accounts schema");
+
+    let occurred_at = shanghai_local_days_ago(120, 9, 0, 0);
+    let month_key = occurred_at[..7].to_string();
+    let invoke_id = "archived-pool-attempt-route-key";
+    let route_key = "https://route.example/base";
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_accounts (
+            id, kind, provider, display_name, status, enabled, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'), datetime('now'))
+        "#,
+    )
+    .bind(42_i64)
+    .bind("api_key_codex")
+    .bind("codex")
+    .bind("Archive account")
+    .bind("active")
+    .bind(1_i64)
+    .execute(&state.pool)
+    .await
+    .expect("insert upstream account");
+    insert_retention_invocation(
+        &state.pool,
+        invoke_id,
+        &occurred_at,
+        SOURCE_PROXY,
+        "success",
+        Some(r#"{"routeMode":"pool","endpoint":"/v1/responses"}"#),
+        "{\"ok\":true}",
+        None,
+        None,
+        None,
+        Some(0.1),
+    )
+    .await;
+
+    let archive_db_path = temp_dir.join("pool-attempts-archive-route-key.sqlite");
+    fs::File::create(&archive_db_path).expect("create archive sqlite file");
+    let archive_pool = SqlitePool::connect(&sqlite_url_for_path(&archive_db_path))
+        .await
+        .expect("open archive sqlite");
+    let create_sql = POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_CREATE_SQL.replace("archive_db.", "");
+    sqlx::query(&create_sql)
+        .execute(&archive_pool)
+        .await
+        .expect("create archive pool attempt schema");
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_request_attempts (
+            id,
+            invoke_id,
+            occurred_at,
+            endpoint,
+            route_mode,
+            sticky_key,
+            upstream_account_id,
+            upstream_route_key,
+            attempt_index,
+            distinct_account_index,
+            same_account_retry_index,
+            requester_ip,
+            started_at,
+            finished_at,
+            status,
+            http_status,
+            failure_kind,
+            error_message,
+            connect_latency_ms,
+            first_byte_latency_ms,
+            stream_latency_ms,
+            upstream_request_id,
+            created_at
+        )
+        VALUES (
+            1, ?1, ?2, '/v1/responses', ?3, 'sticky-key', ?4, ?5, 1, 1, 1, '203.0.113.5', ?2,
+            ?2, ?6, 200, NULL, NULL, 12.5, 34.5, 56.5, 'req_archived', datetime('now')
+        )
+        "#,
+    )
+    .bind(invoke_id)
+    .bind(&occurred_at)
+    .bind(INVOCATION_ROUTE_MODE_POOL)
+    .bind(42_i64)
+    .bind(route_key)
+    .bind(POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS)
+    .execute(&archive_pool)
+    .await
+    .expect("insert archive pool attempt row");
+    archive_pool.close().await;
+
+    let archive_path = temp_dir
+        .join("archives")
+        .join("pool-attempts-archive-route-key.sqlite.gz");
+    deflate_sqlite_file_to_gzip(&archive_db_path, &archive_path)
+        .expect("compress archive pool attempt batch");
+    sqlx::query(
+        r#"
+        INSERT INTO archive_batches (dataset, month_key, file_path, sha256, row_count, status, created_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))
+        "#,
+    )
+    .bind("pool_upstream_request_attempts")
+    .bind(&month_key)
+    .bind(archive_path.to_string_lossy().to_string())
+    .bind(sha256_hex_file(&archive_path).expect("archive sha256"))
+    .bind(1_i64)
+    .bind(ARCHIVE_STATUS_COMPLETED)
+    .execute(&state.pool)
+    .await
+    .expect("insert archive batch manifest");
+
+    let Json(records) = fetch_invocation_pool_attempts(
+        State(state.clone()),
+        axum::extract::Path(invoke_id.to_string()),
+    )
+    .await
+    .expect("fetch archived pool attempt records");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].upstream_route_key.as_deref(), Some(route_key));
+    assert_eq!(
+        records[0].upstream_account_name.as_deref(),
+        Some("Archive account")
+    );
 
     cleanup_temp_test_dir(&temp_dir);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13187,6 +13187,7 @@ async fn capture_target_pool_route_timeout_returns_no_alternate_when_only_same_r
 
     #[derive(Debug, sqlx::FromRow)]
     struct PersistedPayloadRow {
+        error_message: Option<String>,
         payload: Option<String>,
     }
 
@@ -13233,9 +13234,17 @@ async fn capture_target_pool_route_timeout_returns_no_alternate_when_only_same_r
     )
     .await;
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
-    let _ = to_bytes(response.into_body(), usize::MAX)
+    let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read timeout no-alternate response body");
+    let response_payload: Value =
+        serde_json::from_slice(&body).expect("decode timeout no-alternate response body");
+    assert!(
+        response_payload["error"]
+            .as_str()
+            .expect("timeout no-alternate error should be present")
+            .contains("no alternate upstream route is available after timeout")
+    );
 
     wait_for_codex_invocations(&state.pool, 1).await;
     wait_for_pool_attempt_row_count(&state.pool, 2).await;
@@ -13281,7 +13290,7 @@ async fn capture_target_pool_route_timeout_returns_no_alternate_when_only_same_r
 
     let row = sqlx::query_as::<_, PersistedPayloadRow>(
         r#"
-        SELECT payload
+        SELECT error_message, payload
         FROM codex_invocations
         ORDER BY id DESC
         LIMIT 1
@@ -13296,12 +13305,18 @@ async fn capture_target_pool_route_timeout_returns_no_alternate_when_only_same_r
             .expect("timeout no-alternate payload should be present"),
     )
     .expect("decode timeout no-alternate payload");
+    assert!(
+        row.error_message.as_deref().is_some_and(
+            |msg| msg.contains("no alternate upstream route is available after timeout")
+        )
+    );
     assert_eq!(payload["poolAttemptCount"].as_i64(), Some(1));
     assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(1));
     assert_eq!(
         payload["poolAttemptTerminalReason"].as_str(),
         Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
     );
+    assert!(payload["upstreamErrorMessage"].is_null());
 
     shared_upstream_handle.abort();
 }
@@ -13466,6 +13481,7 @@ async fn capture_target_pool_route_timeout_exhausts_after_three_routes() {
 
     #[derive(Debug, sqlx::FromRow)]
     struct PersistedPayloadRow {
+        error_message: Option<String>,
         payload: Option<String>,
     }
 
@@ -13536,9 +13552,17 @@ async fn capture_target_pool_route_timeout_exhausts_after_three_routes() {
     )
     .await;
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
-    let _ = to_bytes(response.into_body(), usize::MAX)
+    let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read timeout terminal response body");
+    let response_payload: Value =
+        serde_json::from_slice(&body).expect("decode timeout terminal response body");
+    assert!(
+        response_payload["error"]
+            .as_str()
+            .expect("timeout terminal error should be present")
+            .contains("no alternate upstream route is available after timeout")
+    );
 
     wait_for_codex_invocations(&state.pool, 1).await;
     wait_for_pool_attempt_row_count(&state.pool, 4).await;
@@ -13579,7 +13603,7 @@ async fn capture_target_pool_route_timeout_exhausts_after_three_routes() {
 
     let row = sqlx::query_as::<_, PersistedPayloadRow>(
         r#"
-        SELECT payload
+        SELECT error_message, payload
         FROM codex_invocations
         ORDER BY id DESC
         LIMIT 1
@@ -13594,6 +13618,11 @@ async fn capture_target_pool_route_timeout_exhausts_after_three_routes() {
             .expect("timeout terminal payload should be present"),
     )
     .expect("decode timeout terminal payload");
+    assert!(
+        row.error_message.as_deref().is_some_and(
+            |msg| msg.contains("no alternate upstream route is available after timeout")
+        )
+    );
     assert_eq!(
         payload["failureKind"].as_str(),
         Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
@@ -13604,6 +13633,7 @@ async fn capture_target_pool_route_timeout_exhausts_after_three_routes() {
         payload["poolAttemptTerminalReason"].as_str(),
         Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
     );
+    assert!(payload["upstreamErrorMessage"].is_null());
 
     slow_one_handle.abort();
     slow_two_handle.abort();

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -9297,8 +9297,11 @@ pub(crate) fn canonical_pool_upstream_route_key(url: &Url) -> String {
     let mut normalized = url.clone();
     normalized.set_query(None);
     normalized.set_fragment(None);
-    if normalized.path().is_empty() {
+    let normalized_path = normalized.path().trim_end_matches('/').to_string();
+    if normalized_path.is_empty() {
         normalized.set_path("/");
+    } else {
+        normalized.set_path(&normalized_path);
     }
     normalized.to_string()
 }

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -9293,6 +9293,16 @@ fn resolve_pool_account_upstream_base_url(
         .map_or_else(|| Ok(global_upstream_base_url.clone()), Ok)
 }
 
+pub(crate) fn canonical_pool_upstream_route_key(url: &Url) -> String {
+    let mut normalized = url.clone();
+    normalized.set_query(None);
+    normalized.set_fragment(None);
+    if normalized.path().is_empty() {
+        normalized.set_path("/");
+    }
+    normalized.to_string()
+}
+
 fn normalize_required_secret(raw: &str, field_name: &str) -> Result<String, (StatusCode, String)> {
     let value = raw.trim();
     if value.is_empty() {
@@ -9825,6 +9835,12 @@ pub(crate) struct PoolResolvedAccount {
     pub(crate) upstream_base_url: Url,
 }
 
+impl PoolResolvedAccount {
+    pub(crate) fn upstream_route_key(&self) -> String {
+        canonical_pool_upstream_route_key(&self.upstream_base_url)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum PoolAccountResolution {
     Resolved(PoolResolvedAccount),
@@ -9877,11 +9893,13 @@ pub(crate) async fn resolve_pool_account_for_request(
     state: &AppState,
     sticky_key: Option<&str>,
     excluded_ids: &[i64],
+    excluded_upstream_route_keys: &HashSet<String>,
 ) -> Result<PoolAccountResolution> {
     let mut tried = excluded_ids.iter().copied().collect::<HashSet<_>>();
     let mut saw_rate_limited_candidate = false;
     let mut saw_non_rate_limited_routing_candidate = false;
     let mut saw_non_routing_candidate = false;
+    let mut sticky_route_excluded_by_route_key = false;
 
     let sticky_route = if let Some(sticky_key) = sticky_key {
         load_sticky_route(&state.pool, sticky_key).await?
@@ -9902,7 +9920,10 @@ pub(crate) async fn resolve_pool_account_for_request(
             tried.insert(route.account_id);
             if is_account_selectable_for_routing(&row) {
                 if let Some(account) = prepare_pool_account(state, &row).await? {
-                    return Ok(PoolAccountResolution::Resolved(account));
+                    if !excluded_upstream_route_keys.contains(&account.upstream_route_key()) {
+                        return Ok(PoolAccountResolution::Resolved(account));
+                    }
+                    sticky_route_excluded_by_route_key = true;
                 }
                 saw_non_rate_limited_routing_candidate = true;
             } else if is_account_rate_limited_for_routing(&row) {
@@ -9918,6 +9939,7 @@ pub(crate) async fn resolve_pool_account_for_request(
         if sticky_source_rule
             .as_ref()
             .is_some_and(|rule| !rule.allow_cut_out)
+            && !sticky_route_excluded_by_route_key
         {
             return Ok(PoolAccountResolution::BlockedByPolicy(
                 "sticky conversation cannot cut out of the current account because a tag rule forbids it"
@@ -9956,6 +9978,9 @@ pub(crate) async fn resolve_pool_account_for_request(
             continue;
         }
         if let Some(account) = prepare_pool_account(state, &row).await? {
+            if excluded_upstream_route_keys.contains(&account.upstream_route_key()) {
+                continue;
+            }
             return Ok(PoolAccountResolution::Resolved(account));
         }
         saw_non_rate_limited_routing_candidate = true;
@@ -11238,6 +11263,9 @@ mod tests {
             database_path: PathBuf::from(":memory:"),
             poll_interval: Duration::from_secs(10),
             request_timeout: Duration::from_secs(5),
+            pool_upstream_responses_attempt_timeout: Duration::from_secs(
+                DEFAULT_POOL_UPSTREAM_RESPONSES_ATTEMPT_TIMEOUT_SECS,
+            ),
             openai_proxy_handshake_timeout: Duration::from_secs(
                 DEFAULT_OPENAI_PROXY_HANDSHAKE_TIMEOUT_SECS,
             ),

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -9297,6 +9297,14 @@ pub(crate) fn canonical_pool_upstream_route_key(url: &Url) -> String {
     let mut normalized = url.clone();
     normalized.set_query(None);
     normalized.set_fragment(None);
+    let scheme_default_port = match normalized.scheme() {
+        "http" => Some(80),
+        "https" => Some(443),
+        _ => None,
+    };
+    if normalized.port().is_some() && normalized.port() == scheme_default_port {
+        let _ = normalized.set_port(None);
+    }
     let normalized_path = normalized.path().trim_end_matches('/').to_string();
     if normalized_path.is_empty() {
         normalized.set_path("/");

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -9922,13 +9922,17 @@ pub(crate) async fn resolve_pool_account_for_request(
         {
             tried.insert(route.account_id);
             if is_account_selectable_for_routing(&row) {
+                let mut sticky_route_was_excluded = false;
                 if let Some(account) = prepare_pool_account(state, &row).await? {
                     if !excluded_upstream_route_keys.contains(&account.upstream_route_key()) {
                         return Ok(PoolAccountResolution::Resolved(account));
                     }
                     sticky_route_excluded_by_route_key = true;
+                    sticky_route_was_excluded = true;
                 }
-                saw_non_rate_limited_routing_candidate = true;
+                if !sticky_route_was_excluded {
+                    saw_non_rate_limited_routing_candidate = true;
+                }
             } else if is_account_rate_limited_for_routing(&row) {
                 saw_rate_limited_candidate = true;
             } else if is_routing_eligible_account(&row) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -354,6 +354,7 @@ export interface ApiPoolUpstreamRequestAttempt {
   stickyKey?: string | null;
   upstreamAccountId?: number | null;
   upstreamAccountName?: string | null;
+  upstreamRouteKey?: string | null;
   attemptIndex: number;
   distinctAccountIndex: number;
   sameAccountRetryIndex: number;


### PR DESCRIPTION
## Summary
- tighten `POST /v1/responses` timeout failover so timeout-shaped failures stop retrying the same upstream route and instead switch by canonical upstream route key
- raise the single-attempt `/v1/responses` first-byte budget to `120s` without widening the global request timeout
- migrate legacy pool-attempt archive batches forward when `upstream_route_key` is missing, and expose archived route keys through the pool-attempts API
- normalize trailing-slash variants of the same upstream base URL so timeout failover really moves to a different route
- add regression coverage for timeout route switching, no-alternate failures, legacy archive compatibility, archived route-key reads, and config/time-budget scoping

## Validation
- `cargo fmt`
- `cargo check`
- `cargo test app_config_from_sources_ -- --nocapture`
- `cargo test pool_upstream_first_chunk_timeout -- --nocapture`
- `cargo test resolve_pool_account_for_request -- --nocapture`
- `cargo test canonical_pool_upstream_route_key_collapses_trailing_slashes -- --nocapture`
- `cargo test retention_archives_into_legacy_pool_attempt_archive_batch_without_route_key_column -- --nocapture`
- `cargo test fetch_invocation_pool_attempts_reads_archived_upstream_route_keys -- --nocapture`
- `cargo test capture_target_pool_route_ -- --nocapture`

## Rollout Notes
- after a timeout-shaped `/v1/responses` failure, `sameAccountRetryIndex` should stay at `1` for that `upstreamRouteKey`
- timeout-driven route switching is capped at the initial route plus two alternates
- if no alternate upstream route is available after a timeout, the request now terminates immediately with `no_alternate_upstream_after_timeout`
- legacy `pool_upstream_request_attempts` archive batches are upgraded in place when they are appended to, so retention will not break after deployment
- production samples already showed timeout-then-next-success cases, but none where the follow-up success arrived within 10 seconds, so removing same-route timeout retries should not hide a fast recovery path