### PR TITLE
fix(ci): freeze release snapshots from merged PRs

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -767,6 +767,7 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     require(ensure_env.get("GITHUB_TOKEN") == "${{ secrets.GITHUB_TOKEN }}", "release.yml.jobs.release-meta: manual snapshot ensure must use GITHUB_TOKEN")
     ensure_run = str(ensure_step.get("run", ""))
     require("release_snapshot.py ensure" in ensure_run, "release.yml.jobs.release-meta: manual snapshot ensure must use release_snapshot.py ensure")
+    require("--snapshot-source manual-backfill" in ensure_run, "release.yml.jobs.release-meta: manual snapshot ensure must mark manual-backfill source")
     require("--skip-publish" in ensure_run, "release.yml.jobs.release-meta: manual snapshot ensure must avoid notes ref writes")
     pending_step = step_config(release_meta, "Select pending release target", "release.yml.jobs.release-meta")
     pending_env = require_mapping(pending_step.get("env"), "release.yml.jobs.release-meta.steps['Select pending release target'].env")
@@ -854,6 +855,62 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     require(continue_step.get("if") == "github.event_name != 'workflow_dispatch' && steps.next-pending.outputs.target_sha != ''", "release.yml.jobs.release-publish: release queue continuation gate drifted")
 
 
+def validate_release_snapshot_pr(path: Path) -> None:
+    workflow = load_yaml(path)
+    workflow_name = workflow.get("name")
+    require(isinstance(workflow_name, str) and workflow_name, "release-snapshot-pr.yml: workflow name must stay non-empty")
+    require(workflow_name == "Release Snapshot PR", "release-snapshot-pr.yml: workflow name drifted")
+
+    on_section = require_mapping(mapping_get(workflow, "on"), "release-snapshot-pr.yml.on")
+    pull_request_target_config = event_config(workflow, "pull_request_target", "release-snapshot-pr.yml")
+    assert_event_types(pull_request_target_config, {"closed"}, "release-snapshot-pr.yml.on.pull_request_target")
+    assert_event_branches(pull_request_target_config, {"main"}, "release-snapshot-pr.yml.on.pull_request_target")
+    require("pull_request" not in on_section, "release-snapshot-pr.yml: pull_request must stay disabled")
+    require("push" not in on_section, "release-snapshot-pr.yml: push must stay disabled")
+    require("workflow_dispatch" not in on_section, "release-snapshot-pr.yml: workflow_dispatch must stay disabled")
+
+    concurrency = require_mapping(workflow.get("concurrency"), "release-snapshot-pr.yml.concurrency")
+    require(
+        concurrency.get("group") == "release-snapshot-pr-${{ github.event.pull_request.merge_commit_sha }}",
+        "release-snapshot-pr.yml.concurrency.group drifted",
+    )
+    require(concurrency.get("cancel-in-progress") is False, "release-snapshot-pr.yml.concurrency.cancel-in-progress must stay false")
+
+    permissions = require_mapping(workflow.get("permissions"), "release-snapshot-pr.yml.permissions")
+    require(permissions.get("contents") == "write", "release-snapshot-pr.yml.permissions.contents must stay write")
+    require(permissions.get("pull-requests") == "read", "release-snapshot-pr.yml.permissions.pull-requests must stay read")
+
+    jobs = require_mapping(workflow.get("jobs"), "release-snapshot-pr.yml.jobs")
+    require(set(jobs.keys()) == {"freeze-release-snapshot"}, "release-snapshot-pr.yml: job set drifted")
+    job = require_mapping(jobs.get("freeze-release-snapshot"), "release-snapshot-pr.yml.jobs.freeze-release-snapshot")
+    require(job.get("name") == "Freeze merged PR release snapshot", "release-snapshot-pr.yml.jobs.freeze-release-snapshot name drifted")
+    require_exact_if(
+        job,
+        "${{ github.event.pull_request.merged == true }}",
+        "release-snapshot-pr.yml.jobs.freeze-release-snapshot",
+    )
+    checkout = checkout_step(job, "Checkout code", "release-snapshot-pr.yml.jobs.freeze-release-snapshot")
+    require(
+        checkout.get("ref") == "${{ github.event.pull_request.merge_commit_sha }}",
+        "release-snapshot-pr.yml.jobs.freeze-release-snapshot checkout ref drifted",
+    )
+    require(
+        checkout.get("fetch-depth") == 0,
+        "release-snapshot-pr.yml.jobs.freeze-release-snapshot checkout must fetch full history",
+    )
+    ensure_step = step_config(job, "Freeze immutable release snapshot", "release-snapshot-pr.yml.jobs.freeze-release-snapshot")
+    ensure_env = require_mapping(ensure_step.get("env"), "release-snapshot-pr.yml.jobs.freeze-release-snapshot.steps['Freeze immutable release snapshot'].env")
+    require(ensure_env.get("GITHUB_TOKEN") == "${{ secrets.GITHUB_TOKEN }}", "release-snapshot-pr.yml: merged PR snapshot must use GITHUB_TOKEN")
+    ensure_run = str(ensure_step.get("run", ""))
+    require("release_snapshot.py ensure" in ensure_run, "release-snapshot-pr.yml: merged PR snapshot must use release_snapshot.py ensure")
+    require("--target-only" in ensure_run, "release-snapshot-pr.yml: merged PR snapshot must stay target-only")
+    require("--snapshot-source merged-pr" in ensure_run, "release-snapshot-pr.yml: merged PR snapshot source drifted")
+    require(
+        "github.event.pull_request.merge_commit_sha" in ensure_run,
+        "release-snapshot-pr.yml: merged PR snapshot must key off merge_commit_sha",
+    )
+
+
 def validate_merge_group_helpers(module: Any) -> None:
     try:
         module.resolve_pull_numbers(
@@ -883,7 +940,7 @@ def materialize_default_repo_root(script_repo_root: Path) -> Path:
     tempdir = Path(tempfile.mkdtemp(prefix="quality-gates-contract-"))
     shutil.copytree(script_repo_root / ".github", tempdir / ".github", dirs_exist_ok=True)
     shutil.copyfile(fixtures_root / "quality-gates.json", tempdir / ".github" / "quality-gates.json")
-    for filename in ("ci-pr.yml", "ci-main.yml", "release.yml", "label-gate.yml", "review-policy.yml"):
+    for filename in ("ci-pr.yml", "ci-main.yml", "release.yml", "label-gate.yml", "review-policy.yml", "release-snapshot-pr.yml"):
         shutil.copyfile(fixtures_root / filename, tempdir / ".github" / "workflows" / filename)
     return tempdir
 
@@ -920,6 +977,7 @@ def main() -> int:
         validate_ci_pr(repo_root / ".github" / "workflows" / "ci-pr.yml", contract)
         validate_ci_main(repo_root / ".github" / "workflows" / "ci-main.yml", contract)
         validate_release(repo_root / ".github" / "workflows" / "release.yml", contract)
+        validate_release_snapshot_pr(repo_root / ".github" / "workflows" / "release-snapshot-pr.yml")
         validate_label_gate(repo_root / ".github" / "workflows" / "label-gate.yml", contract)
         validate_review_policy(repo_root / ".github" / "workflows" / "review-policy.yml", contract)
         validate_merge_group_helpers(module)

--- a/.github/scripts/fixtures/quality-gates-contract/release-snapshot-pr.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release-snapshot-pr.yml
@@ -1,0 +1,54 @@
+name: Release Snapshot PR
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+concurrency:
+  group: release-snapshot-pr-${{ github.event.pull_request.merge_commit_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+env:
+  REGISTRY: ghcr.io
+  RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
+
+jobs:
+  freeze-release-snapshot:
+    name: Freeze merged PR release snapshot
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Freeze immutable release snapshot
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${{ github.event.pull_request.merge_commit_sha }}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --snapshot-source merged-pr \
+            --target-only \
+            --output "$RUNNER_TEMP/release-snapshot.json"

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -176,6 +176,7 @@ jobs:
             --github-token "${GITHUB_TOKEN}" \
             --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
             --registry "${REGISTRY}" \
+            --snapshot-source manual-backfill \
             --target-only \
             --skip-publish \
             --output "$RUNNER_TEMP/release-snapshot.json"

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release-snapshot-pr.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release-snapshot-pr.yml
@@ -1,0 +1,54 @@
+name: Release Snapshot PR
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+concurrency:
+  group: release-snapshot-pr-${{ github.event.pull_request.merge_commit_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+env:
+  REGISTRY: ghcr.io
+  RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
+
+jobs:
+  freeze-release-snapshot:
+    name: Freeze merged PR release snapshot
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Freeze immutable release snapshot
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${{ github.event.pull_request.merge_commit_sha }}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --snapshot-source merged-pr \
+            --target-only \
+            --output "$RUNNER_TEMP/release-snapshot.json"

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -176,6 +176,7 @@ jobs:
             --github-token "${GITHUB_TOKEN}" \
             --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
             --registry "${REGISTRY}" \
+            --snapshot-source manual-backfill \
             --target-only \
             --skip-publish \
             --output "$RUNNER_TEMP/release-snapshot.json"

--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -16,7 +16,13 @@ from urllib import error, parse, request
 
 SNAPSHOT_SCHEMA_VERSION = 1
 DEFAULT_NOTES_REF = "refs/notes/release-snapshots"
-ALLOWED_SNAPSHOT_SOURCES = {"ci-main", "manual-backfill", "pr-intent-artifact", "legacy-pr-labels"}
+ALLOWED_SNAPSHOT_SOURCES = {
+    "ci-main",
+    "manual-backfill",
+    "merged-pr",
+    "pr-intent-artifact",
+    "legacy-pr-labels",
+}
 ALLOWED_TYPE_LABELS = {
     "type:patch",
     "type:minor",
@@ -76,6 +82,7 @@ def parse_args() -> argparse.Namespace:
     ensure.add_argument("--notes-ref", default=DEFAULT_NOTES_REF)
     ensure.add_argument("--registry", default="ghcr.io")
     ensure.add_argument("--api-root", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
+    ensure.add_argument("--snapshot-source", default="ci-main")
     ensure.add_argument("--output", required=True)
     ensure.add_argument("--max-attempts", type=int, default=6)
     ensure.add_argument(
@@ -278,19 +285,39 @@ def load_pr_for_commit(
     allow_zero: bool = False,
 ) -> dict[str, Any] | None:
     owner, repo = repository.split("/", 1)
-    payload = github_request_json(api_root, token, f"/repos/{owner}/{repo}/commits/{target_sha}/pulls")
-    if not isinstance(payload, list):
-        raise SnapshotError("GitHub API returned an unexpected payload for commit-associated PRs")
-    if len(payload) == 0 and allow_zero:
+    payload: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        page_payload = github_request_json(
+            api_root,
+            token,
+            f"/repos/{owner}/{repo}/pulls",
+            {
+                "state": "closed",
+                "sort": "updated",
+                "direction": "desc",
+                "per_page": 100,
+                "page": page,
+            },
+        )
+        if not isinstance(page_payload, list):
+            raise SnapshotError("GitHub API returned an unexpected payload for merged pull requests")
+        payload.extend(item for item in page_payload if isinstance(item, dict))
+        if len(page_payload) < 100:
+            break
+        page += 1
+
+    merged_payload = [pr for pr in payload if pr.get("merged_at") and pr.get("merge_commit_sha") == target_sha]
+    if len(merged_payload) == 0 and allow_zero:
         return None
-    if len(payload) != 1:
-        raise SnapshotError(f"Expected exactly 1 PR associated with commit {target_sha}, got {len(payload)}")
-    pr_summary = payload[0]
+    if len(merged_payload) != 1:
+        raise SnapshotError(f"Expected exactly 1 merged PR associated with commit {target_sha}, got {len(merged_payload)}")
+    pr_summary = merged_payload[0]
     if not isinstance(pr_summary, dict):
         raise SnapshotError("GitHub API returned a malformed PR payload")
     pr_number = pr_summary.get("number")
     if not isinstance(pr_number, int):
-        raise SnapshotError("Commit-associated PR payload is missing a numeric PR number")
+        raise SnapshotError("Merged PR payload is missing a numeric PR number")
     pr = github_request_json(api_root, token, f"/repos/{owner}/{repo}/pulls/{pr_number}")
     if not isinstance(pr, dict):
         raise SnapshotError("GitHub API returned a malformed pull request payload")
@@ -468,13 +495,14 @@ def build_snapshot(
     notes_ref: str,
     registry: str,
     api_root: str,
+    snapshot_source: str = "ci-main",
     pr: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if pr is None:
         pr = load_pr_for_commit(api_root, repository, token, target_sha)
     if pr is None:
         raise SnapshotError(f"Commit {target_sha} is not associated with a merged pull request")
-    type_label, channel_label, snapshot_source, pr_head_sha = resolve_release_intent_for_pr(pr)
+    type_label, channel_label, _, pr_head_sha = resolve_release_intent_for_pr(pr)
     release_bump = type_label.split(":", 1)[1]
     release_channel = channel_label.split(":", 1)[1]
     image_name_lower = repository.lower()
@@ -673,6 +701,7 @@ def ensure_snapshot(args: argparse.Namespace) -> int:
                     notes_ref=args.notes_ref,
                     registry=args.registry,
                     api_root=args.api_root,
+                    snapshot_source=getattr(args, "snapshot_source", "ci-main"),
                     pr=pr,
                 )
                 write_json(temp_note, snapshot)

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -44,7 +44,7 @@ grep -q "implementation_profile='final' does not match workflow profile 'bootstr
 baseline_repo="$tmp_dir/baseline-repo"
 copy_repo_snapshot "$repo_root" "$baseline_repo"
 cp "$fixtures_root/quality-gates.json" "$baseline_repo/.github/quality-gates.json"
-for workflow in ci-pr.yml ci-main.yml release.yml label-gate.yml review-policy.yml; do
+for workflow in ci-pr.yml ci-main.yml release.yml release-snapshot-pr.yml label-gate.yml review-policy.yml; do
   cp "$fixtures_root/$workflow" "$baseline_repo/.github/workflows/$workflow"
 done
 
@@ -53,7 +53,7 @@ bash "$repo_root/.github/scripts/test-inline-metadata-workflows.sh"
 
 simplified_topology_repo="$tmp_dir/simplified-topology-repo"
 copy_repo_snapshot "$baseline_repo" "$simplified_topology_repo"
-for workflow in ci-main.yml release.yml label-gate.yml; do
+for workflow in ci-main.yml release.yml release-snapshot-pr.yml label-gate.yml; do
   cp "$fixtures_root/simplified/$workflow" "$simplified_topology_repo/.github/workflows/$workflow"
 done
 

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -81,6 +81,107 @@ finally:
     module.time.sleep = original_sleep
 
 
+original_github_request_json = module.github_request_json
+try:
+    calls: list[tuple[str, tuple[tuple[str, object], ...] | None]] = []
+
+    def fake_github_request_json(api_root, token, path, query=None, *, max_attempts=4):
+        calls.append((path, tuple(sorted((query or {}).items())) if query else None))
+        if "/commits/" in path:
+            raise AssertionError(f"unexpected commit-associated PR lookup: {path}")
+        if path.endswith("/pulls"):
+            return [
+                {
+                    "number": 699,
+                    "title": "Closed but unmerged",
+                    "merged_at": None,
+                    "merge_commit_sha": "f" * 40,
+                    "head": {"sha": "1" * 40},
+                    "labels": [{"name": "type:patch"}, {"name": "channel:stable"}],
+                },
+                {
+                    "number": 700,
+                    "title": "Merged via squash",
+                    "merged_at": "2026-03-15T00:00:00Z",
+                    "merge_commit_sha": "a" * 40,
+                    "head": {"sha": "2" * 40},
+                    "labels": [{"name": "type:minor"}, {"name": "channel:stable"}],
+                },
+                {
+                    "number": 701,
+                    "title": "Different merged PR",
+                    "merged_at": "2026-03-15T00:00:00Z",
+                    "merge_commit_sha": "b" * 40,
+                    "head": {"sha": "3" * 40},
+                    "labels": [{"name": "type:patch"}, {"name": "channel:rc"}],
+                },
+            ]
+        if path.endswith("/pulls/700"):
+            return {
+                "number": 700,
+                "title": "Merged via squash",
+                "head": {"sha": "2" * 40},
+                "labels": [{"name": "type:minor"}, {"name": "channel:stable"}],
+            }
+        raise AssertionError(f"unexpected GitHub API path: {path}")
+
+    module.github_request_json = fake_github_request_json
+    merged_pr = module.load_pr_for_commit(
+        "https://api.github.test",
+        "IvanLi-CN/codex-vibe-monitor",
+        "token",
+        "a" * 40,
+    )
+    assert merged_pr is not None
+    assert merged_pr["number"] == 700
+    assert module.load_pr_for_commit(
+        "https://api.github.test",
+        "IvanLi-CN/codex-vibe-monitor",
+        "token",
+        "c" * 40,
+        allow_zero=True,
+    ) is None
+    assert all("/commits/" not in path for path, _ in calls)
+finally:
+    module.github_request_json = original_github_request_json
+
+
+with tempfile.TemporaryDirectory(prefix="release-snapshot-merged-pr-") as tmp:
+    repo = Path(tmp)
+    run("init", cwd=repo)
+    run("config", "user.name", "Test User", cwd=repo)
+    run("config", "user.email", "test@example.com", cwd=repo)
+    run("checkout", "-b", "main", cwd=repo)
+    (repo / "Cargo.toml").write_text('[package]\nname = "demo"\nversion = "0.1.0"\n')
+    (repo / "README.md").write_text("base\n")
+    run("add", "Cargo.toml", "README.md", cwd=repo)
+    run("commit", "-m", "base", cwd=repo)
+
+    original_cwd = Path.cwd()
+    original_loader = module.load_pr_for_commit
+    try:
+        os.chdir(repo)
+        module.load_pr_for_commit = lambda api_root, repository, token, target_sha, **kwargs: make_pr(
+            702, "Merged PR", target_sha, ["type:patch", "channel:stable"]
+        )
+        snapshot = module.build_snapshot(
+            target_sha=run("rev-parse", "HEAD", cwd=repo),
+            repository="IvanLi-CN/codex-vibe-monitor",
+            token="token",
+            notes_ref=module.DEFAULT_NOTES_REF,
+            registry="ghcr.io",
+            api_root="https://api.github.com",
+            pr=make_pr(702, "Merged PR", "4" * 40, ["type:patch", "channel:stable"]),
+            snapshot_source="merged-pr",
+        )
+        assert snapshot["snapshot_source"] == "merged-pr"
+        assert snapshot["pr_number"] == 702
+        assert snapshot["release_enabled"] is True
+    finally:
+        module.load_pr_for_commit = original_loader
+        os.chdir(original_cwd)
+
+
 with tempfile.TemporaryDirectory(prefix="release-snapshot-") as tmp:
     repo = Path(tmp)
     run("init", cwd=repo)

--- a/.github/workflows/release-snapshot-pr.yml
+++ b/.github/workflows/release-snapshot-pr.yml
@@ -1,0 +1,54 @@
+name: Release Snapshot PR
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+concurrency:
+  group: release-snapshot-pr-${{ github.event.pull_request.merge_commit_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+env:
+  REGISTRY: ghcr.io
+  RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
+
+jobs:
+  freeze-release-snapshot:
+    name: Freeze merged PR release snapshot
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Freeze immutable release snapshot
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${{ github.event.pull_request.merge_commit_sha }}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --snapshot-source merged-pr \
+            --target-only \
+            --output "$RUNNER_TEMP/release-snapshot.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
             --github-token "${GITHUB_TOKEN}" \
             --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
             --registry "${REGISTRY}" \
+            --snapshot-source manual-backfill \
             --target-only \
             --skip-publish \
             --output "$RUNNER_TEMP/release-snapshot.json"

--- a/docs/archive/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md
+++ b/docs/archive/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md
@@ -48,8 +48,8 @@
 - PR 侧 required checks 继续保持 `Validate PR labels`、`Lint & Format Check`、`Backend Tests`、`Build Artifacts`、`Review Policy Gate`。
 - `CI PR` 对同一 PR 必须保持可抢占；`CI Main` 与 `Release` 对运行中的 main/release run 必须保持非抢占，并使用固定并发组做全局串行。
 - `Label Gate` 必须在 trusted base 上校验 merged PR 进入主线前的 `type:*` / `channel:*` 标签合法性，但不再负责冻结或传递发布意图元数据。
-- `CI Main` 必须为 mainline 上尚未持久化的 merged commits 写入 immutable release snapshot，冻结当前 PR labels、版本分配与镜像/tag 元数据；后续成功的 `CI Main` run 必须能够 catch up 之前因 pending 替换而漏掉的 commits。
-- `CI Main` 写 snapshot 时，自动发布路径必须直接读取 merged commit 关联 PR 的当前 labels；不得依赖 artifact、timeline label 回放或历史 rollout 分支。
+- `CI Main` 必须为 mainline 上尚未持久化的 merged commits 写入 immutable release snapshot；merged PR 关闭事件也必须在 `merge_commit_sha` 上冻结同一份 snapshot，冻结当前 PR labels、版本分配与镜像/tag 元数据；后续成功的 `CI Main` run 必须能够 catch up 之前因 pending 替换而漏掉的 commits。
+- `CI Main` 写 snapshot 时，自动发布路径必须优先读取已冻结的 immutable snapshot；历史兼容补齐只允许按 `merge_commit_sha` 做受控补查，不得再依赖 `commits/{sha}/pulls` 或其它 commit 反查 PR 行为。
 - `Release` 必须同时支持 `workflow_run(CI Main success)` 与 `workflow_dispatch(commit_sha)` 两种入口，并复用同一套 publish 逻辑；自动入口每次只发布 mainline 上最早一个尚未发布的 snapshot，成功后继续串行排下一个；自动与手动入口都只能消费 immutable release snapshot，禁止重新读取 PR labels 或重算版本。
 - 当 `workflow_run` 入口收到非成功的 `CI Main` 结论时，`Release` 必须 fail closed 并显式失败，不能让整条发布 run 以 silent `skipped` 结束。
 - `CI PR` 必须允许同仓库 PR 修改 quality-gates contract 包时使用当前分支 contract 校验当前分支拓扑；fork PR 与普通 PR 继续使用 base trusted source。
@@ -111,7 +111,7 @@
 
 - PR 路径只保留 PR/merge_group 相关 job；release job 从 PR workflow 中完全拆出。
 - `CI Main` 复用现有 lint/test/build 逻辑，但不再承担发布；发布只由 `Release` workflow 负责。
-- `CI Main` 通过 git notes 写入 immutable release snapshot，把 PR labels、版本分配与镜像/tag 元数据冻结到 merge commit。
+- `CI Main` 通过 git notes 写入 immutable release snapshot，把 PR labels、版本分配与镜像/tag 元数据冻结到 merge commit；`pull_request_target.closed && merged == true` 额外负责在合并瞬间冻结同一份 snapshot，避免 squash merge 失去 PR 关联。
 - `Label Gate` 在 trusted source 上校验标签；`CI Main` 再把当前 PR labels 提升为 immutable git-notes snapshot。
 - `Release` 通过统一的 target SHA 解析层兼容自动与手动入口，但只加载 snapshot 并复用现有 smoke / manifest / tag / GitHub Release 步骤。
 - `Release` 在发布元数据解析前先用 `CI Main Gate` 捕获非成功上游结论；成功上游或手动 backfill 不受该 gate 阻断。
@@ -124,6 +124,7 @@
 - 风险：若上游失败只让 `release-meta` 条件跳过，GitHub 会把整条 `Release` 记成 `skipped`，现有失败通知不会触发。
 - 风险：`workflow_dispatch` backfill 若未验证 SHA 所属分支，可能误对非 main commit 执行发布。
 - 风险：若合并后有人手改 release labels，后续手动 backfill 会跟随漂移，因此必须把“merge 后不得改 release labels”写成仓库操作规约。
+- 风险：如果 merged PR 冻结入口和 CI Main 回填入口对同一 `merge_commit_sha` 重复写 note，必须依赖幂等 git notes 处理和重试，而不能靠 commit→PR 关联来兜底。
 - 假设：仓库权限允许 `workflow_run` 触发 release 并继续推 tag / 建 GitHub Release。
 
 ## 变更记录（Change log）
@@ -132,6 +133,7 @@
 - 2026-03-14: 完成 workflow split、final quality-gates contract、release backfill 入口与本地 contract/self-tests。
 - 2026-03-15: 将发布链路进一步收敛为“PR 标签校验 → 全局串行 `CI Main` 写/补 snapshot → 全局串行 `Release` 按最早未发布 snapshot 排队发布”，删除 artifact、rollout 与 legacy fallback 复杂度。
 - 2026-04-29: 增加 `CI Main Gate`，把上游 `CI Main` 非成功结论从 silent skipped 转为显式 failed release；同时允许同仓库 quality-gates contract PR 使用当前分支 contract 自证更新后的拓扑。
+- 2026-05-07: 新增 `Release Snapshot PR` 冻结入口，以 `pull_request_target.closed` 在 `merge_commit_sha` 上先行冻结 immutable snapshot，彻底移除对 `/commits/{sha}/pulls` 的主路径依赖，兼容 squash merge。
 
 ## 参考（References）
 

--- a/docs/archive/specs/sq8gw-release-pr-version-comment/SPEC.md
+++ b/docs/archive/specs/sq8gw-release-pr-version-comment/SPEC.md
@@ -44,7 +44,7 @@
 ### MUST
 
 - 仅在 `release_enabled == true` 的发布路径上执行 PR 评论。
-- 评论必须基于 `release-meta` 已冻结的输出（`pr_number`、`release_tag`、`app_effective_version`、`target_sha`），不得重新推导版本。
+- 评论必须基于 `release-meta` 从 immutable release snapshot 导出的输出（`pr_number`、`release_tag`、`app_effective_version`、`target_sha`），不得重新推导版本或重新查询 PR 标签。
 - 评论必须带固定 marker，便于后续 rerun / backfill 更新同一条评论。
 - 若目标 PR 不存在、`pr_number` 为空或评论 API 调用失败，workflow 应记录 notice / warning，但不能破坏已完成的发布结果或阻断后续 release queue。
 - `release-publish` 必须显式声明完成评论所需的最小权限。
@@ -84,7 +84,7 @@
 ## 风险 / 假设（Risks / Assumptions）
 
 - 风险：GitHub comments API 短暂失败时，PR 版本评论可能缺席；本次选择 best-effort，不让评论失败回滚已完成发布。
-- 假设：发布 commit 总能关联到唯一 merged PR，且 `release-meta.outputs.pr_number` 可用。
+- 假设：发布 commit 的 PR 身份来自以 `merge_commit_sha` 为键冻结的 immutable release snapshot；即使 squash merge 后 GitHub commit 反查 PR 为空，`release-meta.outputs.pr_number` 仍由 snapshot 提供。
 
 ## 参考（References）
 


### PR DESCRIPTION
## Summary
- Add a merged-PR release snapshot workflow that freezes immutable snapshots on `pull_request_target.closed` when the PR is merged.
- Resolve snapshot PR metadata by exact `merge_commit_sha` instead of the commit-associated PR endpoint.
- Update release snapshot tests, quality-gates fixtures, contract checks, and release docs for squash merge compatibility.

## Validation
- `python3 -m py_compile .github/scripts/release_snapshot.py .github/scripts/check_quality_gates_contract.py`
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
- `bash .github/scripts/test-quality-gates-contract.sh`

## References
- Spec: `docs/archive/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md`
- Spec: `docs/archive/specs/sq8gw-release-pr-version-comment/SPEC.md`
- Spec Disposition: update
- Solutions: -
- Project Docs: -
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: n/a(no solution change)
- Project Docs Sync: n/a(no project-doc change)