### PR TITLE
fix(account-pool): align actual usage to quota window

### DIFF
--- a/docs/specs/43bpp-upstream-account-window-actual-usage/SPEC.md
+++ b/docs/specs/43bpp-upstream-account-window-actual-usage/SPEC.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-- Status: 已实现，待截图提交授权 / PR 收敛
+- Status: 已实现
 
 ## 背景 / 问题陈述
 
@@ -14,7 +14,7 @@
 
 ### Goals
 
-- 在账号池 roster 的每个窗口块中，把主摘要切换为本地 rolling window 的 `请求数 / Tokens / 金额`。
+- 在账号池 roster 的每个窗口块中，把主摘要切换为与当前额度窗口对齐的本地 `请求数 / Tokens / 金额`。
 - 保留窗口名、重置时间与 quota progress bar，让“额度窗口”语义不丢失。
 - `Token` 指标支持 hover / focus tooltip，完整展示 `输入 / 输出 / 缓存输入` 三类 token 明细。
 - 后端列表 / 详情接口统一为 `primaryWindow` / `secondaryWindow` 扩展 `actualUsage` 子结构。
@@ -63,11 +63,12 @@
 ## 聚合规则
 
 - “实际使用量”口径固定为本系统本地 `codex_invocations` 中带 `upstreamAccountId` 的调用累计。
-- 每个窗口按 trailing rolling duration 计算，即 `[now - windowDurationMins, now]`。
+- 当窗口带有 `resetsAt` 时，实际使用量必须对齐该 quota 窗口本身：聚合区间为 `[resetsAt - windowDurationMins, min(now, resetsAt)]`。
+- 当窗口没有 `resetsAt` 时，回退为 trailing duration，即 `[now - windowDurationMins, now]`。
 - `requestCount` 统计所有命中的持久化请求，即使该次调用没有 token/cost 也应计数。
 - `totalTokens / totalCost / inputTokens / outputTokens / cacheInputTokens` 仅累加非空数值；缺失字段按 `0` 处理。
 - 若窗口起点早于在线 retention cutoff，则需要联合读取主库 `codex_invocations` 与 `archive_batches` 中的 `codex_invocations` 归档片段。
-- `resetsAt` 只用于展示 quota 信息，不参与 rolling window 聚合边界。
+- `resetsAt` 不只是展示字段；只要存在，就必须参与实际使用量的窗口边界计算。
 
 ## 前端表现
 
@@ -88,8 +89,8 @@
 
 ## 验收标准（Acceptance Criteria）
 
-- Given OAuth 账号同时存在 primary/secondary 窗口，When roster 渲染，Then 每个窗口都显示该 rolling window 内的 `请求数 / Tokens / 金额`，且仍保留原 reset + progress + percent。
-- Given API key 账号没有上游 reset 语义，When roster 渲染，Then 仍按本地 `5h / 7d` rolling window 展示实际使用量。
+- Given OAuth 账号同时存在 primary/secondary 窗口，When roster 渲染，Then 每个窗口都显示与该 `resetsAt + windowDurationMins` 对齐的 quota window 内 `请求数 / Tokens / 金额`，且仍保留原 reset + progress + percent。
+- Given API key 账号没有上游 reset 语义，When roster 渲染，Then 仍按本地 `5h / 7d` trailing window 展示实际使用量。
 - Given 某窗口缺失，When roster 渲染，Then inline 指标、reset 文案与 percent 全部保持 `-` 占位，不出现误导性的 `0`，也不出现空 tooltip。
 - Given 用户 hover 或 focus `Token` 指标，When tooltip 打开，Then 能看到 `输入 / 输出 / 缓存输入` 三类完整数值。
 - Given `/events` 收到新的 `records` 事件，When 页面已完成首轮加载，Then 当前可见账号在节流窗口后静默刷新实际使用量。
@@ -114,7 +115,7 @@
   submission_gate: pending-owner-approval
   story_id_or_title: Account Pool/Components/Upstream Accounts Table/Default
   state: default
-  evidence_note: 验证窗口主摘要已切换为本地 rolling window 的 `Req / Token / Cost`，并保留原有 `Reset + progress + percent` 额度语义。
+  evidence_note: 验证窗口主摘要已切换为与当前额度窗口对齐的 `Req / Token / Cost`，并保留原有 `Reset + progress + percent` 额度语义。
   image:
   ![号池窗口实际使用量默认态](./assets/upstream-account-window-actual-usage-default.png)
 

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -2315,8 +2315,29 @@ impl AccountWindowUsageAccumulator {
 
 #[derive(Debug, Clone, Default)]
 struct AccountWindowUsagePlan {
-    primary_start_at: Option<String>,
-    secondary_start_at: Option<String>,
+    primary: Option<AccountWindowUsageRange>,
+    secondary: Option<AccountWindowUsageRange>,
+}
+
+#[derive(Debug, Clone)]
+struct AccountWindowUsageRange {
+    start_at: String,
+    end_at: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AccountWindowUsageRangeBounds {
+    start_at: DateTime<Utc>,
+    end_at: DateTime<Utc>,
+}
+
+impl AccountWindowUsageRangeBounds {
+    fn into_range(self) -> AccountWindowUsageRange {
+        AccountWindowUsageRange {
+            start_at: format_naive(self.start_at.with_timezone(&Shanghai).naive_local()),
+            end_at: format_naive(self.end_at.with_timezone(&Shanghai).naive_local()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -9264,7 +9285,7 @@ async fn enrich_window_actual_usage_for_summaries(
     }
 
     let now = Utc::now();
-    let Some((plans, max_window_duration_mins)) = collect_account_window_usage_plans(items, now)
+    let Some((plans, query_start, query_end)) = collect_account_window_usage_plans(items, now)
     else {
         return Ok(());
     };
@@ -9273,41 +9294,41 @@ async fn enrich_window_actual_usage_for_summaries(
         return Ok(());
     }
 
-    let query_end_at = format_naive(now.with_timezone(&Shanghai).naive_local());
-    let query_start = now - ChronoDuration::minutes(max_window_duration_mins);
+    let query_start_at = format_naive(query_start.with_timezone(&Shanghai).naive_local());
+    let query_end_at = format_naive(query_end.with_timezone(&Shanghai).naive_local());
     let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
     let mut rows = Vec::new();
 
     let live_start = query_start.max(retention_cutoff);
-    let live_start_at = format_naive(live_start.with_timezone(&Shanghai).naive_local());
-    rows.extend(
-        load_window_actual_usage_rows_from_pool(
-            &state.pool,
-            &account_ids,
-            &live_start_at,
-            &query_end_at,
-            None,
-        )
-        .await?,
-    );
-
-    if query_start < retention_cutoff {
-        let archive_end_at = format_naive(
-            (retention_cutoff - ChronoDuration::seconds(1))
-                .with_timezone(&Shanghai)
-                .naive_local(),
-        );
-        let query_start_at = format_naive(query_start.with_timezone(&Shanghai).naive_local());
+    if live_start <= query_end {
+        let live_start_at = format_naive(live_start.with_timezone(&Shanghai).naive_local());
         rows.extend(
-            load_window_actual_usage_rows_from_archives(
+            load_window_actual_usage_rows_from_pool(
                 &state.pool,
                 &account_ids,
-                &query_start_at,
-                &archive_end_at,
-                &state.config.archive_dir,
+                &live_start_at,
+                &query_end_at,
+                None,
             )
             .await?,
         );
+    }
+
+    if query_start < retention_cutoff {
+        let archive_end = query_end.min(retention_cutoff - ChronoDuration::seconds(1));
+        if query_start <= archive_end {
+            let archive_end_at = format_naive(archive_end.with_timezone(&Shanghai).naive_local());
+            rows.extend(
+                load_window_actual_usage_rows_from_archives(
+                    &state.pool,
+                    &account_ids,
+                    &query_start_at,
+                    &archive_end_at,
+                    &state.config.archive_dir,
+                )
+                .await?,
+            );
+        }
     }
 
     let usage = fold_account_window_usage_rows(rows, &plans);
@@ -9318,54 +9339,72 @@ async fn enrich_window_actual_usage_for_summaries(
 fn collect_account_window_usage_plans(
     items: &[UpstreamAccountSummary],
     now: DateTime<Utc>,
-) -> Option<(HashMap<i64, AccountWindowUsagePlan>, i64)> {
+) -> Option<(
+    HashMap<i64, AccountWindowUsagePlan>,
+    DateTime<Utc>,
+    DateTime<Utc>,
+)> {
     let mut plans = HashMap::new();
-    let mut max_window_duration_mins = 0_i64;
+    let mut earliest_start_at: Option<DateTime<Utc>> = None;
+    let mut latest_end_at: Option<DateTime<Utc>> = None;
 
     for item in items {
-        let primary_start_at = item
-            .primary_window
-            .as_ref()
-            .and_then(|window| build_window_start_at(now, window.window_duration_mins));
-        let secondary_start_at = item
-            .secondary_window
-            .as_ref()
-            .and_then(|window| build_window_start_at(now, window.window_duration_mins));
-        if primary_start_at.is_none() && secondary_start_at.is_none() {
+        let primary = item.primary_window.as_ref().and_then(|window| {
+            build_window_usage_range(
+                now,
+                window.window_duration_mins,
+                window.resets_at.as_deref(),
+            )
+        });
+        let secondary = item.secondary_window.as_ref().and_then(|window| {
+            build_window_usage_range(
+                now,
+                window.window_duration_mins,
+                window.resets_at.as_deref(),
+            )
+        });
+        if primary.is_none() && secondary.is_none() {
             continue;
         }
-        if let Some(window) = item.primary_window.as_ref() {
-            max_window_duration_mins =
-                max_window_duration_mins.max(window.window_duration_mins.max(0));
+
+        for range in [primary, secondary].into_iter().flatten() {
+            earliest_start_at = Some(
+                earliest_start_at
+                    .map(|value| value.min(range.start_at))
+                    .unwrap_or(range.start_at),
+            );
+            latest_end_at = Some(
+                latest_end_at
+                    .map(|value| value.max(range.end_at))
+                    .unwrap_or(range.end_at),
+            );
         }
-        if let Some(window) = item.secondary_window.as_ref() {
-            max_window_duration_mins =
-                max_window_duration_mins.max(window.window_duration_mins.max(0));
-        }
+
         plans.insert(
             item.id,
             AccountWindowUsagePlan {
-                primary_start_at,
-                secondary_start_at,
+                primary: primary.map(AccountWindowUsageRangeBounds::into_range),
+                secondary: secondary.map(AccountWindowUsageRangeBounds::into_range),
             },
         );
     }
 
-    if plans.is_empty() || max_window_duration_mins <= 0 {
-        return None;
-    }
-    Some((plans, max_window_duration_mins))
+    Some((plans, earliest_start_at?, latest_end_at?))
 }
 
-fn build_window_start_at(now: DateTime<Utc>, window_duration_mins: i64) -> Option<String> {
+fn build_window_usage_range(
+    now: DateTime<Utc>,
+    window_duration_mins: i64,
+    resets_at: Option<&str>,
+) -> Option<AccountWindowUsageRangeBounds> {
     if window_duration_mins <= 0 {
         return None;
     }
-    Some(format_naive(
-        (now - ChronoDuration::minutes(window_duration_mins))
-            .with_timezone(&Shanghai)
-            .naive_local(),
-    ))
+    let window_anchor = resets_at.and_then(parse_rfc3339_utc).unwrap_or(now);
+    Some(AccountWindowUsageRangeBounds {
+        start_at: window_anchor - ChronoDuration::minutes(window_duration_mins),
+        end_at: window_anchor.min(now),
+    })
 }
 
 async fn load_window_actual_usage_rows_from_pool(
@@ -9525,18 +9564,16 @@ fn fold_account_window_usage_rows(
             continue;
         };
         let entry = usage.entry(row.upstream_account_id).or_default();
-        if plan
-            .primary_start_at
-            .as_deref()
-            .is_some_and(|start_at| row.occurred_at.as_str() >= start_at)
-        {
+        if plan.primary.as_ref().is_some_and(|range| {
+            row.occurred_at.as_str() >= range.start_at.as_str()
+                && row.occurred_at.as_str() <= range.end_at.as_str()
+        }) {
             entry.primary.add_row(&row);
         }
-        if plan
-            .secondary_start_at
-            .as_deref()
-            .is_some_and(|start_at| row.occurred_at.as_str() >= start_at)
-        {
+        if plan.secondary.as_ref().is_some_and(|range| {
+            row.occurred_at.as_str() >= range.start_at.as_str()
+                && row.occurred_at.as_str() <= range.end_at.as_str()
+        }) {
             entry.secondary.add_row(&row);
         }
     }
@@ -25218,6 +25255,35 @@ mod tests {
         assert!(token.chars().any(|ch| ch.is_ascii_digit()));
     }
 
+    #[test]
+    fn build_window_usage_range_aligns_to_current_reset_window() {
+        let now = parse_rfc3339_utc("2026-03-30T12:30:00Z").expect("fixed now");
+        let range = build_window_usage_range(now, 300, Some("2026-03-30T14:00:00Z"))
+            .expect("aligned range");
+
+        assert_eq!(
+            range.start_at,
+            parse_rfc3339_utc("2026-03-30T09:00:00Z").expect("expected start")
+        );
+        assert_eq!(range.end_at, now);
+    }
+
+    #[test]
+    fn build_window_usage_range_reuses_stale_reset_window_bounds() {
+        let now = parse_rfc3339_utc("2026-03-30T12:30:00Z").expect("fixed now");
+        let range = build_window_usage_range(now, 300, Some("2026-03-29T23:00:00Z"))
+            .expect("historical range");
+
+        assert_eq!(
+            range.start_at,
+            parse_rfc3339_utc("2026-03-29T18:00:00Z").expect("expected historical start")
+        );
+        assert_eq!(
+            range.end_at,
+            parse_rfc3339_utc("2026-03-29T23:00:00Z").expect("expected historical end")
+        );
+    }
+
     #[tokio::test]
     async fn enrich_window_actual_usage_for_summaries_counts_live_window_rows() {
         let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
@@ -25315,6 +25381,85 @@ mod tests {
         assert_eq!(secondary_usage.output_tokens, 1700);
         assert_eq!(secondary_usage.cache_input_tokens, 850);
         assert_cost_close(secondary_usage.total_cost, 0.0595);
+    }
+
+    #[tokio::test]
+    async fn enrich_window_actual_usage_for_summaries_uses_matching_stale_reset_window() {
+        let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+        ensure_window_actual_usage_test_tables(&state.pool).await;
+
+        let account_id = 402_i64;
+        let reset_at = Utc::now() - ChronoDuration::hours(10);
+        let mut summary = test_summary_with_statuses(
+            UPSTREAM_ACCOUNT_WORK_STATUS_RATE_LIMITED,
+            UPSTREAM_ACCOUNT_ENABLE_STATUS_ENABLED,
+            UPSTREAM_ACCOUNT_HEALTH_STATUS_NORMAL,
+            UPSTREAM_ACCOUNT_SYNC_STATE_IDLE,
+        );
+        summary.id = account_id;
+        summary.primary_window = Some(RateWindowSnapshot {
+            used_percent: 100.0,
+            used_text: "100% used".to_string(),
+            limit_text: "5h window".to_string(),
+            resets_at: Some(format_utc_iso(reset_at)),
+            window_duration_mins: 300,
+            actual_usage: None,
+        });
+
+        let inside_window_at = shanghai_local_iso(reset_at - ChronoDuration::hours(1));
+        let before_window_at = shanghai_local_iso(reset_at - ChronoDuration::hours(6));
+        let after_window_at = shanghai_local_iso(Utc::now() - ChronoDuration::minutes(30));
+
+        insert_window_actual_usage_invocation(
+            &state.pool,
+            account_id,
+            &inside_window_at,
+            Some(1800),
+            Some(900),
+            Some(450),
+            Some(3150),
+            Some(0.0315),
+        )
+        .await;
+        insert_window_actual_usage_invocation(
+            &state.pool,
+            account_id,
+            &before_window_at,
+            Some(3000),
+            Some(1200),
+            Some(600),
+            Some(4800),
+            Some(0.048),
+        )
+        .await;
+        insert_window_actual_usage_invocation(
+            &state.pool,
+            account_id,
+            &after_window_at,
+            Some(500),
+            Some(250),
+            Some(100),
+            Some(850),
+            Some(0.0085),
+        )
+        .await;
+
+        let mut items = vec![summary];
+        enrich_window_actual_usage_for_summaries(state.as_ref(), &mut items)
+            .await
+            .expect("enrich stale window actual usage");
+
+        let usage = items[0]
+            .primary_window
+            .as_ref()
+            .and_then(|window| window.actual_usage)
+            .expect("stale primary actual usage");
+        assert_eq!(usage.request_count, 1);
+        assert_eq!(usage.total_tokens, 3150);
+        assert_eq!(usage.input_tokens, 1800);
+        assert_eq!(usage.output_tokens, 900);
+        assert_eq!(usage.cache_input_tokens, 450);
+        assert_cost_close(usage.total_cost, 0.0315);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- align upstream account window actual usage to the rendered quota window instead of using a trailing rolling range when `resetsAt` is present
- reuse trailing-duration fallback only for windows that do not expose `resetsAt`
- add regression coverage for current-window alignment and stale reset windows, and sync the 43bpp spec wording to the corrected behavior