### PR TITLE
fix: prevent stale content-length on pool fast rewrite

### DIFF
--- a/docs/specs/dvwja-proxy-fast-mode-request-rewrite/SPEC.md
+++ b/docs/specs/dvwja-proxy-fast-mode-request-rewrite/SPEC.md
@@ -4,7 +4,7 @@
 
 - Status: 已完成（4/4）
 - Created: 2026-03-09
-- Last: 2026-03-09
+- Last: 2026-04-05
 
 ## 背景 / 问题陈述
 
@@ -55,6 +55,8 @@
 - `force_priority`：无条件把最终请求 tier 改为 `service_tier: 'priority'`。
 - 改写后若请求体存在 `serviceTier` 别名，必须清理冲突并统一为顶层 `service_tier`，避免双字段并存。
 - `requestedServiceTier` 必须始终表示最终发给上游的请求值；未改写时沿用原值，改写命中时返回 `priority`。
+- 任何 pool 路由请求只要最终出站 body 已被重写或物化成新的内存快照，就不得继续转发下游原始 `Content-Length`；上游客户端必须按最终 body 重新计算。
+- 即使 pool transport failure 发生在首字节之前，request raw 与 `requestedServiceTier` 也必须反映最终出站请求，而不是改写前的原始 body。
 - startup backfill 继续只扫描 `source=proxy` 且 `request_raw_path IS NOT NULL` 的记录，并从 request raw 文件回填最终请求值。
 
 ### SHOULD
@@ -133,3 +135,4 @@
 - 2026-03-09: 完成 SQLite 设置迁移、双接口 tier 改写与 `requestedServiceTier` 最终值回写，补齐 Settings UI、Storybook mock、Vitest 与 Playwright 覆盖，并通过 `cargo test`、`cargo check`、`cd web && npm run test`、`cd web && npm run build`。
 - 2026-03-09: 根据 review 调整 `disabled` 模式为真正透明透传；仅在 `fill_missing` / `force_priority` 生效时才标准化 `service_tier` 字段形状，并补充对应回归测试。
 - 2026-03-09: 创建 PR #102，补齐 release labels，并在变基到最新 `main` 后确认本地验证与 GitHub Actions checks 全部通过。
+- 2026-04-05: 补充 pool fast hotfix 不变量：body rewrite 后必须丢弃 stale `Content-Length`，且 send-stage transport failure 仍需保留最终出站 request raw 与 `requestedServiceTier`。

--- a/src/main.rs
+++ b/src/main.rs
@@ -12245,6 +12245,26 @@ struct PreparedPoolRequestBody {
     requested_service_tier: Option<String>,
 }
 
+fn pool_request_snapshot_preserves_content_length(snapshot: &PoolReplayBodySnapshot) -> bool {
+    matches!(snapshot, PoolReplayBodySnapshot::File { .. })
+}
+
+fn pool_request_snapshot_kind(snapshot: &PoolReplayBodySnapshot) -> &'static str {
+    match snapshot {
+        PoolReplayBodySnapshot::Empty => "empty",
+        PoolReplayBodySnapshot::Memory(_) => "memory",
+        PoolReplayBodySnapshot::File { .. } => "file",
+    }
+}
+
+fn pool_request_snapshot_body_bytes(snapshot: &PoolReplayBodySnapshot) -> usize {
+    match snapshot {
+        PoolReplayBodySnapshot::Empty => 0,
+        PoolReplayBodySnapshot::Memory(bytes) => bytes.len(),
+        PoolReplayBodySnapshot::File { size, .. } => *size,
+    }
+}
+
 async fn prepare_pool_request_body_for_account(
     body: Option<&PoolReplayBodySnapshot>,
     original_uri: &Uri,
@@ -13138,8 +13158,22 @@ async fn send_pool_request_with_failover(
                             .clone()
                             .expect("api key pool route should always have an upstream url"),
                     );
+                    let preserve_content_length = pool_request_snapshot_preserves_content_length(
+                        &prepared_request_body.snapshot,
+                    );
+                    let forwarded_content_length = headers
+                        .get(header::CONTENT_LENGTH)
+                        .and_then(|value| value.to_str().ok())
+                        .map(str::to_string);
+                    let outbound_snapshot_kind =
+                        pool_request_snapshot_kind(&prepared_request_body.snapshot);
+                    let outbound_body_bytes =
+                        pool_request_snapshot_body_bytes(&prepared_request_body.snapshot);
                     for (name, value) in headers {
                         if *name == header::AUTHORIZATION {
+                            continue;
+                        }
+                        if *name == header::CONTENT_LENGTH && !preserve_content_length {
                             continue;
                         }
                         if should_forward_proxy_header(name, &request_connection_scoped) {
@@ -13222,6 +13256,21 @@ async fn send_pool_request_with_failover(
                                 ForwardProxyRouteResultKind::NetworkFailure,
                             )
                             .await;
+                            warn!(
+                                invoke_id = trace_context
+                                    .as_ref()
+                                    .map(|trace| trace.invoke_id.as_str())
+                                    .unwrap_or(""),
+                                account_id = account.account_id,
+                                endpoint = original_uri.path(),
+                                requested_service_tier = attempted_requested_service_tier.as_deref(),
+                                snapshot_kind = outbound_snapshot_kind,
+                                outbound_body_bytes,
+                                forwarded_content_length = forwarded_content_length.as_deref(),
+                                preserved_content_length = preserve_content_length,
+                                error = %err,
+                                "pool upstream request send failed before response"
+                            );
                             let message = format!("failed to contact upstream: {err}");
                             let compact_support_observation = classify_compact_support_observation(
                                 original_uri,
@@ -13332,6 +13381,22 @@ async fn send_pool_request_with_failover(
                                 ForwardProxyRouteResultKind::NetworkFailure,
                             )
                             .await;
+                            warn!(
+                                invoke_id = trace_context
+                                    .as_ref()
+                                    .map(|trace| trace.invoke_id.as_str())
+                                    .unwrap_or(""),
+                                account_id = account.account_id,
+                                endpoint = original_uri.path(),
+                                requested_service_tier =
+                                    attempted_requested_service_tier.as_deref(),
+                                snapshot_kind = outbound_snapshot_kind,
+                                outbound_body_bytes,
+                                forwarded_content_length = forwarded_content_length.as_deref(),
+                                preserved_content_length = preserve_content_length,
+                                timeout_ms = attempt_send_timeout.as_millis(),
+                                "pool upstream request send timed out before response"
+                            );
                             let message = proxy_request_send_timeout_message(
                                 capture_target_for_request(original_uri.path(), &method),
                                 attempt_send_timeout,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4322,6 +4322,57 @@ async fn insert_test_pool_api_key_account_with_options(
         .expect("load inserted test pool upstream account id")
 }
 
+async fn create_test_fast_mode_tag(
+    state: &Arc<AppState>,
+    name: &str,
+    fast_mode_rewrite_mode: &str,
+    priority_tier: &str,
+) -> i64 {
+    let payload = serde_json::from_value::<CreateTagRequest>(json!({
+        "name": name,
+        "guardEnabled": false,
+        "allowCutOut": true,
+        "allowCutIn": true,
+        "priorityTier": priority_tier,
+        "fastModeRewriteMode": fast_mode_rewrite_mode,
+    }))
+    .expect("deserialize fast mode tag payload");
+    let Json(_) = create_tag(State(state.clone()), HeaderMap::new(), Json(payload))
+        .await
+        .expect("create fast mode tag");
+    sqlx::query_scalar("SELECT id FROM pool_tags WHERE name = ?1")
+        .bind(name)
+        .fetch_one(&state.pool)
+        .await
+        .expect("load fast mode tag id")
+}
+
+async fn create_test_tagged_pool_api_key_account(
+    state: &Arc<AppState>,
+    display_name: &str,
+    api_key: &str,
+    upstream_base_url: &str,
+    tag_ids: &[i64],
+) -> i64 {
+    let payload: CreateApiKeyAccountRequest = serde_json::from_value(json!({
+        "displayName": display_name,
+        "groupName": test_required_group_name(),
+        "groupBoundProxyKeys": test_required_group_bound_proxy_keys(),
+        "upstreamBaseUrl": upstream_base_url,
+        "apiKey": api_key,
+        "tagIds": tag_ids,
+    }))
+    .expect("deserialize tagged api-key account payload");
+    let Json(_) = create_api_key_account(State(state.clone()), HeaderMap::new(), Json(payload))
+        .await
+        .expect("create tagged pool account");
+    sqlx::query_scalar("SELECT id FROM pool_upstream_accounts WHERE display_name = ?1")
+        .bind(display_name)
+        .fetch_one(&state.pool)
+        .await
+        .expect("load tagged pool account id")
+}
+
 async fn insert_test_pool_limit_sample(
     state: &Arc<AppState>,
     account_id: i64,
@@ -17799,6 +17850,240 @@ async fn pool_openai_v1_responses_failover_reapplies_account_fast_mode_from_orig
 }
 
 #[tokio::test]
+async fn pool_openai_v1_responses_fast_fill_missing_large_body_recomputes_content_length() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct PersistedRow {
+        payload: Option<String>,
+        request_raw_path: Option<String>,
+    }
+
+    let (capture_base, captured_requests, capture_handle) =
+        spawn_capture_target_body_upstream().await;
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+
+    let fill_missing_tag_id =
+        create_test_fast_mode_tag(&state, "fill-missing-large-fast", "fill_missing", "primary")
+            .await;
+    create_test_tagged_pool_api_key_account(
+        &state,
+        "Large Fast Account",
+        "upstream-large-fast",
+        &capture_base,
+        &[fill_missing_tag_id],
+    )
+    .await;
+
+    let request_body = serde_json::to_vec(&json!({
+        "model": "gpt-5.4",
+        "stream": false,
+        "input": [{
+            "role": "user",
+            "content": "x".repeat(POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES + 4096)
+        }],
+        "stickyKey": "sticky-fast-large-success"
+    }))
+    .expect("serialize large fast request body");
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([
+            (
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            ),
+            (
+                http_header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            (
+                http_header::CONTENT_LENGTH,
+                HeaderValue::from_str(&request_body.len().to_string())
+                    .expect("valid content length"),
+            ),
+        ]),
+        Body::from(request_body),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read large fast response body");
+    let response_payload: Value =
+        serde_json::from_slice(&response_body).expect("decode large fast response body");
+    assert_eq!(
+        response_payload["received"]["service_tier"].as_str(),
+        Some("priority")
+    );
+    assert!(response_payload["received"].get("serviceTier").is_none());
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let captured = captured_requests.lock().await;
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0]["service_tier"].as_str(), Some("priority"));
+    assert!(captured[0].get("serviceTier").is_none());
+    drop(captured);
+
+    let row = sqlx::query_as::<_, PersistedRow>(
+        r#"
+        SELECT payload, request_raw_path
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load persisted large fast row");
+    let payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("persisted payload should exist"),
+    )
+    .expect("decode persisted large fast payload");
+    assert_eq!(payload["requestedServiceTier"].as_str(), Some("priority"));
+
+    let request_raw = read_proxy_raw_bytes(
+        row.request_raw_path
+            .as_deref()
+            .expect("large fast request raw path should exist"),
+        state.config.database_path.parent(),
+    )
+    .expect("read large fast request raw");
+    let request_payload: Value =
+        serde_json::from_slice(&request_raw).expect("decode large fast request raw");
+    assert_eq!(request_payload["service_tier"].as_str(), Some("priority"));
+    assert!(request_payload.get("serviceTier").is_none());
+
+    capture_handle.abort();
+}
+
+#[tokio::test]
+async fn pool_openai_v1_responses_fast_fill_missing_transport_failure_persists_rewritten_request_raw()
+ {
+    #[derive(Debug, sqlx::FromRow)]
+    struct PersistedRow {
+        status: Option<String>,
+        error_message: Option<String>,
+        payload: Option<String>,
+        request_raw_path: Option<String>,
+    }
+
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+
+    let fill_missing_tag_id = create_test_fast_mode_tag(
+        &state,
+        "fill-missing-transport-fast",
+        "fill_missing",
+        "primary",
+    )
+    .await;
+    create_test_tagged_pool_api_key_account(
+        &state,
+        "Broken Fast Account",
+        "upstream-broken-fast",
+        "http://127.0.0.1:1/",
+        &[fill_missing_tag_id],
+    )
+    .await;
+
+    let request_body = serde_json::to_vec(&json!({
+        "model": "gpt-5.4",
+        "stream": false,
+        "input": [{
+            "role": "user",
+            "content": "x".repeat(POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES + 4096)
+        }],
+        "stickyKey": "sticky-fast-large-failure"
+    }))
+    .expect("serialize failed large fast request body");
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri("/v1/responses".parse().expect("valid uri")),
+        Method::POST,
+        HeaderMap::from_iter([
+            (
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            ),
+            (
+                http_header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            (
+                http_header::CONTENT_LENGTH,
+                HeaderValue::from_str(&request_body.len().to_string())
+                    .expect("valid content length"),
+            ),
+        ]),
+        Body::from(request_body),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let response_body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read failed large fast response body");
+    let response_text = String::from_utf8_lossy(&response_body);
+    assert!(
+        response_text.contains("failed to contact upstream"),
+        "unexpected failed large fast response body: {response_text}"
+    );
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let row = sqlx::query_as::<_, PersistedRow>(
+        r#"
+        SELECT status, error_message, payload, request_raw_path
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load failed large fast row");
+    assert_eq!(row.status.as_deref(), Some("http_502"));
+    assert!(
+        row.error_message
+            .as_deref()
+            .is_some_and(|message| { message.contains("[failed_contact_upstream]") })
+    );
+
+    let payload: Value = serde_json::from_str(
+        row.payload
+            .as_deref()
+            .expect("failed large fast payload should exist"),
+    )
+    .expect("decode failed large fast payload");
+    assert_eq!(payload["requestedServiceTier"].as_str(), Some("priority"));
+    assert_eq!(
+        payload["failureKind"].as_str(),
+        Some(PROXY_FAILURE_FAILED_CONTACT_UPSTREAM)
+    );
+
+    let request_raw = read_proxy_raw_bytes(
+        row.request_raw_path
+            .as_deref()
+            .expect("failed large fast request raw path should exist"),
+        state.config.database_path.parent(),
+    )
+    .expect("read failed large fast request raw");
+    let request_payload: Value =
+        serde_json::from_slice(&request_raw).expect("decode failed large fast request raw");
+    assert_eq!(request_payload["service_tier"].as_str(), Some("priority"));
+    assert!(request_payload.get("serviceTier").is_none());
+}
+
+#[tokio::test]
 async fn pool_route_responses_compact_limits_follow_up_accounts_to_single_attempt() {
     #[derive(Debug, sqlx::FromRow)]
     struct AttemptRow {
@@ -23697,6 +23982,24 @@ fn rewrite_request_service_tier_for_fast_mode_force_remove_deletes_both_aliases(
     assert!(did_rewrite);
     assert!(payload.get("service_tier").is_none());
     assert!(payload.get("serviceTier").is_none());
+}
+
+#[test]
+fn pool_request_snapshot_preserves_content_length_only_for_file_backed_replays() {
+    assert!(!pool_request_snapshot_preserves_content_length(
+        &PoolReplayBodySnapshot::Empty
+    ));
+    assert!(!pool_request_snapshot_preserves_content_length(
+        &PoolReplayBodySnapshot::Memory(Bytes::from_static(b"{}"))
+    ));
+    assert!(pool_request_snapshot_preserves_content_length(
+        &PoolReplayBodySnapshot::File {
+            temp_file: Arc::new(PoolReplayTempFile {
+                path: PathBuf::from("/tmp/cvm-pool-replay-test.bin"),
+            }),
+            size: 2,
+        }
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- drop stale `Content-Length` when pool `/v1/responses` fast rewrite materializes a new outbound body
- keep rewritten request raw and `requestedServiceTier` consistent for transport-failure captures
- add regressions for large rewritten requests succeeding and transport failures preserving rewritten raw

## Verification
- `cargo test`
- `cargo check`