### PR TITLE
fix: repair pool routing schema upgrade order

### DIFF
--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -2509,28 +2509,6 @@ pub(crate) async fn ensure_upstream_accounts_schema(pool: &Pool<Sqlite>) -> Resu
     )
     .await
     .context("failed to ensure pool_routing_settings.priority_available_account_cap")?;
-
-    sqlx::query(
-        r#"
-        INSERT OR IGNORE INTO pool_routing_settings (
-            id,
-            encrypted_api_key,
-            masked_api_key,
-            responses_first_byte_timeout_secs,
-            compact_first_byte_timeout_secs,
-            responses_stream_timeout_secs,
-            compact_stream_timeout_secs,
-            default_first_byte_timeout_secs,
-            upstream_handshake_timeout_secs,
-            request_read_timeout_secs
-        ) VALUES (?1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-        "#,
-    )
-    .bind(POOL_SETTINGS_SINGLETON_ID)
-    .execute(pool)
-    .await
-    .context("failed to ensure default pool_routing_settings row")?;
-
     ensure_nullable_integer_column(
         pool,
         "pool_routing_settings",
@@ -2572,6 +2550,27 @@ pub(crate) async fn ensure_upstream_accounts_schema(pool: &Pool<Sqlite>) -> Resu
     ensure_nullable_integer_column(pool, "pool_routing_settings", "request_read_timeout_secs")
         .await
         .context("failed to ensure pool_routing_settings.request_read_timeout_secs")?;
+
+    sqlx::query(
+        r#"
+        INSERT OR IGNORE INTO pool_routing_settings (
+            id,
+            encrypted_api_key,
+            masked_api_key,
+            responses_first_byte_timeout_secs,
+            compact_first_byte_timeout_secs,
+            responses_stream_timeout_secs,
+            compact_stream_timeout_secs,
+            default_first_byte_timeout_secs,
+            upstream_handshake_timeout_secs,
+            request_read_timeout_secs
+        ) VALUES (?1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+        "#,
+    )
+    .bind(POOL_SETTINGS_SINGLETON_ID)
+    .execute(pool)
+    .await
+    .context("failed to ensure default pool_routing_settings row")?;
 
     Ok(())
 }
@@ -14867,6 +14866,148 @@ mod tests {
             .expect("second maintenance command should be accepted");
         assert!(matches!(second, AccountSubmitOutcome::Completed(())));
         assert_eq!(state.upstream_accounts.account_ops.actor_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn ensure_upstream_accounts_schema_seeds_pool_routing_settings_for_new_database() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connect sqlite");
+        ensure_upstream_accounts_schema(&pool)
+            .await
+            .expect("ensure schema");
+
+        let config = usage_snapshot_test_config("http://127.0.0.1:9", "codex-vibe-monitor/test");
+        let row = load_pool_routing_settings_seeded(&pool, &config)
+            .await
+            .expect("load seeded routing settings");
+
+        assert_eq!(row.masked_api_key, None);
+        assert_eq!(row.primary_sync_interval_secs, None);
+        assert_eq!(row.secondary_sync_interval_secs, None);
+        assert_eq!(row.priority_available_account_cap, None);
+        assert_eq!(row.responses_first_byte_timeout_secs, None);
+        assert_eq!(row.compact_first_byte_timeout_secs, None);
+        assert_eq!(row.responses_stream_timeout_secs, None);
+        assert_eq!(row.compact_stream_timeout_secs, None);
+        assert_eq!(row.default_first_byte_timeout_secs, None);
+        assert_eq!(row.upstream_handshake_timeout_secs, None);
+        assert_eq!(row.request_read_timeout_secs, None);
+    }
+
+    #[tokio::test]
+    async fn ensure_upstream_accounts_schema_upgrades_legacy_pool_routing_settings_before_seed() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("connect sqlite");
+        sqlx::query(
+            r#"
+            CREATE TABLE pool_routing_settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                encrypted_api_key TEXT,
+                masked_api_key TEXT,
+                primary_sync_interval_secs INTEGER,
+                secondary_sync_interval_secs INTEGER,
+                priority_available_account_cap INTEGER,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("create legacy pool_routing_settings");
+        sqlx::query(
+            r#"
+            INSERT INTO pool_routing_settings (
+                id,
+                encrypted_api_key,
+                masked_api_key,
+                primary_sync_interval_secs,
+                secondary_sync_interval_secs,
+                priority_available_account_cap,
+                updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))
+            "#,
+        )
+        .bind(POOL_SETTINGS_SINGLETON_ID)
+        .bind("legacy-ciphertext")
+        .bind("sk-legacy")
+        .bind(300_i64)
+        .bind(2400_i64)
+        .bind(99_i64)
+        .execute(&pool)
+        .await
+        .expect("insert legacy pool routing row");
+
+        ensure_upstream_accounts_schema(&pool)
+            .await
+            .expect("upgrade schema");
+
+        let columns = sqlx::query("PRAGMA table_info('pool_routing_settings')")
+            .fetch_all(&pool)
+            .await
+            .expect("load table info")
+            .into_iter()
+            .filter_map(|row| row.try_get::<String, _>("name").ok())
+            .collect::<std::collections::HashSet<_>>();
+        for column in [
+            "responses_first_byte_timeout_secs",
+            "compact_first_byte_timeout_secs",
+            "responses_stream_timeout_secs",
+            "compact_stream_timeout_secs",
+            "default_first_byte_timeout_secs",
+            "upstream_handshake_timeout_secs",
+            "request_read_timeout_secs",
+        ] {
+            assert!(
+                columns.contains(column),
+                "expected upgraded schema to contain {column}"
+            );
+        }
+
+        let config = usage_snapshot_test_config("http://127.0.0.1:9", "codex-vibe-monitor/test");
+        let row = load_pool_routing_settings_seeded(&pool, &config)
+            .await
+            .expect("load upgraded routing settings");
+        assert_eq!(row.encrypted_api_key.as_deref(), Some("legacy-ciphertext"));
+        assert_eq!(row.masked_api_key.as_deref(), Some("sk-legacy"));
+        assert_eq!(row.primary_sync_interval_secs, Some(300));
+        assert_eq!(row.secondary_sync_interval_secs, Some(2400));
+        assert_eq!(row.priority_available_account_cap, Some(99));
+        assert_eq!(row.responses_first_byte_timeout_secs, None);
+        assert_eq!(row.compact_first_byte_timeout_secs, None);
+        assert_eq!(row.responses_stream_timeout_secs, None);
+        assert_eq!(row.compact_stream_timeout_secs, None);
+        assert_eq!(row.default_first_byte_timeout_secs, None);
+        assert_eq!(row.upstream_handshake_timeout_secs, None);
+        assert_eq!(row.request_read_timeout_secs, None);
+
+        let resolved = resolve_pool_routing_timeouts(&pool, &config)
+            .await
+            .expect("resolve routing timeouts");
+        let defaults = pool_routing_timeouts_from_config(&config);
+        assert_eq!(
+            resolved.responses_first_byte_timeout,
+            defaults.responses_first_byte_timeout
+        );
+        assert_eq!(
+            resolved.compact_first_byte_timeout,
+            defaults.compact_first_byte_timeout
+        );
+        assert_eq!(
+            resolved.responses_stream_timeout,
+            defaults.responses_stream_timeout
+        );
+        assert_eq!(
+            resolved.compact_stream_timeout,
+            defaults.compact_stream_timeout
+        );
+        assert_eq!(
+            resolved.default_first_byte_timeout,
+            defaults.default_first_byte_timeout
+        );
+        assert_eq!(resolved.default_send_timeout, defaults.default_send_timeout);
+        assert_eq!(resolved.request_read_timeout, defaults.request_read_timeout);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
- repair `ensure_upstream_accounts_schema` so `pool_routing_settings` adds all timeout columns before the singleton seed row is inserted
- preserve existing legacy `pool_routing_settings` values during upgrade while still allowing fresh databases to seed the singleton row
- add regression tests for both the new-database seed path and the legacy-schema upgrade path

## Why
- upgrading from older production databases could crash startup before health checks because the seed insert referenced timeout columns that did not exist yet

## Validation
- `cargo test pool_routing_settings`
- `cargo test ensure_upstream_accounts_schema`
- `cargo test upstream_accounts`

Spec: -
Spec Status: n/a
Spec Sync: n/a(no associated spec)
Spec Drift: none