### PR TITLE
fix: make pool routing reset-aware

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -904,6 +904,7 @@ async fn main() -> Result<()> {
             PromptCacheConversationsCacheState::default(),
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         upstream_accounts,
     });
 
@@ -11957,6 +11958,7 @@ fn parse_retry_after_delay(value: &HeaderValue) -> Option<Duration> {
 
 async fn send_pool_request_with_failover(
     state: Arc<AppState>,
+    proxy_request_id: u64,
     method: Method,
     original_uri: &Uri,
     headers: &HeaderMap,
@@ -11970,6 +11972,9 @@ async fn send_pool_request_with_failover(
     same_account_attempts: u8,
 ) -> Result<PoolUpstreamResponse, PoolUpstreamError> {
     let request_connection_scoped = connection_scoped_header_names(headers);
+    let reservation_key = build_pool_routing_reservation_key(proxy_request_id);
+    let mut reservation_guard =
+        PoolRoutingReservationDropGuard::new(state.clone(), reservation_key.clone());
     let runtime_timeouts = resolve_pool_routing_timeouts(&state.pool, &state.config)
         .await
         .map_err(|err| PoolUpstreamError {
@@ -12367,6 +12372,7 @@ async fn send_pool_request_with_failover(
                 }
             }
         };
+        reserve_pool_routing_account(state.as_ref(), &reservation_key, &account);
         timeout_route_failover_pending = false;
 
         excluded_ids.push(account.account_id);
@@ -13248,6 +13254,7 @@ async fn send_pool_request_with_failover(
                 );
             }
 
+            reservation_guard.disarm();
             return Ok(PoolUpstreamResponse {
                 account: account.clone(),
                 response,
@@ -13312,6 +13319,7 @@ async fn extract_sticky_key_from_replay_snapshot(
 
 async fn continue_or_retry_pool_live_request(
     state: Arc<AppState>,
+    proxy_request_id: u64,
     method: Method,
     original_uri: &Uri,
     headers: &HeaderMap,
@@ -13323,6 +13331,7 @@ async fn continue_or_retry_pool_live_request(
     replay_cancel: &CancellationToken,
     first_error: PoolUpstreamError,
 ) -> Result<PoolUpstreamResponse, PoolUpstreamError> {
+    let reservation_key = build_pool_routing_reservation_key(proxy_request_id);
     let replay_status = { replay_status_rx.borrow().clone() };
     match replay_status {
         PoolReplayBodyStatus::Complete(snapshot) => {
@@ -13374,6 +13383,7 @@ async fn continue_or_retry_pool_live_request(
                 };
             send_pool_request_with_failover(
                 state,
+                proxy_request_id,
                 method,
                 original_uri,
                 headers,
@@ -13388,32 +13398,39 @@ async fn continue_or_retry_pool_live_request(
             )
             .await
         }
-        PoolReplayBodyStatus::ReadError(err) => Err(PoolUpstreamError {
-            account: Some(initial_account),
-            status: err.status,
-            message: err.message,
-            failure_kind: err.failure_kind,
-            connect_latency_ms: first_error.connect_latency_ms,
-            upstream_error_code: None,
-            upstream_error_message: None,
-            upstream_request_id: None,
-            oauth_responses_debug: None,
-            attempt_summary: first_error.attempt_summary.clone(),
-        }),
-        PoolReplayBodyStatus::InternalError(message) => Err(PoolUpstreamError {
-            account: Some(initial_account),
-            status: StatusCode::INTERNAL_SERVER_ERROR,
-            message,
-            failure_kind: PROXY_FAILURE_FAILED_CONTACT_UPSTREAM,
-            connect_latency_ms: first_error.connect_latency_ms,
-            upstream_error_code: None,
-            upstream_error_message: None,
-            upstream_request_id: None,
-            oauth_responses_debug: None,
-            attempt_summary: first_error.attempt_summary.clone(),
-        }),
+        PoolReplayBodyStatus::ReadError(err) => {
+            release_pool_routing_reservation(state.as_ref(), &reservation_key);
+            Err(PoolUpstreamError {
+                account: Some(initial_account),
+                status: err.status,
+                message: err.message,
+                failure_kind: err.failure_kind,
+                connect_latency_ms: first_error.connect_latency_ms,
+                upstream_error_code: None,
+                upstream_error_message: None,
+                upstream_request_id: None,
+                oauth_responses_debug: None,
+                attempt_summary: first_error.attempt_summary.clone(),
+            })
+        }
+        PoolReplayBodyStatus::InternalError(message) => {
+            release_pool_routing_reservation(state.as_ref(), &reservation_key);
+            Err(PoolUpstreamError {
+                account: Some(initial_account),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                message,
+                failure_kind: PROXY_FAILURE_FAILED_CONTACT_UPSTREAM,
+                connect_latency_ms: first_error.connect_latency_ms,
+                upstream_error_code: None,
+                upstream_error_message: None,
+                upstream_request_id: None,
+                oauth_responses_debug: None,
+                attempt_summary: first_error.attempt_summary.clone(),
+            })
+        }
         PoolReplayBodyStatus::Reading | PoolReplayBodyStatus::Incomplete => {
             replay_cancel.cancel();
+            release_pool_routing_reservation(state.as_ref(), &reservation_key);
             Err(first_error)
         }
     }
@@ -13460,6 +13477,7 @@ async fn proxy_openai_v1_via_pool(
     runtime_timeouts: PoolRoutingTimeoutSettingsResolved,
 ) -> Result<Response, (StatusCode, String)> {
     let body_limit = state.config.openai_proxy_max_request_body_bytes;
+    let pool_routing_reservation_key = build_pool_routing_reservation_key(proxy_request_id);
     let capture_target = capture_target_for_request(original_uri.path(), &method);
     let handshake_timeout =
         proxy_upstream_send_timeout_for_capture_target(&runtime_timeouts, capture_target);
@@ -13502,6 +13520,7 @@ async fn proxy_openai_v1_via_pool(
             (
                 send_pool_request_with_failover(
                     state.clone(),
+                    proxy_request_id,
                     method,
                     original_uri,
                     &headers,
@@ -13587,6 +13606,7 @@ async fn proxy_openai_v1_via_pool(
                     (
                         send_pool_request_with_failover(
                             state.clone(),
+                            proxy_request_id,
                             method,
                             original_uri,
                             &headers,
@@ -13619,6 +13639,11 @@ async fn proxy_openai_v1_via_pool(
                         body_limit,
                         runtime_timeouts.request_read_timeout,
                         proxy_request_id,
+                    );
+                    reserve_pool_routing_account(
+                        state.as_ref(),
+                        &pool_routing_reservation_key,
+                        &initial_account,
                     );
                     if let Err(route_err) =
                         record_account_selected(&state.pool, initial_account.account_id).await
@@ -13752,6 +13777,7 @@ async fn proxy_openai_v1_via_pool(
                         };
                         continue_or_retry_pool_live_request(
                             state.clone(),
+                            proxy_request_id,
                             method,
                             original_uri,
                             &headers,
@@ -13818,6 +13844,7 @@ async fn proxy_openai_v1_via_pool(
                                 };
                                 continue_or_retry_pool_live_request(
                                     state.clone(),
+                                    proxy_request_id,
                                     method,
                                     original_uri,
                                     &headers,
@@ -13852,6 +13879,11 @@ async fn proxy_openai_v1_via_pool(
                     body_limit,
                     runtime_timeouts.request_read_timeout,
                     proxy_request_id,
+                );
+                reserve_pool_routing_account(
+                    state.as_ref(),
+                    &pool_routing_reservation_key,
+                    &initial_account,
                 );
                 if let Err(route_err) =
                     record_account_selected(&state.pool, initial_account.account_id).await
@@ -13978,6 +14010,7 @@ async fn proxy_openai_v1_via_pool(
                             };
                             continue_or_retry_pool_live_request(
                                 state.clone(),
+                                proxy_request_id,
                                 method,
                                 original_uri,
                                 &headers,
@@ -14028,6 +14061,7 @@ async fn proxy_openai_v1_via_pool(
                                     };
                                     continue_or_retry_pool_live_request(
                                         state.clone(),
+                                        proxy_request_id,
                                         method,
                                         original_uri,
                                         &headers,
@@ -14060,6 +14094,7 @@ async fn proxy_openai_v1_via_pool(
                         };
                         continue_or_retry_pool_live_request(
                             state.clone(),
+                            proxy_request_id,
                             method,
                             original_uri,
                             &headers,
@@ -14092,6 +14127,7 @@ async fn proxy_openai_v1_via_pool(
                         };
                         continue_or_retry_pool_live_request(
                             state.clone(),
+                            proxy_request_id,
                             method,
                             original_uri,
                             &headers,
@@ -14114,6 +14150,7 @@ async fn proxy_openai_v1_via_pool(
         (
             send_pool_request_with_failover(
                 state.clone(),
+                proxy_request_id,
                 method,
                 original_uri,
                 &headers,
@@ -14182,6 +14219,7 @@ async fn proxy_openai_v1_via_pool(
             "pool upstream response first chunk ready"
         );
     } else {
+        consume_pool_routing_reservation(state.as_ref(), &pool_routing_reservation_key);
         if let Err(route_err) = record_pool_route_success(
             &state.pool,
             account.account_id,
@@ -14203,6 +14241,7 @@ async fn proxy_openai_v1_via_pool(
 
     let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(16);
     let state_for_record = state.clone();
+    let reservation_key_for_record = pool_routing_reservation_key.clone();
     let sticky_key_for_record = sticky_key.clone();
     let invoke_id_for_record = upstream_invoke_id.clone();
     let upstream_attempt_started_at_utc_for_record = upstream_attempt_started_at_utc;
@@ -14246,6 +14285,10 @@ async fn proxy_openai_v1_via_pool(
         }
 
         if let Some(message) = stream_error_message.as_deref() {
+            release_pool_routing_reservation(
+                state_for_record.as_ref(),
+                &reservation_key_for_record,
+            );
             if let Err(route_err) = record_pool_route_transport_failure(
                 &state_for_record.pool,
                 account.account_id,
@@ -14257,16 +14300,22 @@ async fn proxy_openai_v1_via_pool(
             {
                 warn!(account_id = account.account_id, error = %route_err, "failed to record pool stream error");
             }
-        } else if let Err(route_err) = record_pool_route_success(
-            &state_for_record.pool,
-            account.account_id,
-            upstream_attempt_started_at_utc_for_record,
-            sticky_key_for_record.as_deref(),
-            invoke_id_for_record.as_deref(),
-        )
-        .await
-        {
-            warn!(account_id = account.account_id, error = %route_err, "failed to record pool route success");
+        } else {
+            consume_pool_routing_reservation(
+                state_for_record.as_ref(),
+                &reservation_key_for_record,
+            );
+            if let Err(route_err) = record_pool_route_success(
+                &state_for_record.pool,
+                account.account_id,
+                upstream_attempt_started_at_utc_for_record,
+                sticky_key_for_record.as_deref(),
+                invoke_id_for_record.as_deref(),
+            )
+            .await
+            {
+                warn!(account_id = account.account_id, error = %route_err, "failed to record pool route success");
+            }
         }
 
         info!(
@@ -14990,6 +15039,7 @@ async fn proxy_openai_v1_capture_target(
     runtime_timeouts: PoolRoutingTimeoutSettingsResolved,
 ) -> Result<Response, (StatusCode, String)> {
     let capture_started = Instant::now();
+    let pool_routing_reservation_key = build_pool_routing_reservation_key(proxy_request_id);
     let occurred_at_utc = Utc::now();
     let occurred_at = format_naive(occurred_at_utc.with_timezone(&Shanghai).naive_local());
     let body_limit = state.config.openai_proxy_max_request_body_bytes;
@@ -15209,6 +15259,7 @@ async fn proxy_openai_v1_capture_target(
     ) = if pool_route_active {
         match send_pool_request_with_failover(
             state.clone(),
+            proxy_request_id,
             Method::POST,
             &original_uri,
             &upstream_headers,
@@ -15696,6 +15747,7 @@ async fn proxy_openai_v1_capture_target(
     let upstream_content_encoding_for_task = upstream_content_encoding.clone();
     let requester_ip_for_task = requester_ip.clone();
     let sticky_key_for_task = sticky_key.clone();
+    let reservation_key_for_task = pool_routing_reservation_key.clone();
     let prompt_cache_key_for_task = prompt_cache_key.clone();
     let selected_proxy_for_task = selected_proxy.clone();
     let selected_proxy_display_name_for_task = selected_proxy_display_name.clone();
@@ -16063,6 +16115,10 @@ async fn proxy_openai_v1_capture_target(
                     had_logical_stream_failure,
                 );
                 let route_result = if pool_route_success {
+                    consume_pool_routing_reservation(
+                        state_for_task.as_ref(),
+                        &reservation_key_for_task,
+                    );
                     record_pool_route_success(
                         &state_for_task.pool,
                         account.account_id,
@@ -16076,6 +16132,10 @@ async fn proxy_openai_v1_capture_target(
                         .as_deref()
                         .unwrap_or("upstream stream error")
                         .to_string();
+                    release_pool_routing_reservation(
+                        state_for_task.as_ref(),
+                        &reservation_key_for_task,
+                    );
                     record_pool_route_transport_failure(
                         &state_for_task.pool,
                         account.account_id,
@@ -16089,6 +16149,10 @@ async fn proxy_openai_v1_capture_target(
                         .as_deref()
                         .unwrap_or("upstream request failed")
                         .to_string();
+                    release_pool_routing_reservation(
+                        state_for_task.as_ref(),
+                        &reservation_key_for_task,
+                    );
                     record_pool_route_http_failure(
                         &state_for_task.pool,
                         account.account_id,
@@ -21567,6 +21631,103 @@ fn next_proxy_request_id() -> u64 {
     NEXT_PROXY_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+const POOL_ROUTING_RESERVATION_TTL: Duration = Duration::from_secs(90);
+
+#[derive(Debug, Clone, Copy)]
+struct PoolRoutingReservation {
+    account_id: i64,
+    created_at: Instant,
+}
+
+#[derive(Debug)]
+struct PoolRoutingReservationDropGuard {
+    state: Arc<AppState>,
+    reservation_key: String,
+    active: bool,
+}
+
+impl PoolRoutingReservationDropGuard {
+    fn new(state: Arc<AppState>, reservation_key: String) -> Self {
+        Self {
+            state,
+            reservation_key,
+            active: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for PoolRoutingReservationDropGuard {
+    fn drop(&mut self) {
+        if self.active {
+            release_pool_routing_reservation(self.state.as_ref(), &self.reservation_key);
+        }
+    }
+}
+
+fn build_pool_routing_reservation_key(proxy_request_id: u64) -> String {
+    format!("pool-route-{proxy_request_id}")
+}
+
+fn prune_pool_routing_reservations(
+    reservations: &mut HashMap<String, PoolRoutingReservation>,
+    now: Instant,
+) {
+    reservations.retain(|_, reservation| {
+        now.duration_since(reservation.created_at) < POOL_ROUTING_RESERVATION_TTL
+    });
+}
+
+fn pool_routing_reservation_count(state: &AppState, account_id: i64) -> i64 {
+    let mut reservations = state
+        .pool_routing_reservations
+        .lock()
+        .expect("pool routing reservations mutex poisoned");
+    prune_pool_routing_reservations(&mut reservations, Instant::now());
+    reservations
+        .values()
+        .filter(|reservation| reservation.account_id == account_id)
+        .count() as i64
+}
+
+fn reserve_pool_routing_account(
+    state: &AppState,
+    reservation_key: &str,
+    account: &PoolResolvedAccount,
+) {
+    if account.routing_source == PoolRoutingSelectionSource::StickyReuse {
+        return;
+    }
+    let mut reservations = state
+        .pool_routing_reservations
+        .lock()
+        .expect("pool routing reservations mutex poisoned");
+    prune_pool_routing_reservations(&mut reservations, Instant::now());
+    reservations.insert(
+        reservation_key.to_string(),
+        PoolRoutingReservation {
+            account_id: account.account_id,
+            created_at: Instant::now(),
+        },
+    );
+}
+
+fn release_pool_routing_reservation(state: &AppState, reservation_key: &str) {
+    let mut reservations = state
+        .pool_routing_reservations
+        .lock()
+        .expect("pool routing reservations mutex poisoned");
+    prune_pool_routing_reservations(&mut reservations, Instant::now());
+    reservations.remove(reservation_key);
+}
+
+fn consume_pool_routing_reservation(state: &AppState, reservation_key: &str) {
+    release_pool_routing_reservation(state, reservation_key);
+}
+
 fn is_body_too_large_error(err: &reqwest::Error) -> bool {
     error_chain_contains(err, "length limit exceeded")
         || error_chain_contains(err, PROXY_REQUEST_BODY_LIMIT_EXCEEDED)
@@ -22311,6 +22472,7 @@ struct AppState {
     pricing_catalog: Arc<RwLock<PricingCatalog>>,
     prompt_cache_conversation_cache: Arc<Mutex<PromptCacheConversationsCacheState>>,
     maintenance_stats_cache: Arc<Mutex<StatsMaintenanceCacheState>>,
+    pool_routing_reservations: Arc<std::sync::Mutex<HashMap<String, PoolRoutingReservation>>>,
     upstream_accounts: Arc<UpstreamAccountsRuntime>,
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3330,6 +3330,7 @@ async fn test_state_from_config(config: AppConfig, startup_ready: bool) -> Arc<A
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     })
 }
@@ -3363,6 +3364,7 @@ fn clone_state_with_upstream_accounts(
         pricing_catalog: state.pricing_catalog.clone(),
         prompt_cache_conversation_cache: state.prompt_cache_conversation_cache.clone(),
         maintenance_stats_cache: state.maintenance_stats_cache.clone(),
+        pool_routing_reservations: state.pool_routing_reservations.clone(),
         upstream_accounts,
     })
 }
@@ -3414,6 +3416,7 @@ async fn test_state_from_existing_pool(
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     })
 }
@@ -3493,6 +3496,32 @@ async fn insert_test_pool_limit_sample(
     primary_used_percent: Option<f64>,
     secondary_used_percent: Option<f64>,
 ) {
+    insert_test_pool_limit_sample_with_windows(
+        state,
+        account_id,
+        None,
+        primary_used_percent,
+        Some(300),
+        None,
+        secondary_used_percent,
+        Some(300),
+        None,
+    )
+    .await;
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_test_pool_limit_sample_with_windows(
+    state: &Arc<AppState>,
+    account_id: i64,
+    plan_type: Option<&str>,
+    primary_used_percent: Option<f64>,
+    primary_window_minutes: Option<i64>,
+    primary_resets_at: Option<&str>,
+    secondary_used_percent: Option<f64>,
+    secondary_window_minutes: Option<i64>,
+    secondary_resets_at: Option<&str>,
+) {
     ensure_upstream_accounts_schema(&state.pool)
         .await
         .expect("ensure upstream account schema");
@@ -3505,20 +3534,43 @@ async fn insert_test_pool_limit_sample(
             secondary_used_percent, secondary_window_minutes, secondary_resets_at,
             credits_has_credits, credits_unlimited, credits_balance
         ) VALUES (
-            ?1, ?2, NULL, NULL, NULL,
-            ?3, 300, NULL,
-            ?4, 300, NULL,
+            ?1, ?2, NULL, NULL, ?3,
+            ?4, ?5, ?6,
+            ?7, ?8, ?9,
             NULL, NULL, NULL
         )
         "#,
     )
     .bind(account_id)
     .bind(&captured_at)
+    .bind(plan_type)
     .bind(primary_used_percent)
+    .bind(primary_window_minutes)
+    .bind(primary_resets_at)
     .bind(secondary_used_percent)
+    .bind(secondary_window_minutes)
+    .bind(secondary_resets_at)
     .execute(&state.pool)
     .await
     .expect("insert test pool limit sample");
+}
+
+async fn reserve_test_pool_routing_account(
+    state: &Arc<AppState>,
+    reservation_key: &str,
+    account_id: i64,
+) {
+    let account = PoolResolvedAccount {
+        account_id,
+        display_name: format!("reserved-{account_id}"),
+        kind: "api_key_codex".to_string(),
+        auth: PoolResolvedAuth::ApiKey {
+            authorization: format!("Bearer reserved-{account_id}"),
+        },
+        upstream_base_url: Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+        routing_source: PoolRoutingSelectionSource::FreshAssignment,
+    };
+    reserve_pool_routing_account(state.as_ref(), reservation_key, &account);
 }
 
 async fn set_test_account_local_limits(
@@ -10138,6 +10190,7 @@ async fn proxy_openai_v1_models_falls_back_when_merge_body_decode_times_out() {
             PromptCacheConversationsCacheState::default(),
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     });
@@ -11991,6 +12044,7 @@ async fn proxy_openai_v1_allows_slow_upload_with_short_timeout() {
             PromptCacheConversationsCacheState::default(),
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     });
@@ -13446,42 +13500,155 @@ async fn resolve_pool_account_for_request_soft_deprioritizes_accounts_with_only_
 }
 
 #[tokio::test]
-async fn resolve_pool_account_for_request_keeps_existing_sort_order_when_truly_unlimited_accounts_mix_with_limited_candidates()
- {
+async fn resolve_pool_account_for_request_prefers_reset_aware_pressure_over_raw_percent() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let exempt_id = insert_test_pool_api_key_account(&state, "Exempt", "upstream-exempt").await;
-    let limited_id = insert_test_pool_api_key_account(&state, "Limited", "upstream-limited").await;
-    let recent_seen_at = format_utc_iso(Utc::now() - ChronoDuration::minutes(5));
+    let team_id = insert_test_pool_api_key_account(&state, "Team", "upstream-team").await;
+    let free_id = insert_test_pool_api_key_account(&state, "Free", "upstream-free").await;
+    let now = Utc::now();
 
-    set_test_account_local_limits(&state.pool, limited_id, Some(100.0), Some(100.0)).await;
-    insert_test_pool_limit_sample(&state, limited_id, Some(15.0), Some(15.0)).await;
-    for sticky_key in [
-        "sticky-mixed-order-001",
-        "sticky-mixed-order-002",
-        "sticky-mixed-order-003",
-    ] {
-        upsert_test_sticky_route_at(&state.pool, sticky_key, exempt_id, &recent_seen_at).await;
-    }
-
-    let account = match resolve_pool_account_for_request(
-        state.as_ref(),
-        Some("sticky-mixed-order-target"),
-        &[],
-        &HashSet::new(),
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        team_id,
+        Some("team"),
+        Some(70.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(5))),
+        Some(40.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(1))),
     )
-    .await
-    .expect("resolve pool account")
+    .await;
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        free_id,
+        Some("free"),
+        None,
+        None,
+        None,
+        Some(30.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(6))),
+    )
+    .await;
+
+    let account = match resolve_pool_account_for_request(state.as_ref(), None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account")
     {
         PoolAccountResolution::Resolved(account) => account,
         other => panic!("pool account should resolve, got {other:?}"),
     };
 
-    assert!(exempt_id < limited_id);
-    assert_eq!(account.account_id, exempt_id);
-    assert_ne!(account.account_id, limited_id);
+    assert_eq!(account.account_id, team_id);
+    assert_ne!(account.account_id, free_id);
+}
+
+#[tokio::test]
+async fn resolve_pool_account_for_request_applies_tighter_long_only_hard_cap() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let free_id = insert_test_pool_api_key_account(&state, "Free", "upstream-free").await;
+    let team_id = insert_test_pool_api_key_account(&state, "Team", "upstream-team").await;
+    let recent_seen_at = format_utc_iso(Utc::now() - ChronoDuration::minutes(5));
+    let now = Utc::now();
+
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        free_id,
+        Some("free"),
+        None,
+        None,
+        None,
+        Some(5.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(6))),
+    )
+    .await;
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        team_id,
+        Some("team"),
+        Some(65.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(45))),
+        Some(55.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(4))),
+    )
+    .await;
+    for sticky_key in ["sticky-free-001", "sticky-free-002"] {
+        upsert_test_sticky_route_at(&state.pool, sticky_key, free_id, &recent_seen_at).await;
+    }
+
+    let account = match resolve_pool_account_for_request(state.as_ref(), None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
+
+    assert_eq!(account.account_id, team_id);
+    assert_ne!(account.account_id, free_id);
+}
+
+#[tokio::test]
+async fn resolve_pool_account_for_request_counts_in_flight_reservations_toward_effective_load() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let preferred_id =
+        insert_test_pool_api_key_account(&state, "Preferred", "upstream-preferred").await;
+    let fallback_id =
+        insert_test_pool_api_key_account(&state, "Fallback", "upstream-fallback").await;
+    let recent_seen_at = format_utc_iso(Utc::now() - ChronoDuration::minutes(5));
+    let now = Utc::now();
+
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        preferred_id,
+        Some("team"),
+        Some(5.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(30))),
+        Some(5.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(3))),
+    )
+    .await;
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        fallback_id,
+        Some("team"),
+        Some(25.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(30))),
+        Some(25.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(3))),
+    )
+    .await;
+    for sticky_key in ["sticky-pref-001", "sticky-pref-002"] {
+        upsert_test_sticky_route_at(&state.pool, sticky_key, preferred_id, &recent_seen_at).await;
+    }
+    reserve_test_pool_routing_account(&state, "reservation-001", preferred_id).await;
+
+    let account = match resolve_pool_account_for_request(state.as_ref(), None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
+
+    assert_eq!(account.account_id, fallback_id);
+    assert_ne!(account.account_id, preferred_id);
 }
 
 #[tokio::test]
@@ -17052,10 +17219,12 @@ async fn pool_route_oauth_passthrough_replays_large_file_backed_body() {
         },
         upstream_base_url: oauth_bridge::oauth_codex_upstream_base_url()
             .expect("oauth upstream base url"),
+        routing_source: PoolRoutingSelectionSource::FreshAssignment,
     };
 
     let upstream = send_pool_request_with_failover(
         state,
+        424242,
         Method::POST,
         &"/v1/chat/completions".parse().expect("valid uri"),
         &HeaderMap::from_iter([(
@@ -18148,6 +18317,7 @@ async fn pool_route_large_oauth_responses_falls_back_to_api_key_account() {
 
     let upstream = send_pool_request_with_failover(
         state.clone(),
+        626262,
         Method::POST,
         &"/v1/responses?mode=delay".parse().expect("valid uri"),
         &HeaderMap::from_iter([(
@@ -18304,10 +18474,12 @@ async fn pool_route_oauth_responses_rejects_large_file_backed_rewrite_body() {
         },
         upstream_base_url: oauth_bridge::oauth_codex_upstream_base_url()
             .expect("oauth upstream base url"),
+        routing_source: PoolRoutingSelectionSource::FreshAssignment,
     };
 
     let err = send_pool_request_with_failover(
         state,
+        515151,
         Method::POST,
         &"/v1/responses".parse().expect("valid uri"),
         &HeaderMap::from_iter([(
@@ -18567,6 +18739,7 @@ fn capture_target_pool_route_prefers_account_upstream_base_for_redirect_rewrite(
         },
         upstream_base_url: Url::parse("https://proxy.example.com/gateway")
             .expect("account upstream base url"),
+        routing_source: PoolRoutingSelectionSource::FreshAssignment,
     };
 
     assert_eq!(
@@ -18709,6 +18882,7 @@ async fn proxy_openai_v1_e2e_stream_survives_short_request_timeout() {
             PromptCacheConversationsCacheState::default(),
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     });
@@ -19515,6 +19689,7 @@ async fn proxy_openai_v1_returns_bad_gateway_on_upstream_handshake_timeout() {
             PromptCacheConversationsCacheState::default(),
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     });
@@ -19589,6 +19764,7 @@ async fn proxy_openai_v1_returns_bad_gateway_on_upstream_handshake_timeout_with_
             PromptCacheConversationsCacheState::default(),
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     });
@@ -26456,6 +26632,7 @@ async fn quota_latest_returns_degraded_when_empty() {
             PromptCacheConversationsCacheState::default(),
         )),
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+        pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
         upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
     });

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -134,7 +134,6 @@ const DEFAULT_STICKY_KEY_LIMIT: i64 = 50;
 const DEFAULT_UPSTREAM_ACCOUNT_LIST_PAGE_SIZE: usize = 20;
 const UPSTREAM_ACCOUNT_LIST_PAGE_SIZE_OPTIONS: [usize; 3] = [20, 50, 100];
 const POOL_ROUTE_ACTIVE_STICKY_WINDOW_MINUTES: i64 = 30;
-const POOL_ROUTE_ACTIVE_STICKY_SOFT_LIMIT: i64 = 2;
 pub(crate) const COMPACT_SUPPORT_STATUS_UNKNOWN: &str = "unknown";
 pub(crate) const COMPACT_SUPPORT_STATUS_SUPPORTED: &str = "supported";
 pub(crate) const COMPACT_SUPPORT_STATUS_UNSUPPORTED: &str = "unsupported";
@@ -1932,22 +1931,151 @@ struct PoolStickyRouteRow {
 #[derive(Debug, Clone, FromRow)]
 struct AccountRoutingCandidateRow {
     id: i64,
+    plan_type: Option<String>,
     secondary_used_percent: Option<f64>,
+    secondary_window_minutes: Option<i64>,
+    secondary_resets_at: Option<String>,
     primary_used_percent: Option<f64>,
+    primary_window_minutes: Option<i64>,
+    primary_resets_at: Option<String>,
     credits_has_credits: Option<i64>,
     credits_unlimited: Option<i64>,
     credits_balance: Option<String>,
     last_selected_at: Option<String>,
-    has_local_limits: bool,
     active_sticky_conversations: i64,
+    #[sqlx(default)]
+    in_flight_reservations: i64,
 }
 
 impl AccountRoutingCandidateRow {
-    fn has_any_limits(&self) -> bool {
-        self.has_local_limits
-            || self.primary_used_percent.is_some()
-            || self.secondary_used_percent.is_some()
+    fn effective_load(&self) -> i64 {
+        self.active_sticky_conversations
+            .saturating_add(self.in_flight_reservations.max(0))
     }
+
+    fn capacity_profile(&self) -> RoutingCapacityProfile {
+        let pressure = self.normalized_window_pressure(Utc::now());
+        if pressure.short_pressure.is_some() {
+            RoutingCapacityProfile {
+                soft_limit: 2,
+                hard_cap: 3,
+            }
+        } else if pressure.long_pressure.is_some() {
+            RoutingCapacityProfile {
+                soft_limit: 1,
+                hard_cap: 2,
+            }
+        } else {
+            RoutingCapacityProfile {
+                soft_limit: 2,
+                hard_cap: 3,
+            }
+        }
+    }
+
+    fn normalized_window_pressure(&self, now: DateTime<Utc>) -> NormalizedRoutingPressure {
+        let mut short_pressure = None;
+        let mut long_pressure = None;
+        for window in [
+            routing_window_state(
+                self.primary_used_percent,
+                self.primary_window_minutes,
+                self.primary_resets_at.as_deref(),
+                now,
+            ),
+            routing_window_state(
+                self.secondary_used_percent,
+                self.secondary_window_minutes,
+                self.secondary_resets_at.as_deref(),
+                now,
+            ),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            match window.bucket {
+                RoutingWindowBucket::Short => {
+                    short_pressure = Some(short_pressure.unwrap_or(0.0_f64).max(window.pressure));
+                }
+                RoutingWindowBucket::Long => {
+                    long_pressure = Some(long_pressure.unwrap_or(0.0_f64).max(window.pressure));
+                }
+            }
+        }
+        NormalizedRoutingPressure {
+            short_pressure,
+            long_pressure,
+        }
+    }
+
+    fn scarcity_score(&self, now: DateTime<Utc>) -> f64 {
+        let pressure = self.normalized_window_pressure(now);
+        match (pressure.short_pressure, pressure.long_pressure) {
+            (Some(short), Some(long)) => (0.65 * short) + (0.35 * long),
+            (Some(short), None) => short,
+            (None, Some(long)) => long,
+            (None, None) => 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RoutingCapacityProfile {
+    soft_limit: i64,
+    hard_cap: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NormalizedRoutingPressure {
+    short_pressure: Option<f64>,
+    long_pressure: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RoutingWindowState {
+    bucket: RoutingWindowBucket,
+    pressure: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoutingWindowBucket {
+    Short,
+    Long,
+}
+
+fn routing_window_state(
+    used_percent: Option<f64>,
+    window_minutes: Option<i64>,
+    resets_at: Option<&str>,
+    now: DateTime<Utc>,
+) -> Option<RoutingWindowState> {
+    let used_ratio = normalize_unit_ratio(used_percent? / 100.0);
+    let window_minutes = window_minutes?.max(1);
+    let bucket = if window_minutes <= 360 {
+        RoutingWindowBucket::Short
+    } else {
+        RoutingWindowBucket::Long
+    };
+    let window_duration_secs = (window_minutes as f64) * 60.0;
+    let remaining_ratio = resets_at
+        .and_then(parse_rfc3339_utc)
+        .map(|reset_at| {
+            normalize_unit_ratio(
+                (reset_at - now).num_seconds().max(0) as f64 / window_duration_secs,
+            )
+        })
+        .unwrap_or(1.0);
+    Some(RoutingWindowState {
+        bucket,
+        pressure: used_ratio * remaining_ratio,
+    })
+}
+
+fn normalize_unit_ratio(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    value.clamp(0.0, 1.0)
 }
 
 #[derive(Debug, FromRow)]
@@ -13029,12 +13157,19 @@ pub(crate) struct PoolResolvedAccount {
     pub(crate) kind: String,
     pub(crate) auth: PoolResolvedAuth,
     pub(crate) upstream_base_url: Url,
+    pub(crate) routing_source: PoolRoutingSelectionSource,
 }
 
 impl PoolResolvedAccount {
     pub(crate) fn upstream_route_key(&self) -> String {
         canonical_pool_upstream_route_key(&self.upstream_base_url)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PoolRoutingSelectionSource {
+    StickyReuse,
+    FreshAssignment,
 }
 
 #[derive(Debug, Clone)]
@@ -13122,6 +13257,8 @@ pub(crate) async fn resolve_pool_account_for_request(
             if is_account_selectable_for_routing(&row, sticky_snapshot_exhausted) {
                 let mut sticky_route_was_excluded = false;
                 if let Some(account) = prepare_pool_account(state, &row).await? {
+                    let mut account = account;
+                    account.routing_source = PoolRoutingSelectionSource::StickyReuse;
                     if !excluded_upstream_route_keys.contains(&account.upstream_route_key()) {
                         return Ok(PoolAccountResolution::Resolved(account));
                     }
@@ -13155,43 +13292,65 @@ pub(crate) async fn resolve_pool_account_for_request(
     }
 
     let mut candidates = load_account_routing_candidates(&state.pool, &tried).await?;
+    for candidate in &mut candidates {
+        candidate.in_flight_reservations = pool_routing_reservation_count(state, candidate.id);
+    }
     candidates.sort_by(compare_routing_candidates);
+    let mut primary_candidates = Vec::new();
+    let mut overflow_candidates = Vec::new();
     for candidate in candidates {
-        let Some(row) = load_upstream_account_row(&state.pool, candidate.id).await? else {
-            continue;
-        };
-        let snapshot_exhausted = routing_candidate_snapshot_is_exhausted(&candidate);
-        if !is_account_selectable_for_routing(&row, snapshot_exhausted) {
-            if is_account_rate_limited_for_routing(&row, snapshot_exhausted) {
-                saw_rate_limited_candidate = true;
-            } else if is_routing_eligible_account(&row) {
-                saw_non_rate_limited_routing_candidate = true;
-            } else {
-                saw_non_routing_candidate = true;
+        if candidate.effective_load() < candidate.capacity_profile().hard_cap {
+            primary_candidates.push(candidate);
+        } else {
+            overflow_candidates.push(candidate);
+        }
+    }
+    let candidate_passes = if primary_candidates.is_empty() {
+        vec![overflow_candidates]
+    } else if overflow_candidates.is_empty() {
+        vec![primary_candidates]
+    } else {
+        vec![primary_candidates, overflow_candidates]
+    };
+    for pass_candidates in candidate_passes {
+        for candidate in pass_candidates {
+            let Some(row) = load_upstream_account_row(&state.pool, candidate.id).await? else {
+                continue;
+            };
+            let snapshot_exhausted = routing_candidate_snapshot_is_exhausted(&candidate);
+            if !is_account_selectable_for_routing(&row, snapshot_exhausted) {
+                if is_account_rate_limited_for_routing(&row, snapshot_exhausted) {
+                    saw_rate_limited_candidate = true;
+                } else if is_routing_eligible_account(&row) {
+                    saw_non_rate_limited_routing_candidate = true;
+                } else {
+                    saw_non_routing_candidate = true;
+                }
+                continue;
             }
-            continue;
-        }
-        let effective_rule = load_effective_routing_rule_for_account(&state.pool, row.id).await?;
-        if !account_accepts_sticky_assignment(
-            &state.pool,
-            row.id,
-            sticky_key,
-            sticky_source_id,
-            &effective_rule,
-        )
-        .await?
-        {
-            saw_non_rate_limited_routing_candidate = true;
-            continue;
-        }
-        if let Some(account) = prepare_pool_account(state, &row).await? {
-            if excluded_upstream_route_keys.contains(&account.upstream_route_key()) {
+            let effective_rule =
+                load_effective_routing_rule_for_account(&state.pool, row.id).await?;
+            if !account_accepts_sticky_assignment(
+                &state.pool,
+                row.id,
+                sticky_key,
+                sticky_source_id,
+                &effective_rule,
+            )
+            .await?
+            {
                 saw_non_rate_limited_routing_candidate = true;
                 continue;
             }
-            return Ok(PoolAccountResolution::Resolved(account));
+            if let Some(account) = prepare_pool_account(state, &row).await? {
+                if excluded_upstream_route_keys.contains(&account.upstream_route_key()) {
+                    saw_non_rate_limited_routing_candidate = true;
+                    continue;
+                }
+                return Ok(PoolAccountResolution::Resolved(account));
+            }
+            saw_non_rate_limited_routing_candidate = true;
         }
-        saw_non_rate_limited_routing_candidate = true;
     }
 
     if saw_rate_limited_candidate && !saw_non_rate_limited_routing_candidate {
@@ -13584,6 +13743,7 @@ async fn prepare_pool_account(
                 authorization: format!("Bearer {}", value.api_key),
             },
             upstream_base_url,
+            routing_source: PoolRoutingSelectionSource::FreshAssignment,
         })),
         StoredCredentials::Oauth(mut value) => {
             let expires_at = row.token_expires_at.as_deref().and_then(parse_rfc3339_utc);
@@ -13742,6 +13902,7 @@ async fn prepare_pool_account(
                     chatgpt_account_id: row.chatgpt_account_id.clone(),
                 },
                 upstream_base_url,
+                routing_source: PoolRoutingSelectionSource::FreshAssignment,
             }))
         }
     }
@@ -13809,6 +13970,13 @@ async fn load_account_routing_candidates(
         SELECT
             account.id,
             (
+                SELECT sample.plan_type
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS plan_type,
+            (
                 SELECT sample.secondary_used_percent
                 FROM pool_upstream_account_limit_samples sample
                 WHERE sample.account_id = account.id
@@ -13816,12 +13984,40 @@ async fn load_account_routing_candidates(
                 LIMIT 1
             ) AS secondary_used_percent,
             (
+                SELECT sample.secondary_window_minutes
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS secondary_window_minutes,
+            (
+                SELECT sample.secondary_resets_at
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS secondary_resets_at,
+            (
                 SELECT sample.primary_used_percent
                 FROM pool_upstream_account_limit_samples sample
                 WHERE sample.account_id = account.id
                 ORDER BY sample.captured_at DESC
                 LIMIT 1
             ) AS primary_used_percent,
+            (
+                SELECT sample.primary_window_minutes
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS primary_window_minutes,
+            (
+                SELECT sample.primary_resets_at
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS primary_resets_at,
             (
                 SELECT sample.credits_has_credits
                 FROM pool_upstream_account_limit_samples sample
@@ -13844,12 +14040,6 @@ async fn load_account_routing_candidates(
                 LIMIT 1
             ) AS credits_balance,
             account.last_selected_at,
-            CASE
-                WHEN account.local_primary_limit IS NOT NULL
-                  OR account.local_secondary_limit IS NOT NULL
-                THEN 1
-                ELSE 0
-            END AS has_local_limits,
             (
                 SELECT COUNT(*)
                 FROM pool_sticky_routes route
@@ -13895,6 +14085,13 @@ async fn load_account_routing_candidate(
         SELECT
             account.id,
             (
+                SELECT sample.plan_type
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS plan_type,
+            (
                 SELECT sample.secondary_used_percent
                 FROM pool_upstream_account_limit_samples sample
                 WHERE sample.account_id = account.id
@@ -13902,12 +14099,40 @@ async fn load_account_routing_candidate(
                 LIMIT 1
             ) AS secondary_used_percent,
             (
+                SELECT sample.secondary_window_minutes
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS secondary_window_minutes,
+            (
+                SELECT sample.secondary_resets_at
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS secondary_resets_at,
+            (
                 SELECT sample.primary_used_percent
                 FROM pool_upstream_account_limit_samples sample
                 WHERE sample.account_id = account.id
                 ORDER BY sample.captured_at DESC
                 LIMIT 1
             ) AS primary_used_percent,
+            (
+                SELECT sample.primary_window_minutes
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS primary_window_minutes,
+            (
+                SELECT sample.primary_resets_at
+                FROM pool_upstream_account_limit_samples sample
+                WHERE sample.account_id = account.id
+                ORDER BY sample.captured_at DESC
+                LIMIT 1
+            ) AS primary_resets_at,
             (
                 SELECT sample.credits_has_credits
                 FROM pool_upstream_account_limit_samples sample
@@ -13930,12 +14155,6 @@ async fn load_account_routing_candidate(
                 LIMIT 1
             ) AS credits_balance,
             account.last_selected_at,
-            CASE
-                WHEN account.local_primary_limit IS NOT NULL
-                  OR account.local_secondary_limit IS NOT NULL
-                THEN 1
-                ELSE 0
-            END AS has_local_limits,
             (
                 SELECT COUNT(*)
                 FROM pool_sticky_routes route
@@ -13959,25 +14178,28 @@ fn compare_routing_candidates(
     lhs: &AccountRoutingCandidateRow,
     rhs: &AccountRoutingCandidateRow,
 ) -> std::cmp::Ordering {
-    let lhs_over_soft_limit = lhs.has_any_limits()
-        && lhs.active_sticky_conversations > POOL_ROUTE_ACTIVE_STICKY_SOFT_LIMIT;
-    let rhs_over_soft_limit = rhs.has_any_limits()
-        && rhs.active_sticky_conversations > POOL_ROUTE_ACTIVE_STICKY_SOFT_LIMIT;
-    let lhs_secondary = lhs.secondary_used_percent.unwrap_or(0.0);
-    let rhs_secondary = rhs.secondary_used_percent.unwrap_or(0.0);
+    compare_routing_candidates_at(lhs, rhs, Utc::now())
+}
+
+fn compare_routing_candidates_at(
+    lhs: &AccountRoutingCandidateRow,
+    rhs: &AccountRoutingCandidateRow,
+    now: DateTime<Utc>,
+) -> std::cmp::Ordering {
+    let lhs_capacity = lhs.capacity_profile();
+    let rhs_capacity = rhs.capacity_profile();
+    let lhs_over_soft_limit = lhs.effective_load() > lhs_capacity.soft_limit;
+    let rhs_over_soft_limit = rhs.effective_load() > rhs_capacity.soft_limit;
+    let lhs_score = lhs.scarcity_score(now);
+    let rhs_score = rhs.scarcity_score(now);
     lhs_over_soft_limit
         .cmp(&rhs_over_soft_limit)
         .then_with(|| {
-            lhs_secondary
-                .partial_cmp(&rhs_secondary)
+            lhs_score
+                .partial_cmp(&rhs_score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
-        .then_with(|| {
-            lhs.primary_used_percent
-                .unwrap_or(0.0)
-                .partial_cmp(&rhs.primary_used_percent.unwrap_or(0.0))
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
+        .then_with(|| lhs.effective_load().cmp(&rhs.effective_load()))
         .then_with(|| lhs.last_selected_at.cmp(&rhs.last_selected_at))
         .then_with(|| lhs.id.cmp(&rhs.id))
 }
@@ -15077,6 +15299,7 @@ mod tests {
                 },
             )),
             maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+            pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
             upstream_accounts: Arc::new(
                 UpstreamAccountsRuntime::test_instance_with_maintenance_parallelism(
@@ -15255,6 +15478,7 @@ mod tests {
                 },
             )),
             maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
+            pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
             upstream_accounts: Arc::new(UpstreamAccountsRuntime::test_instance()),
         });
@@ -16623,100 +16847,113 @@ mod tests {
         );
     }
 
-    #[test]
-    fn compare_routing_candidates_soft_deprioritizes_remote_window_accounts_over_limit() {
-        let limited_remote = AccountRoutingCandidateRow {
-            id: 1,
-            secondary_used_percent: Some(8.0),
-            primary_used_percent: Some(8.0),
+    fn test_routing_candidate(id: i64) -> AccountRoutingCandidateRow {
+        AccountRoutingCandidateRow {
+            id,
+            plan_type: None,
+            secondary_used_percent: None,
+            secondary_window_minutes: None,
+            secondary_resets_at: None,
+            primary_used_percent: None,
+            primary_window_minutes: None,
+            primary_resets_at: None,
             credits_has_credits: None,
             credits_unlimited: None,
             credits_balance: None,
             last_selected_at: Some("2026-03-23T11:00:00Z".to_string()),
-            has_local_limits: false,
-            active_sticky_conversations: POOL_ROUTE_ACTIVE_STICKY_SOFT_LIMIT + 1,
-        };
-        let unlimited = AccountRoutingCandidateRow {
-            id: 2,
-            secondary_used_percent: Some(18.0),
-            primary_used_percent: Some(18.0),
-            credits_has_credits: None,
-            credits_unlimited: None,
-            credits_balance: None,
-            last_selected_at: Some("2026-03-23T11:05:00Z".to_string()),
-            has_local_limits: false,
             active_sticky_conversations: 0,
-        };
-
-        assert_eq!(
-            compare_routing_candidates(&limited_remote, &unlimited),
-            std::cmp::Ordering::Greater,
-            "accounts with only remote window limits should still be soft-deprioritized once they exceed the active sticky threshold"
-        );
+            in_flight_reservations: 0,
+        }
     }
 
     #[test]
-    fn compare_routing_candidates_treats_single_remote_window_as_limited() {
-        let single_remote_window = AccountRoutingCandidateRow {
-            id: 1,
-            secondary_used_percent: None,
-            primary_used_percent: Some(0.0),
-            credits_has_credits: None,
-            credits_unlimited: None,
-            credits_balance: None,
-            last_selected_at: Some("2026-03-23T11:00:00Z".to_string()),
-            has_local_limits: false,
-            active_sticky_conversations: POOL_ROUTE_ACTIVE_STICKY_SOFT_LIMIT + 1,
-        };
-        let unlimited = AccountRoutingCandidateRow {
-            id: 2,
-            secondary_used_percent: None,
-            primary_used_percent: None,
-            credits_has_credits: None,
-            credits_unlimited: None,
-            credits_balance: None,
-            last_selected_at: Some("2026-03-23T11:05:00Z".to_string()),
-            has_local_limits: false,
-            active_sticky_conversations: 0,
-        };
+    fn compare_routing_candidates_prefers_short_window_that_is_about_to_reset() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 26, 7, 0, 0)
+            .single()
+            .expect("valid now");
+        let mut short_reset_soon = test_routing_candidate(1);
+        short_reset_soon.plan_type = Some("team".to_string());
+        short_reset_soon.primary_used_percent = Some(70.0);
+        short_reset_soon.primary_window_minutes = Some(300);
+        short_reset_soon.primary_resets_at = Some(format_utc_iso(now + ChronoDuration::minutes(5)));
+        short_reset_soon.secondary_used_percent = Some(40.0);
+        short_reset_soon.secondary_window_minutes = Some(7 * 24 * 60);
+        short_reset_soon.secondary_resets_at = Some(format_utc_iso(now + ChronoDuration::days(1)));
+
+        let mut long_only = test_routing_candidate(2);
+        long_only.plan_type = Some("free".to_string());
+        long_only.secondary_used_percent = Some(30.0);
+        long_only.secondary_window_minutes = Some(7 * 24 * 60);
+        long_only.secondary_resets_at = Some(format_utc_iso(now + ChronoDuration::days(6)));
 
         assert_eq!(
-            compare_routing_candidates(&single_remote_window, &unlimited),
-            std::cmp::Ordering::Greater,
-            "a single remote window sample, even at 0%, should mark the account as limited for soft deprioritization"
-        );
-    }
-
-    #[test]
-    fn compare_routing_candidates_keeps_unlimited_accounts_on_existing_ordering() {
-        let busier_unlimited = AccountRoutingCandidateRow {
-            id: 1,
-            secondary_used_percent: None,
-            primary_used_percent: None,
-            credits_has_credits: None,
-            credits_unlimited: None,
-            credits_balance: None,
-            last_selected_at: Some("2026-03-23T11:00:00Z".to_string()),
-            has_local_limits: false,
-            active_sticky_conversations: POOL_ROUTE_ACTIVE_STICKY_SOFT_LIMIT + 3,
-        };
-        let quieter_unlimited = AccountRoutingCandidateRow {
-            id: 2,
-            secondary_used_percent: Some(10.0),
-            primary_used_percent: Some(10.0),
-            credits_has_credits: None,
-            credits_unlimited: None,
-            credits_balance: None,
-            last_selected_at: Some("2026-03-23T11:05:00Z".to_string()),
-            has_local_limits: false,
-            active_sticky_conversations: 0,
-        };
-
-        assert_eq!(
-            compare_routing_candidates(&busier_unlimited, &quieter_unlimited),
+            compare_routing_candidates_at(&short_reset_soon, &long_only, now),
             std::cmp::Ordering::Less,
-            "accounts without any local or remote limit signal should not be soft-deprioritized by active sticky count alone"
+            "a short-window account that is about to reset should beat a lower-used long-only account whose reset is still far away",
         );
+    }
+
+    #[test]
+    fn compare_routing_candidates_penalizes_far_from_reset_pressure() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 26, 7, 0, 0)
+            .single()
+            .expect("valid now");
+        let mut stretched_team = test_routing_candidate(1);
+        stretched_team.plan_type = Some("team".to_string());
+        stretched_team.primary_used_percent = Some(95.0);
+        stretched_team.primary_window_minutes = Some(300);
+        stretched_team.primary_resets_at = Some(format_utc_iso(now + ChronoDuration::minutes(250)));
+        stretched_team.secondary_used_percent = Some(80.0);
+        stretched_team.secondary_window_minutes = Some(7 * 24 * 60);
+        stretched_team.secondary_resets_at = Some(format_utc_iso(now + ChronoDuration::days(6)));
+
+        let mut healthier_long = test_routing_candidate(2);
+        healthier_long.plan_type = Some("free".to_string());
+        healthier_long.secondary_used_percent = Some(20.0);
+        healthier_long.secondary_window_minutes = Some(7 * 24 * 60);
+        healthier_long.secondary_resets_at = Some(format_utc_iso(now + ChronoDuration::days(3)));
+
+        assert_eq!(
+            compare_routing_candidates_at(&stretched_team, &healthier_long, now),
+            std::cmp::Ordering::Greater,
+            "near-exhausted windows with lots of time left should sort behind healthier long-window accounts",
+        );
+    }
+
+    #[test]
+    fn compare_routing_candidates_treats_zero_percent_single_window_as_limited() {
+        let mut single_window = test_routing_candidate(1);
+        single_window.primary_used_percent = Some(0.0);
+        single_window.primary_window_minutes = Some(7 * 24 * 60);
+        single_window.active_sticky_conversations = 2;
+
+        let unlimited = test_routing_candidate(2);
+
+        assert_eq!(
+            compare_routing_candidates(&single_window, &unlimited),
+            std::cmp::Ordering::Greater,
+            "a single remote window sample, even at 0%, should still participate in the tighter long-window load caps",
+        );
+    }
+
+    #[test]
+    fn candidate_capacity_profile_tightens_for_long_only_accounts() {
+        let mut long_only = test_routing_candidate(1);
+        long_only.secondary_used_percent = Some(10.0);
+        long_only.secondary_window_minutes = Some(7 * 24 * 60);
+        let mut short_window = test_routing_candidate(2);
+        short_window.primary_used_percent = Some(10.0);
+        short_window.primary_window_minutes = Some(300);
+
+        let long_only_capacity = long_only.capacity_profile();
+        let short_window_capacity = short_window.capacity_profile();
+
+        assert_eq!(long_only_capacity.soft_limit, 1);
+        assert_eq!(long_only_capacity.hard_cap, 2);
+        assert_eq!(short_window_capacity.soft_limit, 2);
+        assert_eq!(short_window_capacity.hard_cap, 3);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make pool routing score accounts with reset-aware window pressure instead of raw usage percent alone
- add in-flight per-account reservations so new sticky assignments spread before success is persisted
- keep sticky reuse semantics unchanged while adding long-window tighter caps and two-pass overflow fallback

## Testing
- cargo test resolve_pool_account_for_request_ -- --nocapture
- cargo test compare_routing_candidates_prefers_short_window_that_is_about_to_reset -- --nocapture
- cargo test 'compare_routing_candidates_' -- --nocapture && cargo test candidate_capacity_profile_tightens_for_long_only_accounts -- --nocapture
- cargo test pool_route_oauth_passthrough_replays_large_file_backed_body -- --nocapture
- cargo test pool_route_oauth_passthrough_streams_without_eager_prebuffering -- --nocapture
- cargo test pool_route_oauth_responses_sends_uuid_account_header_and_persists_observability -- --nocapture

Spec: -
Spec Sync: n/a(no spec)
Spec Drift: none