### PR TITLE
fix(upstream-accounts): decode KaisouMail message details

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -342,7 +342,7 @@ struct CrsStatsConfig {
     poll_interval: Duration,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UpstreamAccountsKaisouMailConfig {
     base_url: Url,
@@ -350,6 +350,18 @@ struct UpstreamAccountsKaisouMailConfig {
     api_key: String,
     default_mail_domain: String,
     default_subdomain: String,
+}
+
+impl fmt::Debug for UpstreamAccountsKaisouMailConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UpstreamAccountsKaisouMailConfig")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"<redacted>")
+            .field("default_mail_domain", &self.default_mail_domain)
+            .field("default_subdomain", &self.default_subdomain)
+            .finish()
+    }
 }
 
 impl AppConfig {

--- a/src/upstream_accounts/sync_mailbox_and_filters.rs
+++ b/src/upstream_accounts/sync_mailbox_and_filters.rs
@@ -63,15 +63,42 @@ struct KaisouMailMessageDetailPayload {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 struct KaisouMailMessageDetail {
     id: String,
     subject: Option<String>,
-    #[serde(alias = "text", alias = "previewText")]
     content: Option<String>,
     html: Option<String>,
     received_at: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KaisouMailMessageDetailRaw {
+    id: String,
+    subject: Option<String>,
+    content: Option<String>,
+    text: Option<String>,
+    preview_text: Option<String>,
+    html: Option<String>,
+    received_at: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for KaisouMailMessageDetail {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = KaisouMailMessageDetailRaw::deserialize(deserializer)?;
+        Ok(Self {
+            id: raw.id,
+            subject: raw.subject,
+            content: raw.content.or(raw.text).or(raw.preview_text),
+            html: raw.html,
+            received_at: raw.received_at,
+        })
+    }
 }
 
 const MAILBOX_CODE_CONTEXT_WINDOW_BYTES: usize = 64;

--- a/src/upstream_accounts/tests_part_6.rs
+++ b/src/upstream_accounts/tests_part_6.rs
@@ -1932,6 +1932,49 @@
     }
 
     #[test]
+    fn decode_mailbox_detail_accepts_text_and_preview_text_together() {
+        let payload: KaisouMailMessageDetailPayload = serde_json::from_value(json!({
+            "message": {
+                "id": "msg_preview_and_text",
+                "subject": "Your temporary ChatGPT verification code",
+                "previewText": "Preview fallback 123456",
+                "text": null,
+                "html": "<p>OpenAI verification code: 654321</p>",
+                "receivedAt": "2026-05-06T20:09:49.322Z"
+            }
+        }))
+        .expect("decode message detail with both previewText and text");
+
+        assert_eq!(payload.message.id, "msg_preview_and_text");
+        assert_eq!(
+            payload.message.content.as_deref(),
+            Some("Preview fallback 123456")
+        );
+        assert_eq!(
+            parse_mailbox_code(&payload.message)
+                .expect("code from subject/html")
+                .value,
+            "654321"
+        );
+    }
+
+    #[test]
+    fn kaisoumail_config_debug_redacts_api_key() {
+        let config = UpstreamAccountsKaisouMailConfig {
+            base_url: Url::parse("https://km.example.test").expect("url"),
+            api_key: "cfm_secret_value".to_string(),
+            default_mail_domain: "example.test".to_string(),
+            default_subdomain: "mail".to_string(),
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains("api_key"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("cfm_secret_value"));
+    }
+
+    #[test]
     fn parse_mailbox_code_falls_back_to_body_match() {
         let detail = KaisouMailMessageDetail {
             id: "msg_2".to_string(),


### PR DESCRIPTION
## Summary

- Fix KaisouMail message detail decoding when `previewText` and `text: null` are both present.
- Preserve mailbox verification/invite parsing by selecting content from `content`, then `text`, then `previewText`.
- Redact the KaisouMail API key from `UpstreamAccountsKaisouMailConfig` debug output so startup logs do not expose secrets.

## Verification

- `cargo fmt --check`
- `cargo test decode_mailbox_detail_accepts_text_and_preview_text_together -- --test-threads=1`
- `cargo test kaisoumail_config_debug_redacts_api_key -- --test-threads=1`
- `cargo test mailbox -- --test-threads=1`
- `cargo check`

## References

- Specs: -
- Solutions: -
- Project Docs: -

## Release Labels

- `type:patch`
- `channel:stable`