### PR TITLE
fix(web): remember account pool group selection

### DIFF
--- a/web/src/components/AccountTagField.test.tsx
+++ b/web/src/components/AccountTagField.test.tsx
@@ -153,6 +153,7 @@ function createDetail(summary: TagSummary): TagDetail {
 function createHarness(options?: {
   initialSelectedTagIds?: number[]
   pageCreatedTagIds?: number[]
+  hideLabel?: boolean
   onChangeSpy?: (tagIds: number[]) => void
   onCreateTagSpy?: (payload: CreateTagPayload) => void
   onUpdateTagSpy?: (tagId: number, payload: UpdateTagPayload) => void
@@ -161,6 +162,7 @@ function createHarness(options?: {
   const {
     initialSelectedTagIds = [],
     pageCreatedTagIds = [],
+    hideLabel = false,
     onChangeSpy,
     onCreateTagSpy,
     onUpdateTagSpy,
@@ -229,6 +231,7 @@ function createHarness(options?: {
         selectedTagIds={selectedTagIds}
         writesEnabled
         pageCreatedTagIds={pageCreatedTagIds}
+        hideLabel={hideLabel}
         labels={labels}
         onChange={onChange}
         onCreateTag={onCreateTag}
@@ -240,6 +243,19 @@ function createHarness(options?: {
 }
 
 describe('AccountTagField', () => {
+  it('can hide the visible label while keeping an accessible label', () => {
+    const Harness = createHarness({ hideLabel: true })
+    render(<Harness />)
+
+    const label = Array.from(document.body.querySelectorAll('.field-label')).find(
+      (node) => node.textContent === 'Tags',
+    )
+
+    expect(label).toBeTruthy()
+    expect(label?.classList.contains('sr-only')).toBe(true)
+    expect(document.querySelector('button[aria-label="Add tag"]')).toBeTruthy()
+  })
+
   it('renders empty state inline and keeps the popover open while toggling multiple tags', () => {
     const onChangeSpy = vi.fn()
     const Harness = createHarness({ onChangeSpy })

--- a/web/src/components/AccountTagField.tsx
+++ b/web/src/components/AccountTagField.tsx
@@ -53,6 +53,7 @@ interface AccountTagFieldProps {
   selectedTagIds: number[]
   writesEnabled: boolean
   pageCreatedTagIds?: number[]
+  hideLabel?: boolean
   labels: AccountTagFieldLabels
   onChange: (tagIds: number[]) => void
   onCreateTag: (payload: CreateTagPayload) => Promise<TagDetail>
@@ -65,6 +66,7 @@ export function AccountTagField({
   selectedTagIds,
   writesEnabled,
   pageCreatedTagIds = [],
+  hideLabel = false,
   labels,
   onChange,
   onCreateTag,
@@ -174,7 +176,7 @@ export function AccountTagField({
 
   return (
     <div className="field gap-3">
-      <span className="field-label">{labels.label}</span>
+      <span className={cn('field-label', hideLabel && 'sr-only')}>{labels.label}</span>
       <div
         className={cn(
           'flex min-h-12 items-center gap-2 rounded-[1.2rem] border border-base-300/80 bg-base-100/55 px-3 py-2 shadow-sm transition-colors',

--- a/web/src/components/UpstreamAccountCreatePage.batch-oauth.stories.tsx
+++ b/web/src/components/UpstreamAccountCreatePage.batch-oauth.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, userEvent, within } from 'storybook/test'
 import type { OauthMailboxSession } from '../lib/api'
+import { UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY } from '../lib/upstreamAccountGroups'
 import { createPendingSession } from './UpstreamAccountsPage.story-data'
 import {
   AccountPoolStoryRouter,
@@ -241,6 +242,29 @@ export const GenerateAutoCopyFallback: Story = {
         value: originalExecCommand,
       })
     }
+  },
+}
+
+export const RememberedGroupHeaderAlignment: Story = {
+  render: () => {
+    window.localStorage.setItem(
+      UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY,
+      JSON.stringify({
+        production: 1700000000000,
+        staging: 1700000005000,
+      }),
+    )
+    return <AccountPoolStoryRouter initialEntry="/account-pool/upstream-accounts/new?mode=batchOauth" />
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const defaultGroupTrigger = canvas.getAllByRole('combobox')[0]
+    await expect(defaultGroupTrigger).toHaveTextContent(/staging/i)
+    const tagLabel = Array.from(canvasElement.querySelectorAll('.field-label')).find(
+      (node) => node.textContent?.trim().toLowerCase() === 'tags',
+    )
+    await expect(tagLabel).toHaveClass('sr-only')
+    await expect(canvas.getByRole('button', { name: /添加 tag|add tag/i })).toBeInTheDocument()
   },
 }
 

--- a/web/src/lib/upstreamAccountGroups.test.ts
+++ b/web/src/lib/upstreamAccountGroups.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { buildGroupNameSuggestions, upsertGroupSummary } from './upstreamAccountGroups'
+import {
+  buildGroupNameSuggestions,
+  buildGroupOptions,
+  markUpstreamAccountGroupUsed,
+  readUpstreamAccountGroupUsage,
+  resolveMostRecentlyUsedGroupName,
+  upsertGroupSummary,
+  writeUpstreamAccountGroupUsage,
+} from './upstreamAccountGroups'
 
 describe('buildGroupNameSuggestions', () => {
   it('includes page draft group names alongside persisted groups and account names', () => {
@@ -14,6 +22,63 @@ describe('buildGroupNameSuggestions', () => {
         },
       ),
     ).toEqual(['draft-team', 'prod', 'shared'])
+  })
+})
+
+describe('buildGroupOptions', () => {
+  it('orders recently used groups first and keeps alphabetical fallback order', () => {
+    const options = buildGroupOptions(
+      ['alpha', 'gamma'],
+      [
+        { groupName: 'beta', accountCount: 2 },
+        { groupName: 'delta', accountCount: 1 },
+      ],
+      {},
+      {
+        beta: 20,
+        alpha: 30,
+      },
+    )
+
+    expect(options.map((option) => option.groupName)).toEqual([
+      'alpha',
+      'beta',
+      'delta',
+      'gamma',
+    ])
+  })
+
+  it('lets a newly selected draft group participate in recent-use ordering', () => {
+    const usage = markUpstreamAccountGroupUsed({ alpha: 10 }, ' draft-team ', 40)
+    const options = buildGroupOptions(['alpha'], [], { 'draft-team': '' }, usage)
+
+    expect(options.map((option) => option.groupName)).toEqual(['draft-team', 'alpha'])
+    expect(resolveMostRecentlyUsedGroupName(options, usage)).toBe('draft-team')
+  })
+})
+
+describe('local group usage storage', () => {
+  it('degrades when window.localStorage access is blocked', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        get localStorage() {
+          throw new Error('storage blocked')
+        },
+      },
+    })
+
+    try {
+      expect(readUpstreamAccountGroupUsage()).toEqual({})
+      expect(() => writeUpstreamAccountGroupUsage({ alpha: 10 })).not.toThrow()
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, 'window', descriptor)
+      } else {
+        Reflect.deleteProperty(globalThis, 'window')
+      }
+    }
   })
 })
 

--- a/web/src/lib/upstreamAccountGroups.ts
+++ b/web/src/lib/upstreamAccountGroups.ts
@@ -6,8 +6,84 @@ export interface UpstreamAccountGroupOption {
   isPersisted?: boolean
 }
 
+export type UpstreamAccountGroupUsageMap = Record<string, number>
+
+export const UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY =
+  'codex-vibe-monitor.account-pool.create.group-usage'
+
 export function normalizeGroupName(value?: string | null): string {
   return value?.trim() ?? ''
+}
+
+export function readUpstreamAccountGroupUsage(
+  storage?: Storage,
+): UpstreamAccountGroupUsageMap {
+  try {
+    const resolvedStorage =
+      storage ?? (typeof window === 'undefined' ? undefined : window.localStorage)
+    if (!resolvedStorage) return {}
+    const raw = resolvedStorage.getItem(UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const usage: UpstreamAccountGroupUsageMap = {}
+    for (const [groupName, usedAt] of Object.entries(parsed)) {
+      const normalized = normalizeGroupName(groupName)
+      if (!normalized || typeof usedAt !== 'number' || !Number.isFinite(usedAt)) continue
+      usage[normalized] = usedAt
+    }
+    return usage
+  } catch {
+    return {}
+  }
+}
+
+export function writeUpstreamAccountGroupUsage(
+  usage: UpstreamAccountGroupUsageMap,
+  storage?: Storage,
+) {
+  try {
+    const resolvedStorage =
+      storage ?? (typeof window === 'undefined' ? undefined : window.localStorage)
+    if (!resolvedStorage) return
+    resolvedStorage.setItem(UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY, JSON.stringify(usage))
+  } catch {
+    // Ignore storage quota/privacy failures; group memory is only a preference.
+  }
+}
+
+export function markUpstreamAccountGroupUsed(
+  usage: UpstreamAccountGroupUsageMap,
+  groupName?: string | null,
+  usedAt = Date.now(),
+): UpstreamAccountGroupUsageMap {
+  const normalized = normalizeGroupName(groupName)
+  if (!normalized) return usage
+  return {
+    ...usage,
+    [normalized]: usedAt,
+  }
+}
+
+export function resolveMostRecentlyUsedGroupName(
+  options: UpstreamAccountGroupOption[],
+  usage: UpstreamAccountGroupUsageMap,
+): string {
+  return options.reduce<{ groupName: string; usedAt: number }>(
+    (current, option) => {
+      const normalized = normalizeGroupName(option.groupName)
+      const usedAt = normalized ? usage[normalized] : undefined
+      if (typeof usedAt !== 'number' || !Number.isFinite(usedAt)) return current
+      if (!current.groupName || usedAt > current.usedAt) {
+        return { groupName: normalized, usedAt }
+      }
+      if (usedAt === current.usedAt && normalized.localeCompare(current.groupName) < 0) {
+        return { groupName: normalized, usedAt }
+      }
+      return current
+    },
+    { groupName: '', usedAt: Number.NEGATIVE_INFINITY },
+  ).groupName
 }
 
 export function buildGroupNoteMap(groups: UpstreamAccountGroupSummary[]): Map<string, string> {
@@ -40,6 +116,7 @@ export function buildGroupOptions(
   names: Array<string | null | undefined>,
   groups: UpstreamAccountGroupSummary[],
   drafts: Record<string, string>,
+  usage: UpstreamAccountGroupUsageMap = {},
 ): UpstreamAccountGroupOption[] {
   const values = new Set<string>()
   const options = new Map<string, UpstreamAccountGroupOption>()
@@ -76,7 +153,19 @@ export function buildGroupOptions(
   }
 
   return Array.from(values)
-    .sort((left, right) => left.localeCompare(right))
+    .sort((left, right) => {
+      const leftUsedAt = usage[left]
+      const rightUsedAt = usage[right]
+      const leftHasUsage = typeof leftUsedAt === 'number' && Number.isFinite(leftUsedAt)
+      const rightHasUsage = typeof rightUsedAt === 'number' && Number.isFinite(rightUsedAt)
+      if (leftHasUsage && rightHasUsage && leftUsedAt !== rightUsedAt) {
+        return rightUsedAt - leftUsedAt
+      }
+      if (leftHasUsage !== rightHasUsage) {
+        return leftHasUsage ? -1 : 1
+      }
+      return left.localeCompare(right)
+    })
     .map((groupName) => options.get(groupName) ?? {
       groupName,
       accountCount: 0,

--- a/web/src/pages/account-pool/UpstreamAccountCreate.page-impl.tsx
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.page-impl.tsx
@@ -21,7 +21,11 @@ import { apiConcurrencyLimitToSliderValue } from "../../lib/concurrencyLimit";
 import {
   buildGroupOptions,
   isExistingGroup,
+  markUpstreamAccountGroupUsed,
   normalizeGroupName,
+  readUpstreamAccountGroupUsage,
+  resolveMostRecentlyUsedGroupName,
+  writeUpstreamAccountGroupUsage,
 } from "../../lib/upstreamAccountGroups";
 import { validateUpstreamBaseUrl } from "../../lib/upstreamBaseUrl";
 import { applyMotherUpdateToItems } from "../../lib/upstreamMother";
@@ -332,6 +336,9 @@ export default function UpstreamAccountCreatePage() {
   const importValidationEventCleanupRef = useRef<(() => void) | null>(null);
   const importValidationJobIdRef = useRef<string | null>(null);
   const [pageCreatedTagIds, setPageCreatedTagIds] = useState<number[]>([]);
+  const [groupUsage, setGroupUsage] = useState(() =>
+    readUpstreamAccountGroupUsage(),
+  );
   const previousBatchTagIdsRef = useRef<number[] | null>(null);
   const previousCompletedSharedTagBaselineRef = useRef<string | null>(null);
   const [batchRows, setBatchRows] = useState<BatchOauthRow[]>(
@@ -562,8 +569,10 @@ export default function UpstreamAccountCreatePage() {
           ),
           ...groupDraftNotes,
         },
+        groupUsage,
       ),
     [
+      groupUsage,
       groupDraftBoundProxyKeys,
       groupDraftConcurrencyLimits,
       groupDraftNodeShuntEnabled,
@@ -574,6 +583,49 @@ export default function UpstreamAccountCreatePage() {
       items,
     ],
   );
+  const markGroupUsed = useCallback((groupName?: string | null) => {
+    const normalized = normalizeGroupName(groupName);
+    if (!normalized) return;
+    setGroupUsage((current) => {
+      const next = markUpstreamAccountGroupUsed(current, normalized);
+      writeUpstreamAccountGroupUsage(next);
+      return next;
+    });
+  }, []);
+  const rememberedBatchDefaultGroupAppliedRef = useRef(false);
+  useEffect(() => {
+    if (rememberedBatchDefaultGroupAppliedRef.current) return;
+    if (draft?.batchOauth?.defaultGroupName) {
+      rememberedBatchDefaultGroupAppliedRef.current = true;
+      return;
+    }
+    if (batchDefaultGroupName.trim()) {
+      rememberedBatchDefaultGroupAppliedRef.current = true;
+      return;
+    }
+    const rememberedGroupName = resolveMostRecentlyUsedGroupName(
+      groupOptions,
+      groupUsage,
+    );
+    if (!rememberedGroupName) return;
+    rememberedBatchDefaultGroupAppliedRef.current = true;
+    setBatchDefaultGroupName(rememberedGroupName);
+    setBatchRows((current) =>
+      current.map((row) =>
+        row.inheritsDefaultGroup
+          ? {
+              ...row,
+              groupName: rememberedGroupName,
+            }
+          : row,
+      ),
+    );
+  }, [
+    batchDefaultGroupName,
+    draft?.batchOauth?.defaultGroupName,
+    groupOptions,
+    groupUsage,
+  ]);
   const formatGroupAccountCountLabel = useCallback(
     (count: number) =>
       t("accountPool.upstreamAccounts.groupOptionCount", { count }),
@@ -1804,47 +1856,101 @@ export default function UpstreamAccountCreatePage() {
   const handleOauthGroupCreateRequest = useCallback(
     (groupName: string) => {
       openGroupNoteEditor(groupName, {
-        onSaved: (savedGroupName) => setOauthGroupName(savedGroupName),
+        onSaved: (savedGroupName) => {
+          setOauthGroupName(savedGroupName);
+          markGroupUsed(savedGroupName);
+        },
       });
     },
-    [openGroupNoteEditor],
+    [markGroupUsed, openGroupNoteEditor],
   );
 
   const handleImportGroupCreateRequest = useCallback(
     (groupName: string) => {
       openGroupNoteEditor(groupName, {
-        onSaved: (savedGroupName) => setImportGroupName(savedGroupName),
+        onSaved: (savedGroupName) => {
+          setImportGroupName(savedGroupName);
+          markGroupUsed(savedGroupName);
+        },
       });
     },
-    [openGroupNoteEditor],
+    [markGroupUsed, openGroupNoteEditor],
   );
 
   const handleApiKeyGroupCreateRequest = useCallback(
     (groupName: string) => {
       openGroupNoteEditor(groupName, {
-        onSaved: (savedGroupName) => setApiKeyGroupName(savedGroupName),
+        onSaved: (savedGroupName) => {
+          setApiKeyGroupName(savedGroupName);
+          markGroupUsed(savedGroupName);
+        },
       });
     },
-    [openGroupNoteEditor],
+    [markGroupUsed, openGroupNoteEditor],
   );
 
   const handleBatchDefaultGroupCreateRequest = useCallback(
     (groupName: string) => {
       openGroupNoteEditor(groupName, {
-        onSaved: (savedGroupName) => handleBatchDefaultGroupChange(savedGroupName),
+        onSaved: (savedGroupName) => {
+          handleBatchDefaultGroupChange(savedGroupName);
+          markGroupUsed(savedGroupName);
+        },
       });
     },
-    [handleBatchDefaultGroupChange, openGroupNoteEditor],
+    [handleBatchDefaultGroupChange, markGroupUsed, openGroupNoteEditor],
   );
 
   const handleBatchRowGroupCreateRequest = useCallback(
     (rowId: string, groupName: string) => {
       openGroupNoteEditor(groupName, {
-        onSaved: (savedGroupName) =>
-          handleBatchGroupValueChange(rowId, savedGroupName),
+        onSaved: (savedGroupName) => {
+          handleBatchGroupValueChange(rowId, savedGroupName);
+          markGroupUsed(savedGroupName);
+        },
       });
     },
-    [handleBatchGroupValueChange, openGroupNoteEditor],
+    [handleBatchGroupValueChange, markGroupUsed, openGroupNoteEditor],
+  );
+
+  const handleRememberingBatchDefaultGroupChange = useCallback(
+    (value: string) => {
+      handleBatchDefaultGroupChange(value);
+      markGroupUsed(value);
+    },
+    [handleBatchDefaultGroupChange, markGroupUsed],
+  );
+
+  const handleRememberingBatchGroupValueChange = useCallback(
+    (rowId: string, value: string) => {
+      handleBatchGroupValueChange(rowId, value);
+      markGroupUsed(value);
+    },
+    [handleBatchGroupValueChange, markGroupUsed],
+  );
+
+  const setRememberingOauthGroupName = useCallback(
+    (value: string) => {
+      setOauthGroupName(value);
+      markGroupUsed(value);
+    },
+    [markGroupUsed],
+  );
+
+  const setRememberingImportGroupName = useCallback(
+    (value: string) => {
+      setImportGroupName(value);
+      markGroupUsed(value);
+    },
+    [markGroupUsed],
+  );
+
+  const setRememberingApiKeyGroupName = useCallback(
+    (value: string) => {
+      setApiKeyGroupName(value);
+      markGroupUsed(value);
+    },
+    [markGroupUsed],
   );
 
 
@@ -2146,11 +2252,11 @@ export default function UpstreamAccountCreatePage() {
     handleBatchCopyMailboxCode,
     handleBatchCopyOauthUrl,
     handleBatchDefaultGroupCreateRequest,
-    handleBatchDefaultGroupChange,
+    handleBatchDefaultGroupChange: handleRememberingBatchDefaultGroupChange,
     handleBatchGenerateMailbox,
     handleBatchGenerateOauthUrl,
     handleBatchRowGroupCreateRequest,
-    handleBatchGroupValueChange,
+    handleBatchGroupValueChange: handleRememberingBatchGroupValueChange,
     handleBatchMailboxEditorValueChange,
     handleBatchMailboxFetch,
     handleBatchMetadataChange,
@@ -2253,7 +2359,7 @@ export default function UpstreamAccountCreatePage() {
     setActionError,
     setApiKeyDisplayName,
     setApiKeyEmail,
-    setApiKeyGroupName,
+    setApiKeyGroupName: setRememberingApiKeyGroupName,
     setApiKeyIsMother,
     setApiKeyLimitUnit,
     setApiKeyNote,
@@ -2269,7 +2375,7 @@ export default function UpstreamAccountCreatePage() {
     setDuplicateDetailOpen,
     setGroupNoteEditor,
     setGroupNoteError,
-    setImportGroupName,
+    setImportGroupName: setRememberingImportGroupName,
     setImportPasteDraft,
     setImportPasteDraftSerial,
     setImportPasteError,
@@ -2281,7 +2387,7 @@ export default function UpstreamAccountCreatePage() {
     setOauthDisplayName,
     setOauthEmail,
     setOauthEmailResolution,
-    setOauthGroupName,
+    setOauthGroupName: setRememberingOauthGroupName,
     setOauthIsMother,
     setOauthMailboxInput,
     setOauthNote,

--- a/web/src/pages/account-pool/UpstreamAccountCreate.primary-card.tsx
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.primary-card.tsx
@@ -144,6 +144,7 @@ export function UpstreamAccountCreatePrimaryCard() {
                   selectedTagIds={batchTagIds}
                   writesEnabled={writesEnabled && !hasBatchMetadataBusy}
                   pageCreatedTagIds={pageCreatedTagIds}
+                  hideLabel
                   labels={tagFieldLabels}
                   onChange={(nextTagIds) => {
                     batchSharedTagSyncEnabledRef.current = true;

--- a/web/src/pages/account-pool/UpstreamAccountCreate.test.tsx
+++ b/web/src/pages/account-pool/UpstreamAccountCreate.test.tsx
@@ -30,6 +30,7 @@ import type {
   ImportedOauthValidationRow,
   LoginSessionStatusResponse,
 } from "../../lib/api";
+import { UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY } from "../../lib/upstreamAccountGroups";
 import UpstreamAccountCreatePage from "./UpstreamAccountCreate";
 
 const navigateMock = vi.hoisted(() => vi.fn());
@@ -390,25 +391,28 @@ function rerender(
     search: normalizedEntry.search,
     state: {
       ...baseState,
-      draft: {
-        ...baseDraft,
-        oauth: {
-          groupName: TEST_REQUIRED_GROUP_NAME,
-          ...oauthDraft,
-        },
-        batchOauth: {
-          defaultGroupName: TEST_REQUIRED_GROUP_NAME,
-          ...batchOauthDraft,
-        },
-        import: {
-          defaultGroupName: TEST_REQUIRED_GROUP_NAME,
-          ...importDraft,
-        },
-        apiKey: {
-          groupName: TEST_REQUIRED_GROUP_NAME,
-          ...apiKeyDraft,
-        },
-      },
+      draft:
+        baseState.__skipDefaultDraft === true
+          ? baseState.draft
+          : {
+              ...baseDraft,
+              oauth: {
+                groupName: TEST_REQUIRED_GROUP_NAME,
+                ...oauthDraft,
+              },
+              batchOauth: {
+                defaultGroupName: TEST_REQUIRED_GROUP_NAME,
+                ...batchOauthDraft,
+              },
+              import: {
+                defaultGroupName: TEST_REQUIRED_GROUP_NAME,
+                ...importDraft,
+              },
+              apiKey: {
+                groupName: TEST_REQUIRED_GROUP_NAME,
+                ...apiKeyDraft,
+              },
+            },
     },
   } satisfies RenderEntry;
   act(() => {
@@ -1129,6 +1133,99 @@ function clickGroupSettingsButtonForInput(selector: string) {
   });
   return button;
 }
+
+describe("UpstreamAccountCreatePage group memory", () => {
+  it("uses the latest remembered group for batch OAuth when no draft overrides it", async () => {
+    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+      if (key === "codex-vibe-monitor.locale") return "en";
+      if (key === UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY) {
+        return JSON.stringify({ alpha: 100, beta: 300 });
+      }
+      return null;
+    });
+    mockUpstreamAccounts();
+
+    render({
+      pathname: "/account-pool/upstream-accounts/new",
+      search: "?mode=batchOauth",
+      state: { __skipDefaultDraft: true },
+    });
+    await flushAsync();
+
+    expect(readHiddenInputValue('[name="batchOauthDefaultGroupName"]')).toBe("beta");
+    expect(readHiddenInputValue('[name^="batchOauthGroupName-"]')).toBe("beta");
+  });
+
+  it("keeps a restored draft group ahead of remembered local preference", async () => {
+    vi.mocked(window.localStorage.getItem).mockImplementation((key: string) => {
+      if (key === "codex-vibe-monitor.locale") return "en";
+      if (key === UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY) {
+        return JSON.stringify({ beta: 300 });
+      }
+      return null;
+    });
+    mockUpstreamAccounts();
+
+    render({
+      pathname: "/account-pool/upstream-accounts/new",
+      search: "?mode=batchOauth",
+      state: {
+        __skipDefaultDraft: true,
+        draft: {
+          batchOauth: {
+            defaultGroupName: "alpha",
+            rows: [
+              {
+                id: "row-1",
+                groupName: "alpha",
+                inheritsDefaultGroup: true,
+              },
+            ],
+          },
+        },
+      },
+    });
+    await flushAsync();
+
+    expect(readHiddenInputValue('[name="batchOauthDefaultGroupName"]')).toBe("alpha");
+    expect(readHiddenInputValue('[name^="batchOauthGroupName-"]')).toBe("alpha");
+  });
+
+  it("stores the selected batch default group as the latest local preference", async () => {
+    mockUpstreamAccounts();
+
+    render({
+      pathname: "/account-pool/upstream-accounts/new",
+      search: "?mode=batchOauth",
+      state: { __skipDefaultDraft: true },
+    });
+    await flushAsync();
+
+    const defaultGroupTrigger = Array.from(
+      document.body.querySelectorAll('button[role="combobox"]'),
+    )[0] as HTMLButtonElement;
+    act(() => {
+      defaultGroupTrigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushAsync();
+
+    const betaOption = Array.from(document.body.querySelectorAll("[cmdk-item]")).find(
+      (candidate) => candidate.textContent?.includes("beta"),
+    );
+    if (!(betaOption instanceof HTMLElement)) {
+      throw new Error("missing beta group option");
+    }
+    act(() => {
+      betaOption.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushAsync();
+
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      UPSTREAM_ACCOUNT_CREATE_GROUP_USAGE_STORAGE_KEY,
+      expect.stringContaining('"beta"'),
+    );
+  });
+});
 
 describe("UpstreamAccountCreatePage group deletion", () => {
   it("clears selected group fields after deleting the active saved group", async () => {


### PR DESCRIPTION
## Summary
- Remember the last selected account-pool group in browser localStorage and use it as the Batch OAuth default when no draft value exists.
- Sort create-page group options by local last-used time, falling back to alphabetical order.
- Hide the visible Batch OAuth tags label while preserving the accessible label.

## Verification
- `cd web && bun run test -- UpstreamAccountCreate.test.tsx AccountTagField.test.tsx upstreamAccountGroups.test.ts`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- Codex review proof: clear after fixing the localStorage access guard.

## References
- Specs: `docs/specs/quhzx-ui-guidelines-system/SPEC.md`
- Solutions: -
- Project Docs: -