### PR TITLE
fix(web): hydrate reauth account details

### DIFF
--- a/web/src/components/UpstreamAccountCreatePage.oauth.stories.tsx
+++ b/web/src/components/UpstreamAccountCreatePage.oauth.stories.tsx
@@ -281,6 +281,22 @@ export const ManualMailboxUnsupported: Story = {
   },
 }
 
+
+export const ReauthDetailOutsideRoster: Story = {
+  render: () => (
+    <AccountPoolStoryRouter initialEntry="/account-pool/upstream-accounts/new?mode=oauth&accountId=2660" />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(await canvas.findByDisplayValue('Codex Pro - Reauth Hidden Lane')).toBeInTheDocument()
+    await expect(canvas.getByDisplayValue('reauth-hidden-lane@example.com')).toBeInTheDocument()
+    await expect(canvas.getByDisplayValue('production')).toBeInTheDocument()
+    await expect(canvas.getByText(/intentionally absent from the current roster page/i)).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: /generate oauth url/i }))
+    await expect(canvas.getByRole('button', { name: /copy oauth url/i })).toBeEnabled()
+  },
+}
+
 export const ReauthManualMailboxAttached: Story = {
   render: () => (
     <AccountPoolStoryRouter initialEntry="/account-pool/upstream-accounts/new?mode=oauth&accountId=101" />

--- a/web/src/components/UpstreamAccountsPage.story-runtime-core.ts
+++ b/web/src/components/UpstreamAccountsPage.story-runtime-core.ts
@@ -1637,6 +1637,8 @@ export function createStore(): StoryStore {
     storyId?.endsWith('--bulk-selection') === true ||
     storyId?.endsWith('--slow-page-switch') === true
   const dynamicRosterStory = isDynamicRosterStoryId(storyId)
+  const reauthDetailOutsideRosterStory =
+    storyId?.endsWith('--reauth-detail-outside-roster') === true
 
   const baseOauthStoryOverrides: Partial<UpstreamAccountDetail> = {
     tags: pickStoryTags('vip', 'stickyPool', 'priority'),
@@ -2364,6 +2366,23 @@ export function createStore(): StoryStore {
   const details = Object.fromEntries(
     storyAccounts.map((account) => [account.id, account]),
   )
+  if (reauthDetailOutsideRosterStory) {
+    details[2660] = createOauthAccount(2660, {
+      displayName: 'Codex Pro - Reauth Hidden Lane',
+      email: 'reauth-hidden-lane@example.com',
+      groupName: 'production',
+      isMother: false,
+      status: 'needs_reauth',
+      displayStatus: 'needs_reauth',
+      healthStatus: 'needs_reauth',
+      workStatus: 'idle',
+      syncState: 'idle',
+      tags: pickStoryTags('vip', 'rescue'),
+      note: 'This account is intentionally absent from the current roster page but available through the detail endpoint.',
+      lastError: 'refresh token expired',
+      lastErrorAt: '2026-03-17T12:05:00.000Z',
+    })
+  }
   return {
     writesEnabled: true,
     routing: {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -336,6 +336,12 @@ const baseTranslations = {
       "Re-authorize upstream account",
     "accountPool.upstreamAccounts.createPage.relinkDescription":
       "Generate a fresh OAuth link for {{name}}, then paste the localhost callback URL here to keep the stored credentials valid.",
+    "accountPool.upstreamAccounts.createPage.relinkLoading":
+      "Loading the saved account metadata before re-authorization…",
+    "accountPool.upstreamAccounts.createPage.relinkLoadFailed":
+      "Unable to load the account for re-authorization.",
+    "accountPool.upstreamAccounts.createPage.relinkNonOauth":
+      "Only OAuth upstream accounts can be re-authorized from this page.",
     "accountPool.upstreamAccounts.createPage.helpTitle": "Creation notes",
     "accountPool.upstreamAccounts.createPage.helpDescription":
       "Pick the account type first, then provide the metadata or local quota placeholders required for onboarding.",
@@ -2199,6 +2205,12 @@ const baseTranslations = {
     "accountPool.upstreamAccounts.createPage.relinkTitle": "重新授权账号",
     "accountPool.upstreamAccounts.createPage.relinkDescription":
       "为 {{name}} 重新生成 OAuth 地址，再把 localhost 回调链接贴回这里，保持已保存凭据可续期。",
+    "accountPool.upstreamAccounts.createPage.relinkLoading":
+      "正在加载已保存账号信息，用于重新授权…",
+    "accountPool.upstreamAccounts.createPage.relinkLoadFailed":
+      "无法加载要重新授权的账号。",
+    "accountPool.upstreamAccounts.createPage.relinkNonOauth":
+      "只有 OAuth 上游账号可以在这个页面重新授权。",
     "accountPool.upstreamAccounts.createPage.helpTitle": "创建说明",
     "accountPool.upstreamAccounts.createPage.helpDescription":
       "先选账号类型，再填写必要的元数据或本地额度占位信息，完成后会回到账号列表。",

--- a/web/src/pages/account-pool/UpstreamAccountCreate.actions.ts
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.actions.ts
@@ -75,6 +75,9 @@ export function useUpstreamAccountCreateActions(ctx: UpstreamAccountCreateContro
     oauthNote,
     oauthTagIds,
     relinkAccountId,
+    relinkDetailError,
+    relinkDetailLoading,
+    relinkReady,
     removeOauthMailboxSession,
     resolveMailboxIssue,
     resolvePendingGroupConcurrencyLimitForName,
@@ -346,6 +349,15 @@ export function useUpstreamAccountCreateActions(ctx: UpstreamAccountCreateContro
   };
 
   const handleGenerateOauthUrl = async () => {
+    if (!relinkReady) {
+      setActionError(
+        relinkDetailLoading
+          ? t("accountPool.upstreamAccounts.createPage.relinkLoading")
+          : relinkDetailError ??
+              t("accountPool.upstreamAccounts.createPage.relinkLoadFailed"),
+      );
+      return;
+    }
     if (oauthGroupProxyState.error) {
       setActionError(oauthGroupProxyState.error);
       return;

--- a/web/src/pages/account-pool/UpstreamAccountCreate.oauth-section.tsx
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.oauth-section.tsx
@@ -53,6 +53,7 @@ export function UpstreamAccountCreateOauthSection() {
     isSupportedMailboxSession,
     mailboxInputMatchesSession,
     manualCopyFieldRef,
+    markRelinkMetadataDirty,
     manualCopyOpen,
     normalizeGroupName,
     oauthCallbackUrl,
@@ -75,6 +76,7 @@ export function UpstreamAccountCreateOauthSection() {
     oauthNote,
     oauthSessionActive,
     oauthTagIds,
+    relinkReady,
     openDuplicateDetailDialog,
     openGroupNoteEditor,
     pageCreatedTagIds,
@@ -116,6 +118,7 @@ export function UpstreamAccountCreateOauthSection() {
         value={oauthDisplayName}
         aria-invalid={oauthDisplayNameConflict != null}
         onChange={(event) => {
+          markRelinkMetadataDirty();
           setOauthDisplayName(event.target.value);
           setActionError(null);
           invalidateSingleOauthSessionForMetadataEdit();
@@ -143,6 +146,7 @@ export function UpstreamAccountCreateOauthSection() {
           )}
           value={oauthMailboxInput}
           onChange={(event) => {
+            markRelinkMetadataDirty();
             const nextValue = event.target.value;
             setOauthMailboxInput(nextValue);
             setOauthEmail(nextValue);
@@ -345,6 +349,7 @@ export function UpstreamAccountCreateOauthSection() {
         onCreateRequested={handleOauthGroupCreateRequest}
         formatAccountCountLabel={formatGroupAccountCountLabel}
         onValueChange={(value) => {
+          markRelinkMetadataDirty();
           setOauthGroupName(value);
           setActionError(null);
           invalidateSingleOauthSessionForMetadataEdit();
@@ -392,6 +397,7 @@ export function UpstreamAccountCreateOauthSection() {
       "accountPool.upstreamAccounts.mother.toggleDescription",
     )}
     onToggle={() => {
+      markRelinkMetadataDirty();
       setOauthIsMother((current: boolean) => !current);
       setActionError(null);
       invalidateSingleOauthSessionForMetadataEdit();
@@ -406,6 +412,7 @@ export function UpstreamAccountCreateOauthSection() {
       name="oauthNote"
       value={oauthNote}
       onChange={(event) => {
+        markRelinkMetadataDirty();
         setOauthNote(event.target.value);
         setActionError(null);
         invalidateSingleOauthSessionForMetadataEdit();
@@ -419,6 +426,7 @@ export function UpstreamAccountCreateOauthSection() {
     pageCreatedTagIds={pageCreatedTagIds}
     labels={tagFieldLabels}
     onChange={(nextTagIds) => {
+      markRelinkMetadataDirty();
       setOauthTagIds(nextTagIds);
       setActionError(null);
       invalidateSingleOauthSessionForMetadataEdit();
@@ -611,6 +619,7 @@ export function UpstreamAccountCreateOauthSection() {
           disabled={
             busyAction === "oauth-generate" ||
             !writesEnabled ||
+            !relinkReady ||
             Boolean(oauthGroupProxyState.error) ||
             session?.status === "completed"
           }

--- a/web/src/pages/account-pool/UpstreamAccountCreate.page-impl.tsx
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.page-impl.tsx
@@ -144,7 +144,25 @@ export default function UpstreamAccountCreatePage() {
         : (items.find((item) => item.id === relinkAccountId) ?? null),
     [items, relinkAccountId],
   );
+  const [relinkDetail, setRelinkDetail] =
+    useState<UpstreamAccountDetail | null>(null);
+  const [relinkDetailLoading, setRelinkDetailLoading] = useState(false);
+  const [relinkDetailError, setRelinkDetailError] = useState<string | null>(
+    null,
+  );
+  const relinkMetadataDirtyRef = useRef(false);
   const isRelinking = relinkAccountId != null;
+  const matchingRelinkDetail =
+    relinkDetail != null && relinkDetail.id === relinkAccountId
+      ? relinkDetail
+      : null;
+  const relinkAccount = matchingRelinkDetail ?? relinkSummary;
+  const relinkReady =
+    !isRelinking ||
+    (matchingRelinkDetail != null &&
+      matchingRelinkDetail.kind === "oauth_codex" &&
+      !relinkDetailLoading &&
+      relinkDetailError == null);
   const initialBatchRows = useMemo(() => {
     const defaultGroupName = draft?.batchOauth?.defaultGroupName ?? "";
     if (!draft?.batchOauth?.rows?.length) {
@@ -647,6 +665,11 @@ export default function UpstreamAccountCreatePage() {
     const nextItems = applyMotherUpdateToItems(items, updated);
     notifyMotherSwitches(items, nextItems);
   };
+  const markRelinkMetadataDirty = useCallback(() => {
+    if (isRelinking) {
+      relinkMetadataDirtyRef.current = true;
+    }
+  }, [isRelinking]);
   const {
     resolveGroupNodeShuntEnabledForName,
     resolvePendingGroupNoteForName,
@@ -1350,18 +1373,63 @@ export default function UpstreamAccountCreatePage() {
   }, [isRelinking, location.search]);
 
   useEffect(() => {
-    if (!isRelinking || !relinkSummary) return;
+    relinkMetadataDirtyRef.current = false;
+    setRelinkDetail(null);
+    setRelinkDetailError(null);
+    if (!isRelinking || relinkAccountId == null) {
+      setRelinkDetailLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setRelinkDetailLoading(true);
+    void fetchUpstreamAccountDetail(relinkAccountId)
+      .then((detail) => {
+        if (cancelled) return;
+        setRelinkDetail(detail);
+        setRelinkDetailError(
+          detail.kind === "oauth_codex"
+            ? null
+            : t("accountPool.upstreamAccounts.createPage.relinkNonOauth"),
+        );
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setRelinkDetail(null);
+        setRelinkDetailError(
+          err instanceof Error
+            ? err.message
+            : t("accountPool.upstreamAccounts.createPage.relinkLoadFailed"),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setRelinkDetailLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isRelinking, relinkAccountId, t]);
+
+  useEffect(() => {
+    if (!isRelinking || !relinkAccount) return;
     setActiveTab("oauth");
-    setOauthDisplayName((current) => current || relinkSummary.displayName);
-    setOauthEmail((current) => current || relinkSummary.email || "");
-    setOauthGroupName((current) => current || relinkSummary.groupName || "");
+    if (relinkMetadataDirtyRef.current) return;
+    setOauthDisplayName((current) => current || relinkAccount.displayName);
+    setOauthEmail((current) => current || relinkAccount.email || "");
+    setOauthMailboxInput((current) => current || relinkAccount.email || "");
+    setOauthGroupName((current) => current || relinkAccount.groupName || "");
     setOauthTagIds((current) =>
       current.length > 0
         ? current
-        : (relinkSummary.tags ?? []).map((tag) => tag.id),
+        : (relinkAccount.tags ?? []).map((tag) => tag.id),
     );
-    setOauthIsMother((current) => current || relinkSummary.isMother);
-  }, [isRelinking, relinkSummary]);
+    setOauthIsMother((current) => current || relinkAccount.isMother);
+    if ("note" in relinkAccount) {
+      const relinkNote = relinkAccount.note;
+      setOauthNote((current) =>
+        current || (typeof relinkNote === "string" ? relinkNote : ""),
+      );
+    }
+  }, [isRelinking, relinkAccount]);
 
   useEffect(() => {
     if (!manualCopyOpen) return;
@@ -1916,6 +1984,9 @@ export default function UpstreamAccountCreatePage() {
     oauthTagIds,
     persistDraftGroupSettings,
     relinkAccountId,
+    relinkDetailError,
+    relinkDetailLoading,
+    relinkReady,
     removeOauthMailboxSession,
     resolveMailboxIssue,
     resolvePendingGroupConcurrencyLimitForName,
@@ -2169,7 +2240,11 @@ export default function UpstreamAccountCreatePage() {
     pageCreatedTagIds,
     refreshClockMs,
     refresh,
-    relinkSummary,
+    relinkDetailError,
+    relinkDetailLoading,
+    relinkReady,
+    relinkSummary: relinkAccount,
+    markRelinkMetadataDirty,
     removeBatchRow,
     resolveRequiredGroupProxyState,
     selectAllReadonlyText,

--- a/web/src/pages/account-pool/UpstreamAccountCreate.relink-detail.txt
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.relink-detail.txt
@@ -1,0 +1,139 @@
+describe("UpstreamAccountCreatePage relink detail hydration", () => {
+  it("loads relink metadata by account id when the account is outside the current roster", async () => {
+    const hookState = mockUpstreamAccounts({ items: [] });
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValueOnce({
+      id: 2660,
+      kind: "oauth_codex",
+      provider: "codex",
+      displayName: "Reauth Account 2660",
+      email: "reauth-2660@example.com",
+      groupName: "prod",
+      isMother: true,
+      status: "needs_reauth",
+      enabled: true,
+      duplicateInfo: null,
+      history: [],
+      note: "Keep this saved note during reauth.",
+      tags: [
+        {
+          id: 1,
+          name: "vip",
+          routingRule: {
+            guardEnabled: false,
+            allowCutOut: true,
+            allowCutIn: true,
+          },
+        },
+      ],
+      effectiveRoutingRule: {
+        guardEnabled: false,
+        allowCutOut: true,
+        allowCutIn: true,
+        sourceTagIds: [],
+        sourceTagNames: [],
+        guardRules: [],
+      },
+    });
+
+    render({
+      pathname: "/account-pool/upstream-accounts/new",
+      search: "?accountId=2660",
+      state: { draft: { oauth: { groupName: "" } } },
+    });
+    await flushAsync();
+
+    expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenCalledWith(2660);
+    expect((host?.querySelector('input[name="oauthDisplayName"]') as HTMLInputElement).value).toBe("Reauth Account 2660");
+    expect((host?.querySelector('input[name="oauthMailboxInput"]') as HTMLInputElement).value).toBe("reauth-2660@example.com");
+    expect((host?.querySelector('input[name="oauthGroupName"]') as HTMLInputElement).value).toBe("prod");
+    expect((host?.querySelector('textarea[name="oauthNote"]') as HTMLTextAreaElement).value).toBe("Keep this saved note during reauth.");
+    expect(host?.textContent).toContain("vip");
+
+    clickButton(/Generate OAuth URL/i);
+    await flushAsync();
+
+    expect(hookState.beginOauthLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 2660,
+        displayName: "Reauth Account 2660",
+        email: "reauth-2660@example.com",
+        groupName: "prod",
+        note: "Keep this saved note during reauth.",
+        tagIds: [1],
+        isMother: true,
+      }),
+    );
+  });
+
+  it("does not overwrite a relink draft edited before the detail response returns", async () => {
+    mockUpstreamAccounts({ items: [] });
+    let resolveDetail: (value: Record<string, unknown>) => void = () => undefined;
+    apiMocks.fetchUpstreamAccountDetail.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    render("/account-pool/upstream-accounts/new?accountId=2660");
+    setInputValue('input[name="oauthDisplayName"]', "Owner Edited Name");
+    resolveDetail({
+      id: 2660,
+      kind: "oauth_codex",
+      provider: "codex",
+      displayName: "Server Name",
+      email: "server@example.com",
+      groupName: "prod",
+      isMother: false,
+      status: "active",
+      enabled: true,
+      duplicateInfo: null,
+      history: [],
+      note: "Server note",
+      tags: [],
+    });
+    await flushAsync();
+
+    expect((host?.querySelector('input[name="oauthDisplayName"]') as HTMLInputElement).value).toBe("Owner Edited Name");
+    expect((host?.querySelector('input[name="oauthMailboxInput"]') as HTMLInputElement).value).toBe("");
+  });
+
+  it("blocks OAuth generation when the relink detail cannot be loaded", async () => {
+    const hookState = mockUpstreamAccounts({ items: [] });
+    apiMocks.fetchUpstreamAccountDetail.mockRejectedValueOnce(new Error("missing account 2660"));
+
+    render("/account-pool/upstream-accounts/new?accountId=2660");
+    await flushAsync();
+
+    expect(host?.textContent).toContain("missing account 2660");
+    const generateButton = findButton(/Generate OAuth URL/i);
+    expect(generateButton.disabled).toBe(true);
+    clickButton(/Generate OAuth URL/i);
+    await flushAsync();
+    expect(hookState.beginOauthLogin).not.toHaveBeenCalled();
+  });
+
+  it("blocks OAuth generation when the target account is not OAuth", async () => {
+    const hookState = mockUpstreamAccounts({ items: [] });
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValueOnce({
+      id: 2660,
+      kind: "api_key_codex",
+      provider: "codex",
+      displayName: "API key target",
+      groupName: "staging",
+      isMother: false,
+      status: "active",
+      enabled: true,
+      duplicateInfo: null,
+      history: [],
+      note: null,
+      tags: [],
+    });
+
+    render("/account-pool/upstream-accounts/new?accountId=2660");
+    await flushAsync();
+
+    expect(host?.textContent).toContain("Only OAuth upstream accounts can be re-authorized from this page.");
+    expect(findButton(/Generate OAuth URL/i).disabled).toBe(true);
+    expect(hookState.beginOauthLogin).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/account-pool/UpstreamAccountCreate.sections.tsx
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.sections.tsx
@@ -25,6 +25,8 @@ export function UpstreamAccountCreatePageSections() {
     isRelinking,
     listError,
     oauthCompletedDetail,
+    relinkDetailError,
+    relinkDetailLoading,
     relinkSummary,
     session,
     sessionHint,
@@ -74,7 +76,9 @@ export function UpstreamAccountCreatePageSections() {
                   : t("accountPool.upstreamAccounts.createPage.description")}
               </p>
             </div>
-            {isLoading ? <Spinner className="text-primary" /> : null}
+            {isLoading || relinkDetailLoading ? (
+              <Spinner className="text-primary" />
+            ) : null}
           </div>
 
           {!writesEnabled ? (
@@ -92,6 +96,28 @@ export function UpstreamAccountCreatePageSections() {
                   {t("accountPool.upstreamAccounts.writesDisabledBody")}
                 </p>
               </div>
+            </Alert>
+          ) : null}
+
+          {relinkDetailLoading ? (
+            <Alert variant="info">
+              <AppIcon
+                name="loading"
+                className="mt-0.5 h-4 w-4 shrink-0 animate-spin"
+                aria-hidden
+              />
+              <div>{t("accountPool.upstreamAccounts.createPage.relinkLoading")}</div>
+            </Alert>
+          ) : null}
+
+          {relinkDetailError ? (
+            <Alert variant="error">
+              <AppIcon
+                name="alert-circle-outline"
+                className="mt-0.5 h-4 w-4 shrink-0"
+                aria-hidden
+              />
+              <div>{relinkDetailError}</div>
             </Alert>
           ) : null}
 

--- a/web/src/pages/account-pool/UpstreamAccountCreate.test.tsx
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.test.tsx
@@ -8,6 +8,7 @@ import suite4 from "./UpstreamAccountCreate.display-name-b.txt?raw";
 import suite5 from "./UpstreamAccountCreate.oauth-mailbox.txt?raw";
 import suite6 from "./UpstreamAccountCreate.api-key.txt?raw";
 import suite7 from "./UpstreamAccountCreate.imported-oauth.txt?raw";
+import suite8 from "./UpstreamAccountCreate.relink-detail.txt?raw";
 
 /** @vitest-environment jsdom */
 import { act } from "react";
@@ -1074,6 +1075,7 @@ evalChunk(suite4);
 evalChunk(suite5);
 evalChunk(suite6);
 evalChunk(suite7);
+evalChunk(suite8);
 
 function clickCreateTab(matcher: RegExp) {
   const tab = Array.from(document.body.querySelectorAll('[role="tab"]')).find(


### PR DESCRIPTION
## Summary
- Hydrate the upstream account reauthorization page from `/api/pool/upstream-accounts/:id` instead of relying on the current roster page.
- Add explicit loading/error/non-OAuth relink states and block OAuth URL generation until the target detail is authoritative.
- Add regression coverage plus a Storybook scenario for an account that is outside the current roster but loadable by detail endpoint.

## Verification
- `cd web && bun run test -- UpstreamAccountCreate.test.tsx`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- `codex review --base origin/main` (review clear)

## Storybook / Visual Evidence
- Story: `web/src/components/UpstreamAccountCreatePage.oauth.stories.tsx` / `ReauthDetailOutsideRoster`
- Play coverage: verifies detail-prefilled fields and OAuth URL generation with target account metadata.
- Screenshot evidence was shared in the Codex thread; no screenshot artifact is committed.

## References
- Specs: `docs/specs/g4ek6-account-pool-upstream-accounts/SPEC.md`
- Solutions: -
- Project Docs: -

## Notes
- `spec_disposition=link`
- `solution_disposition=none`
- `project_doc_disposition=none`
