### PR TITLE
test: stabilize parallel work current minute stats

### DIFF
--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -481,8 +481,9 @@ async fn parallel_work_stats_zero_fills_current_page_period() {
     )
     .await;
     let now = Utc::now();
+    let observed_now = now - ChronoDuration::seconds(20);
     let current_minute_epoch =
-        align_reporting_bucket_epoch(now.timestamp(), 60, Shanghai).expect("align minute");
+        align_reporting_bucket_epoch(observed_now.timestamp(), 60, Shanghai).expect("align minute");
     let inserted_current_minute = Utc
         .timestamp_opt(current_minute_epoch, 0)
         .single()


### PR DESCRIPTION
## Summary
- Stabilize the parallel work current-page minute stats test by anchoring inserted records to an already-observed minute.
- Unblocks the failed `CI Main` backend job after PR #384.

## Verification
- `cargo fmt`
- `for i in 1 2 3 4 5; do cargo test --locked --all-features tests::parallel_work_stats_zero_fills_current_page_period -- --exact || exit $?; done`
- pre-commit: `cargo check`

## References
- Specs: `docs/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md`
- Solutions: `docs/solutions/workflow/main-branch-protection-quality-gates.md`
- Project Docs: -
