### PR TITLE
fix(pool): skip ungrouped routing candidates

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17183,6 +17183,171 @@ async fn pool_route_returns_specific_ungrouped_error_when_all_candidates_are_ung
 }
 
 #[tokio::test]
+async fn pool_route_cuts_out_from_ungrouped_sticky_account_when_allowed() {
+    let (upstream_base, attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let sticky_source_id =
+        insert_test_pool_api_key_account(&state, "Ungrouped Sticky", "upstream-primary").await;
+    let grouped_id =
+        insert_test_pool_api_key_account(&state, "Grouped", "upstream-secondary").await;
+    sqlx::query("UPDATE pool_upstream_accounts SET group_name = NULL WHERE id = ?1")
+        .bind(sticky_source_id)
+        .execute(&state.pool)
+        .await
+        .expect("clear sticky source group");
+    let sticky_seen_at = format_utc_iso(Utc::now());
+    upsert_test_sticky_route_at(
+        &state.pool,
+        "sticky-ungrouped-cut-out",
+        sticky_source_id,
+        &sticky_seen_at,
+    )
+    .await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-ungrouped-cut-out"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read proxy response");
+    let payload: Value = serde_json::from_slice(&body).expect("decode proxy response");
+    assert_eq!(payload["authorization"], "Bearer upstream-secondary");
+    assert_eq!(payload["attempt"], 1);
+
+    let attempts = attempts.lock().expect("lock attempts");
+    assert_eq!(attempts.get("Bearer upstream-primary").copied(), None);
+    assert_eq!(attempts.get("Bearer upstream-secondary").copied(), Some(1));
+    drop(attempts);
+
+    let mut route_account_id =
+        load_test_sticky_route_account_id(&state.pool, "sticky-ungrouped-cut-out").await;
+    for _ in 0..20 {
+        if route_account_id == Some(grouped_id) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        route_account_id =
+            load_test_sticky_route_account_id(&state.pool, "sticky-ungrouped-cut-out").await;
+    }
+    let route_account_id = route_account_id.expect("sticky route should be persisted");
+    assert_eq!(route_account_id, grouped_id);
+    assert_ne!(route_account_id, sticky_source_id);
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_route_returns_ungrouped_error_for_sticky_account_when_cut_out_is_forbidden() {
+    let (upstream_base, attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let sticky_source_id =
+        insert_test_pool_api_key_account(&state, "Ungrouped Sticky", "upstream-primary").await;
+    insert_test_pool_api_key_account(&state, "Grouped", "upstream-secondary").await;
+    sqlx::query("UPDATE pool_upstream_accounts SET group_name = NULL WHERE id = ?1")
+        .bind(sticky_source_id)
+        .execute(&state.pool)
+        .await
+        .expect("clear sticky source group");
+    let sticky_seen_at = format_utc_iso(Utc::now());
+    upsert_test_sticky_route_at(
+        &state.pool,
+        "sticky-ungrouped-forbidden",
+        sticky_source_id,
+        &sticky_seen_at,
+    )
+    .await;
+
+    let now_iso = format_utc_iso(Utc::now());
+    let disallow_cut_out_tag_id: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO pool_tags (
+            name, guard_enabled, lookback_hours, max_conversations,
+            allow_cut_out, allow_cut_in, created_at, updated_at
+        ) VALUES (?1, 0, NULL, NULL, 0, 1, ?2, ?2)
+        RETURNING id
+        "#,
+    )
+    .bind("ungrouped-no-cut-out")
+    .bind(&now_iso)
+    .fetch_one(&state.pool)
+    .await
+    .expect("insert no-cut-out tag");
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_account_tags (
+            account_id, tag_id, created_at, updated_at
+        ) VALUES (?1, ?2, ?3, ?3)
+        "#,
+    )
+    .bind(sticky_source_id)
+    .bind(disallow_cut_out_tag_id)
+    .bind(&now_iso)
+    .execute(&state.pool)
+    .await
+    .expect("attach no-cut-out tag");
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-ungrouped-forbidden"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read failure body");
+    let payload: Value = serde_json::from_slice(&body).expect("decode failure payload");
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|value| value.contains("upstream account is not assigned to a group")),
+        "unexpected error payload: {payload:?}"
+    );
+
+    let attempts = attempts.lock().expect("lock attempts");
+    assert_eq!(attempts.get("Bearer upstream-primary").copied(), None);
+    assert_eq!(attempts.get("Bearer upstream-secondary").copied(), None);
+    drop(attempts);
+
+    assert_eq!(
+        load_test_sticky_route_account_id(&state.pool, "sticky-ungrouped-forbidden").await,
+        Some(sticky_source_id)
+    );
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn pool_route_returns_429_after_three_distinct_accounts_hit_upstream_429() {
     #[derive(Debug, sqlx::FromRow)]
     struct AttemptRow {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17078,6 +17078,111 @@ async fn pool_route_keeps_generic_no_candidate_when_other_accounts_are_unavailab
 }
 
 #[tokio::test]
+async fn pool_route_skips_ungrouped_account_when_grouped_alternate_exists() {
+    let (upstream_base, attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let ungrouped_id =
+        insert_test_pool_api_key_account(&state, "Ungrouped", "upstream-primary").await;
+    let grouped_id =
+        insert_test_pool_api_key_account(&state, "Grouped", "upstream-secondary").await;
+    sqlx::query("UPDATE pool_upstream_accounts SET group_name = NULL WHERE id = ?1")
+        .bind(ungrouped_id)
+        .execute(&state.pool)
+        .await
+        .expect("clear ungrouped account group");
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-ungrouped-fresh"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read proxy response");
+    let payload: Value = serde_json::from_slice(&body).expect("decode proxy response");
+    assert_eq!(payload["authorization"], "Bearer upstream-secondary");
+    assert_eq!(payload["attempt"], 1);
+
+    let attempts = attempts.lock().expect("lock attempts");
+    assert_eq!(attempts.get("Bearer upstream-primary").copied(), None);
+    assert_eq!(attempts.get("Bearer upstream-secondary").copied(), Some(1));
+    drop(attempts);
+
+    let route_account_id =
+        wait_for_test_sticky_route_account_id(&state.pool, "sticky-ungrouped-fresh")
+            .await
+            .expect("sticky route should bind to grouped alternate");
+    assert_eq!(route_account_id, grouped_id);
+    assert_ne!(route_account_id, ungrouped_id);
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_route_returns_specific_ungrouped_error_when_all_candidates_are_ungrouped() {
+    let (upstream_base, attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let ungrouped_id =
+        insert_test_pool_api_key_account(&state, "Ungrouped", "upstream-primary").await;
+    sqlx::query("UPDATE pool_upstream_accounts SET group_name = NULL WHERE id = ?1")
+        .bind(ungrouped_id)
+        .execute(&state.pool)
+        .await
+        .expect("clear ungrouped account group");
+
+    let response = proxy_openai_v1(
+        State(state),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(
+            r#"{"model":"gpt-5","input":"hello","stickyKey":"sticky-ungrouped-only"}"#
+                .as_bytes()
+                .to_vec(),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read failure body");
+    let payload: Value = serde_json::from_slice(&body).expect("decode failure payload");
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|value| value.contains("upstream account is not assigned to a group")),
+        "unexpected error payload: {payload:?}"
+    );
+
+    let attempts = attempts.lock().expect("lock attempts");
+    assert_eq!(attempts.get("Bearer upstream-primary").copied(), None);
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn pool_route_returns_429_after_three_distinct_accounts_hit_upstream_429() {
     #[derive(Debug, sqlx::FromRow)]
     struct AttemptRow {

--- a/src/upstream_accounts/mod.rs
+++ b/src/upstream_accounts/mod.rs
@@ -15208,9 +15208,16 @@ async fn resolve_pool_account_group_proxy_routing_readiness(
     state: &AppState,
     group_name: Option<&str>,
 ) -> Result<PoolAccountGroupProxyRoutingReadiness> {
-    let group_metadata = load_group_metadata(&state.pool, group_name).await?;
+    let normalized_group_name = group_name.map(str::trim).filter(|value| !value.is_empty());
+    let Some(group_name) = normalized_group_name else {
+        return Ok(PoolAccountGroupProxyRoutingReadiness::Blocked(
+            missing_account_group_error_message(),
+        ));
+    };
+    let group_metadata = load_group_metadata(&state.pool, Some(group_name)).await?;
     let scope = match load_required_account_forward_proxy_scope_from_group_metadata(
-        state, group_name,
+        state,
+        Some(group_name),
     )
     .await
     {
@@ -23485,6 +23492,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolver_skips_ungrouped_candidate_when_healthy_grouped_account_exists() {
+        let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+        let crypto_key = state
+            .upstream_accounts
+            .crypto_key
+            .as_ref()
+            .expect("test crypto key");
+        let ungrouped = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Ungrouped Candidate",
+            "ungrouped-candidate@example.com",
+            "org_ungrouped_candidate",
+            "user_ungrouped_candidate",
+        )
+        .await;
+        let healthy = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Healthy Grouped Candidate",
+            "healthy-grouped-candidate@example.com",
+            "org_healthy_grouped_candidate",
+            "user_healthy_grouped_candidate",
+        )
+        .await;
+        set_test_account_group_name(&state.pool, ungrouped, None).await;
+        let now_iso = format_utc_iso(Utc::now());
+        insert_limit_sample_with_usage(&state.pool, ungrouped, &now_iso, Some(1.0), Some(1.0))
+            .await;
+        insert_limit_sample_with_usage(&state.pool, healthy, &now_iso, Some(80.0), Some(10.0))
+            .await;
+
+        let resolution = resolve_pool_account_for_request(&state, None, &[], &HashSet::new())
+            .await
+            .expect("resolve pool account");
+        let PoolAccountResolution::Resolved(account) = resolution else {
+            panic!("expected resolver to skip ungrouped account and pick healthy grouped account");
+        };
+        assert_eq!(account.account_id, healthy);
+    }
+
+    #[tokio::test]
     async fn resolver_returns_specific_group_proxy_error_when_only_bad_groups_remain() {
         let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
         let crypto_key = state
@@ -23513,6 +23562,34 @@ mod tests {
             message,
             "upstream account group \"missing-bindings\" has no bound forward proxy nodes; bind at least one proxy node to the group"
         );
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_specific_group_proxy_error_when_only_ungrouped_accounts_remain() {
+        let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+        let crypto_key = state
+            .upstream_accounts
+            .crypto_key
+            .as_ref()
+            .expect("test crypto key");
+        let account = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Only Ungrouped Candidate",
+            "only-ungrouped-candidate@example.com",
+            "org_only_ungrouped_candidate",
+            "user_only_ungrouped_candidate",
+        )
+        .await;
+        set_test_account_group_name(&state.pool, account, None).await;
+
+        let resolution = resolve_pool_account_for_request(&state, None, &[], &HashSet::new())
+            .await
+            .expect("resolve pool account");
+        let PoolAccountResolution::BlockedByPolicy(message) = resolution else {
+            panic!("expected ungrouped account to surface a specific routing error");
+        };
+        assert_eq!(message, missing_account_group_error_message());
     }
 
     #[tokio::test]
@@ -23934,6 +24011,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolver_can_cut_out_from_ungrouped_sticky_account_when_allowed() {
+        let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+        let crypto_key = state
+            .upstream_accounts
+            .crypto_key
+            .as_ref()
+            .expect("test crypto key");
+        let sticky_account = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Sticky Ungrouped Account",
+            "sticky-ungrouped-account@example.com",
+            "org_sticky_ungrouped_account",
+            "user_sticky_ungrouped_account",
+        )
+        .await;
+        let fallback_account = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Fallback Healthy Grouped Account",
+            "fallback-healthy-grouped-account@example.com",
+            "org_fallback_healthy_grouped_account",
+            "user_fallback_healthy_grouped_account",
+        )
+        .await;
+        set_test_account_group_name(&state.pool, sticky_account, None).await;
+        upsert_sticky_route(
+            &state.pool,
+            "sticky-ungrouped-account",
+            sticky_account,
+            &format_utc_iso(Utc::now()),
+        )
+        .await
+        .expect("upsert sticky route");
+
+        let resolution = resolve_pool_account_for_request(
+            &state,
+            Some("sticky-ungrouped-account"),
+            &[],
+            &HashSet::new(),
+        )
+        .await
+        .expect("resolve pool account");
+        let PoolAccountResolution::Resolved(account) = resolution else {
+            panic!("expected resolver to cut out from ungrouped sticky account");
+        };
+        assert_eq!(account.account_id, fallback_account);
+    }
+
+    #[tokio::test]
     async fn resolver_returns_group_proxy_error_for_sticky_account_when_cut_out_is_forbidden() {
         let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
         let crypto_key = state
@@ -24001,6 +24128,73 @@ mod tests {
             message,
             "upstream account group \"sticky-missing\" has no bound forward proxy nodes; bind at least one proxy node to the group"
         );
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_ungrouped_error_for_sticky_account_when_cut_out_is_forbidden() {
+        let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+        let crypto_key = state
+            .upstream_accounts
+            .crypto_key
+            .as_ref()
+            .expect("test crypto key");
+        let sticky_account = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Sticky Ungrouped Locked Account",
+            "sticky-ungrouped-locked-account@example.com",
+            "org_sticky_ungrouped_locked_account",
+            "user_sticky_ungrouped_locked_account",
+        )
+        .await;
+        let _fallback_account = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Ignored Healthy Grouped Account",
+            "ignored-healthy-grouped-account@example.com",
+            "org_ignored_healthy_grouped_account",
+            "user_ignored_healthy_grouped_account",
+        )
+        .await;
+        set_test_account_group_name(&state.pool, sticky_account, None).await;
+        let lock_tag = insert_tag(
+            &state.pool,
+            "sticky-ungrouped-lock",
+            &TagRoutingRule {
+                guard_enabled: false,
+                lookback_hours: None,
+                max_conversations: None,
+                allow_cut_out: false,
+                allow_cut_in: true,
+                concurrency_limit: 0,
+            },
+        )
+        .await
+        .expect("insert lock tag");
+        sync_account_tag_links(&state.pool, sticky_account, &[lock_tag.summary.id])
+            .await
+            .expect("attach lock tag");
+        upsert_sticky_route(
+            &state.pool,
+            "sticky-ungrouped-locked",
+            sticky_account,
+            &format_utc_iso(Utc::now()),
+        )
+        .await
+        .expect("upsert sticky route");
+
+        let resolution = resolve_pool_account_for_request(
+            &state,
+            Some("sticky-ungrouped-locked"),
+            &[],
+            &HashSet::new(),
+        )
+        .await
+        .expect("resolve pool account");
+        let PoolAccountResolution::BlockedByPolicy(message) = resolution else {
+            panic!("expected sticky ungrouped error when cut-out is forbidden");
+        };
+        assert_eq!(message, missing_account_group_error_message());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- treat ungrouped pool accounts as blocked during routing readiness instead of letting them fail candidate preparation
- keep scanning fresh and sticky failover candidates so healthy grouped accounts can still serve `/v1/responses`
- add regression coverage for ungrouped fresh and sticky routing behavior

## Verification
- `cargo fmt --check`
- `cargo test ungrouped`
- `cargo test group_proxy`
- `cargo check`