### PR TITLE
test(proxy): stabilize live retry file-backed route regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,11 @@ RUN apt-get update \
         arm64) XRAY_ZIP="Xray-linux-arm64-v8a.zip" ;; \
         *) echo "Unsupported TARGETARCH=${TARGETARCH} resolved_arch=${ARCH} for Xray-core" >&2; exit 1 ;; \
       esac \
-    && curl -fsSL -o /tmp/xray.zip "https://github.com/XTLS/Xray-core/releases/download/v${XRAY_CORE_VERSION}/${XRAY_ZIP}" \
+    && XRAY_PRIMARY_URL="https://github.com/XTLS/Xray-core/releases/download/v${XRAY_CORE_VERSION}/${XRAY_ZIP}" \
+    && XRAY_FALLBACK_URL="https://downloads.sourceforge.net/project/xray-core.mirror/v${XRAY_CORE_VERSION}/${XRAY_ZIP}" \
+    && if ! curl --retry 5 --retry-all-errors --retry-delay 2 -fsSL -o /tmp/xray.zip "${XRAY_PRIMARY_URL}"; then \
+         curl --retry 5 --retry-all-errors --retry-delay 2 -fsSL -o /tmp/xray.zip "${XRAY_FALLBACK_URL}"; \
+       fi \
     && unzip -q /tmp/xray.zip -d /tmp/xray \
     && install -m 0755 /tmp/xray/xray /usr/local/bin/xray \
     && install -d /usr/local/share/licenses/xray-core \

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14879,6 +14879,20 @@ async fn pool_retry_upstream(
         .into_response()
 }
 
+async fn pool_retry_upstream_after_body_read(
+    State(state): State<PoolRetryUpstreamState>,
+    request: axum::extract::Request,
+) -> Response {
+    // Responses-family live-body retries need the upstream to consume the full upload before
+    // replying; otherwise CI can race into a transport send error instead of the intended
+    // retryable HTTP failure.
+    let (parts, body) = request.into_parts();
+    let _body = to_bytes(body, usize::MAX)
+        .await
+        .expect("read pool retry upstream request body");
+    pool_retry_upstream(State(state), parts.headers).await
+}
+
 async fn pool_rate_limit_responses_upstream(
     State(state): State<PoolRateLimitResponsesUpstreamState>,
     headers: HeaderMap,
@@ -15941,6 +15955,40 @@ async fn spawn_pool_retry_upstream(
         axum::serve(listener, app)
             .await
             .expect("pool retry upstream should run");
+    });
+    (format!("http://{addr}"), attempts, handle)
+}
+
+async fn spawn_pool_retry_upstream_after_body_read(
+    fail_before_success: &[(&str, usize)],
+) -> (
+    String,
+    Arc<StdMutex<HashMap<String, usize>>>,
+    JoinHandle<()>,
+) {
+    let attempts = Arc::new(StdMutex::new(HashMap::new()));
+    let fail_before_success = Arc::new(
+        fail_before_success
+            .iter()
+            .map(|(authorization, failures)| ((*authorization).to_string(), *failures))
+            .collect::<HashMap<_, _>>(),
+    );
+    let app = Router::new()
+        .route("/v1/responses", post(pool_retry_upstream_after_body_read))
+        .with_state(PoolRetryUpstreamState {
+            attempts: attempts.clone(),
+            fail_before_success,
+        });
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind draining pool retry upstream");
+    let addr = listener
+        .local_addr()
+        .expect("draining pool retry upstream addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("draining pool retry upstream should run");
     });
     (format!("http://{addr}"), attempts, handle)
 }
@@ -25137,7 +25185,7 @@ async fn proxy_openai_v1_via_pool_live_retry_ignores_late_file_backed_sticky_rou
     drop(probe_state);
 
     let (upstream_base, attempts, upstream_handle) =
-        spawn_pool_retry_upstream(&[(expected_default_authorization, 1)]).await;
+        spawn_pool_retry_upstream_after_body_read(&[(expected_default_authorization, 1)]).await;
 
     let state =
         test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))


### PR DESCRIPTION
## Summary
- stabilize the file-backed live-retry regression test by making the retry upstream consume the full request body before replying
- scope the draining upstream helper to the flaky `/v1/responses` retry test so the rest of the suite keeps its current behavior
- harden the Dockerfile Xray download step with retries plus a SourceForge mirror fallback so transient GitHub release 404s stop blocking artifact builds and releases

## Verification
- `cargo test proxy_openai_v1_via_pool_ -- --nocapture`
- `cargo test proxy_openai_v1_via_pool_live_retry_ignores_late_file_backed_sticky_route -- --nocapture`
- `for i in {1..30}; do cargo test proxy_openai_v1_via_pool_live_retry_ignores_late_file_backed_sticky_route -- --nocapture >/tmp/cvm-release-unblock-$i.log 2>&1 || break; done`
- `cargo test --tests`
- verified the Dockerfile download logic by downloading/unzipping `Xray-linux-64.zip` from both the primary GitHub release URL and the fallback SourceForge mirror