### PR TITLE
fix(proxy): ignore installation id for compact attribution

### DIFF
--- a/docs/specs/g3amk-codex-remote-compact-observability/SPEC.md
+++ b/docs/specs/g3amk-codex-remote-compact-observability/SPEC.md
@@ -75,7 +75,7 @@
 - `prepare_target_request_body()` 在 compact 路径只做 JSON 解析与信息提取，不执行 Fast rewrite，也不执行 chat stream usage 注入。
 - 响应采集阶段沿用现有 usage / model 解析逻辑，compact 的 `response.compaction` 响应若携带 `usage` 即正常提取 tokens。
 - payload summary 通过 `target.endpoint()` 持久化 compact endpoint，后续 `/api/invocations`、SSE `records`、startup backfill 与详情展示均保持同一来源。
-- 普通 `/v1/responses` 成功提取 `promptCacheKey` 时，后端维护运行期“客户端稳定指纹 -> 最近 `promptCacheKey` / `stickyKey`”映射；stable key 只使用 `session_id`、`originator`、`x-codex-window-id`、`x-codex-installation-id`，且必须至少包含 `session_id` 或 `x-codex-window-id` 这类强稳定键，`traceparent` 仅作为诊断 fingerprint 保存。
+- 普通 `/v1/responses` 成功提取 `promptCacheKey` 时，后端维护运行期“客户端稳定指纹 -> 最近 `promptCacheKey` / `stickyKey`”映射；stable key 只使用 `session_id`、`originator`、`x-codex-window-id`，且必须至少包含 `session_id` 或 `x-codex-window-id` 这类强稳定键，`x-codex-installation-id` 与 `traceparent` 仅作为诊断 fingerprint 保存。
 - compact 缺少 key 时，从同一 stable client fingerprint 的近期唯一映射补齐对话归因，并写入 `promptCacheKeyAttributionSource="client_fingerprint_recent"`；无 stable fingerprint、TTL 过期、无法匹配或同一 fingerprint 在 TTL 内出现多个不同 key 时保持无 key。
 - 前端通过现有 `endpoint` 字段判断 compact，并在主列表 badge 位置显示“远程压缩 / Compact”。
 - 统计接口继续使用同一 `codex_invocations` 数据源，因此 compact 自动进入 totals、summary 与 timeseries。
@@ -163,8 +163,7 @@
 - 风险：旧 compact payload 若缺少 prompt-cache key，不会出现在 prompt-cache conversation 归因视图；当前按“仅修未来”策略避免历史误归因。
 - 风险：compact 若未来公开 `service_tier` 参数，当前实现仍会保持“不注入”策略，需要后续根据官方文档再评估。
 - 假设：compact 响应中的 `usage` 结构继续与现有 usage 解析兼容。
-- 假设：`session_id`、`originator`、`x-codex-window-id`、`x-codex-installation-id` 在同一客户端窗口内足够稳定，可用于短 TTL 内归因；`traceparent` 可能逐请求变化，不参与 stable matching。
-- 开放问题：GitHub MCP 当前不可用，fast-track 的远端 push / PR 环节存在阻断。
+- 假设：`session_id`、`originator`、`x-codex-window-id` 在同一客户端窗口内足够稳定，可用于短 TTL 内归因；`x-codex-installation-id` 与 `traceparent` 可能在普通 responses 与 compact 间不一致，不参与 stable matching。
 
 ## 变更记录（Change log）
 

--- a/src/proxy/payload_utils.rs
+++ b/src/proxy/payload_utils.rs
@@ -1947,12 +1947,7 @@ pub(crate) fn client_prompt_cache_attribution_context_from_headers(
     headers: &HeaderMap,
 ) -> ClientPromptCacheAttributionContext {
     const STRONG_STABLE_HEADER_NAMES: &[&str] = &["session_id", "x-codex-window-id"];
-    const STABLE_HEADER_NAMES: &[&str] = &[
-        "session_id",
-        "originator",
-        "x-codex-window-id",
-        "x-codex-installation-id",
-    ];
+    const STABLE_HEADER_NAMES: &[&str] = &["session_id", "originator", "x-codex-window-id"];
     const DIAGNOSTIC_HEADER_NAMES: &[&str] = &[
         "session_id",
         "originator",

--- a/src/tests/slices/compact_prompt_cache_attribution.rs
+++ b/src/tests/slices/compact_prompt_cache_attribution.rs
@@ -2,6 +2,15 @@ static COMPACT_ATTRIBUTION_TEST_LOCK: Lazy<std::sync::Mutex<()>> =
     Lazy::new(|| std::sync::Mutex::new(()));
 
 fn client_headers(session_id: &str, window_id: &str, traceparent: &str) -> HeaderMap {
+    client_headers_with_installation(session_id, window_id, Some("installation-a"), traceparent)
+}
+
+fn client_headers_with_installation(
+    session_id: &str,
+    window_id: &str,
+    installation_id: Option<&str>,
+    traceparent: &str,
+) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(
         HeaderName::from_static("session_id"),
@@ -15,15 +24,64 @@ fn client_headers(session_id: &str, window_id: &str, traceparent: &str) -> Heade
         HeaderName::from_static("x-codex-window-id"),
         HeaderValue::from_str(window_id).expect("valid window id header"),
     );
-    headers.insert(
-        HeaderName::from_static("x-codex-installation-id"),
-        HeaderValue::from_static("installation-a"),
-    );
+    if let Some(installation_id) = installation_id {
+        headers.insert(
+            HeaderName::from_static("x-codex-installation-id"),
+            HeaderValue::from_str(installation_id).expect("valid installation id header"),
+        );
+    }
     headers.insert(
         HeaderName::from_static("traceparent"),
         HeaderValue::from_str(traceparent).expect("valid traceparent header"),
     );
     headers
+}
+
+#[test]
+fn compact_prompt_cache_attribution_ignores_installation_id_mismatch() {
+    let _guard = COMPACT_ATTRIBUTION_TEST_LOCK.lock().expect("test lock");
+    clear_prompt_cache_attribution_for_tests();
+    let now = Instant::now();
+    let response_context = client_prompt_cache_attribution_context_from_headers(
+        &client_headers_with_installation(
+            "session-a",
+            "window-a",
+            None,
+            "00-00000000000000000000000000000001-0000000000000001-01",
+        ),
+    );
+    let compact_context = client_prompt_cache_attribution_context_from_headers(
+        &client_headers_with_installation(
+            "session-a",
+            "window-a",
+            Some("installation-a"),
+            "00-00000000000000000000000000000002-0000000000000002-01",
+        ),
+    );
+
+    assert!(response_context.fingerprint.is_some());
+    assert_eq!(response_context.cache_key, compact_context.cache_key);
+    assert!(!response_context
+        .header_fingerprints
+        .contains_key("x-codex-installation-id"));
+    assert!(compact_context
+        .header_fingerprints
+        .contains_key("x-codex-installation-id"));
+
+    remember_prompt_cache_attribution(
+        &response_context,
+        "prompt-cache-a",
+        Some("sticky-a"),
+        now,
+    );
+
+    let attribution = lookup_recent_prompt_cache_attribution(
+        &compact_context,
+        now + Duration::from_secs(30),
+    )
+    .expect("compact should reuse attribution when only installation id differs");
+    assert_eq!(attribution.prompt_cache_key, "prompt-cache-a");
+    assert_eq!(attribution.sticky_key.as_deref(), Some("sticky-a"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Exclude `x-codex-installation-id` from the compact prompt-cache attribution stable key.
- Keep installation ID as hashed diagnostic metadata in `clientHeaderFingerprints`.
- Add a regression test for responses without installation ID followed by compact requests that include it.

## Test Plan
- `cargo fmt -- --check`
- `cargo test compact_prompt_cache_attribution`
- `cargo test compact_request_body_still_avoids_rewrite_and_usage_injection`
- `cargo test prompt_cache_recent_invocations_include_attributed_compact_preview`
- `cargo check`
- `cd web && bun run build`
- `codex -m gpt-5.5 -c model_reasoning_effort="low" --sandbox read-only -a never review --base origin/main`

## References
Spec: `docs/specs/g3amk-codex-remote-compact-observability/SPEC.md`
Spec Disposition: update
Solutions: -
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: n/a(no solution change)
Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->