### PR TITLE
fix(ci): fail release on unsuccessful main ci

### DIFF
--- a/.github/quality-gates.json
+++ b/.github/quality-gates.json
@@ -98,6 +98,7 @@
     {
       "workflow": "Release",
       "jobs": [
+        "CI Main Gate",
         "Release Meta (snapshot + tags)",
         "Build + Smoke + Push Candidate (linux/amd64)",
         "Build + Smoke + Push Candidate (linux/arm64)",

--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -455,6 +455,18 @@ def validate_ci_pr(path: Path, contract: ContractModel) -> None:
     require('supports_final_topology="true"' in trusted_run, "ci-pr.yml.jobs.lint: rollout support flag drifted")
     require('source_kind="merge-group-base-branch"' in trusted_run, "ci-pr.yml.jobs.lint: merge_group trusted source kind drifted")
     require(
+        'github.event.pull_request.head.repo.full_name' in trusted_run,
+        "ci-pr.yml.jobs.lint: same-repository quality-gates source detection drifted",
+    )
+    require(
+        'changed_quality_gate_paths="$(git diff --name-only "${source_ref}...HEAD" -- "${paths[@]}" "${final_topology_paths[@]}")"' in trusted_run,
+        "ci-pr.yml.jobs.lint: quality-gates change detection drifted",
+    )
+    require(
+        'source_kind="current-branch-quality-gates-change"' in trusted_run,
+        "ci-pr.yml.jobs.lint: quality-gates change source kind drifted",
+    )
+    require(
         "keeping trusted scripts pinned to base and skipping trusted final-topology checks during rollout" in trusted_run,
         "ci-pr.yml.jobs.lint: rollout warning drifted",
     )
@@ -702,6 +714,21 @@ def validate_release(path: Path, contract: ContractModel) -> None:
 
     permissions = require_mapping(workflow.get("permissions"), "release.yml.permissions")
     require(permissions.get("contents") == "read", "release.yml.permissions.contents must stay read")
+
+    ci_main_gate = named_job_config(workflow, "ci-main-gate", expected_jobs, "release.yml")
+    require(ci_main_gate.get("runs-on") == "ubuntu-latest", "release.yml.jobs.ci-main-gate.runs-on drifted")
+    require_exact_if(
+        ci_main_gate,
+        "${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}",
+        "release.yml.jobs.ci-main-gate",
+    )
+    require_fail_closed(ci_main_gate, "release.yml.jobs.ci-main-gate")
+    gate_step = step_config(ci_main_gate, "Fail on unsuccessful CI Main", "release.yml.jobs.ci-main-gate")
+    gate_run = str(gate_step.get("run", ""))
+    require("github.event.workflow_run.conclusion" in gate_run, "release.yml.jobs.ci-main-gate: failure output must include upstream conclusion")
+    require("github.event.workflow_run.head_sha" in gate_run, "release.yml.jobs.ci-main-gate: failure output must include upstream head sha")
+    require("Release is blocked until CI Main succeeds." in gate_run, "release.yml.jobs.ci-main-gate: failure output drifted")
+    require("exit 1" in gate_run, "release.yml.jobs.ci-main-gate: unsuccessful CI Main must fail release")
 
     release_meta = named_job_config(workflow, "release-meta", expected_jobs, "release.yml")
     require_exact_if(

--- a/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
@@ -77,6 +77,12 @@ jobs:
         working-directory: web
         run: bun install --frozen-lockfile
 
+      - name: Install docs-site dependencies
+        run: bun install --cwd docs-site --frozen-lockfile
+
+      - name: Worktree bootstrap smoke
+        run: bash scripts/test-worktree-bootstrap.sh
+
       - name: Bun-first guard
         run: bun run check:bun-first
 
@@ -153,6 +159,17 @@ jobs:
                 source_kind="merge-group-bootstrap-compatible-base-branch"
               fi
             fi
+
+            if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+              changed_quality_gate_paths="$(git diff --name-only "${source_ref}...HEAD" -- "${paths[@]}" "${final_topology_paths[@]}")"
+              if [ -n "${changed_quality_gate_paths}" ]; then
+                echo "::notice::Same-repository PR changes quality-gates contract sources; using current branch sources to validate the updated topology."
+                printf '%s\n' "${changed_quality_gate_paths}"
+                source_ref="HEAD"
+                source_kind="current-branch-quality-gates-change"
+                supports_final_topology="true"
+              fi
+            fi
           fi
 
           for path in "${paths[@]}"; do
@@ -203,6 +220,39 @@ jobs:
         working-directory: web
         run: bun run lint
 
+      - name: Build Storybook static site
+        working-directory: web
+        run: bun run storybook:build -- --quiet
+
+      - name: Compute DOCS_BASE
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY##*/}"
+          if [[ "${repo}" == "${owner}.github.io" ]]; then
+            echo "DOCS_BASE=/" >> "$GITHUB_ENV"
+          else
+            echo "DOCS_BASE=/${repo}/" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build docs site
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docs-site
+          DOCS_BASE="${DOCS_BASE}" bun run build
+
+      - name: Assemble public docs site smoke check
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/assemble-pages-site.sh docs-site/doc_build web/storybook-static .tmp/pages-site
+          test -f .tmp/pages-site/index.html
+          test -f .tmp/pages-site/storybook/index.html
+          test -f .tmp/pages-site/storybook.html
+          grep -q "${DOCS_BASE}storybook.html" .tmp/pages-site/index.html
+
   frontend-tests:
     name: Front-end Tests
     runs-on: ubuntu-latest
@@ -223,6 +273,14 @@ jobs:
       - name: Run front-end Vitest suite
         working-directory: web
         run: bun run test
+
+      - name: Install Playwright Chromium for Storybook
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run Storybook accessibility suite
+        working-directory: web
+        run: bun run test-storybook
 
   records-overlay-e2e:
     name: Records Overlay E2E

--- a/.github/scripts/fixtures/quality-gates-contract/quality-gates.json
+++ b/.github/scripts/fixtures/quality-gates-contract/quality-gates.json
@@ -98,6 +98,7 @@
     {
       "workflow": "Release",
       "jobs": [
+        "CI Main Gate",
         "Release Meta (snapshot + tags)",
         "Build + Smoke + Push Candidate (linux/amd64)",
         "Build + Smoke + Push Candidate (linux/arm64)",

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -31,6 +31,18 @@ env:
   RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
 
 jobs:
+  ci-main-gate:
+    name: CI Main Gate
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}
+    steps:
+      - name: Fail on unsuccessful CI Main
+        shell: bash
+        run: |
+          echo "CI Main completed with conclusion '${{ github.event.workflow_run.conclusion }}' for ${{ github.event.workflow_run.head_sha }}." >&2
+          echo "Release is blocked until CI Main succeeds." >&2
+          exit 1
+
   release-meta:
     name: Release Meta (snapshot + tags)
     runs-on: ubuntu-latest

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -31,6 +31,18 @@ env:
   RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
 
 jobs:
+  ci-main-gate:
+    name: CI Main Gate
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}
+    steps:
+      - name: Fail on unsuccessful CI Main
+        shell: bash
+        run: |
+          echo "CI Main completed with conclusion '${{ github.event.workflow_run.conclusion }}' for ${{ github.event.workflow_run.head_sha }}." >&2
+          echo "Release is blocked until CI Main succeeds." >&2
+          exit 1
+
   release-meta:
     name: Release Meta (snapshot + tags)
     runs-on: ubuntu-latest

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -170,6 +170,28 @@ fi
 
 grep -q "workflow_run.workflows drifted" "$tmp_dir/release-workflow.log"
 
+release_ci_gate_repo="$tmp_dir/release-ci-gate-repo"
+copy_repo_snapshot "$baseline_repo" "$release_ci_gate_repo"
+python3 - <<'PY' "$release_ci_gate_repo"
+from pathlib import Path
+import sys
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/release.yml"
+text = path.read_text()
+needle = "${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}"
+replacement = "${{ github.event_name == 'workflow_run' }}"
+if needle not in text:
+    raise SystemExit("failed to rewrite release CI Main Gate condition")
+path.write_text(text.replace(needle, replacement, 1))
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$release_ci_gate_repo" --profile final >/dev/null 2>"$tmp_dir/release-ci-gate.log"; then
+  echo "expected release CI Main Gate fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "release.yml.jobs.ci-main-gate.if must stay" "$tmp_dir/release-ci-gate.log"
+
 ci_main_repo="$tmp_dir/ci-main-repo"
 copy_repo_snapshot "$baseline_repo" "$ci_main_repo"
 python3 - <<'PY' "$ci_main_repo"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -159,6 +159,17 @@ jobs:
                 source_kind="merge-group-bootstrap-compatible-base-branch"
               fi
             fi
+
+            if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+              changed_quality_gate_paths="$(git diff --name-only "${source_ref}...HEAD" -- "${paths[@]}" "${final_topology_paths[@]}")"
+              if [ -n "${changed_quality_gate_paths}" ]; then
+                echo "::notice::Same-repository PR changes quality-gates contract sources; using current branch sources to validate the updated topology."
+                printf '%s\n' "${changed_quality_gate_paths}"
+                source_ref="HEAD"
+                source_kind="current-branch-quality-gates-change"
+                supports_final_topology="true"
+              fi
+            fi
           fi
 
           for path in "${paths[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,18 @@ env:
   RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
 
 jobs:
+  ci-main-gate:
+    name: CI Main Gate
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}
+    steps:
+      - name: Fail on unsuccessful CI Main
+        shell: bash
+        run: |
+          echo "CI Main completed with conclusion '${{ github.event.workflow_run.conclusion }}' for ${{ github.event.workflow_run.head_sha }}." >&2
+          echo "Release is blocked until CI Main succeeds." >&2
+          exit 1
+
   release-meta:
     name: Release Meta (snapshot + tags)
     runs-on: ubuntu-latest

--- a/docs/solutions/workflow/main-branch-protection-quality-gates.md
+++ b/docs/solutions/workflow/main-branch-protection-quality-gates.md
@@ -40,9 +40,13 @@
 - `.github/quality-gates.json` 与 fixtures 必须同步更新，避免 contract self-test 通过而 live fixtures 仍停留在旧规则。
 - `check_quality_gates_contract.py` 应明确禁止为 PR gate 保留 `informational_checks`。
 - `check_live_quality_gates.py` 的输出需要单独带出 `bypass_actor_status`，方便区分 `verified` 与 `unverified`。
+- 由上游 workflow 触发的发布链路应把上游失败转成显式 failed gate，而不是依赖后续 job 的 `if` 条件自然跳过；否则失败通知通常只监听 `failure`，不会覆盖 `skipped`。
+- 当 PR 本身修改 quality-gates contract 包或受控 workflow 拓扑时，PR lint 需要一个同仓库限定的 current-branch self-validation 路径；否则 base branch 的旧 contract 会永久挡住新增受控 job。
 
 ## 常见坑
 
 - 只把 required checks 写进文档，没有同步 GitHub ruleset，结果高权限用户仍可直推 `main`。
 - 把 `Front-end Tests`、`Records Overlay E2E` 留在 informational，导致“PR 检查全过”只是口头说法，不是服务端硬门。
 - live 脚本把缺失的 `bypass_actors` 当成空数组，误报“已验证没有 bypass”。
+- `Release` 只在 `CI Main success` 时运行发布 job，但没有单独的失败 gate，导致上游失败时发布 run 显示为 `skipped` 且通知链路不报警。
+- 新增受控 workflow job 时只更新目标 workflow，却不更新 PR trusted-source 自举规则，导致 PR 被 `main` 上旧 contract 判定为 drift。

--- a/docs/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md
+++ b/docs/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md
@@ -4,7 +4,7 @@
 
 - Status: 部分完成（3/4）
 - Created: 2026-03-14
-- Last: 2026-03-15
+- Last: 2026-04-29
 
 ## 背景 / 问题陈述
 
@@ -51,6 +51,8 @@
 - `CI Main` 必须为 mainline 上尚未持久化的 merged commits 写入 immutable release snapshot，冻结当前 PR labels、版本分配与镜像/tag 元数据；后续成功的 `CI Main` run 必须能够 catch up 之前因 pending 替换而漏掉的 commits。
 - `CI Main` 写 snapshot 时，自动发布路径必须直接读取 merged commit 关联 PR 的当前 labels；不得依赖 artifact、timeline label 回放或历史 rollout 分支。
 - `Release` 必须同时支持 `workflow_run(CI Main success)` 与 `workflow_dispatch(commit_sha)` 两种入口，并复用同一套 publish 逻辑；自动入口每次只发布 mainline 上最早一个尚未发布的 snapshot，成功后继续串行排下一个；自动与手动入口都只能消费 immutable release snapshot，禁止重新读取 PR labels 或重算版本。
+- 当 `workflow_run` 入口收到非成功的 `CI Main` 结论时，`Release` 必须 fail closed 并显式失败，不能让整条发布 run 以 silent `skipped` 结束。
+- `CI PR` 必须允许同仓库 PR 修改 quality-gates contract 包时使用当前分支 contract 校验当前分支拓扑；fork PR 与普通 PR 继续使用 base trusted source。
 - `workflow_dispatch` 只接受 `commit_sha`，且对非法/不可解析输入、既未通过 `CI Main` 也不满足“仅 `Release Snapshot` 失败”的目标 SHA 一律 fail closed。
 - merge 后的 `type:*` / `channel:*` labels 视为发布输入的一部分；若合并后人为改动标签，后续 backfill 将按改动后的标签重建 snapshot，仓库规则必须禁止这种操作。
 - `quality-gates` contract、fixtures 与自测必须升级到 `final` profile，并校验新的 workflow 家族。
@@ -85,6 +87,9 @@
 - Given 本仓库执行 `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
   When 校验 split topology
   Then contract、fixtures 与 trusted metadata gate 全部通过。
+- Given `CI Main` 以 `failure`、`cancelled` 或其他非 `success` 结论完成
+  When `Release` 被 `workflow_run` 触发
+  Then `CI Main Gate` 必须失败并让 `Release` run 进入 `failure`，从而触发现有 release failure 通知链路。
 
 ## 非功能性验收 / 质量门槛（Quality Gates）
 
@@ -109,11 +114,14 @@
 - `CI Main` 通过 git notes 写入 immutable release snapshot，把 PR labels、版本分配与镜像/tag 元数据冻结到 merge commit。
 - `Label Gate` 在 trusted source 上校验标签；`CI Main` 再把当前 PR labels 提升为 immutable git-notes snapshot。
 - `Release` 通过统一的 target SHA 解析层兼容自动与手动入口，但只加载 snapshot 并复用现有 smoke / manifest / tag / GitHub Release 步骤。
+- `Release` 在发布元数据解析前先用 `CI Main Gate` 捕获非成功上游结论；成功上游或手动 backfill 不受该 gate 阻断。
+- `CI PR` 对同仓库 quality-gates contract 变更启用 current-branch self-validation，避免旧 base contract 永久挡住新增受控 workflow job。
 - `quality-gates` contract 扩展为显式声明 PR/main/release workflow 家族，contract checker 与 fixtures 一起升级，避免只改 workflow 不改自证体系。
 
 ## 风险 / 假设（Risks / Assumptions）
 
 - 风险：workflow 拆分后，contract checker、fixtures 与 live-quality-gates 之间容易出现声明不一致。
+- 风险：若上游失败只让 `release-meta` 条件跳过，GitHub 会把整条 `Release` 记成 `skipped`，现有失败通知不会触发。
 - 风险：`workflow_dispatch` backfill 若未验证 SHA 所属分支，可能误对非 main commit 执行发布。
 - 风险：若合并后有人手改 release labels，后续手动 backfill 会跟随漂移，因此必须把“merge 后不得改 release labels”写成仓库操作规约。
 - 假设：仓库权限允许 `workflow_run` 触发 release 并继续推 tag / 建 GitHub Release。
@@ -123,6 +131,7 @@
 - 2026-03-14: 创建 strict anti-cancel release topology spec，冻结三段式 workflow + final quality-gates 升级范围。
 - 2026-03-14: 完成 workflow split、final quality-gates contract、release backfill 入口与本地 contract/self-tests。
 - 2026-03-15: 将发布链路进一步收敛为“PR 标签校验 → 全局串行 `CI Main` 写/补 snapshot → 全局串行 `Release` 按最早未发布 snapshot 排队发布”，删除 artifact、rollout 与 legacy fallback 复杂度。
+- 2026-04-29: 增加 `CI Main Gate`，把上游 `CI Main` 非成功结论从 silent skipped 转为显式 failed release；同时允许同仓库 quality-gates contract PR 使用当前分支 contract 自证更新后的拓扑。
 
 ## 参考（References）
 

--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -538,29 +538,24 @@ async fn parallel_work_stats_zero_fills_current_page_period() {
     .await
     .expect("fetch parallel-work stats");
 
-    let response_next_minute = DateTime::parse_from_rfc3339(&response.current.range_end)
-        .expect("parse minute range end")
-        .with_timezone(&Utc);
-    let response_current_minute = response_next_minute - ChronoDuration::minutes(1);
-    let response_previous_minute = response_next_minute - ChronoDuration::minutes(2);
-    let response_empty_minute = response_next_minute - ChronoDuration::minutes(4);
+    let inserted_empty_minute = inserted_current_minute - ChronoDuration::minutes(3);
     let current_minute_point = response
         .current
         .points
         .iter()
-        .find(|point| point.bucket_start == format_utc_iso(response_current_minute))
-        .expect("current minute point");
+        .find(|point| point.bucket_start == format_utc_iso(inserted_current_minute))
+        .expect("inserted current minute point");
     let previous_minute_point = response
         .current
         .points
         .iter()
-        .find(|point| point.bucket_start == format_utc_iso(response_previous_minute))
-        .expect("previous minute point");
+        .find(|point| point.bucket_start == format_utc_iso(inserted_previous_minute))
+        .expect("inserted previous minute point");
     let empty_minute_point = response
         .current
         .points
         .iter()
-        .find(|point| point.bucket_start == format_utc_iso(response_empty_minute))
+        .find(|point| point.bucket_start == format_utc_iso(inserted_empty_minute))
         .expect("empty minute point");
     assert_eq!(current_minute_point.parallel_count, 1);
     assert_eq!(previous_minute_point.parallel_count, 1);


### PR DESCRIPTION
## Summary
- Add a `CI Main Gate` job to `Release` so unsuccessful upstream `CI Main` conclusions fail loudly instead of ending as a silent skipped release.
- Update quality-gates declarations, contract checks, fixtures, and self-tests to lock the new gate.
- Add a same-repository quality-gates self-validation path so contract/topology PRs can validate their own updated contract instead of being blocked by the old base contract.
- Stabilize `parallel_work_stats_zero_fills_current_page_period` against minute-boundary races observed in CI.

## Verification
- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-live-quality-gates.sh`
- `cargo test --locked --all-features tests::parallel_work_stats_zero_fills_current_page_period -- --exact`
- `git diff --check`
- `codex review --base origin/main` x2

## References
- Specs: `docs/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md`
- Solutions: `docs/solutions/workflow/main-branch-protection-quality-gates.md`
- Project Docs: -
