### PR TITLE
fix: retry transient server overload responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,7 @@ const PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT: &str = "upstream_handshake_timeo
 const PROXY_FAILURE_UPSTREAM_STREAM_ERROR: &str = "upstream_stream_error";
 const PROXY_FAILURE_POOL_ATTEMPT_INTERRUPTED: &str = "pool_attempt_interrupted";
 const PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED: &str = "upstream_response_failed";
+const UPSTREAM_ERROR_CODE_SERVER_IS_OVERLOADED: &str = "server_is_overloaded";
 const PROXY_FAILURE_POOL_NO_AVAILABLE_ACCOUNT: &str = "pool_no_available_account";
 const PROXY_FAILURE_POOL_ALL_ACCOUNTS_RATE_LIMITED: &str = "pool_all_accounts_rate_limited";
 const PROXY_FAILURE_POOL_MAX_DISTINCT_ACCOUNTS_EXHAUSTED: &str = "max_distinct_accounts_exhausted";
@@ -11837,6 +11838,32 @@ pub(crate) fn upstream_error_indicates_quota_exhausted(message: &str) -> bool {
     .any(|needle| normalized.contains(needle))
 }
 
+fn upstream_error_code_is_server_overloaded(code: Option<&str>) -> bool {
+    code.is_some_and(|value| value.eq_ignore_ascii_case(UPSTREAM_ERROR_CODE_SERVER_IS_OVERLOADED))
+}
+
+fn route_http_failure_is_retryable_server_overloaded(
+    status: StatusCode,
+    error_message: &str,
+) -> bool {
+    if status != StatusCode::OK {
+        return false;
+    }
+
+    let normalized = error_message.to_ascii_lowercase();
+    normalized.contains(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED)
+        && normalized.contains(UPSTREAM_ERROR_CODE_SERVER_IS_OVERLOADED)
+}
+
+fn response_info_is_retryable_server_overloaded(
+    status: StatusCode,
+    response_info: &ResponseCaptureInfo,
+) -> bool {
+    status == StatusCode::OK
+        && response_info.stream_terminal_event.is_some()
+        && upstream_error_code_is_server_overloaded(response_info.upstream_error_code.as_deref())
+}
+
 pub(crate) fn classify_pool_account_http_failure(
     account_kind: &str,
     status: StatusCode,
@@ -13648,6 +13675,186 @@ async fn send_pool_request_with_failover(
                 }
             };
 
+            let first_byte_latency_ms = elapsed_ms(first_byte_started);
+            let response_is_event_stream = response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("text/event-stream"));
+            let (response, first_chunk) = if original_uri.path() == "/v1/responses"
+                && status == StatusCode::OK
+                && response_is_event_stream
+            {
+                match gate_pool_initial_response_stream(
+                    response,
+                    first_chunk,
+                    attempt_pre_first_byte_timeout,
+                    connect_started,
+                )
+                .await
+                {
+                    Ok(PoolInitialSseGateOutcome::Forward {
+                        response,
+                        prefetched_bytes,
+                    }) => (response, prefetched_bytes),
+                    Ok(PoolInitialSseGateOutcome::RetrySameAccount {
+                        message,
+                        upstream_error_code,
+                        upstream_error_message,
+                        upstream_request_id,
+                    }) => {
+                        let finished_at = shanghai_now_string();
+                        if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
+                            && let Err(record_err) = finalize_pool_upstream_request_attempt(
+                                &state.pool,
+                                pending_attempt_record,
+                                finished_at.as_str(),
+                                POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_HTTP_FAILURE,
+                                Some(status),
+                                Some(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED),
+                                Some(message.as_str()),
+                                Some(connect_latency_ms),
+                                Some(first_byte_latency_ms),
+                                None,
+                                upstream_request_id.as_deref(),
+                                None,
+                                None,
+                            )
+                            .await
+                        {
+                            warn!(
+                                invoke_id = pending_attempt_record.invoke_id,
+                                error = %record_err,
+                                "failed to persist pool retryable response.failed attempt"
+                            );
+                        }
+                        if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
+                            && let Err(err) = broadcast_pool_upstream_attempts_snapshot(
+                                state.as_ref(),
+                                &pending_attempt_record.invoke_id,
+                            )
+                            .await
+                        {
+                            warn!(
+                                invoke_id = pending_attempt_record.invoke_id,
+                                error = %err,
+                                "failed to broadcast retryable response.failed snapshot"
+                            );
+                        }
+
+                        let has_retry_budget =
+                            same_account_attempt + 1 < same_account_attempt_budget;
+                        if has_retry_budget {
+                            let retry_delay =
+                                fallback_proxy_429_retry_delay(u32::from(same_account_attempt) + 1);
+                            info!(
+                                account_id = account.account_id,
+                                retry_index = same_account_attempt + 1,
+                                max_same_account_attempts = same_account_attempt_budget,
+                                retry_after_ms = retry_delay.as_millis(),
+                                "pool upstream reported retryable response.failed before forwarding; retrying same account"
+                            );
+                            sleep(retry_delay).await;
+                            continue;
+                        }
+
+                        if let Err(route_err) = record_pool_route_retryable_overload_failure(
+                            &state.pool,
+                            account.account_id,
+                            sticky_key,
+                            &message,
+                            trace_context.as_ref().map(|trace| trace.invoke_id.as_str()),
+                        )
+                        .await
+                        {
+                            warn!(account_id = account.account_id, error = %route_err, "failed to record retryable response.failed route state");
+                        }
+                        last_error = Some(PoolUpstreamError {
+                            account: Some(account.clone()),
+                            status,
+                            message: message.clone(),
+                            failure_kind: PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED,
+                            connect_latency_ms,
+                            upstream_error_code,
+                            upstream_error_message,
+                            upstream_request_id,
+                            oauth_responses_debug: oauth_responses_debug.clone(),
+                            attempt_summary: PoolAttemptSummary::default(),
+                        });
+                        exhausted_accounts_all_rate_limited = false;
+                        continue 'account_loop;
+                    }
+                    Err(err) => {
+                        let message = format!("failed to gate first response event: {err}");
+                        let finished_at = shanghai_now_string();
+                        if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
+                            && let Err(record_err) = finalize_pool_upstream_request_attempt(
+                                &state.pool,
+                                pending_attempt_record,
+                                finished_at.as_str(),
+                                POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+                                None,
+                                Some(PROXY_FAILURE_UPSTREAM_STREAM_ERROR),
+                                Some(message.as_str()),
+                                Some(connect_latency_ms),
+                                Some(first_byte_latency_ms),
+                                None,
+                                None,
+                                None,
+                                None,
+                            )
+                            .await
+                        {
+                            warn!(
+                                invoke_id = pending_attempt_record.invoke_id,
+                                error = %record_err,
+                                "failed to persist first-event gate failure attempt"
+                            );
+                        }
+                        if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
+                            && let Err(err) = broadcast_pool_upstream_attempts_snapshot(
+                                state.as_ref(),
+                                &pending_attempt_record.invoke_id,
+                            )
+                            .await
+                        {
+                            warn!(
+                                invoke_id = pending_attempt_record.invoke_id,
+                                error = %err,
+                                "failed to broadcast first-event gate failure snapshot"
+                            );
+                        }
+                        if let Err(route_err) = record_pool_route_transport_failure(
+                            &state.pool,
+                            account.account_id,
+                            sticky_key,
+                            &message,
+                            trace_context.as_ref().map(|trace| trace.invoke_id.as_str()),
+                        )
+                        .await
+                        {
+                            warn!(account_id = account.account_id, error = %route_err, "failed to record first-event gate transport failure");
+                        }
+                        last_error = Some(PoolUpstreamError {
+                            account: Some(account.clone()),
+                            status: StatusCode::BAD_GATEWAY,
+                            message: message.clone(),
+                            failure_kind: PROXY_FAILURE_UPSTREAM_STREAM_ERROR,
+                            connect_latency_ms,
+                            upstream_error_code: None,
+                            upstream_error_message: None,
+                            upstream_request_id: None,
+                            oauth_responses_debug: oauth_responses_debug.clone(),
+                            attempt_summary: PoolAttemptSummary::default(),
+                        });
+                        exhausted_accounts_all_rate_limited = false;
+                        continue 'account_loop;
+                    }
+                }
+            } else {
+                (response, first_chunk)
+            };
+
             if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
                 && let Err(err) = advance_pool_upstream_request_attempt_phase(
                     state.as_ref(),
@@ -13697,11 +13904,11 @@ async fn send_pool_request_with_failover(
                 oauth_responses_debug,
                 connect_latency_ms,
                 attempt_started_at_utc,
-                first_byte_latency_ms: elapsed_ms(first_byte_started),
+                first_byte_latency_ms,
                 first_chunk,
                 pending_attempt_record: pending_attempt_record.map(|mut pending| {
                     pending.connect_latency_ms = connect_latency_ms;
-                    pending.first_byte_latency_ms = elapsed_ms(first_byte_started);
+                    pending.first_byte_latency_ms = first_byte_latency_ms;
                     pending.compact_support_status = compact_support_observation
                         .as_ref()
                         .map(|value| value.status.to_string());
@@ -15638,16 +15845,28 @@ async fn proxy_openai_v1_capture_target(
                         state_for_task.as_ref(),
                         &reservation_key_for_task,
                     );
-                    record_pool_route_http_failure(
-                        &state_for_task.pool,
-                        account.account_id,
-                        &account.kind,
-                        sticky_key_for_task.as_deref(),
-                        upstream_status,
-                        &route_message,
-                        None,
-                    )
-                    .await
+                    if response_info_is_retryable_server_overloaded(upstream_status, &response_info)
+                    {
+                        record_pool_route_retryable_overload_failure(
+                            &state_for_task.pool,
+                            account.account_id,
+                            sticky_key_for_task.as_deref(),
+                            &route_message,
+                            None,
+                        )
+                        .await
+                    } else {
+                        record_pool_route_http_failure(
+                            &state_for_task.pool,
+                            account.account_id,
+                            &account.kind,
+                            sticky_key_for_task.as_deref(),
+                            upstream_status,
+                            &route_message,
+                            None,
+                        )
+                        .await
+                    }
                 };
                 if let Err(err) = route_result {
                     warn!(account_id = account.account_id, error = %err, "failed to record pool capture route state");
@@ -17003,6 +17222,120 @@ fn extract_upstream_request_id(value: &Value) -> Option<String> {
             extract_upstream_error_message(value)
                 .and_then(|message| extract_request_id_from_message(&message))
         })
+}
+
+fn find_first_sse_event_boundary(bytes: &[u8]) -> Option<usize> {
+    let mut index = 0usize;
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'\n' && bytes[index + 1] == b'\n' {
+            return Some(index + 2);
+        }
+        if index + 3 < bytes.len()
+            && bytes[index] == b'\r'
+            && bytes[index + 1] == b'\n'
+            && bytes[index + 2] == b'\r'
+            && bytes[index + 3] == b'\n'
+        {
+            return Some(index + 4);
+        }
+        index += 1;
+    }
+    None
+}
+
+fn rebuild_proxy_upstream_response_stream(
+    status: StatusCode,
+    headers: &HeaderMap,
+    stream: Pin<Box<dyn futures_util::Stream<Item = Result<Bytes, io::Error>> + Send>>,
+) -> Result<ProxyUpstreamResponseBody, String> {
+    let mut response_builder = Response::builder().status(status);
+    for (name, value) in headers {
+        response_builder = response_builder.header(name, value);
+    }
+    response_builder
+        .body(Body::from_stream(stream))
+        .map(ProxyUpstreamResponseBody::Axum)
+        .map_err(|err| format!("failed to rebuild upstream response stream: {err}"))
+}
+
+enum PoolInitialSseGateOutcome {
+    Forward {
+        response: ProxyUpstreamResponseBody,
+        prefetched_bytes: Option<Bytes>,
+    },
+    RetrySameAccount {
+        message: String,
+        upstream_error_code: Option<String>,
+        upstream_error_message: Option<String>,
+        upstream_request_id: Option<String>,
+    },
+}
+
+async fn gate_pool_initial_response_stream(
+    response: ProxyUpstreamResponseBody,
+    prefetched_first_chunk: Option<Bytes>,
+    total_timeout: Duration,
+    started: Instant,
+) -> Result<PoolInitialSseGateOutcome, String> {
+    let status = response.status();
+    let headers = response.headers().clone();
+    let mut stream = response.into_bytes_stream();
+    let mut buffered = Vec::new();
+    if let Some(chunk) = prefetched_first_chunk {
+        buffered.extend_from_slice(&chunk);
+    }
+
+    let mut gate_stream_error: Option<io::Error> = None;
+    loop {
+        if let Some(event_end) = find_first_sse_event_boundary(&buffered) {
+            let response_info = parse_stream_response_payload(&buffered[..event_end]);
+            if response_info_is_retryable_server_overloaded(status, &response_info) {
+                return Ok(PoolInitialSseGateOutcome::RetrySameAccount {
+                    message: format_upstream_response_failed_message(&response_info),
+                    upstream_error_code: response_info.upstream_error_code,
+                    upstream_error_message: response_info.upstream_error_message,
+                    upstream_request_id: response_info.upstream_request_id,
+                });
+            }
+            break;
+        }
+        if buffered.len() >= RAW_RESPONSE_PREVIEW_LIMIT {
+            break;
+        }
+
+        let Some(timeout_budget) = remaining_timeout_budget(total_timeout, started.elapsed())
+        else {
+            break;
+        };
+        let next_chunk = match timeout(timeout_budget, stream.next()).await {
+            Ok(next_chunk) => next_chunk,
+            Err(_) => break,
+        };
+        let Some(next_chunk) = next_chunk else {
+            break;
+        };
+        match next_chunk {
+            Ok(chunk) => buffered.extend_from_slice(&chunk),
+            Err(err) => {
+                gate_stream_error = Some(io::Error::other(err.to_string()));
+                break;
+            }
+        }
+    }
+
+    let remaining_stream: Pin<
+        Box<dyn futures_util::Stream<Item = Result<Bytes, io::Error>> + Send>,
+    > = if let Some(err) = gate_stream_error {
+        Box::pin(stream::once(async move { Err(err) }))
+    } else {
+        stream
+    };
+    let rebuilt_response =
+        rebuild_proxy_upstream_response_stream(status, &headers, remaining_stream)?;
+    Ok(PoolInitialSseGateOutcome::Forward {
+        response: rebuilt_response,
+        prefetched_bytes: (!buffered.is_empty()).then_some(Bytes::from(buffered)),
+    })
 }
 
 fn extract_request_id_from_message(message: &str) -> Option<String> {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12124,6 +12124,17 @@ struct PoolFirstChunkRetryUpstreamState {
 }
 
 #[derive(Clone)]
+struct PoolResponseFailedRetryUpstreamState {
+    attempts: Arc<StdMutex<HashMap<String, usize>>>,
+    fail_before_success: Arc<HashMap<String, usize>>,
+}
+
+#[derive(Clone)]
+struct PoolLateResponseFailedUpstreamState {
+    attempts: Arc<StdMutex<HashMap<String, usize>>>,
+}
+
+#[derive(Clone)]
 struct PoolDelayedFirstChunkUpstreamState {
     first_chunk_delay: Duration,
 }
@@ -12431,6 +12442,101 @@ async fn pool_first_chunk_retry_upstream(
             "authorization": authorization,
             "attempt": attempt,
         })),
+    )
+        .into_response()
+}
+
+async fn pool_response_failed_retry_upstream(
+    State(state): State<PoolResponseFailedRetryUpstreamState>,
+    headers: HeaderMap,
+) -> Response {
+    let authorization = headers
+        .get(http_header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+
+    let attempt = {
+        let mut attempts = state
+            .attempts
+            .lock()
+            .expect("lock pool response.failed retry attempts");
+        let entry = attempts.entry(authorization.clone()).or_insert(0);
+        *entry += 1;
+        *entry
+    };
+
+    if attempt
+        <= state
+            .fail_before_success
+            .get(&authorization)
+            .copied()
+            .unwrap_or(0)
+    {
+        let payload = [
+            "event: response.failed\n",
+            r#"data: {"type":"response.failed","response":{"id":"resp_overloaded_retry","model":"gpt-5.4","status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}}"#,
+            "\n\n",
+        ]
+        .concat();
+        return (
+            StatusCode::OK,
+            [(
+                http_header::CONTENT_TYPE,
+                HeaderValue::from_static("text/event-stream"),
+            )],
+            Body::from(payload),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "authorization": authorization,
+            "attempt": attempt,
+        })),
+    )
+        .into_response()
+}
+
+async fn pool_late_response_failed_upstream(
+    State(state): State<PoolLateResponseFailedUpstreamState>,
+    headers: HeaderMap,
+) -> Response {
+    let authorization = headers
+        .get(http_header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+
+    {
+        let mut attempts = state
+            .attempts
+            .lock()
+            .expect("lock pool late response.failed attempts");
+        let entry = attempts.entry(authorization).or_insert(0);
+        *entry += 1;
+    }
+
+    let payload = [
+        "event: response.created\n",
+        r#"data: {"type":"response.created","response":{"id":"resp_overloaded_late","model":"gpt-5.4","status":"in_progress"}}"#,
+        "\n\n",
+        "event: response.failed\n",
+        r#"data: {"type":"response.failed","response":{"id":"resp_overloaded_late","model":"gpt-5.4","status":"failed","error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}}"#,
+        "\n\n",
+    ]
+    .concat();
+
+    (
+        StatusCode::OK,
+        [(
+            http_header::CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream"),
+        )],
+        Body::from(payload),
     )
         .into_response()
 }
@@ -13066,6 +13172,65 @@ async fn spawn_pool_first_chunk_retry_upstream(
         axum::serve(listener, app)
             .await
             .expect("pool first chunk retry upstream should run");
+    });
+    (format!("http://{addr}"), attempts, handle)
+}
+
+async fn spawn_pool_response_failed_retry_upstream(
+    fail_before_success: &[(&str, usize)],
+) -> (
+    String,
+    Arc<StdMutex<HashMap<String, usize>>>,
+    JoinHandle<()>,
+) {
+    let attempts = Arc::new(StdMutex::new(HashMap::new()));
+    let fail_before_success = Arc::new(
+        fail_before_success
+            .iter()
+            .map(|(authorization, failures)| ((*authorization).to_string(), *failures))
+            .collect::<HashMap<_, _>>(),
+    );
+    let app = Router::new()
+        .route("/v1/responses", post(pool_response_failed_retry_upstream))
+        .with_state(PoolResponseFailedRetryUpstreamState {
+            attempts: attempts.clone(),
+            fail_before_success,
+        });
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind pool response.failed retry upstream");
+    let addr = listener
+        .local_addr()
+        .expect("pool response.failed retry upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("pool response.failed retry upstream should run");
+    });
+    (format!("http://{addr}"), attempts, handle)
+}
+
+async fn spawn_pool_late_response_failed_upstream() -> (
+    String,
+    Arc<StdMutex<HashMap<String, usize>>>,
+    JoinHandle<()>,
+) {
+    let attempts = Arc::new(StdMutex::new(HashMap::new()));
+    let app = Router::new()
+        .route("/v1/responses", post(pool_late_response_failed_upstream))
+        .with_state(PoolLateResponseFailedUpstreamState {
+            attempts: attempts.clone(),
+        });
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind pool late response.failed upstream");
+    let addr = listener
+        .local_addr()
+        .expect("pool late response.failed upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("pool late response.failed upstream should run");
     });
     (format!("http://{addr}"), attempts, handle)
 }
@@ -17073,6 +17238,141 @@ async fn pool_openai_v1_responses_stream_timeout_does_not_cap_same_account_retry
 }
 
 #[tokio::test]
+async fn pool_openai_v1_responses_retries_same_account_on_server_overloaded_before_forwarding() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct AttemptRouteRow {
+        distinct_account_index: i64,
+        status: String,
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct AccountActionRow {
+        action: Option<String>,
+        reason_code: Option<String>,
+        cooldown_until: Option<String>,
+    }
+
+    let (upstream_base, attempts, upstream_handle) =
+        spawn_pool_response_failed_retry_upstream(&[("Bearer route-one", 2)]).await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let account_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Retry Route One",
+        "route-one",
+        None,
+        None,
+        Some(upstream_base.as_str()),
+    )
+    .await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5.4","stream":true,"input":"hello","stickyKey":"sticky-overloaded-retry-001"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read retryable overloaded response");
+    let response_payload: Value =
+        serde_json::from_slice(&body).expect("decode retryable overloaded success body");
+    assert_eq!(response_payload["ok"].as_bool(), Some(true));
+    assert_eq!(
+        response_payload["authorization"].as_str(),
+        Some("Bearer route-one"),
+    );
+    let body_text = String::from_utf8(body.to_vec()).expect("utf8 retryable overloaded body");
+    assert!(!body_text.contains("response.failed"));
+    assert!(!body_text.contains("server_is_overloaded"));
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    wait_for_pool_attempt_row_count(&state.pool, 3).await;
+
+    let attempt_rows = sqlx::query_as::<_, AttemptRouteRow>(
+        r#"
+        SELECT distinct_account_index, status
+        FROM pool_upstream_request_attempts
+        ORDER BY attempt_index ASC
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load overloaded retry attempt rows");
+    assert_eq!(attempt_rows.len(), 3);
+    assert_eq!(
+        attempt_rows[0].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_HTTP_FAILURE
+    );
+    assert_eq!(
+        attempt_rows[1].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_HTTP_FAILURE
+    );
+    assert_eq!(
+        attempt_rows[2].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS
+    );
+    assert!(
+        attempt_rows
+            .iter()
+            .all(|row| row.distinct_account_index == 1)
+    );
+
+    let row = sqlx::query_as::<_, AccountActionRow>(
+        r#"
+        SELECT last_action AS action, last_action_reason_code AS reason_code, cooldown_until
+        FROM pool_upstream_accounts
+        WHERE id = ?1
+        "#,
+    )
+    .bind(account_id)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load overloaded retry account state");
+    assert_eq!(row.action.as_deref(), Some("route_recovered"));
+    assert!(row.reason_code.is_none());
+    assert!(row.cooldown_until.is_none());
+
+    let recent_actions: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT action
+        FROM pool_upstream_account_events
+        WHERE account_id = ?1
+        ORDER BY id DESC
+        LIMIT 5
+        "#,
+    )
+    .bind(account_id)
+    .fetch_all(&state.pool)
+    .await
+    .expect("load overloaded retry account events");
+    assert!(
+        !recent_actions
+            .iter()
+            .any(|action| action == "route_cooldown_started")
+    );
+
+    let attempts = attempts.lock().expect("lock retryable overloaded attempts");
+    assert_eq!(attempts.get("Bearer route-one").copied(), Some(3));
+    drop(attempts);
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn pool_route_marks_oauth_missing_scopes_as_error_and_persists_upstream_details() {
     let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
         .lock()
@@ -18959,6 +19259,136 @@ async fn capture_target_pool_route_marks_response_failed_stream_as_route_failure
             .is_none(),
         "logical stream failure should detach the sticky binding",
     );
+
+    upstream_handle.abort();
+}
+
+async fn capture_target_pool_route_marks_server_overloaded_after_forward_as_retryable_without_cooldown()
+ {
+    #[derive(sqlx::FromRow)]
+    struct RouteStateRow {
+        status: String,
+        last_action: Option<String>,
+        last_action_reason_code: Option<String>,
+        last_action_http_status: Option<i64>,
+        cooldown_until: Option<String>,
+        last_route_failure_kind: Option<String>,
+    }
+
+    let (upstream_base, attempts, upstream_handle) =
+        spawn_pool_late_response_failed_upstream().await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let account_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Primary",
+        "upstream-primary",
+        None,
+        None,
+        Some(upstream_base.as_str()),
+    )
+    .await;
+    record_pool_route_success(
+        &state.pool,
+        account_id,
+        Utc::now(),
+        Some("sticky-cap-overloaded-late"),
+        None,
+    )
+    .await
+    .expect("seed sticky route");
+
+    let request_body = serde_json::to_vec(&json!({
+        "model": "gpt-5.4",
+        "stream": true,
+        "input": "hello",
+        "stickyKey": "sticky-cap-overloaded-late"
+    }))
+    .expect("serialize request body");
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(request_body),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read late overloaded response body");
+    let body_text = String::from_utf8(body.to_vec()).expect("utf8 late overloaded body");
+    assert!(body_text.contains("response.created"));
+    assert!(body_text.contains("server_is_overloaded"));
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let route_state = sqlx::query_as::<_, RouteStateRow>(
+        r#"
+        SELECT
+            status,
+            last_action,
+            last_action_reason_code,
+            last_action_http_status,
+            cooldown_until,
+            last_route_failure_kind
+        FROM pool_upstream_accounts
+        WHERE id = ?1
+        "#,
+    )
+    .bind(account_id)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load late overloaded route state");
+    assert_eq!(route_state.status, "active");
+    assert_eq!(
+        route_state.last_action.as_deref(),
+        Some("route_retryable_failure")
+    );
+    assert_eq!(
+        route_state.last_action_reason_code.as_deref(),
+        Some("upstream_server_overloaded")
+    );
+    assert_eq!(route_state.last_action_http_status, Some(200));
+    assert!(route_state.cooldown_until.is_none());
+    assert_eq!(
+        route_state.last_route_failure_kind.as_deref(),
+        Some("upstream_response_failed")
+    );
+    assert_eq!(
+        load_test_sticky_route_account_id(&state.pool, "sticky-cap-overloaded-late").await,
+        Some(account_id),
+        "retryable overload should keep the sticky binding",
+    );
+
+    let recent_actions: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT action
+        FROM pool_upstream_account_events
+        WHERE account_id = ?1
+        ORDER BY id DESC
+        LIMIT 5
+        "#,
+    )
+    .bind(account_id)
+    .fetch_all(&state.pool)
+    .await
+    .expect("load late overloaded events");
+    assert!(
+        !recent_actions
+            .iter()
+            .any(|action| action == "route_cooldown_started")
+    );
+
+    let attempts = attempts.lock().expect("lock late overloaded attempts");
+    assert_eq!(attempts.get("Bearer upstream-primary").copied(), Some(1));
+    drop(attempts);
 
     upstream_handle.abort();
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19263,6 +19263,7 @@ async fn capture_target_pool_route_marks_response_failed_stream_as_route_failure
     upstream_handle.abort();
 }
 
+#[tokio::test]
 async fn capture_target_pool_route_marks_server_overloaded_after_forward_as_retryable_without_cooldown()
  {
     #[derive(sqlx::FromRow)]

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -71,6 +71,7 @@ const UPSTREAM_ACCOUNT_SYNC_STATE_IDLE: &str = "idle";
 const UPSTREAM_ACCOUNT_SYNC_STATE_SYNCING: &str = "syncing";
 const UPSTREAM_ACCOUNT_ACTION_ROUTE_RECOVERED: &str = "route_recovered";
 const UPSTREAM_ACCOUNT_ACTION_ROUTE_COOLDOWN_STARTED: &str = "route_cooldown_started";
+const UPSTREAM_ACCOUNT_ACTION_ROUTE_RETRYABLE_FAILURE: &str = "route_retryable_failure";
 const UPSTREAM_ACCOUNT_ACTION_ROUTE_HARD_UNAVAILABLE: &str = "route_hard_unavailable";
 const UPSTREAM_ACCOUNT_ACTION_SYNC_SUCCEEDED: &str = "sync_succeeded";
 const UPSTREAM_ACCOUNT_ACTION_SYNC_HARD_UNAVAILABLE: &str = "sync_hard_unavailable";
@@ -95,6 +96,8 @@ const UPSTREAM_ACCOUNT_ACTION_REASON_UPSTREAM_HTTP_429_RATE_LIMIT: &str =
 const UPSTREAM_ACCOUNT_ACTION_REASON_UPSTREAM_HTTP_429_QUOTA_EXHAUSTED: &str =
     "upstream_http_429_quota_exhausted";
 const UPSTREAM_ACCOUNT_ACTION_REASON_TRANSPORT_FAILURE: &str = "transport_failure";
+const UPSTREAM_ACCOUNT_ACTION_REASON_UPSTREAM_SERVER_OVERLOADED: &str =
+    "upstream_server_overloaded";
 const UPSTREAM_ACCOUNT_ACTION_REASON_REAUTH_REQUIRED: &str = "reauth_required";
 const BULK_UPSTREAM_ACCOUNT_ACTION_ENABLE: &str = "enable";
 const BULK_UPSTREAM_ACCOUNT_ACTION_DISABLE: &str = "disable";
@@ -11028,6 +11031,7 @@ fn derive_upstream_account_health_status(
         last_error_at,
         last_route_failure_at,
         last_route_failure_kind,
+        last_action_reason_code,
     ) {
         return UPSTREAM_ACCOUNT_HEALTH_STATUS_NORMAL;
     }
@@ -11078,6 +11082,7 @@ fn is_transient_route_failure_error(
     last_error_at: Option<&str>,
     last_route_failure_at: Option<&str>,
     last_route_failure_kind: Option<&str>,
+    last_action_reason_code: Option<&str>,
 ) -> bool {
     if last_error_at.is_none() || last_error_at != last_route_failure_at {
         return false;
@@ -11085,6 +11090,12 @@ fn is_transient_route_failure_error(
     let failure_kind = last_route_failure_kind
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    if matches!(
+        last_action_reason_code,
+        Some(UPSTREAM_ACCOUNT_ACTION_REASON_UPSTREAM_SERVER_OVERLOADED)
+    ) {
+        return matches!(failure_kind, Some(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED));
+    }
     route_failure_kind_is_rate_limited(failure_kind)
         || matches!(
             failure_kind,
@@ -13899,6 +13910,17 @@ pub(crate) async fn record_pool_route_http_failure(
     error_message: &str,
     invoke_id: Option<&str>,
 ) -> Result<()> {
+    if route_http_failure_is_retryable_server_overloaded(status, error_message) {
+        return record_pool_route_retryable_overload_failure(
+            pool,
+            account_id,
+            sticky_key,
+            error_message,
+            invoke_id,
+        )
+        .await;
+    }
+
     let classification = classify_pool_account_http_failure(account_kind, status, error_message);
     match classification.disposition {
         UpstreamAccountFailureDisposition::HardUnavailable => {
@@ -13970,6 +13992,53 @@ pub(crate) async fn record_pool_route_http_failure(
             .await
         }
     }
+}
+
+pub(crate) async fn record_pool_route_retryable_overload_failure(
+    pool: &Pool<Sqlite>,
+    account_id: i64,
+    sticky_key: Option<&str>,
+    error_message: &str,
+    invoke_id: Option<&str>,
+) -> Result<()> {
+    let now_iso = format_utc_iso(Utc::now());
+    sqlx::query(
+        r#"
+        UPDATE pool_upstream_accounts
+        SET status = ?2,
+            last_error = ?3,
+            last_error_at = ?4,
+            last_route_failure_at = ?4,
+            last_route_failure_kind = ?5,
+            cooldown_until = NULL,
+            updated_at = ?4
+        WHERE id = ?1
+        "#,
+    )
+    .bind(account_id)
+    .bind(UPSTREAM_ACCOUNT_STATUS_ACTIVE)
+    .bind(error_message)
+    .bind(&now_iso)
+    .bind(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED)
+    .execute(pool)
+    .await?;
+    record_upstream_account_action(
+        pool,
+        account_id,
+        UpstreamAccountActionPayload {
+            action: UPSTREAM_ACCOUNT_ACTION_ROUTE_RETRYABLE_FAILURE,
+            source: UPSTREAM_ACCOUNT_ACTION_SOURCE_CALL,
+            reason_code: Some(UPSTREAM_ACCOUNT_ACTION_REASON_UPSTREAM_SERVER_OVERLOADED),
+            reason_message: Some(error_message),
+            http_status: Some(StatusCode::OK),
+            failure_kind: Some(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED),
+            invoke_id,
+            sticky_key,
+            occurred_at: &now_iso,
+        },
+    )
+    .await?;
+    Ok(())
 }
 
 pub(crate) async fn record_pool_route_transport_failure(
@@ -18010,6 +18079,58 @@ mod tests {
             Some(FORWARD_PROXY_FAILURE_UPSTREAM_HTTP_429_QUOTA_EXHAUSTED)
         );
         assert!(row.cooldown_until.is_none());
+    }
+
+    #[tokio::test]
+    async fn record_pool_route_http_failure_keeps_server_overloaded_as_retryable_without_cooldown()
+    {
+        let pool = test_pool().await;
+        let account_id = insert_api_key_account(&pool, "Overloaded Key").await;
+
+        record_pool_route_http_failure(
+            &pool,
+            account_id,
+            UPSTREAM_ACCOUNT_KIND_API_KEY_CODEX,
+            Some("sticky-overloaded"),
+            StatusCode::OK,
+            "[upstream_response_failed] server_is_overloaded: Our servers are currently overloaded. Please try again later.",
+            Some("invk_overloaded"),
+        )
+        .await
+        .expect("record retryable overload route failure");
+
+        let row = load_upstream_account_row(&pool, account_id)
+            .await
+            .expect("load overloaded row")
+            .expect("overloaded row exists");
+        assert_eq!(row.status, UPSTREAM_ACCOUNT_STATUS_ACTIVE);
+        assert_eq!(
+            row.last_action.as_deref(),
+            Some(UPSTREAM_ACCOUNT_ACTION_ROUTE_RETRYABLE_FAILURE)
+        );
+        assert_eq!(
+            row.last_action_reason_code.as_deref(),
+            Some(UPSTREAM_ACCOUNT_ACTION_REASON_UPSTREAM_SERVER_OVERLOADED)
+        );
+        assert_eq!(row.last_action_http_status, Some(200));
+        assert_eq!(
+            row.last_route_failure_kind.as_deref(),
+            Some(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED)
+        );
+        assert!(row.cooldown_until.is_none());
+        assert_eq!(row.consecutive_route_failures, 0);
+
+        let summary = build_summary_from_row(
+            &row,
+            None,
+            row.last_activity_at.clone(),
+            vec![],
+            None,
+            0,
+            Utc::now(),
+        );
+        assert_eq!(summary.health_status, UPSTREAM_ACCOUNT_HEALTH_STATUS_NORMAL);
+        assert_eq!(summary.work_status, UPSTREAM_ACCOUNT_WORK_STATUS_IDLE);
     }
 
     #[test]

--- a/web/src/components/UpstreamAccountsTable.stories.tsx
+++ b/web/src/components/UpstreamAccountsTable.stories.tsx
@@ -197,6 +197,7 @@ const labels = {
   action: (action?: string | null) =>
     ({
       route_hard_unavailable: 'Hard unavailable',
+      route_retryable_failure: 'Temporary upstream failure',
       route_cooldown_started: 'Route cooldown',
       sync_failed: 'Sync failed',
     })[action ?? ''] ?? action ?? null,
@@ -208,6 +209,7 @@ const labels = {
   actionReason: (reason?: string | null) =>
     ({
       upstream_http_429_quota_exhausted: 'Weekly cap exhausted',
+      upstream_server_overloaded: 'Upstream is temporarily overloaded',
       reauth_required: 'Needs reauth',
     })[reason ?? ''] ?? reason ?? null,
   latestActionFieldAction: 'Action',
@@ -264,6 +266,7 @@ const chineseLabels = {
   action: (action?: string | null) =>
     ({
       route_hard_unavailable: '硬拒绝',
+      route_retryable_failure: '临时上游失败',
       route_cooldown_started: '冷却开始',
       sync_failed: '同步失败',
     })[action ?? ''] ?? action ?? null,
@@ -275,6 +278,7 @@ const chineseLabels = {
   actionReason: (reason?: string | null) =>
     ({
       upstream_http_429_quota_exhausted: '周限额耗尽',
+      upstream_server_overloaded: '上游暂时过载',
       reauth_required: '需要重新授权',
     })[reason ?? ''] ?? reason ?? null,
   latestActionFieldAction: '动作',

--- a/web/src/components/UpstreamAccountsTable.test.tsx
+++ b/web/src/components/UpstreamAccountsTable.test.tsx
@@ -81,6 +81,7 @@ const labels = {
   action: (action?: string | null) =>
     ({
       route_hard_unavailable: 'Hard unavailable',
+      route_retryable_failure: 'Temporary upstream failure',
       route_cooldown_started: 'Route cooldown',
       sync_failed: 'Sync failed',
       sync_recovery_blocked: 'Recovery blocked',
@@ -105,6 +106,7 @@ const labels = {
     ({
       upstream_http_402: 'Plan or billing rejected',
       upstream_http_429_quota_exhausted: 'Weekly cap exhausted',
+      upstream_server_overloaded: 'Upstream is temporarily overloaded',
       quota_still_exhausted: 'Still exhausted',
       reauth_required: 'Needs reauth',
     })[reason ?? ''] ??

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -870,6 +870,8 @@ const baseTranslations = {
       "Unknown",
     "accountPool.upstreamAccounts.latestAction.actions.route_recovered":
       "Route recovered",
+    "accountPool.upstreamAccounts.latestAction.actions.route_retryable_failure":
+      "Temporary upstream failure",
     "accountPool.upstreamAccounts.latestAction.actions.route_cooldown_started":
       "Route cooldown",
     "accountPool.upstreamAccounts.latestAction.actions.route_hard_unavailable":
@@ -909,6 +911,8 @@ const baseTranslations = {
       "Manual recovery is required before the account can return to routing",
     "accountPool.upstreamAccounts.latestAction.reasons.transport_failure":
       "Transport failure",
+    "accountPool.upstreamAccounts.latestAction.reasons.upstream_server_overloaded":
+      "Upstream is temporarily overloaded",
     "accountPool.upstreamAccounts.latestAction.reasons.reauth_required":
       "Reauthentication required",
     "accountPool.upstreamAccounts.latestAction.reasons.upstream_http_401":
@@ -2336,6 +2340,8 @@ const baseTranslations = {
     "accountPool.upstreamAccounts.latestAction.fields.message": "消息",
     "accountPool.upstreamAccounts.latestAction.actions.route_recovered":
       "路由恢复成功",
+    "accountPool.upstreamAccounts.latestAction.actions.route_retryable_failure":
+      "临时上游失败",
     "accountPool.upstreamAccounts.latestAction.actions.route_cooldown_started":
       "进入冷却",
     "accountPool.upstreamAccounts.latestAction.actions.route_hard_unavailable":
@@ -2373,6 +2379,8 @@ const baseTranslations = {
       "账号返回路由前仍需要人工恢复",
     "accountPool.upstreamAccounts.latestAction.reasons.transport_failure":
       "网络或传输失败",
+    "accountPool.upstreamAccounts.latestAction.reasons.upstream_server_overloaded":
+      "上游暂时过载",
     "accountPool.upstreamAccounts.latestAction.reasons.reauth_required":
       "需要重新登录",
     "accountPool.upstreamAccounts.latestAction.reasons.upstream_http_401":

--- a/web/src/pages/account-pool/UpstreamAccounts.test.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.test.tsx
@@ -665,6 +665,62 @@ describe("UpstreamAccountsPage duplicates", () => {
     expect(document.body.textContent).toContain("invk_action_001");
   });
 
+  it("renders retryable upstream overload actions without cooldown wording", async () => {
+    mockAccountsPage({
+      selectedSummary: {
+        status: "active",
+        displayStatus: "active",
+        healthStatus: "normal",
+        workStatus: "working",
+        lastAction: "route_retryable_failure",
+        lastActionSource: "call",
+        lastActionReasonCode: "upstream_server_overloaded",
+        lastActionReasonMessage:
+          "[upstream_response_failed] server_is_overloaded: Our servers are currently overloaded. Please try again later.",
+        lastActionHttpStatus: 200,
+      },
+      detail: {
+        status: "active",
+        displayStatus: "active",
+        healthStatus: "normal",
+        workStatus: "working",
+        lastAction: "route_retryable_failure",
+        lastActionSource: "call",
+        lastActionReasonCode: "upstream_server_overloaded",
+        lastActionReasonMessage:
+          "[upstream_response_failed] server_is_overloaded: Our servers are currently overloaded. Please try again later.",
+        lastActionHttpStatus: 200,
+        recentActions: [
+          {
+            id: 73,
+            occurredAt: "2026-03-27T07:06:29.000Z",
+            action: "route_retryable_failure",
+            source: "call",
+            reasonCode: "upstream_server_overloaded",
+            reasonMessage:
+              "[upstream_response_failed] server_is_overloaded: Our servers are currently overloaded. Please try again later.",
+            httpStatus: 200,
+            failureKind: "upstream_response_failed",
+            invokeId: "invk_overloaded_001",
+            stickyKey: "sticky-overloaded-001",
+            createdAt: "2026-03-27T07:06:29.000Z",
+          },
+        ],
+      },
+    });
+    render("/account-pool/upstream-accounts");
+
+    clickFirstRosterRow();
+    await flushAsync();
+    clickTab(/Health & events/i);
+    await flushAsync();
+
+    expect(document.body.textContent).toContain("Temporary upstream failure");
+    expect(document.body.textContent).toContain("Upstream is temporarily overloaded");
+    expect(document.body.textContent).toContain("HTTP 200");
+    expect(document.body.textContent).not.toContain("Route cooldown");
+  });
+
   it("renders blocked recovery actions with translated source and reason labels", async () => {
     mockAccountsPage({
       selectedSummary: {


### PR DESCRIPTION
## Summary
- stop classifying `HTTP 200` `response.failed` streams with `server_is_overloaded` as cooldown-worthy route failures
- gate the first `/v1/responses` SSE event so transient overloads retry the same account before any downstream bytes are forwarded
- add a non-cooldown account action/reason and update the account-pool UI labels/tests to render the transient failure correctly

## Verification
- `cargo test server_overloaded_as_retryable_without_cooldown`
- `cargo test retries_same_account_on_server_overloaded_before_forwarding`
- `cargo test server_overloaded_after_forward_as_retryable_without_cooldown`
- `cargo test capture_target_pool_route_marks_response_failed_stream_as_route_failure`
- `cargo test pool_openai_v1_responses_stream_timeout_does_not_cap_same_account_retry_before_first_byte`
- `cd web && bun install`
- `cd web && bun run test -- src/pages/account-pool/UpstreamAccounts.test.tsx src/components/UpstreamAccountsTable.test.tsx`