### PR TITLE
fix(proxy): preserve legacy bound aliases across param renames

### DIFF
--- a/docs/specs/mww8f-pool-bound-forward-proxy-routing/SPEC.md
+++ b/docs/specs/mww8f-pool-bound-forward-proxy-routing/SPEC.md
@@ -4,7 +4,7 @@
 
 - Status: 已完成
 - Created: 2026-03-26
-- Last: 2026-03-29
+- Last: 2026-03-30
 
 ## 背景
 
@@ -94,13 +94,13 @@
   - `selectable`
 - 新保存的 `boundProxyKeys` 必须写入稳定节点身份键；稳定键默认忽略纯展示字段，如 share-link fragment、`ps`、仅用于命名的 label，但保留协议、主机、端口、账号/UUID/密码与传输配置等真实连接身份字段。
 - 若当前 inventory 中仍能定位到同一真实节点，`forwardProxyNodes[].aliasKeys` 必须返回可映射到当前稳定键的历史 legacy key，供前端在编辑弹窗中自动规范化旧绑定并继续保存。
-- `forwardProxyNodes[].aliasKeys` 对 `vless/trojan` 必须同时覆盖“显式写出默认参数”和“省略默认参数”这两类旧式 share-link 哈希，只要真实连接身份不变，都应映射回同一当前稳定键。
+- `forwardProxyNodes[].aliasKeys` 对 `vless/trojan` 必须同时覆盖“显式写出默认参数”、“省略默认参数”以及 `type/net`、`sni/serverName`、`fp/fingerprint`、`serviceName/service_name` 这类同义 query key 命名差异导致的旧式 share-link 哈希，只要真实连接身份不变，都应映射回同一当前稳定键。
 - `forwardProxyNodes[].displayName` 只负责展示，不参与绑定匹配；非 ASCII 名称必须按人类可读文本返回。
 - `PUT /api/pool/upstream-account-groups/:groupName` 支持更新 `note` 与 `boundProxyKeys`；若分组不存在实际账号，返回 `404`。
 - 当 `boundProxyKeys` 非空但当前选中集合里没有任何 `selectable=true` 的节点时，`PUT /api/pool/upstream-account-groups/:groupName` 必须返回 `400`，拒绝把“零可选节点”状态再次写回 metadata。
 - 已保存但当前 inventory 已不存在的 `boundProxyKeys` 会继续保留在分组 metadata 中；前端需标记为失效，运行时只使用仍然 `selectable=true` 的 key。
 - 历史旧 key 不做自动迁移；若当前 inventory 中找不到它们，接口应优先从 metadata history 恢复 `displayName` 并返回不可用节点，只有在完全没有展示元数据时才允许回退到原始 key。
-- `forward_proxy_runtime`、attempt/hourly 统计与 metadata history 中的历史旧 key 也不做 DB migration；只要当前 settings 或 metadata 仍能提供同一真实节点的 raw identity，运行时和统计查询都必须把旧 raw URL key、旧式 `vless/trojan` 哈希以及默认参数显式/省略两种 legacy key 归并回当前稳定键。
+- `forward_proxy_runtime`、attempt/hourly 统计与 metadata history 中的历史旧 key 也不做 DB migration；只要当前 settings 或 metadata 仍能提供同一真实节点的 raw identity，运行时和统计查询都必须把旧 raw URL key、旧式 `vless/trojan` 哈希、默认参数显式/省略变体，以及同义 query key 命名差异产生的 legacy key 归并回当前稳定键。
 
 ### 分组绑定弹窗
 
@@ -131,8 +131,8 @@
 - Given 用户已保存分组绑定，When 订阅刷新或节点备注名变化但真实连接身份不变，Then 刷新后 `boundProxyKeys` 仍稳定回显到同一节点。
 - Given 节点名称包含非 ASCII 字符，When 打开号池分组设置，Then 可选、不可选与历史失效三种状态都显示人类可读名称，且只在没有任何展示元数据时才回退到 key。
 - Given 打开号池分组设置且当前选中的绑定节点全部不可用，When 用户尝试保存，Then UI 禁用保存按钮并显示 warning，后端接口也返回 `400` 拒绝该提交。
-- Given 分组 metadata 中仍保存着旧版 VLESS/Trojan legacy key，When 当前 inventory 里还能匹配到同一真实节点，Then 弹窗会自动将其规范到当前稳定键、保持该节点可选可保存，且不会误显示为 Missing / Unavailable。
-- Given 历史 runtime 或 hourly 统计仍使用旧版 VLESS/Trojan legacy key，When 当前 settings 或 metadata 里还能定位到同一真实节点，Then 权重、惩罚态和 24 小时趋势都会继续归并到当前稳定键，不因 stable-key 语义修正而断档。
+- Given 分组 metadata 中仍保存着旧版 VLESS/Trojan legacy key，When 当前 inventory 里还能匹配到同一真实节点，即使订阅把 `type/net`、`sni/serverName`、`fp/fingerprint`、`serviceName/service_name` 改成了另一套同义命名，Then 弹窗也会自动将其规范到当前稳定键、保持该节点可选可保存，且不会误显示为 Missing / Unavailable。
+- Given 历史 runtime 或 hourly 统计仍使用旧版 VLESS/Trojan legacy key，When 当前 settings 或 metadata 里还能定位到同一真实节点，即使当前 share-link 只剩同义 query key 命名差异，Then 权重、惩罚态和 24 小时趋势都会继续归并到当前稳定键，不因 stable-key 语义修正而断档。
 - Given 用户在已被删除的分组设置弹窗里发起保存，When 请求同时带着无效 `boundProxyKeys`，Then API 仍优先返回 `404 group not found`，而不是把它误判成绑定校验失败。
 - Given 打开号池分组设置，When 用户查看绑定节点列表，Then 页面不显示任何 `ss://`、`vless://`、`vmess://`、`trojan://`、`http://`、`https://` 原始订阅地址，只显示截断标题和协议类型。
 - Given 打开号池分组设置且存在 `9+` 个节点，When 用户浏览节点列表，Then footer 仍然可见，节点区内部可滚动，页面本身不需要额外滚动。

--- a/src/main.rs
+++ b/src/main.rs
@@ -23338,13 +23338,14 @@ fn canonical_stream_query_pairs(
         "tls" => {
             consumed_keys.extend([
                 "sni",
+                "serverName",
                 "allowInsecure",
                 "insecure",
                 "fp",
                 "fingerprint",
                 "alpn",
             ]);
-            let server_name = normalized_query_value(&query, &["sni"])
+            let server_name = normalized_query_value(&query, &["sni", "serverName"])
                 .map(|value| value.to_ascii_lowercase())
                 .or_else(|| (!host.is_empty()).then_some(host.clone()))
                 .or_else(|| url.host_str().map(|value| value.to_ascii_lowercase()))
@@ -23373,8 +23374,16 @@ fn canonical_stream_query_pairs(
             query_pairs.push(("serverName".to_string(), server_name));
         }
         "reality" => {
-            consumed_keys.extend(["sni", "fp", "fingerprint", "pbk", "sid", "spx"]);
-            let server_name = normalized_query_value(&query, &["sni"])
+            consumed_keys.extend([
+                "sni",
+                "serverName",
+                "fp",
+                "fingerprint",
+                "pbk",
+                "sid",
+                "spx",
+            ]);
+            let server_name = normalized_query_value(&query, &["sni", "serverName"])
                 .map(|value| value.to_ascii_lowercase())
                 .or_else(|| (!host.is_empty()).then_some(host.clone()))
                 .or_else(|| url.host_str().map(|value| value.to_ascii_lowercase()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -22857,29 +22857,59 @@ pub(crate) fn legacy_bound_proxy_key_aliases(
             LegacyDefaultQueryParamSpec {
                 keys: &["encryption"],
                 explicit_keys: &["encryption"],
-                default_value: "none",
+                default_value: Some("none"),
             },
             LegacyDefaultQueryParamSpec {
                 keys: &["security"],
                 explicit_keys: &["security"],
-                default_value: "none",
+                default_value: Some("none"),
             },
             LegacyDefaultQueryParamSpec {
                 keys: &["type", "net"],
                 explicit_keys: &["type", "net"],
-                default_value: "tcp",
+                default_value: Some("tcp"),
+            },
+            LegacyDefaultQueryParamSpec {
+                keys: &["sni", "serverName"],
+                explicit_keys: &["sni", "serverName"],
+                default_value: None,
+            },
+            LegacyDefaultQueryParamSpec {
+                keys: &["fp", "fingerprint"],
+                explicit_keys: &["fp", "fingerprint"],
+                default_value: None,
+            },
+            LegacyDefaultQueryParamSpec {
+                keys: &["serviceName", "service_name"],
+                explicit_keys: &["serviceName", "service_name"],
+                default_value: None,
             },
         ][..],
         ForwardProxyProtocol::Trojan => &[
             LegacyDefaultQueryParamSpec {
                 keys: &["security"],
                 explicit_keys: &["security"],
-                default_value: "tls",
+                default_value: Some("tls"),
             },
             LegacyDefaultQueryParamSpec {
                 keys: &["type", "net"],
                 explicit_keys: &["type", "net"],
-                default_value: "tcp",
+                default_value: Some("tcp"),
+            },
+            LegacyDefaultQueryParamSpec {
+                keys: &["sni", "serverName"],
+                explicit_keys: &["sni", "serverName"],
+                default_value: None,
+            },
+            LegacyDefaultQueryParamSpec {
+                keys: &["fp", "fingerprint"],
+                explicit_keys: &["fp", "fingerprint"],
+                default_value: None,
+            },
+            LegacyDefaultQueryParamSpec {
+                keys: &["serviceName", "service_name"],
+                explicit_keys: &["serviceName", "service_name"],
+                default_value: None,
             },
         ][..],
         _ => &[][..],
@@ -23148,7 +23178,47 @@ fn canonical_query_string(query_pairs: Vec<(String, String)>) -> String {
 struct LegacyDefaultQueryParamSpec {
     keys: &'static [&'static str],
     explicit_keys: &'static [&'static str],
-    default_value: &'static str,
+    default_value: Option<&'static str>,
+}
+
+fn build_legacy_query_param_variant_choices(
+    matching_pairs: &[(String, String)],
+    spec: &LegacyDefaultQueryParamSpec,
+) -> Option<Vec<Vec<(String, String)>>> {
+    let shared_value = if let Some((_, value)) = matching_pairs.first() {
+        if !matching_pairs
+            .iter()
+            .all(|(_, candidate)| candidate.trim().eq_ignore_ascii_case(value.trim()))
+        {
+            return None;
+        }
+        value.trim().to_string()
+    } else {
+        spec.default_value?.to_string()
+    };
+
+    let explicit_keys = if spec.explicit_keys.is_empty() {
+        spec.keys
+    } else {
+        spec.explicit_keys
+    };
+    let mut choices = Vec::new();
+    if spec
+        .default_value
+        .is_some_and(|default_value| shared_value.eq_ignore_ascii_case(default_value))
+    {
+        choices.push(Vec::new());
+    }
+    for mask in 1usize..(1usize << explicit_keys.len()) {
+        let mut pairs = Vec::new();
+        for (index, key) in explicit_keys.iter().enumerate() {
+            if (mask & (1usize << index)) != 0 {
+                pairs.push(((*key).to_string(), shared_value.clone()));
+            }
+        }
+        choices.push(pairs);
+    }
+    Some(choices)
 }
 
 fn legacy_share_link_identity_variants(
@@ -23158,7 +23228,7 @@ fn legacy_share_link_identity_variants(
     let original_query_pairs = sorted_query_pairs(url);
     let mut static_pairs = Vec::new();
     let mut handled_keys = HashSet::new();
-    let mut variant_choices: Vec<Vec<Option<(String, String)>>> = Vec::new();
+    let mut variant_choices: Vec<Vec<Vec<(String, String)>>> = Vec::new();
 
     for spec in default_specs {
         let matching_pairs = original_query_pairs
@@ -23171,28 +23241,10 @@ fn legacy_share_link_identity_variants(
             handled_keys.insert(*key);
         }
 
-        let all_default = matching_pairs.is_empty()
-            || matching_pairs
-                .iter()
-                .all(|(_, value)| value.trim().eq_ignore_ascii_case(spec.default_value));
-        if !all_default {
+        let Some(choices) = build_legacy_query_param_variant_choices(&matching_pairs, spec) else {
             static_pairs.extend(matching_pairs);
             continue;
-        }
-
-        let mut explicit_pairs = matching_pairs
-            .iter()
-            .map(|(key, _)| (key.clone(), spec.default_value.to_string()))
-            .collect::<Vec<_>>();
-        for key in spec.explicit_keys {
-            if explicit_pairs.iter().any(|(existing, _)| existing == key) {
-                continue;
-            }
-            explicit_pairs.push(((*key).to_string(), spec.default_value.to_string()));
-        }
-
-        let mut choices = vec![None];
-        choices.extend(explicit_pairs.into_iter().map(Some));
+        };
         variant_choices.push(choices);
     }
 
@@ -23210,9 +23262,7 @@ fn legacy_share_link_identity_variants(
         for variant in &variants {
             for choice in &choices {
                 let mut updated = variant.clone();
-                if let Some((key, value)) = choice {
-                    updated.push((key.clone(), value.clone()));
-                }
+                updated.extend(choice.iter().cloned());
                 updated.sort();
                 let query = canonical_query_string(updated.clone());
                 if seen.insert(query) {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1809,6 +1809,64 @@ fn legacy_vless_and_trojan_bound_proxy_keys_route_to_matching_stable_endpoints()
 }
 
 #[test]
+fn legacy_vless_bound_proxy_keys_still_match_when_query_param_names_change() {
+    let legacy_type_proxy_url = "vless://11111111-1111-1111-1111-111111111111@vless.example.com:443?encryption=none&security=tls&type=ws&host=cdn.example.com&path=%2Fws&sni=edge.example.com&fingerprint=chrome#东京节点";
+    let current_net_proxy_url = "vless://11111111-1111-1111-1111-111111111111@vless.example.com:443?encryption=none&security=tls&net=ws&host=cdn.example.com&path=%2Fws&serverName=edge.example.com&fp=chrome#东京节点";
+    let normalized_legacy_type_proxy_url =
+        normalize_share_link_scheme(legacy_type_proxy_url, "vless")
+            .expect("normalize legacy vless url");
+    let normalized_current_net_proxy_url =
+        normalize_share_link_scheme(current_net_proxy_url, "vless")
+            .expect("normalize current vless url");
+
+    let legacy_bound_proxy_key = {
+        let parsed = Url::parse(&normalized_legacy_type_proxy_url)
+            .expect("parse legacy normalized vless url");
+        stable_forward_proxy_key(&canonical_share_link_identity(&parsed))
+    };
+    let stable_proxy_key = normalize_single_proxy_key(current_net_proxy_url)
+        .expect("normalize stable vless proxy key");
+    assert_ne!(legacy_bound_proxy_key, stable_proxy_key);
+
+    let aliases = legacy_bound_proxy_key_aliases(
+        &normalized_current_net_proxy_url,
+        ForwardProxyProtocol::Vless,
+    );
+    assert!(
+        aliases.contains(&legacy_bound_proxy_key),
+        "legacy alias list should include the historical type=ws key"
+    );
+
+    let mut manager = ForwardProxyManager::new(
+        ForwardProxySettings {
+            proxy_urls: vec![current_net_proxy_url.to_string()],
+            subscription_urls: vec![],
+            subscription_update_interval_secs: 3600,
+            insert_direct: false,
+        },
+        vec![],
+    );
+    for endpoint in &mut manager.endpoints {
+        endpoint.endpoint_url = Some(
+            Url::parse("socks5://127.0.0.1:11082")
+                .expect("parse synthesized synonym-compatible endpoint url"),
+        );
+    }
+
+    assert!(
+        manager.has_selectable_bound_proxy_keys(&[legacy_bound_proxy_key.clone()]),
+        "legacy key with synonymous query params should remain selectable"
+    );
+
+    let scope =
+        ForwardProxyRouteScope::from_group_binding(Some("东京组"), vec![legacy_bound_proxy_key]);
+    let selected = manager
+        .select_proxy_for_scope(&scope)
+        .expect("legacy bound key with synonymous query params should still route");
+    assert_eq!(selected.key, stable_proxy_key);
+}
+
+#[test]
 fn forward_proxy_manager_v2_clamps_persisted_runtime_weight_on_startup() {
     let proxy_url = "http://127.0.0.1:7890".to_string();
     let proxy_key = normalize_single_proxy_key(&proxy_url).expect("normalize proxy key");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -302,10 +302,26 @@ fn stable_proxy_keys_ignore_share_link_display_name_only_changes() {
     );
     assert_eq!(
         normalize_single_proxy_key(
+            "vless://11111111-1111-1111-1111-111111111111@vless.example.com:443?security=tls&type=ws&path=%2Fws&host=cdn.vless.example.com&sni=edge.vless.example.com&fingerprint=chrome#东京节点"
+        ),
+        normalize_single_proxy_key(
+            "vless://11111111-1111-1111-1111-111111111111@vless.example.com:443?security=tls&net=ws&path=%2Fws&host=cdn.vless.example.com&serverName=edge.vless.example.com&fp=chrome#Tokyo%20Edge"
+        ),
+    );
+    assert_eq!(
+        normalize_single_proxy_key(
             "trojan://password@trojan.example.com:443?type=ws&path=%2Fws&host=cdn.trojan.example.com#东京节点"
         ),
         normalize_single_proxy_key(
             "trojan://password@trojan.example.com:443?host=cdn.trojan.example.com&path=%2Fws&type=ws#Tokyo%20Edge"
+        ),
+    );
+    assert_eq!(
+        normalize_single_proxy_key(
+            "trojan://password@trojan.example.com:443?security=tls&type=ws&path=%2Fws&host=cdn.trojan.example.com&sni=edge.trojan.example.com&fingerprint=chrome#东京节点"
+        ),
+        normalize_single_proxy_key(
+            "trojan://password@trojan.example.com:443?security=tls&net=ws&path=%2Fws&host=cdn.trojan.example.com&serverName=edge.trojan.example.com&fp=chrome#Tokyo%20Edge"
         ),
     );
     assert_eq!(


### PR DESCRIPTION
## Summary
- extend legacy bound proxy alias generation to cover synonymous VLESS/Trojan query parameter names in addition to omitted default params
- add a regression test that keeps legacy `type=ws` bindings routable after subscriptions switch to canonical `net=ws`/`serverName`/`fp` naming
- sync the forward-proxy binding spec so alias coverage and acceptance criteria match the backend behavior

## Verification
- `cargo fmt`
- `cargo check`
- `cargo test legacy_vless -- --nocapture`
- `cargo test update_upstream_account_group_rejects_bindings_without_selectable_nodes -- --nocapture`