### PR TITLE
fix: preserve pool routing guardrails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21631,11 +21631,10 @@ fn next_proxy_request_id() -> u64 {
     NEXT_PROXY_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-const POOL_ROUTING_RESERVATION_TTL: Duration = Duration::from_secs(90);
-
 #[derive(Debug, Clone, Copy)]
 struct PoolRoutingReservation {
     account_id: i64,
+    #[allow(dead_code)]
     created_at: Instant,
 }
 
@@ -21672,21 +21671,11 @@ fn build_pool_routing_reservation_key(proxy_request_id: u64) -> String {
     format!("pool-route-{proxy_request_id}")
 }
 
-fn prune_pool_routing_reservations(
-    reservations: &mut HashMap<String, PoolRoutingReservation>,
-    now: Instant,
-) {
-    reservations.retain(|_, reservation| {
-        now.duration_since(reservation.created_at) < POOL_ROUTING_RESERVATION_TTL
-    });
-}
-
 fn pool_routing_reservation_count(state: &AppState, account_id: i64) -> i64 {
-    let mut reservations = state
+    let reservations = state
         .pool_routing_reservations
         .lock()
         .expect("pool routing reservations mutex poisoned");
-    prune_pool_routing_reservations(&mut reservations, Instant::now());
     reservations
         .values()
         .filter(|reservation| reservation.account_id == account_id)
@@ -21705,7 +21694,6 @@ fn reserve_pool_routing_account(
         .pool_routing_reservations
         .lock()
         .expect("pool routing reservations mutex poisoned");
-    prune_pool_routing_reservations(&mut reservations, Instant::now());
     reservations.insert(
         reservation_key.to_string(),
         PoolRoutingReservation {
@@ -21720,7 +21708,6 @@ fn release_pool_routing_reservation(state: &AppState, reservation_key: &str) {
         .pool_routing_reservations
         .lock()
         .expect("pool routing reservations mutex poisoned");
-    prune_pool_routing_reservations(&mut reservations, Instant::now());
     reservations.remove(reservation_key);
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13652,6 +13652,170 @@ async fn resolve_pool_account_for_request_counts_in_flight_reservations_toward_e
 }
 
 #[tokio::test]
+async fn resolve_pool_account_for_request_keeps_old_in_flight_reservations_counted() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let preferred_id =
+        insert_test_pool_api_key_account(&state, "Preferred", "upstream-preferred").await;
+    let fallback_id =
+        insert_test_pool_api_key_account(&state, "Fallback", "upstream-fallback").await;
+    let recent_seen_at = format_utc_iso(Utc::now() - ChronoDuration::minutes(5));
+    let now = Utc::now();
+
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        preferred_id,
+        Some("team"),
+        Some(5.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(30))),
+        Some(5.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(3))),
+    )
+    .await;
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        fallback_id,
+        Some("team"),
+        Some(25.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(30))),
+        Some(25.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(3))),
+    )
+    .await;
+    for sticky_key in ["sticky-pref-001", "sticky-pref-002"] {
+        upsert_test_sticky_route_at(&state.pool, sticky_key, preferred_id, &recent_seen_at).await;
+    }
+    state
+        .pool_routing_reservations
+        .lock()
+        .expect("pool routing reservations mutex poisoned")
+        .insert(
+            "reservation-old".to_string(),
+            PoolRoutingReservation {
+                account_id: preferred_id,
+                created_at: std::time::Instant::now() - Duration::from_secs(5 * 60),
+            },
+        );
+
+    let account = match resolve_pool_account_for_request(state.as_ref(), None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
+
+    assert_eq!(account.account_id, fallback_id);
+    assert_ne!(account.account_id, preferred_id);
+}
+
+#[tokio::test]
+async fn resolve_pool_account_for_request_preserves_long_only_cap_without_window_metadata() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let legacy_long_only_id =
+        insert_test_pool_api_key_account(&state, "Legacy Long Only", "upstream-legacy").await;
+    let team_id = insert_test_pool_api_key_account(&state, "Team", "upstream-team").await;
+    let recent_seen_at = format_utc_iso(Utc::now() - ChronoDuration::minutes(5));
+    let now = Utc::now();
+
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        legacy_long_only_id,
+        Some("free"),
+        None,
+        None,
+        None,
+        Some(5.0),
+        None,
+        None,
+    )
+    .await;
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        team_id,
+        Some("team"),
+        Some(25.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(30))),
+        Some(25.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(3))),
+    )
+    .await;
+    for sticky_key in ["sticky-legacy-001", "sticky-legacy-002"] {
+        upsert_test_sticky_route_at(
+            &state.pool,
+            sticky_key,
+            legacy_long_only_id,
+            &recent_seen_at,
+        )
+        .await;
+    }
+
+    let account = match resolve_pool_account_for_request(state.as_ref(), None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
+
+    assert_eq!(account.account_id, team_id);
+    assert_ne!(account.account_id, legacy_long_only_id);
+}
+
+#[tokio::test]
+async fn resolve_pool_account_for_request_preserves_local_long_limit_without_samples() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let locally_limited_id =
+        insert_test_pool_api_key_account(&state, "Locally Limited", "upstream-local").await;
+    let team_id = insert_test_pool_api_key_account(&state, "Team", "upstream-team").await;
+    let recent_seen_at = format_utc_iso(Utc::now() - ChronoDuration::minutes(5));
+    let now = Utc::now();
+
+    set_test_account_local_limits(&state.pool, locally_limited_id, None, Some(100.0)).await;
+    insert_test_pool_limit_sample_with_windows(
+        &state,
+        team_id,
+        Some("team"),
+        Some(25.0),
+        Some(300),
+        Some(&format_utc_iso(now + ChronoDuration::minutes(30))),
+        Some(25.0),
+        Some(7 * 24 * 60),
+        Some(&format_utc_iso(now + ChronoDuration::days(3))),
+    )
+    .await;
+    for sticky_key in ["sticky-local-001", "sticky-local-002"] {
+        upsert_test_sticky_route_at(&state.pool, sticky_key, locally_limited_id, &recent_seen_at)
+            .await;
+    }
+
+    let account = match resolve_pool_account_for_request(state.as_ref(), None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account")
+    {
+        PoolAccountResolution::Resolved(account) => account,
+        other => panic!("pool account should resolve, got {other:?}"),
+    };
+
+    assert_eq!(account.account_id, team_id);
+    assert_ne!(account.account_id, locally_limited_id);
+}
+
+#[tokio::test]
 async fn resolve_pool_account_for_request_defers_sticky_binding_until_success() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -1938,6 +1938,8 @@ struct AccountRoutingCandidateRow {
     primary_used_percent: Option<f64>,
     primary_window_minutes: Option<i64>,
     primary_resets_at: Option<String>,
+    local_primary_limit: Option<f64>,
+    local_secondary_limit: Option<f64>,
     credits_has_credits: Option<i64>,
     credits_unlimited: Option<i64>,
     credits_balance: Option<String>,
@@ -1954,13 +1956,13 @@ impl AccountRoutingCandidateRow {
     }
 
     fn capacity_profile(&self) -> RoutingCapacityProfile {
-        let pressure = self.normalized_window_pressure(Utc::now());
-        if pressure.short_pressure.is_some() {
+        let signals = self.window_signals();
+        if signals.short_signal {
             RoutingCapacityProfile {
                 soft_limit: 2,
                 hard_cap: 3,
             }
-        } else if pressure.long_pressure.is_some() {
+        } else if signals.long_signal {
             RoutingCapacityProfile {
                 soft_limit: 1,
                 hard_cap: 2,
@@ -1982,12 +1984,14 @@ impl AccountRoutingCandidateRow {
                 self.primary_window_minutes,
                 self.primary_resets_at.as_deref(),
                 now,
+                RoutingWindowBucket::Short,
             ),
             routing_window_state(
                 self.secondary_used_percent,
                 self.secondary_window_minutes,
                 self.secondary_resets_at.as_deref(),
                 now,
+                RoutingWindowBucket::Long,
             ),
         ]
         .into_iter()
@@ -2005,6 +2009,35 @@ impl AccountRoutingCandidateRow {
         NormalizedRoutingPressure {
             short_pressure,
             long_pressure,
+        }
+    }
+
+    fn window_signals(&self) -> RoutingWindowSignals {
+        let mut short_signal = false;
+        let mut long_signal = false;
+        for window_minutes in [self.primary_window_minutes, self.secondary_window_minutes]
+            .into_iter()
+            .flatten()
+        {
+            if window_minutes <= 360 {
+                short_signal = true;
+            } else {
+                long_signal = true;
+            }
+        }
+        if self.primary_window_minutes.is_none()
+            && (self.primary_used_percent.is_some() || self.local_primary_limit.is_some())
+        {
+            short_signal = true;
+        }
+        if self.secondary_window_minutes.is_none()
+            && (self.secondary_used_percent.is_some() || self.local_secondary_limit.is_some())
+        {
+            long_signal = true;
+        }
+        RoutingWindowSignals {
+            short_signal,
+            long_signal,
         }
     }
 
@@ -2032,6 +2065,12 @@ struct NormalizedRoutingPressure {
 }
 
 #[derive(Debug, Clone, Copy)]
+struct RoutingWindowSignals {
+    short_signal: bool,
+    long_signal: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
 struct RoutingWindowState {
     bucket: RoutingWindowBucket,
     pressure: f64,
@@ -2048,23 +2087,29 @@ fn routing_window_state(
     window_minutes: Option<i64>,
     resets_at: Option<&str>,
     now: DateTime<Utc>,
+    default_bucket: RoutingWindowBucket,
 ) -> Option<RoutingWindowState> {
     let used_ratio = normalize_unit_ratio(used_percent? / 100.0);
-    let window_minutes = window_minutes?.max(1);
-    let bucket = if window_minutes <= 360 {
-        RoutingWindowBucket::Short
+    let (bucket, remaining_ratio) = if let Some(window_minutes) = window_minutes {
+        let window_minutes = window_minutes.max(1);
+        let bucket = if window_minutes <= 360 {
+            RoutingWindowBucket::Short
+        } else {
+            RoutingWindowBucket::Long
+        };
+        let window_duration_secs = (window_minutes as f64) * 60.0;
+        let remaining_ratio = resets_at
+            .and_then(parse_rfc3339_utc)
+            .map(|reset_at| {
+                normalize_unit_ratio(
+                    (reset_at - now).num_seconds().max(0) as f64 / window_duration_secs,
+                )
+            })
+            .unwrap_or(1.0);
+        (bucket, remaining_ratio)
     } else {
-        RoutingWindowBucket::Long
+        (default_bucket, 1.0)
     };
-    let window_duration_secs = (window_minutes as f64) * 60.0;
-    let remaining_ratio = resets_at
-        .and_then(parse_rfc3339_utc)
-        .map(|reset_at| {
-            normalize_unit_ratio(
-                (reset_at - now).num_seconds().max(0) as f64 / window_duration_secs,
-            )
-        })
-        .unwrap_or(1.0);
     Some(RoutingWindowState {
         bucket,
         pressure: used_ratio * remaining_ratio,
@@ -14018,6 +14063,8 @@ async fn load_account_routing_candidates(
                 ORDER BY sample.captured_at DESC
                 LIMIT 1
             ) AS primary_resets_at,
+            account.local_primary_limit,
+            account.local_secondary_limit,
             (
                 SELECT sample.credits_has_credits
                 FROM pool_upstream_account_limit_samples sample
@@ -14133,6 +14180,8 @@ async fn load_account_routing_candidate(
                 ORDER BY sample.captured_at DESC
                 LIMIT 1
             ) AS primary_resets_at,
+            account.local_primary_limit,
+            account.local_secondary_limit,
             (
                 SELECT sample.credits_has_credits
                 FROM pool_upstream_account_limit_samples sample
@@ -16857,6 +16906,8 @@ mod tests {
             primary_used_percent: None,
             primary_window_minutes: None,
             primary_resets_at: None,
+            local_primary_limit: None,
+            local_secondary_limit: None,
             credits_has_credits: None,
             credits_unlimited: None,
             credits_balance: None,
@@ -16954,6 +17005,23 @@ mod tests {
         assert_eq!(long_only_capacity.hard_cap, 2);
         assert_eq!(short_window_capacity.soft_limit, 2);
         assert_eq!(short_window_capacity.hard_cap, 3);
+    }
+
+    #[test]
+    fn candidate_capacity_profile_preserves_legacy_limit_signals_without_window_metadata() {
+        let mut legacy_long_only = test_routing_candidate(1);
+        legacy_long_only.secondary_used_percent = Some(10.0);
+
+        let mut locally_limited = test_routing_candidate(2);
+        locally_limited.local_secondary_limit = Some(100.0);
+
+        let legacy_capacity = legacy_long_only.capacity_profile();
+        let local_capacity = locally_limited.capacity_profile();
+
+        assert_eq!(legacy_capacity.soft_limit, 1);
+        assert_eq!(legacy_capacity.hard_cap, 2);
+        assert_eq!(local_capacity.soft_limit, 1);
+        assert_eq!(local_capacity.hard_cap, 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- keep in-flight pool routing reservations counted until explicit release instead of aging them out mid-request
- preserve long-window routing caps when older remote samples or local limits still lack explicit window metadata
- add regressions for long-lived reservations, legacy long-only samples, and local long-window limits

## Testing
- cargo fmt
- cargo test resolve_pool_account_for_request_keeps_old_in_flight_reservations_counted -- --nocapture
- cargo test resolve_pool_account_for_request_preserves_ -- --nocapture
- cargo test resolve_pool_account_for_request_ -- --nocapture
- cargo test 'compare_routing_candidates_' -- --nocapture
- cargo test candidate_capacity_profile_ -- --nocapture

Follow-up to #245.

Spec: -
Spec Sync: n/a(no spec)
Spec Drift: none