### PR TITLE
fix: auto-tag websocket unsupported upstreams

### DIFF
--- a/docs/specs/w5s2x-openai-websocket-proxy/HISTORY.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/HISTORY.md
@@ -7,3 +7,4 @@
 - 增加双开关与账号 capability tag：downstream 是否允许 WS、proxy-to-upstream 是否默认使用 WS 分开控制；`unsupported_transport:websocket` 系统 tag 标记不支持 WS 的上游账号并强制其使用 HTTP 路径。
 - 补齐成本与 UI 证据：Responses WS terminal usage 事件进入既有 invocation/cost 统计；设置页提供两个可保存的 WS 全局开关；账号池列表展示 `不支持 WS` 标签。
 - 修正 WS 开关契约：环境变量只作为首次初始化默认值，后续由数据库中的全局设置控制，UI 保存后即时影响新连接。
+- 修正 WS 运行时收敛：上游 WS 握手明确返回 403/404/405/426/501 时自动补写 `unsupported_transport:websocket` 系统 tag；upstream 终态帧先转发给下游，再执行 usage 持久化，避免 `response.completed` 被记账阻塞。

--- a/docs/specs/w5s2x-openai-websocket-proxy/HISTORY.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/HISTORY.md
@@ -7,4 +7,4 @@
 - 增加双开关与账号 capability tag：downstream 是否允许 WS、proxy-to-upstream 是否默认使用 WS 分开控制；`unsupported_transport:websocket` 系统 tag 标记不支持 WS 的上游账号并强制其使用 HTTP 路径。
 - 补齐成本与 UI 证据：Responses WS terminal usage 事件进入既有 invocation/cost 统计；设置页提供两个可保存的 WS 全局开关；账号池列表展示 `不支持 WS` 标签。
 - 修正 WS 开关契约：环境变量只作为首次初始化默认值，后续由数据库中的全局设置控制，UI 保存后即时影响新连接。
-- 修正 WS 运行时收敛：上游 WS 握手明确返回 403/404/405/426/501 时自动补写 `unsupported_transport:websocket` 系统 tag；upstream 终态帧先转发给下游，再执行 usage 持久化，避免 `response.completed` 被记账阻塞。
+- 修正 WS 运行时收敛：上游 WS 握手明确返回 403/404/405/426/501 时自动补写 `unsupported_transport:websocket` 系统 tag；upstream 终态帧先转发给下游，再执行 usage 持久化，避免 `response.completed` 被记账阻塞；终态前的 upstream close 统一转成下游 `1013 retry` 并记录路由失败。

--- a/docs/specs/w5s2x-openai-websocket-proxy/IMPLEMENTATION.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/IMPLEMENTATION.md
@@ -6,10 +6,12 @@
 - 已实现：`websocketEnabled` downstream 全局设置，默认关闭；关闭时 WS upgrade 返回 `503` 且不连接上游。`OPENAI_PROXY_WEBSOCKET_ENABLED` 只作为首次初始化默认值。
 - 已实现：`upstreamWebsocketDefaultEnabled` upstream 默认 WS 全局设置，默认关闭；关闭时 downstream WS 不会连接上游 WS。`OPENAI_PROXY_UPSTREAM_WEBSOCKET_DEFAULT_ENABLED` 只作为首次初始化默认值。
 - 已实现：受保护系统 tag `unsupported_transport:websocket` / `不支持 WS`；带 tag 账号退出 WS 上游候选，HTTP 路由不受影响。
+- 已实现：上游 WS 握手返回明确不支持 WS 的 HTTP 状态时，自动给该账号补写 `unsupported_transport:websocket` / `不支持 WS`，后续 WS 调度跳过该账号；网络 reset、timeout、502 等不确定故障不自动标记。
 - 已实现：账号池选择、downstream upgrade 前的上游 WS 握手 failover、上游 `ws/wss` URL 构造与透明 text/binary/ping/pong/close 帧中继。
 - 已实现：API key 与 OAuth 账号的 upstream `Authorization` 覆盖、安全 header 转发、HTTP/HTTPS CONNECT 与 SOCKS5/SOCKS5H forward-proxy 隧道。
 - 已实现：连接级 pool attempt 记录、reservation 释放与广播。
 - 已实现：Responses WS terminal usage 事件的保守计费解析，完整 `input_tokens` + `output_tokens` 才生成 invocation/cost 记录。
+- 已实现：upstream WS text 帧先转发给 downstream，再执行 terminal usage 持久化，避免计费写入阻塞 `response.completed` 交付。
 - 已实现：设置页可保存 downstream WS 与 upstream WS 默认开关，后续 WS 请求运行时读取持久化全局设置；账号池 Storybook 展示 `不支持 WS` 系统标签。
 
 ## Account Failover

--- a/docs/specs/w5s2x-openai-websocket-proxy/IMPLEMENTATION.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/IMPLEMENTATION.md
@@ -8,6 +8,7 @@
 - 已实现：受保护系统 tag `unsupported_transport:websocket` / `不支持 WS`；带 tag 账号退出 WS 上游候选，HTTP 路由不受影响。
 - 已实现：上游 WS 握手返回明确不支持 WS 的 HTTP 状态时，自动给该账号补写 `unsupported_transport:websocket` / `不支持 WS`，后续 WS 调度跳过该账号；网络 reset、timeout、502 等不确定故障不自动标记。
 - 已实现：账号池选择、downstream upgrade 前的上游 WS 握手 failover、上游 `ws/wss` URL 构造与透明 text/binary/ping/pong/close 帧中继。
+- 已实现：上游在 `response.completed` 前主动 close 时，不再透传原始 close 给下游，而是改发 `1013 upstream_unavailable; retry` 并记录路由失败。
 - 已实现：API key 与 OAuth 账号的 upstream `Authorization` 覆盖、安全 header 转发、HTTP/HTTPS CONNECT 与 SOCKS5/SOCKS5H forward-proxy 隧道。
 - 已实现：连接级 pool attempt 记录、reservation 释放与广播。
 - 已实现：Responses WS terminal usage 事件的保守计费解析，完整 `input_tokens` + `output_tokens` 才生成 invocation/cost 记录。

--- a/docs/specs/w5s2x-openai-websocket-proxy/SPEC.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/SPEC.md
@@ -75,7 +75,7 @@ OpenAI Responses API 已公开 WebSocket mode，Codex 也已开始使用 WebSock
   - 单个上游 WS 连接或握手失败：记录 transport failure attempt，释放该账号 reservation，标记路由 transport failure，排除失败账号与 route key，并在同一个 downstream 请求内继续选择下一个账号。
   - 单个上游 WS 握手返回 403/404/405/426/501：除记录失败与继续切号外，还必须自动标记该账号 `不支持 WS`，使后续 WS 调度跳过该账号。
   - 所有可用候选耗尽或达到 distinct-account retry budget：返回最后一次可重试失败对应的 HTTP error，或返回 pool 不可用错误。
-  - 已建立隧道后的上游异常或 EOF：发送 downstream close `1013` / `upstream_unavailable; retry` 并记录终态；客户端重连后由服务端重新走 pool selection，失败账号的现有路由失败记录和降权逻辑参与下一次选择。
+  - 已建立隧道后的上游异常、EOF 或在终态前主动 close：发送 downstream close `1013` / `upstream_unavailable; retry` 并记录终态；客户端重连后由服务端重新走 pool selection，失败账号的现有路由失败记录和降权逻辑参与下一次选择。
 
 ## 验收标准
 
@@ -83,7 +83,7 @@ OpenAI Responses API 已公开 WebSocket mode，Codex 也已开始使用 WebSock
 - Given 有效账号与 mock upstream WS，When downstream 发送 text/binary/ping/close，Then upstream 收到对应帧，且 upstream 响应帧被转发给 downstream。
 - Given 第一个上游账号 WS 连接失败且池内还有候选，When downstream 发起 upgrade，Then 代理在 downstream upgrade 前记录失败并切到下一个账号；若下一个账号成功，downstream 得到正常 WebSocket 隧道而不是先断开再依赖客户端重连。
 - Given 所有上游 WS 连接失败，When downstream 发起 upgrade，Then downstream 收到 HTTP error，所有失败账号的 pool reservation 被释放，attempt 记录为 transport failure。
-- Given 已建立隧道后上游异常断开，When downstream 等待下一帧，Then downstream 收到 close `1013` 且 reason 包含 `retry`，下一次连接重新进入号池调度。
+- Given 已建立隧道后上游异常断开或在 `response.completed` 前主动 close，When downstream 等待下一帧，Then downstream 收到 close `1013` 且 reason 包含 `retry`，下一次连接重新进入号池调度。
 - Given 账号带 `unsupported_transport:websocket` 系统 tag，When downstream 发起 WebSocket upgrade，Then 该账号不作为上游 WS 候选；When 普通 HTTP 请求路由，Then 该账号仍可作为 HTTP 候选。
 - Given 未带 `unsupported_transport:websocket` 的账号在上游 WS 握手阶段返回 403/404/405/426/501，When 代理记录该失败，Then 自动补写 `不支持 WS` tag，且下一次 WS 调度跳过该账号；When 后续普通 HTTP 请求路由，Then 该账号仍可作为 HTTP 候选。
 - Given 上游发出 `response.completed` 且包含完整 `response.usage`，When downstream 继续接收该 WS turn，Then 代理为该 turn 生成可计费 usage/cost 记录并进入既有 invocation 统计。

--- a/docs/specs/w5s2x-openai-websocket-proxy/SPEC.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/SPEC.md
@@ -54,6 +54,7 @@ OpenAI Responses API 已公开 WebSocket mode，Codex 也已开始使用 WebSock
 - Downstream feature flag: 全局设置 `websocketEnabled=false` 时，WebSocket upgrade 返回 HTTP `503` JSON error；设置为 `true` 后才允许 downstream WS。`OPENAI_PROXY_WEBSOCKET_ENABLED` 只作为首次初始化默认值，普通 HTTP proxy 不受该开关影响。
 - Upstream default flag: 全局设置 `upstreamWebsocketDefaultEnabled=false` 时，proxy 不主动连接上游 WS；设置为 `true` 后，downstream WS 请求才会尝试上游 WS。`OPENAI_PROXY_UPSTREAM_WEBSOCKET_DEFAULT_ENABLED` 只作为首次初始化默认值，普通 HTTP 请求仍走 HTTP，除非后续版本实现并启用可验证 HTTP→WS 事件桥接。
 - Account capability tag: protected system tag `unsupported_transport:websocket` / `不支持 WS` 表示该账号不支持 upstream WS；WS 调度必须跳过该账号，HTTP 调度不跳过。
+- Account auto-tagging: 上游 WS 握手若返回明确不支持 WS 的 HTTP 状态，代理必须自动给该账号补写 `unsupported_transport:websocket` / `不支持 WS`；网络 reset、timeout、502 等非确定性故障不得自动打该 tag。
 - Upstream URL:
   - account/global upstream base `https://host/base` -> `wss://host/base/<original-path>?<query>`
   - account/global upstream base `http://host/base` -> `ws://host/base/<original-path>?<query>`
@@ -72,6 +73,7 @@ OpenAI Responses API 已公开 WebSocket mode，Codex 也已开始使用 WebSock
   - 上游 URL 构造失败：HTTP `502` JSON error，记录失败且不重试该请求。
   - `upstreamWebsocketDefaultEnabled=false` 或所有候选都带 no-ws tag：WebSocket upgrade 返回 `503`，不建立不可靠隧道。
   - 单个上游 WS 连接或握手失败：记录 transport failure attempt，释放该账号 reservation，标记路由 transport failure，排除失败账号与 route key，并在同一个 downstream 请求内继续选择下一个账号。
+  - 单个上游 WS 握手返回 403/404/405/426/501：除记录失败与继续切号外，还必须自动标记该账号 `不支持 WS`，使后续 WS 调度跳过该账号。
   - 所有可用候选耗尽或达到 distinct-account retry budget：返回最后一次可重试失败对应的 HTTP error，或返回 pool 不可用错误。
   - 已建立隧道后的上游异常或 EOF：发送 downstream close `1013` / `upstream_unavailable; retry` 并记录终态；客户端重连后由服务端重新走 pool selection，失败账号的现有路由失败记录和降权逻辑参与下一次选择。
 
@@ -83,6 +85,7 @@ OpenAI Responses API 已公开 WebSocket mode，Codex 也已开始使用 WebSock
 - Given 所有上游 WS 连接失败，When downstream 发起 upgrade，Then downstream 收到 HTTP error，所有失败账号的 pool reservation 被释放，attempt 记录为 transport failure。
 - Given 已建立隧道后上游异常断开，When downstream 等待下一帧，Then downstream 收到 close `1013` 且 reason 包含 `retry`，下一次连接重新进入号池调度。
 - Given 账号带 `unsupported_transport:websocket` 系统 tag，When downstream 发起 WebSocket upgrade，Then 该账号不作为上游 WS 候选；When 普通 HTTP 请求路由，Then 该账号仍可作为 HTTP 候选。
+- Given 未带 `unsupported_transport:websocket` 的账号在上游 WS 握手阶段返回 403/404/405/426/501，When 代理记录该失败，Then 自动补写 `不支持 WS` tag，且下一次 WS 调度跳过该账号；When 后续普通 HTTP 请求路由，Then 该账号仍可作为 HTTP 候选。
 - Given 上游发出 `response.completed` 且包含完整 `response.usage`，When downstream 继续接收该 WS turn，Then 代理为该 turn 生成可计费 usage/cost 记录并进入既有 invocation 统计。
 - Given 上游 usage JSON 缺字段或类型不对，When downstream 继续接收 WS，Then 代理保守地跳过该 event 的计费，不产生半字段成本。
 - Given account `upstreamBaseUrl=https://example.test/base`，When 下游连接 `/v1/responses?model=x`，Then 上游目标为 `wss://example.test/base/v1/responses?model=x`。

--- a/src/proxy/websocket.rs
+++ b/src/proxy/websocket.rs
@@ -552,6 +552,7 @@ async fn prepare_single_upstream_websocket_attempt(
         }
         Ok(Err(err)) => {
             let message = format!("failed to contact websocket upstream: {err}");
+            let should_mark_ws_unsupported = websocket_upstream_error_marks_account_ws_unsupported(&err);
             finalize_ws_attempt(
                 state.as_ref(),
                 pending_attempt_record.as_ref(),
@@ -586,6 +587,19 @@ async fn prepare_single_upstream_websocket_attempt(
                     error = %err,
                     "failed to record websocket pool route transport failure"
                 );
+            }
+            if should_mark_ws_unsupported {
+                if let Err(err) =
+                    ensure_account_has_websocket_unsupported_tag(&state.pool, account.account_id)
+                        .await
+                {
+                    warn!(
+                        invoke_id = %trace.invoke_id,
+                        account_id = account.account_id,
+                        error = %err,
+                        "failed to mark upstream account as websocket unsupported"
+                    );
+                }
             }
             reservation_guard.release();
             return Err(WsAttemptFailure {
@@ -717,6 +731,8 @@ async fn proxy_websocket_tunnel(
     let mut failure: Option<String> = None;
     let mut upstream_route_failure: Option<String> = None;
     let mut usage_tracker = WsUsageTracker::new(account, trace);
+    let mut saw_downstream_request = false;
+    let mut saw_terminal_upstream_event = false;
 
     loop {
         tokio::select! {
@@ -724,6 +740,9 @@ async fn proxy_websocket_tunnel(
                 match downstream_msg {
                     Some(Ok(message)) => {
                         let close_seen = matches!(message, AxumWsMessage::Close(_));
+                        if matches!(message, AxumWsMessage::Text(_) | AxumWsMessage::Binary(_)) {
+                            saw_downstream_request = true;
+                        }
                         match axum_to_tungstenite_message(message) {
                             Some(message) => {
                                 if let Err(err) = upstream_tx.send(message).await {
@@ -750,8 +769,15 @@ async fn proxy_websocket_tunnel(
                 match upstream_msg {
                     Some(Ok(message)) => {
                         let close_seen = matches!(message, TungsteniteMessage::Close(_));
-                        if let TungsteniteMessage::Text(text) = &message {
-                            usage_tracker.observe_upstream_text(state.as_ref(), text.as_str()).await;
+                        let upstream_text = match &message {
+                            TungsteniteMessage::Text(text) => Some(text.as_str().to_owned()),
+                            _ => None,
+                        };
+                        if upstream_text
+                            .as_deref()
+                            .is_some_and(ws_text_event_is_terminal)
+                        {
+                            saw_terminal_upstream_event = true;
                         }
                         if let Some(message) = tungstenite_to_axum_message(message)
                             && let Err(err) = downstream_tx.send(message).await
@@ -759,7 +785,15 @@ async fn proxy_websocket_tunnel(
                             failure = Some(format!("failed to forward upstream websocket frame downstream: {err}"));
                             break;
                         }
+                        if let Some(text) = upstream_text.as_deref() {
+                            usage_tracker.observe_upstream_text(state.as_ref(), text).await;
+                        }
                         if close_seen {
+                            if saw_downstream_request && !saw_terminal_upstream_event {
+                                failure = Some(
+                                    "upstream websocket closed before response.completed".to_string(),
+                                );
+                            }
                             break;
                         }
                     }
@@ -776,7 +810,11 @@ async fn proxy_websocket_tunnel(
                         break;
                     }
                     None => {
-                        let message = "upstream websocket closed without a close frame".to_string();
+                        let message = if saw_downstream_request && !saw_terminal_upstream_event {
+                            "upstream websocket closed before response.completed".to_string()
+                        } else {
+                            "upstream websocket closed without a close frame".to_string()
+                        };
                         upstream_route_failure = Some(message.clone());
                         failure = Some(message);
                         let _ = downstream_tx
@@ -915,6 +953,30 @@ fn ws_event_type_has_billable_usage(event_type: &str) -> bool {
         event_type,
         "response.completed" | "response.done" | "response.failed"
     )
+}
+
+fn websocket_upstream_error_marks_account_ws_unsupported(err: &tungstenite::Error) -> bool {
+    match err {
+        tungstenite::Error::Http(response) => matches!(
+            response.status(),
+            tungstenite::http::StatusCode::FORBIDDEN
+                | tungstenite::http::StatusCode::NOT_FOUND
+                | tungstenite::http::StatusCode::METHOD_NOT_ALLOWED
+                | tungstenite::http::StatusCode::UPGRADE_REQUIRED
+                | tungstenite::http::StatusCode::NOT_IMPLEMENTED
+        ),
+        _ => false,
+    }
+}
+
+fn ws_text_event_is_terminal(event_type: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(event_type) else {
+        return false;
+    };
+    value
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(ws_event_type_has_billable_usage)
 }
 
 async fn persist_ws_usage_event(
@@ -1862,6 +1924,39 @@ mod websocket_tests {
             Some(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED)
         );
         assert_eq!(ws_terminal_event_failure_kind("response.completed"), None);
+    }
+
+    #[test]
+    fn websocket_upstream_http_unsupported_errors_mark_account_no_ws() {
+        for status in [
+            tungstenite::http::StatusCode::FORBIDDEN,
+            tungstenite::http::StatusCode::NOT_FOUND,
+            tungstenite::http::StatusCode::METHOD_NOT_ALLOWED,
+            tungstenite::http::StatusCode::UPGRADE_REQUIRED,
+            tungstenite::http::StatusCode::NOT_IMPLEMENTED,
+        ] {
+            let response = tungstenite::http::Response::builder()
+                .status(status)
+                .body(None)
+                .expect("response");
+            assert!(
+                websocket_upstream_error_marks_account_ws_unsupported(&tungstenite::Error::Http(
+                    Box::new(response),
+                )),
+                "status {status} should mark no-ws"
+            );
+        }
+
+        let response = tungstenite::http::Response::builder()
+            .status(tungstenite::http::StatusCode::BAD_GATEWAY)
+            .body(None)
+            .expect("response");
+        assert!(!websocket_upstream_error_marks_account_ws_unsupported(
+            &tungstenite::Error::Http(Box::new(response))
+        ));
+        assert!(!websocket_upstream_error_marks_account_ws_unsupported(
+            &tungstenite::Error::ConnectionClosed
+        ));
     }
 
     #[tokio::test]

--- a/src/proxy/websocket.rs
+++ b/src/proxy/websocket.rs
@@ -779,6 +779,24 @@ async fn proxy_websocket_tunnel(
                         {
                             saw_terminal_upstream_event = true;
                         }
+                        if close_seen
+                            && ws_upstream_close_requires_retry(
+                                saw_downstream_request,
+                                saw_terminal_upstream_event,
+                            )
+                        {
+                            let message =
+                                "upstream websocket closed before response.completed".to_string();
+                            upstream_route_failure = Some(message.clone());
+                            failure = Some(message);
+                            let _ = downstream_tx
+                                .send(AxumWsMessage::Close(Some(axum::extract::ws::CloseFrame {
+                                    code: axum::extract::ws::close_code::AGAIN,
+                                    reason: "upstream_unavailable; retry".into(),
+                                })))
+                                .await;
+                            break;
+                        }
                         if let Some(message) = tungstenite_to_axum_message(message)
                             && let Err(err) = downstream_tx.send(message).await
                         {
@@ -789,11 +807,6 @@ async fn proxy_websocket_tunnel(
                             usage_tracker.observe_upstream_text(state.as_ref(), text).await;
                         }
                         if close_seen {
-                            if saw_downstream_request && !saw_terminal_upstream_event {
-                                failure = Some(
-                                    "upstream websocket closed before response.completed".to_string(),
-                                );
-                            }
                             break;
                         }
                     }
@@ -977,6 +990,13 @@ fn ws_text_event_is_terminal(event_type: &str) -> bool {
         .get("type")
         .and_then(Value::as_str)
         .is_some_and(ws_event_type_has_billable_usage)
+}
+
+fn ws_upstream_close_requires_retry(
+    saw_downstream_request: bool,
+    saw_terminal_upstream_event: bool,
+) -> bool {
+    saw_downstream_request && !saw_terminal_upstream_event
 }
 
 async fn persist_ws_usage_event(
@@ -1924,6 +1944,13 @@ mod websocket_tests {
             Some(PROXY_FAILURE_UPSTREAM_RESPONSE_FAILED)
         );
         assert_eq!(ws_terminal_event_failure_kind("response.completed"), None);
+    }
+
+    #[test]
+    fn websocket_upstream_close_requires_retry_until_terminal_event() {
+        assert!(ws_upstream_close_requires_retry(true, false));
+        assert!(!ws_upstream_close_requires_retry(false, false));
+        assert!(!ws_upstream_close_requires_retry(true, true));
     }
 
     #[test]

--- a/src/upstream_accounts/sync_account_imports_tags.rs
+++ b/src/upstream_accounts/sync_account_imports_tags.rs
@@ -97,6 +97,28 @@ pub(crate) async fn ensure_account_has_gpt55_unsupported_tag(
     Ok(())
 }
 
+pub(crate) async fn ensure_account_has_websocket_unsupported_tag(
+    pool: &Pool<Sqlite>,
+    account_id: i64,
+) -> Result<()> {
+    ensure_websocket_unsupported_system_tag(pool).await?;
+    let now_iso = format_utc_iso(Utc::now());
+    sqlx::query(
+        r#"
+        INSERT OR IGNORE INTO pool_upstream_account_tags (account_id, tag_id, created_at, updated_at)
+        SELECT ?1, tag.id, ?3, ?3
+        FROM pool_tags tag
+        WHERE tag.system_key = ?2
+        "#,
+    )
+    .bind(account_id)
+    .bind(WEBSOCKET_UNSUPPORTED_SYSTEM_TAG_KEY)
+    .bind(&now_iso)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 pub(crate) async fn account_has_gpt55_unsupported_tag(
     pool: &Pool<Sqlite>,
     account_id: i64,


### PR DESCRIPTION
## Summary
- Auto-tag upstream accounts as `unsupported_transport:websocket` / `不支持 WS` when the upstream WS handshake returns a deterministic no-WS HTTP status.
- Keep transient network failures such as resets, timeouts, and 502s from mutating account capabilities.
- Forward upstream WS text frames to downstream before terminal usage persistence so `response.completed` is not blocked by cost recording.

## Validation
- `cargo fmt --check`
- `cargo test websocket_ -- --nocapture`
- pre-commit hook: `cargo check`

## References
- Specs: `docs/specs/w5s2x-openai-websocket-proxy/SPEC.md`
- Solutions: -
- Project Docs: -

## Notes
- Visual evidence: not applicable; backend/proxy behavior and spec-only docs change.
- Project Docs disposition: none.