### PR TITLE
fix(web): correct dashboard active-tail rate cards

### DIFF
--- a/docs/specs/2qsev-dashboard-tpm-cost-per-minute-kpi/SPEC.md
+++ b/docs/specs/2qsev-dashboard-tpm-cost-per-minute-kpi/SPEC.md
@@ -2,9 +2,9 @@
 
 ## 状态
 
-- Status: 部分完成（3/4）
+- Status: 已实现，待 PR / CI / review-proof 收敛
 - Created: 2026-04-10
-- Last: 2026-04-10
+- Last: 2026-04-28
 
 ## 背景 / 问题陈述
 
@@ -16,8 +16,9 @@
 
 ### Goals
 
-- 将今日 KPI 的首个 tile 改为 `TPM (5m avg)`，并新增 `Cost/min (5m avg)`。
-- 速率口径固定为最近 5 个已完成分钟桶的均值：忽略当前进行中的分钟，缺失分钟按 `0` 计入。
+- 将今日 KPI 的首个 tile 改为 `TPM`，并新增 `消费速率` / `Spend rate`。
+- 速率口径固定为最近 5 分钟内的活跃尾段均值：当前进行中分钟参与计算，首个非零 token/cost 桶之前的前置空闲时间不参与分母，首个活动桶之后的空闲时间继续参与分母。
+- 数据卡片标题可点击 / 聚焦 / 悬停打开 tooltip，解释字段含义与速率算法。
 - summary 成功但 timeseries 尚未可用时，只让两个速率 tile 进入 skeleton / `—` 降级，其余累计 tile 保持可读。
 - `TodayStatsOverview` 升级成 6 个等权 tile，并在 Storybook `desktop1440` 下保持单行。
 - 生成并归档 Storybook 视觉证据，供快车道 PR merge-ready 使用。
@@ -48,9 +49,10 @@
 
 ### MUST
 
-- 最近 5 分钟均值只统计已完成分钟桶。
-- trailing window 内缺失分钟必须按 `0` 补齐，而不是缩小分母。
-- 今日完整分钟数少于 5 时，按已有完整分钟数求均值；若为 `0`，显示数值 `0`。
+- 最近 5 分钟均值按活跃尾段时间加权计算。
+- trailing window 内首个非零 token/cost 桶之前的前置 0 时间不参与分母；首个活动桶之后的缺失或 0 时间继续参与分母，避免一有请求就产生尖峰。
+- 今日窗口内活动尾段少于 5 分钟时，按实际活动尾段 elapsed minutes 求均值；若无活动，显示数值 `0`。
+- 当前进行中分钟参与显示速率；由于 timeseries 为 1m 桶，首个活动秒级起点按该桶 `bucketStart` 近似。
 - summary error 时保持整个 today overview 现有 alert 语义。
 - timeseries error 时，仅两个速率 tile 显示 `—`。
 
@@ -67,13 +69,14 @@
 
 ### Core flows
 
-- Dashboard 今日视图加载成功后，KPI 行显示：`TPM (5m avg)`、`Cost/min (5m avg)`、`成功`、`失败`、`总成本`、`总 Tokens`。
-- `TPM` 与 `Cost/min` 来自 today 1 分钟时序：选取最新 `5` 个已完成分钟桶（或当日可用完整分钟数），总量除以窗口分钟数得到每分钟均值。
-- 当前自然分钟仍在进行中时，该分钟桶不参与显示速率。
+- Dashboard 今日视图加载成功后，KPI 行显示：`TPM`、`消费速率` / `Spend rate`、`成功`、`失败`、`总成本`、`总 Tokens`。
+- `TPM` 与 `消费速率` 来自 today 1 分钟时序：以同自然日内较新的 `now` / `rangeEnd` 为 anchor，取最近 5 分钟内的 points，找到最早的非零 token/cost bucket，并用 `anchor - activeStart` 作为分母。
+- 如果最近 5 分钟内前三分半都是 0、后 1.5 分钟有数据，则使用后 1.5 分钟总量除以 `1.5`。
+- 如果首个活动桶之后存在缺失分钟或 0 值分钟，这段时间继续计入分母。
 
 ### Edge cases / errors
 
-- 今日尚无完整分钟时：速率显示 `0`，不是 `—`。
+- 今日最近 5 分钟无 token/cost 活动时：速率显示 `0`，不是 `—`。
 - timeseries 正在加载且 summary 已成功：速率 tile skeleton，其余 4 个 tile 正常显示。
 - timeseries 加载失败且 summary 已成功：速率 tile 显示 `—`，其余 4 个 tile 正常显示。
 - summary 失败时：整体显示现有 alert，不做混合态拼接。
@@ -82,9 +85,9 @@
 
 ### 接口清单（Inventory）
 
-| 接口（Name） | 类型（Kind） | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner） | 使用方（Consumers） | 备注（Notes） |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Dashboard today rate snapshot | ui-component-prop | internal | Modify | None | web/dashboard | `DashboardActivityOverview` -> `TodayStatsOverview` | 仅前端本地派生，不扩展 API |
+| 接口（Name）                  | 类型（Kind）      | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner） | 使用方（Consumers）                                 | 备注（Notes）              |
+| ----------------------------- | ----------------- | ------------- | -------------- | ------------------------ | --------------- | --------------------------------------------------- | -------------------------- |
+| Dashboard today rate snapshot | ui-component-prop | internal      | Modify         | None                     | web/dashboard   | `DashboardActivityOverview` -> `TodayStatsOverview` | 仅前端本地派生，不扩展 API |
 
 ### 契约文档（按 Kind 拆分）
 
@@ -92,10 +95,11 @@
 
 ## 验收标准（Acceptance Criteria）
 
-- Given 最近 5 个已完成分钟桶累计 `5000 tokens / US$0.50`，When 打开 Dashboard 今日视图，Then `TPM = 1000` 且 `Cost/min = US$0.10`。
-- Given trailing 5 分钟内缺少某些分钟桶，When 计算速率，Then 缺失分钟按 `0` 计入窗口。
-- Given 当前自然分钟尚未完成，When 计算速率，Then 当前分钟不计入 displayed rate。
-- Given 今日还没有任何完整分钟桶，When timeseries 已返回，Then 两个速率 tile 显示 `0`。
+- Given 最近 5 分钟内前三分半都是 0、后 1.5 分钟累计 `1500 tokens / US$0.15`，When 打开 Dashboard 今日视图，Then `TPM = 1000` 且 `消费速率 = US$0.10`。
+- Given trailing 5 分钟内首个活动桶之后缺少某些分钟桶，When 计算速率，Then 缺失时间继续计入分母。
+- Given 当前自然分钟尚未完成但已有数据，When 计算速率，Then 当前分钟参与 displayed rate，分母使用实际 elapsed minutes。
+- Given 最近 5 分钟没有任何 token/cost 活动，When timeseries 已返回，Then 两个速率 tile 显示 `0`。
+- Given 点击或聚焦任一 KPI 标题，When tooltip 打开，Then 能看到该字段的本地化说明。
 - Given summary 成功但 timeseries 正在加载，When 渲染 today KPI，Then 只有两个速率 tile 显示 skeleton。
 - Given summary 成功但 timeseries 失败，When 渲染 today KPI，Then 只有两个速率 tile 显示 `—`。
 - Given summary 失败，When 渲染 today KPI，Then 保持现有整块 alert 语义。
@@ -111,7 +115,7 @@
 
 ### Testing
 
-- Unit tests: `dashboardTodayRateSnapshot` 速率计算覆盖完整分钟、缺桶补零、忽略当前分钟、零分钟窗口。
+- Unit tests: `dashboardTodayRateSnapshot` 速率计算覆盖活跃尾段、前置 0 不稀释、当前部分分钟参与、活动后静默计入分母、零活动窗口。
 - Integration tests: `TodayStatsOverview.test.tsx`、`DashboardActivityOverview.test.tsx`、`Dashboard.test.tsx` 覆盖 6 tile 与 partial fallback。
 - E2E tests (if applicable): None。
 
@@ -143,12 +147,22 @@
 
 - source_type: storybook_canvas
   target_program: mock-only
+  capture_scope: browser-viewport
+  sensitive_exclusion: N/A
+  submission_gate: chat-reviewed
+  story_id_or_title: `dashboard-todaystatsoverview--populated`
+  state: populated with KPI title tooltip open
+  evidence_note: 证明 KPI 标题可点击打开字段说明 tooltip，TPM 文案明确说明最近 5 分钟活跃尾段均值；本次证据只回传聊天快照，不新增提交截图文件。
+  PR: no-image
+
+- source_type: storybook_canvas
+  target_program: mock-only
   capture_scope: element
   sensitive_exclusion: N/A
   submission_gate: approved
   story_id_or_title: `dashboard-todaystatsoverview--desktop-single-row`
   state: desktop single row
-  evidence_note: 证明 `desktop1440` 下 6 个 KPI tile 保持单行，且首两项已替换为 `TPM (5m avg)` 与 `Cost/min (5m avg)`。
+  evidence_note: 证明 `desktop1440` 下 6 个 KPI tile 保持单行，且首两项为 `TPM` 与 `消费速率`，标题 tooltip 可解释最近 5 分钟活跃尾段均值。
   PR: include
   image:
   ![Today KPI desktop single row](./assets/today-kpi-desktop-single-row.png)
@@ -184,7 +198,7 @@
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 
-- 风险：如果 `useTimeseries(today)` 的 `rangeEnd` 与当前分钟对齐处理不一致，可能误把进行中分钟算进窗口；需要单测锁死。
+- 风险：`useTimeseries(today)` 只提供 1m 桶，无法恢复首个非零桶内的真实秒级活动起点；本轮按 `bucketStart` 近似并通过 tooltip 明确口径。
 - 风险：6 tile 在较窄桌面宽度下可能压缩数值，需要继续依赖 `AdaptiveMetricValue` 的 compact fallback。
 - 假设：`desktop1440` 是本次“单行 KPI”主要验收视口。
 
@@ -192,6 +206,7 @@
 
 - 2026-04-10: 新建 follow-up spec，冻结 Dashboard 今日 KPI 切换为 5m-avg TPM 与 Cost/min 的范围、验收与视觉证据要求。
 - 2026-04-10: 完成前端 5m-avg 速率派生、6-tile KPI 重排、Vitest/Storybook 覆盖与本地视觉证据归档，并获主人授权将截图随 PR 一起提交。
+- 2026-04-28: 根据主人反馈修正速率口径：从最近 5 个已完成分钟桶改为最近 5 分钟活跃尾段均值，当前部分分钟参与，前置空闲不稀释速率，活动后的安静期会随当前时间继续拉长分母；同时为 KPI 标题增加字段说明 tooltip。
 
 ## 参考（References）
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,6 +9,7 @@
 | ID | Title | Status | Spec | Last | Notes |
 | ben7x | 号池上游 413 原账号补试与切号 | 已实现，待 PR / CI / review-proof 收敛 | `ben7x-pool-upstream-413-retry/SPEC.md` | 2026-04-27 | fast-track / 上游 `413` 原账号补试 1 次 / 仍失败后沿用 pool failover 切号 / 最终上游 413 保持 HTTP 413 |
 | a6pm6 | Dashboard 活动总览趋势图增强 | 进行中 | `a6pm6-dashboard-activity-trend-chart/SPEC.md` | 2026-04-27 | fast-track / 今日与昨日新增趋势图 / 消费速率命名统一 / 次数图叠加首字总耗时 |
+| 2qsev | Dashboard 今日 KPI 改成 TPM + 金额/分钟 | 已实现，待 PR / CI / review-proof 收敛 | `2qsev-dashboard-tpm-cost-per-minute-kpi/SPEC.md` | 2026-04-28 | fast-track / TPM + 消费速率使用最近 5 分钟活跃尾段均值 / 前置空闲不稀释速率 / 当前部分分钟参与 / KPI 标题 tooltip 解释字段口径 |
 | g3amk | Codex 远程压缩请求记录、展示与计费接入 | 已完成（5/5） | `g3amk-codex-remote-compact-observability/SPEC.md` | 2026-04-27 | follow-up / future compact 缺 key 时可通过同一客户端稳定指纹继承近期 responses 的 prompt-cache 归因 / 旧 compact 不 backfill |
 | qz42n | SQLite 写入可靠性与后台背压 | 已实现，待 PR / CI / review-proof 收敛 | `qz42n-sqlite-write-backpressure/SPEC.md` | 2026-04-26 | fast-track / follow-up of `#ay33j` + `#uhn89` + `#jpvwj` / 101 生产 2026-04-26 15:30-16:30 CST SQLite lock + pool acquire timeout 事故 / 后台 DB pressure gate + 账号热点索引 |
 | v7se4 | Worktree bootstrap 同步开发环境配置 | 已完成 | `v7se4-worktree-bootstrap/SPEC.md` | 2026-03-14 | fast-track / PR #129 / checks green / review fixes landed |

--- a/web/src/components/DashboardActivityOverview.test.tsx
+++ b/web/src/components/DashboardActivityOverview.test.tsx
@@ -356,7 +356,7 @@ describe('DashboardActivityOverview', () => {
     expect(host?.querySelector('[data-testid="dashboard-activity-range-7d"]')).toBeNull()
     expect(host?.querySelector('[data-testid="dashboard-activity-range-usage"]')).toBeNull()
     expect(host?.querySelector('[data-testid="today-stats-overview-mock"]')?.textContent).toBe(
-      'total:12;surface:false;header:false;badge:false;tpm:1400;spendRate:0.14;rateLoading:false;rateError:null',
+      'total:12;surface:false;header:false;badge:false;tpm:1000;spendRate:0.1;rateLoading:false;rateError:null',
     )
     expect(host?.querySelector('[data-testid="dashboard-today-activity-chart-mock"]')?.textContent).toBe(
       'metric:totalCount',

--- a/web/src/components/DashboardActivityOverview.tsx
+++ b/web/src/components/DashboardActivityOverview.tsx
@@ -20,6 +20,7 @@ export const DASHBOARD_ACTIVITY_RANGE_STORAGE_KEY = 'dashboard.activityOverview.
 export const ACCOUNT_ACTIVITY_RANGE_STORAGE_KEY_PREFIX = 'account.activityOverview.activeRange.v1'
 
 const DEFAULT_RANGE: RangeKey = 'today'
+const LIVE_RATE_REFRESH_MS = 15_000
 const RANGE_OPTIONS: Array<{ key: RangeKey; labelKey: string }> = [
   { key: 'today', labelKey: 'dashboard.activityOverview.rangeToday' },
   { key: 'yesterday', labelKey: 'dashboard.activityOverview.rangeYesterday' },
@@ -131,9 +132,23 @@ function DashboardNaturalDaySummaryOverview({
     isLoading: summaryLoading,
     error: summaryError,
   } = useScopedSummary(summaryWindow, upstreamAccountId)
+  const [rateNow, setRateNow] = useState(() => new Date())
+
+  useEffect(() => {
+    if (closedNaturalDay) return
+    setRateNow(new Date())
+    const timer = window.setInterval(() => {
+      setRateNow(new Date())
+    }, LIVE_RATE_REFRESH_MS)
+    return () => window.clearInterval(timer)
+  }, [closedNaturalDay])
+
   const rate = useMemo(
-    () => buildDashboardTodayRateSnapshot(response, { closedNaturalDay }),
-    [closedNaturalDay, response],
+    () => buildDashboardTodayRateSnapshot(response, {
+      closedNaturalDay,
+      now: rateNow,
+    }),
+    [closedNaturalDay, rateNow, response],
   )
 
   return (

--- a/web/src/components/TodayStatsOverview.stories.tsx
+++ b/web/src/components/TodayStatsOverview.stories.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, waitFor, within } from 'storybook/test'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
 import { I18nProvider } from '../i18n'
 import type { StatsResponse } from '../lib/api'
 import { TodayStatsOverview } from './TodayStatsOverview'
@@ -51,6 +51,11 @@ export const Populated: Story = {
     rate: sampleRate,
     loading: false,
     error: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /tokens per minute|每分钟 tokens/i }))
+    await expect(within(document.body).getByRole('tooltip')).toBeInTheDocument()
   },
 }
 

--- a/web/src/components/TodayStatsOverview.test.tsx
+++ b/web/src/components/TodayStatsOverview.test.tsx
@@ -14,6 +14,12 @@ vi.mock('../i18n', () => ({
         'dashboard.today.dayBadge': 'Today',
         'dashboard.today.tokensPerMinute': 'TPM',
         'dashboard.today.spendRate': 'Spend rate',
+        'dashboard.today.tokensPerMinuteDescription': 'TPM uses the active tail inside the latest 5-minute window.',
+        'dashboard.today.spendRateDescription': 'Spend rate uses the active tail inside the latest 5-minute window.',
+        'dashboard.today.successDescription': 'Successful calls in the selected day.',
+        'dashboard.today.failuresDescription': 'Failed calls in the selected day.',
+        'dashboard.today.totalCostDescription': 'Total cost in the selected day.',
+        'dashboard.today.totalTokensDescription': 'Total tokens in the selected day.',
         'stats.cards.loadError': 'Load error',
         'stats.cards.success': 'Success',
         'stats.cards.failures': 'Failures',
@@ -213,6 +219,40 @@ describe('TodayStatsOverview', () => {
     expect(tpmText).toContain('1,001')
     expect(tpmText).not.toContain('.')
     expect(spendRateText).toContain('$0.10')
+  })
+
+  it('opens field descriptions from metric titles', () => {
+    render(
+      <TodayStatsOverview
+        stats={{
+          totalCount: 42,
+          successCount: 40,
+          failureCount: 2,
+          totalCost: 1.48,
+          totalTokens: 9000,
+        }}
+        rate={{
+          tokensPerMinute: 1000,
+          spendRate: 0.1,
+          windowMinutes: 5,
+          available: true,
+        }}
+        loading={false}
+        error={null}
+      />,
+    )
+
+    const tpmTitle = [...(host?.querySelectorAll('[role="button"]') ?? [])]
+      .find((element) => element.textContent === 'TPM')
+    expect(tpmTitle).toBeInstanceOf(HTMLElement)
+    expect(tpmTitle?.getAttribute('aria-label')).toBeNull()
+
+    act(() => {
+      tpmTitle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const tooltip = document.body.querySelector('[role="tooltip"]')
+    expect(tooltip?.textContent).toContain('active tail inside the latest 5-minute window')
   })
 
   it('shows unavailable placeholders for rate tiles when timeseries loading fails', () => {

--- a/web/src/components/TodayStatsOverview.tsx
+++ b/web/src/components/TodayStatsOverview.tsx
@@ -1,10 +1,12 @@
 import type { StatsResponse } from '../lib/api'
+import type { KeyboardEvent } from 'react'
 import { useTranslation } from '../i18n'
 import { cn } from '../lib/utils'
 import { getBrowserTimeZone } from '../lib/timeZone'
 import { AdaptiveMetricValue, type AdaptiveMetricValueKind } from './AdaptiveMetricValue'
 import { Alert } from './ui/alert'
 import { Badge } from './ui/badge'
+import { Tooltip } from './ui/tooltip'
 import type { DashboardTodayRateSnapshot } from './dashboardTodayRateSnapshot'
 
 const RATE_UNAVAILABLE_PLACEHOLDER = '—'
@@ -23,6 +25,7 @@ export interface TodayStatsOverviewProps {
 
 interface MetricTileProps {
   label: string
+  description: string
   value?: number
   localeTag: string
   loading: boolean
@@ -35,6 +38,7 @@ interface MetricTileProps {
 
 function MetricTile({
   label,
+  description,
   value,
   localeTag,
   loading,
@@ -44,12 +48,31 @@ function MetricTile({
   displayText,
   subdued = false,
 }: MetricTileProps) {
+  const handleLabelKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    event.currentTarget.click()
+  }
+
   return (
     <div
       data-testid="today-stats-metric-tile"
       className="min-w-0 rounded-xl border border-base-300/75 bg-base-200/60 p-4"
     >
-      <div className="text-xs font-semibold uppercase tracking-[0.14em] text-base-content/65">{label}</div>
+      <Tooltip
+        content={description}
+        side="bottom"
+        sideOffset={8}
+        triggerProps={{
+          role: 'button',
+          tabIndex: 0,
+          onKeyDown: handleLabelKeyDown,
+        }}
+      >
+        <span className="inline-flex cursor-help text-left text-xs font-semibold uppercase tracking-[0.14em] text-base-content/65 underline decoration-dotted underline-offset-4 transition-colors hover:text-base-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary">
+          {label}
+        </span>
+      </Tooltip>
       {loading ? (
         <div className="mt-2 h-8 w-28 animate-pulse rounded bg-base-300/65" />
       ) : displayText != null ? (
@@ -131,6 +154,7 @@ export function TodayStatsOverview({
         >
           <MetricTile
             label={t('dashboard.today.tokensPerMinute')}
+            description={t('dashboard.today.tokensPerMinuteDescription')}
             value={tokensPerMinute}
             localeTag={localeTag}
             loading={loading || rateLoading}
@@ -142,6 +166,7 @@ export function TodayStatsOverview({
           />
           <MetricTile
             label={t('dashboard.today.spendRate')}
+            description={t('dashboard.today.spendRateDescription')}
             value={spendRate}
             localeTag={localeTag}
             loading={loading || rateLoading}
@@ -152,6 +177,7 @@ export function TodayStatsOverview({
           />
           <MetricTile
             label={t('stats.cards.success')}
+            description={t('dashboard.today.successDescription')}
             value={successCount}
             localeTag={localeTag}
             loading={loading}
@@ -160,6 +186,7 @@ export function TodayStatsOverview({
           />
           <MetricTile
             label={t('stats.cards.failures')}
+            description={t('dashboard.today.failuresDescription')}
             value={failureCount}
             localeTag={localeTag}
             loading={loading}
@@ -168,6 +195,7 @@ export function TodayStatsOverview({
           />
           <MetricTile
             label={t('stats.cards.totalCost')}
+            description={t('dashboard.today.totalCostDescription')}
             value={totalCost}
             localeTag={localeTag}
             loading={loading}
@@ -176,6 +204,7 @@ export function TodayStatsOverview({
           />
           <MetricTile
             label={t('stats.cards.totalTokens')}
+            description={t('dashboard.today.totalTokensDescription')}
             value={totalTokens}
             localeTag={localeTag}
             loading={loading}

--- a/web/src/components/TodayStatsOverview.tsx
+++ b/web/src/components/TodayStatsOverview.tsx
@@ -61,6 +61,7 @@ function MetricTile({
     >
       <Tooltip
         content={description}
+        clickToOpen
         side="bottom"
         sideOffset={8}
         triggerProps={{

--- a/web/src/components/dashboardTodayRateSnapshot.test.ts
+++ b/web/src/components/dashboardTodayRateSnapshot.test.ts
@@ -16,7 +16,7 @@ function minutePoint(offsetMinutes: number, totalTokens: number, totalCost: numb
 }
 
 describe('buildDashboardTodayRateSnapshot', () => {
-  it('uses the latest completed minute bucket as the default rate source', () => {
+  it('uses the active tail inside the latest five-minute window as the default rate source', () => {
     const snapshot = buildDashboardTodayRateSnapshot(
       {
         rangeStart: '2026-04-10 00:00:00',
@@ -34,29 +34,54 @@ describe('buildDashboardTodayRateSnapshot', () => {
       { now: new Date(2026, 3, 10, 0, 6, 30, 0) },
     )
 
-    expect(snapshot?.tokensPerMinute).toBe(1400)
-    expect(snapshot?.spendRate).toBeCloseTo(0.14, 6)
-    expect(snapshot?.windowMinutes).toBe(1)
+    expect(snapshot?.tokensPerMinute).toBe(2000)
+    expect(snapshot?.spendRate).toBeCloseTo(0.2, 6)
+    expect(snapshot?.windowMinutes).toBe(5)
     expect(snapshot?.available).toBe(true)
   })
 
-  it('fills missing minutes with zero instead of shrinking the denominator when a wider target window is requested', () => {
+  it('does not let leading zero minutes dilute the active tail average', () => {
     const snapshot = buildDashboardTodayRateSnapshot(
       {
         rangeStart: '2026-04-10 00:00:00',
-        rangeEnd: '2026-04-10 00:05:20',
+        rangeEnd: '2026-04-10 00:05:30',
         bucketSeconds: 60,
-        points: [minutePoint(1, 1000, 0.1), minutePoint(3, 2000, 0.2)],
+        points: [
+          minutePoint(1, 0, 0),
+          minutePoint(2, 0, 0),
+          minutePoint(3, 0, 0),
+          minutePoint(4, 900, 0.09),
+          minutePoint(5, 600, 0.06),
+        ],
       },
-      { now: new Date(2026, 3, 10, 0, 5, 20, 0), targetWindowMinutes: 5 },
+      { now: new Date(2026, 3, 10, 0, 5, 30, 0), targetWindowMinutes: 5 },
     )
 
-    expect(snapshot?.tokensPerMinute).toBe(600)
-    expect(snapshot?.spendRate).toBeCloseTo(0.06, 6)
+    expect(snapshot?.tokensPerMinute).toBe(1000)
+    expect(snapshot?.spendRate).toBeCloseTo(0.1, 6)
+    expect(snapshot?.windowMinutes).toBe(1.5)
+  })
+
+  it('counts the active bucket that overlaps the rolling window start', () => {
+    const snapshot = buildDashboardTodayRateSnapshot(
+      {
+        rangeStart: '2026-04-10 00:00:00',
+        rangeEnd: '2026-04-10 00:05:30',
+        bucketSeconds: 60,
+        points: [
+          minutePoint(0, 500, 0.05),
+          minutePoint(1, 500, 0.05),
+        ],
+      },
+      { now: new Date(2026, 3, 10, 0, 5, 30, 0), targetWindowMinutes: 5 },
+    )
+
+    expect(snapshot?.tokensPerMinute).toBe(200)
+    expect(snapshot?.spendRate).toBeCloseTo(0.02, 6)
     expect(snapshot?.windowMinutes).toBe(5)
   })
 
-  it('uses one completed minute when today has fewer than five full minutes by default', () => {
+  it('includes the current partial minute and divides by the actual active elapsed minutes', () => {
     const snapshot = buildDashboardTodayRateSnapshot(
       {
         rangeStart: '2026-04-10 00:00:00',
@@ -67,31 +92,62 @@ describe('buildDashboardTodayRateSnapshot', () => {
       { now: new Date(2026, 3, 10, 0, 3, 10, 0) },
     )
 
-    expect(snapshot?.tokensPerMinute).toBe(1500)
-    expect(snapshot?.spendRate).toBeCloseTo(0.15, 6)
-    expect(snapshot?.windowMinutes).toBe(1)
+    expect(snapshot?.tokensPerMinute).toBeCloseTo(3000 / (19 / 6), 6)
+    expect(snapshot?.spendRate).toBeCloseTo(0.3 / (19 / 6), 6)
+    expect(snapshot?.windowMinutes).toBeCloseTo(19 / 6, 6)
   })
 
-  it('ignores the current in-progress minute even when a partial bucket exists', () => {
+  it('keeps post-activity quiet time in the denominator to avoid spikes', () => {
     const snapshot = buildDashboardTodayRateSnapshot(
       {
         rangeStart: '2026-04-10 00:00:00',
         rangeEnd: '2026-04-10 00:05:40',
         bucketSeconds: 60,
         points: [
-          minutePoint(0, 500, 0.05),
-          minutePoint(1, 500, 0.05),
-          minutePoint(2, 500, 0.05),
-          minutePoint(3, 500, 0.05),
-          minutePoint(4, 500, 0.05),
-          minutePoint(5, 9000, 0.9),
+          minutePoint(1, 1200, 0.12),
+          minutePoint(2, 0, 0),
+          minutePoint(3, 0, 0),
+          minutePoint(4, 0, 0),
+          minutePoint(5, 0, 0),
         ],
       },
       { now: new Date(2026, 3, 10, 0, 5, 40, 0) },
     )
 
-    expect(snapshot?.tokensPerMinute).toBe(500)
-    expect(snapshot?.spendRate).toBeCloseTo(0.05, 6)
+    expect(snapshot?.tokensPerMinute).toBeCloseTo(1200 / (14 / 3), 6)
+    expect(snapshot?.spendRate).toBeCloseTo(0.12 / (14 / 3), 6)
+    expect(snapshot?.windowMinutes).toBeCloseTo(14 / 3, 6)
+  })
+
+  it('uses current same-day time so active-tail rates decay during quiet periods', () => {
+    const snapshot = buildDashboardTodayRateSnapshot(
+      {
+        rangeStart: '2026-04-10 00:00:00',
+        rangeEnd: '2026-04-10 00:02:00',
+        bucketSeconds: 60,
+        points: [minutePoint(1, 1200, 0.12)],
+      },
+      { now: new Date(2026, 3, 10, 0, 5, 0, 0) },
+    )
+
+    expect(snapshot?.tokensPerMinute).toBe(300)
+    expect(snapshot?.spendRate).toBeCloseTo(0.03, 6)
+    expect(snapshot?.windowMinutes).toBe(4)
+  })
+
+  it('keeps fixed fixture days anchored to their response end instead of wall-clock now', () => {
+    const snapshot = buildDashboardTodayRateSnapshot(
+      {
+        rangeStart: '2026-04-10 00:00:00',
+        rangeEnd: '2026-04-10 00:02:00',
+        bucketSeconds: 60,
+        points: [minutePoint(1, 1200, 0.12)],
+      },
+      { now: new Date(2026, 3, 11, 0, 5, 0, 0) },
+    )
+
+    expect(snapshot?.tokensPerMinute).toBe(1200)
+    expect(snapshot?.spendRate).toBeCloseTo(0.12, 6)
     expect(snapshot?.windowMinutes).toBe(1)
   })
 
@@ -108,7 +164,7 @@ describe('buildDashboardTodayRateSnapshot', () => {
 
     expect(snapshot?.tokensPerMinute).toBe(0)
     expect(snapshot?.spendRate).toBe(0)
-    expect(snapshot?.windowMinutes).toBe(0)
+    expect(snapshot?.windowMinutes).toBeCloseTo(1 / 3, 6)
     expect(snapshot?.available).toBe(true)
   })
 
@@ -172,9 +228,9 @@ describe('buildDashboardTodayRateSnapshot', () => {
       },
     )
 
-    expect(snapshot?.tokensPerMinute).toBe(900)
-    expect(snapshot?.spendRate).toBeCloseTo(0.09, 6)
-    expect(snapshot?.windowMinutes).toBe(1)
+    expect(snapshot?.tokensPerMinute).toBe(700)
+    expect(snapshot?.spendRate).toBeCloseTo(0.07, 6)
+    expect(snapshot?.windowMinutes).toBe(5)
     expect(snapshot?.available).toBe(true)
   })
 })

--- a/web/src/components/dashboardTodayRateSnapshot.test.ts
+++ b/web/src/components/dashboardTodayRateSnapshot.test.ts
@@ -62,6 +62,27 @@ describe('buildDashboardTodayRateSnapshot', () => {
     expect(snapshot?.windowMinutes).toBe(1.5)
   })
 
+  it('uses separate active tails when tokens and cost start in different buckets', () => {
+    const snapshot = buildDashboardTodayRateSnapshot(
+      {
+        rangeStart: '2026-04-10 00:00:00',
+        rangeEnd: '2026-04-10 00:05:00',
+        bucketSeconds: 60,
+        points: [
+          minutePoint(1, 600, 0),
+          minutePoint(2, 0, 0),
+          minutePoint(3, 0, 0.12),
+          minutePoint(4, 0, 0.08),
+        ],
+      },
+      { now: new Date(2026, 3, 10, 0, 5, 0, 0) },
+    )
+
+    expect(snapshot?.tokensPerMinute).toBe(150)
+    expect(snapshot?.spendRate).toBeCloseTo(0.1, 6)
+    expect(snapshot?.windowMinutes).toBe(4)
+  })
+
   it('counts the active bucket that overlaps the rolling window start', () => {
     const snapshot = buildDashboardTodayRateSnapshot(
       {

--- a/web/src/components/dashboardTodayRateSnapshot.ts
+++ b/web/src/components/dashboardTodayRateSnapshot.ts
@@ -7,6 +7,13 @@ import {
 const MINUTE_MS = 60_000
 const DEFAULT_WINDOW_MINUTES = 5
 
+interface RateBucket {
+  bucketStartMs: number
+  bucketEndMs: number
+  totalTokens: number
+  totalCost: number
+}
+
 export interface DashboardTodayRateSnapshot {
   tokensPerMinute: number
   spendRate: number
@@ -78,34 +85,23 @@ export function buildDashboardTodayRateSnapshot(
   const buckets = [...pointMap.entries()]
     .map(([bucketStartMs, bucket]) => ({ bucketStartMs, ...bucket }))
     .sort((a, b) => a.bucketStartMs - b.bucketStartMs)
-  const firstActiveBucket = buckets.find((bucket) => (
-    bucket.totalTokens > 0 ||
-    bucket.totalCost > 0
-  ))
-
-  if (!firstActiveBucket) {
-    return {
-      tokensPerMinute: 0,
-      spendRate: 0,
-      windowMinutes: Math.max(0, (anchorMs - windowStartMs) / MINUTE_MS),
-      available: true,
-    }
-  }
-
-  const activeStartMs = Math.max(windowStartMs, firstActiveBucket.bucketStartMs)
-  const windowMinutes = Math.max((anchorMs - activeStartMs) / MINUTE_MS, 0)
-  let totalTokens = 0
-  let totalCost = 0
-  for (const bucket of buckets) {
-    if (bucket.bucketEndMs <= activeStartMs || bucket.bucketStartMs >= anchorMs) continue
-    totalTokens += bucket.totalTokens
-    totalCost += bucket.totalCost
-  }
+  const tokensRate = computeActiveTailRate({
+    buckets,
+    anchorMs,
+    windowStartMs,
+    value: (bucket) => bucket.totalTokens,
+  })
+  const costRate = computeActiveTailRate({
+    buckets,
+    anchorMs,
+    windowStartMs,
+    value: (bucket) => bucket.totalCost,
+  })
 
   return {
-    tokensPerMinute: windowMinutes > 0 ? totalTokens / windowMinutes : 0,
-    spendRate: windowMinutes > 0 ? totalCost / windowMinutes : 0,
-    windowMinutes,
+    tokensPerMinute: tokensRate.rate,
+    spendRate: costRate.rate,
+    windowMinutes: Math.max(tokensRate.windowMinutes, costRate.windowMinutes),
     available: true,
   }
 }
@@ -130,6 +126,39 @@ function isSameLocalDay(left: Date, right: Date) {
     left.getMonth() === right.getMonth() &&
     left.getDate() === right.getDate()
   )
+}
+
+function computeActiveTailRate({
+  buckets,
+  anchorMs,
+  windowStartMs,
+  value,
+}: {
+  buckets: RateBucket[]
+  anchorMs: number
+  windowStartMs: number
+  value: (bucket: RateBucket) => number
+}) {
+  const firstActiveBucket = buckets.find((bucket) => value(bucket) > 0)
+  if (!firstActiveBucket) {
+    return {
+      rate: 0,
+      windowMinutes: Math.max(0, (anchorMs - windowStartMs) / MINUTE_MS),
+    }
+  }
+
+  const activeStartMs = Math.max(windowStartMs, firstActiveBucket.bucketStartMs)
+  const windowMinutes = Math.max((anchorMs - activeStartMs) / MINUTE_MS, 0)
+  let total = 0
+  for (const bucket of buckets) {
+    if (bucket.bucketEndMs <= activeStartMs || bucket.bucketStartMs >= anchorMs) continue
+    total += value(bucket)
+  }
+
+  return {
+    rate: windowMinutes > 0 ? total / windowMinutes : 0,
+    windowMinutes,
+  }
 }
 
 function floorToMinute(date: Date) {

--- a/web/src/components/dashboardTodayRateSnapshot.ts
+++ b/web/src/components/dashboardTodayRateSnapshot.ts
@@ -5,7 +5,7 @@ import {
 } from './dashboardNaturalDayWindow'
 
 const MINUTE_MS = 60_000
-const DEFAULT_WINDOW_MINUTES = 1
+const DEFAULT_WINDOW_MINUTES = 5
 
 export interface DashboardTodayRateSnapshot {
   tokensPerMinute: number
@@ -28,9 +28,8 @@ export function buildDashboardTodayRateSnapshot(
     response,
     options?.closedNaturalDay ?? false,
   )
-  const anchor = floorToMinute(
-    closedNaturalDayEnd ?? parseDateInput(response.rangeEnd) ?? fallbackNow,
-  )
+  const responseEnd = parseDateInput(response.rangeEnd)
+  const anchor = closedNaturalDayEnd ?? resolveLiveNaturalDayAnchor(responseEnd, fallbackNow)
   const start = closedNaturalDayEnd
     ? floorToMinute(
         parseDateInput(response.rangeStart) ??
@@ -39,6 +38,7 @@ export function buildDashboardTodayRateSnapshot(
     : startOfLocalDay(anchor)
   const startMs = start.getTime()
   const anchorMs = anchor.getTime()
+  const windowStartMs = Math.max(startMs, anchorMs - targetWindowMinutes * MINUTE_MS)
 
   if (anchorMs <= startMs) {
     return {
@@ -49,19 +49,11 @@ export function buildDashboardTodayRateSnapshot(
     }
   }
 
-  const completedMinuteCount = Math.max(0, Math.floor((anchorMs - startMs) / MINUTE_MS))
-  const windowMinutes = Math.min(targetWindowMinutes, completedMinuteCount)
-
-  if (windowMinutes <= 0) {
-    return {
-      tokensPerMinute: 0,
-      spendRate: 0,
-      windowMinutes: 0,
-      available: true,
-    }
-  }
-
-  const pointMap = new Map<number, { totalTokens: number; totalCost: number }>()
+  const pointMap = new Map<number, {
+    bucketEndMs: number
+    totalTokens: number
+    totalCost: number
+  }>()
 
   for (const point of response.points ?? []) {
     const bucketStart = parseDateInput(point.bucketStart)
@@ -69,27 +61,50 @@ export function buildDashboardTodayRateSnapshot(
     if (!bucketStart || !bucketEnd) continue
 
     const bucketStartMs = floorToMinute(bucketStart).getTime()
-    const bucketEndMs = floorToMinute(bucketEnd).getTime()
-    if (bucketStartMs < startMs || bucketEndMs > anchorMs) continue
+    const bucketEndMs = bucketEnd.getTime()
+    if (bucketStartMs >= anchorMs || bucketEndMs <= windowStartMs) continue
 
-    const current = pointMap.get(bucketStartMs) ?? { totalTokens: 0, totalCost: 0 }
+    const current = pointMap.get(bucketStartMs) ?? {
+      bucketEndMs,
+      totalTokens: 0,
+      totalCost: 0,
+    }
+    current.bucketEndMs = Math.max(current.bucketEndMs, bucketEndMs)
     current.totalTokens += point.totalTokens ?? 0
     current.totalCost += point.totalCost ?? 0
     pointMap.set(bucketStartMs, current)
   }
 
+  const buckets = [...pointMap.entries()]
+    .map(([bucketStartMs, bucket]) => ({ bucketStartMs, ...bucket }))
+    .sort((a, b) => a.bucketStartMs - b.bucketStartMs)
+  const firstActiveBucket = buckets.find((bucket) => (
+    bucket.totalTokens > 0 ||
+    bucket.totalCost > 0
+  ))
+
+  if (!firstActiveBucket) {
+    return {
+      tokensPerMinute: 0,
+      spendRate: 0,
+      windowMinutes: Math.max(0, (anchorMs - windowStartMs) / MINUTE_MS),
+      available: true,
+    }
+  }
+
+  const activeStartMs = Math.max(windowStartMs, firstActiveBucket.bucketStartMs)
+  const windowMinutes = Math.max((anchorMs - activeStartMs) / MINUTE_MS, 0)
   let totalTokens = 0
   let totalCost = 0
-  for (let offset = windowMinutes; offset >= 1; offset -= 1) {
-    const bucketStartMs = anchorMs - offset * MINUTE_MS
-    const bucket = pointMap.get(bucketStartMs)
-    totalTokens += bucket?.totalTokens ?? 0
-    totalCost += bucket?.totalCost ?? 0
+  for (const bucket of buckets) {
+    if (bucket.bucketEndMs <= activeStartMs || bucket.bucketStartMs >= anchorMs) continue
+    totalTokens += bucket.totalTokens
+    totalCost += bucket.totalCost
   }
 
   return {
-    tokensPerMinute: totalTokens / windowMinutes,
-    spendRate: totalCost / windowMinutes,
+    tokensPerMinute: windowMinutes > 0 ? totalTokens / windowMinutes : 0,
+    spendRate: windowMinutes > 0 ? totalCost / windowMinutes : 0,
     windowMinutes,
     available: true,
   }
@@ -99,6 +114,22 @@ function startOfLocalDay(date: Date) {
   const next = new Date(date)
   next.setHours(0, 0, 0, 0)
   return next
+}
+
+function resolveLiveNaturalDayAnchor(responseEnd: Date | null, now: Date) {
+  if (!responseEnd) return now
+  if (isSameLocalDay(responseEnd, now) && now.getTime() > responseEnd.getTime()) {
+    return now
+  }
+  return responseEnd
+}
+
+function isSameLocalDay(left: Date, right: Date) {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  )
 }
 
 function floorToMinute(date: Date) {

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -91,6 +91,7 @@ export function Tooltip({
 }: TooltipProps) {
   const longPressTimerRef = React.useRef<number | null>(null)
   const [hoverOpen, setHoverOpen] = React.useState(false)
+  const [clickOpen, setClickOpen] = React.useState(false)
   const [longPressOpen, setLongPressOpen] = React.useState(false)
   const [rootElement, setRootElement] = React.useState<HTMLSpanElement | null>(null)
   const resolvedContainer = useResolvedOverlayContainer(container)
@@ -130,7 +131,7 @@ export function Tooltip({
     setLongPressOpen(false)
   }, [clearLongPressTimer, open])
 
-  const resolvedOpen = open ?? (hoverOpen || longPressOpen)
+  const resolvedOpen = open ?? (hoverOpen || clickOpen || longPressOpen)
 
   return (
     <TooltipPrimitive.Provider delayDuration={120}>
@@ -140,10 +141,29 @@ export function Tooltip({
             ref={setRootElement}
             className={cn('inline-flex', className)}
             {...triggerProps}
-            onBlur={open === undefined ? () => setHoverOpen(false) : undefined}
-            onFocus={open === undefined ? () => setHoverOpen(true) : undefined}
-            onMouseEnter={open === undefined ? () => setHoverOpen(true) : undefined}
-            onMouseLeave={open === undefined ? () => setHoverOpen(false) : undefined}
+            onBlur={(event) => {
+              triggerProps?.onBlur?.(event)
+              if (open !== undefined) return
+              setHoverOpen(false)
+              setClickOpen(false)
+            }}
+            onClick={(event) => {
+              triggerProps?.onClick?.(event)
+              if (open !== undefined || event.defaultPrevented) return
+              setClickOpen((current) => !current)
+            }}
+            onFocus={(event) => {
+              triggerProps?.onFocus?.(event)
+              if (open === undefined) setHoverOpen(true)
+            }}
+            onMouseEnter={(event) => {
+              triggerProps?.onMouseEnter?.(event)
+              if (open === undefined) setHoverOpen(true)
+            }}
+            onMouseLeave={(event) => {
+              triggerProps?.onMouseLeave?.(event)
+              if (open === undefined) setHoverOpen(false)
+            }}
             onPointerDownCapture={handlePointerDown}
             onPointerDown={handlePointerDown}
             onPointerUpCapture={handlePointerRelease}

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -74,6 +74,7 @@ interface TooltipProps {
   side?: 'top' | 'right' | 'bottom' | 'left'
   sideOffset?: number
   open?: boolean
+  clickToOpen?: boolean
   triggerProps?: React.HTMLAttributes<HTMLSpanElement>
 }
 
@@ -87,6 +88,7 @@ export function Tooltip({
   side = 'top',
   sideOffset = 10,
   open,
+  clickToOpen = false,
   triggerProps,
 }: TooltipProps) {
   const longPressTimerRef = React.useRef<number | null>(null)
@@ -149,7 +151,7 @@ export function Tooltip({
             }}
             onClick={(event) => {
               triggerProps?.onClick?.(event)
-              if (open !== undefined || event.defaultPrevented) return
+              if (!clickToOpen || open !== undefined || event.defaultPrevented) return
               setClickOpen((current) => !current)
             }}
             onFocus={(event) => {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1412,6 +1412,18 @@ const baseTranslations = {
     "dashboard.today.dayBadge": "Today",
     "dashboard.today.tokensPerMinute": "TPM",
     "dashboard.today.spendRate": "Spend rate",
+    "dashboard.today.tokensPerMinuteDescription":
+      "Tokens per minute, calculated from the active tail inside the latest 5-minute window. Leading idle time is ignored.",
+    "dashboard.today.spendRateDescription":
+      "Cost per minute, calculated from the active tail inside the latest 5-minute window. Leading idle time is ignored.",
+    "dashboard.today.successDescription":
+      "Successful invocations accumulated in the selected natural-day window.",
+    "dashboard.today.failuresDescription":
+      "Failed invocations accumulated in the selected natural-day window.",
+    "dashboard.today.totalCostDescription":
+      "Total estimated spend accumulated in the selected natural-day window.",
+    "dashboard.today.totalTokensDescription":
+      "Total input, output, and cached tokens accumulated in the selected natural-day window.",
     "stats.range.lastHour": "Past hour",
     "stats.range.today": "Today",
     "stats.range.lastDay": "Past day",
@@ -3213,6 +3225,18 @@ const baseTranslations = {
     "dashboard.today.dayBadge": "今日",
     "dashboard.today.tokensPerMinute": "TPM",
     "dashboard.today.spendRate": "消费速率",
+    "dashboard.today.tokensPerMinuteDescription":
+      "每分钟 Tokens，按最近 5 分钟窗口内的活跃尾段计算均值；前置空闲时间不参与分母。",
+    "dashboard.today.spendRateDescription":
+      "每分钟消费金额，按最近 5 分钟窗口内的活跃尾段计算均值；前置空闲时间不参与分母。",
+    "dashboard.today.successDescription":
+      "所选自然日窗口内累计成功的调用数。",
+    "dashboard.today.failuresDescription":
+      "所选自然日窗口内累计失败的调用数。",
+    "dashboard.today.totalCostDescription":
+      "所选自然日窗口内累计的预估消费金额。",
+    "dashboard.today.totalTokensDescription":
+      "所选自然日窗口内累计的输入、输出和缓存 Tokens。",
     "stats.range.lastHour": "最近 1 小时",
     "stats.range.today": "今日",
     "stats.range.lastDay": "最近 1 天",


### PR DESCRIPTION
## Summary
- Change Today TPM and spend-rate cards to use a rolling 5-minute active-tail average: leading idle time before the first nonzero token/cost bucket is ignored, while quiet time after activity remains in the denominator.
- Include the current partial minute and drive live Today recomputation with a lightweight timer so rates decay during quiet periods.
- Add clickable/focusable KPI title tooltips with localized field descriptions and Storybook coverage.

## Verification
- `cd web && bun run test -- src/components/dashboardTodayRateSnapshot.test.ts src/components/TodayStatsOverview.test.tsx src/components/DashboardActivityOverview.test.tsx`
- `cd web && bun run test`
- `cd web && bun run lint`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- `codex review --base origin/main`: no regressions found after convergence

## Visual Evidence
- Storybook mock evidence for `dashboard-todaystatsoverview--populated` with the TPM tooltip open was generated and shown in the Codex thread. No new screenshot artifact is committed in this PR.

## References
- Specs: `docs/specs/2qsev-dashboard-tpm-cost-per-minute-kpi/SPEC.md`
- Solutions: -
- Project Docs: `docs/specs/README.md`

## Notes
- `project_doc_disposition=update`: updated the existing spec index only.
- `solution_disposition=none`: no matching reusable solution doc needed an update.