### PR TITLE
feat(web): add dashboard chart pan and zoom

### DIFF
--- a/src/tests/slices/broadcast_runtime_and_harness.rs
+++ b/src/tests/slices/broadcast_runtime_and_harness.rs
@@ -2278,7 +2278,7 @@ async fn forward_proxy_timeseries_reads_pending_archived_node_health_without_mat
 
     let older_attempt_at = Utc
         .timestamp_opt(
-            align_bucket_epoch((Utc::now() - ChronoDuration::days(70)).timestamp(), 3600, 0)
+            align_bucket_epoch((Utc::now() - ChronoDuration::days(75)).timestamp(), 3600, 0)
                 + 5 * 60,
             0,
         )
@@ -2286,7 +2286,7 @@ async fn forward_proxy_timeseries_reads_pending_archived_node_health_without_mat
         .expect("older archived attempt timestamp should be valid");
     let newer_attempt_at = Utc
         .timestamp_opt(
-            align_bucket_epoch((Utc::now() - ChronoDuration::days(40)).timestamp(), 3600, 0)
+            align_bucket_epoch((Utc::now() - ChronoDuration::days(35)).timestamp(), 3600, 0)
                 + 10 * 60,
             0,
         )

--- a/web/src/components/DashboardTodayActivityChart.stories.tsx
+++ b/web/src/components/DashboardTodayActivityChart.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, waitFor, within } from "storybook/test";
 import { I18nProvider } from "../i18n";
 import type { TimeseriesResponse } from "../lib/api";
 import { DashboardTodayActivityChart } from "./DashboardTodayActivityChart";
@@ -232,6 +233,57 @@ export const CountBarsMinuteGranularityZoom: Story = {
       </div>
     </div>
   ),
+};
+
+export const CountBarsInteractiveViewport: Story = {
+  args: {
+    response: buildFullNaturalDayResponse(1.18),
+    loading: false,
+    error: null,
+    metric: "totalCount",
+    closedNaturalDay: true,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: "desktop1440",
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const chart = await canvas.findByTestId("dashboard-today-activity-chart");
+    const layer = await canvas.findByTestId(
+      "dashboard-today-activity-chart-interaction-layer",
+    );
+    const rect = layer.getBoundingClientRect();
+
+    layer.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        deltaY: -700,
+        clientX: rect.left + rect.width / 2,
+      }),
+    );
+
+    await expect(chart).toHaveAttribute("data-zoomed", "true");
+    const zoomedStart = Number(chart.getAttribute("data-visible-start-index"));
+
+    layer.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        deltaX: 320,
+        deltaY: 4,
+        clientX: rect.left + rect.width / 2,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(Number(chart.getAttribute("data-visible-start-index"))).toBeGreaterThan(
+        zoomedStart,
+      );
+    });
+  },
 };
 
 export const EmptyState: Story = {

--- a/web/src/components/DashboardTodayActivityChart.test.tsx
+++ b/web/src/components/DashboardTodayActivityChart.test.tsx
@@ -34,7 +34,12 @@ vi.mock("recharts", () => ({
     <div data-testid="responsive">{children}</div>
   ),
   CartesianGrid: () => <div data-testid="grid" />,
-  XAxis: () => <div data-testid="x-axis" />,
+  XAxis: ({ domain }: { domain?: [number, number] }) => (
+    <div
+      data-testid="x-axis"
+      data-domain={domain == null ? "" : domain.join(":")}
+    />
+  ),
   YAxis: () => <div data-testid="y-axis" />,
   Tooltip: ({
     content,
@@ -225,6 +230,99 @@ function render(ui: React.ReactNode) {
   root = createRoot(host);
   act(() => {
     root?.render(ui);
+  });
+}
+
+function rerender(ui: React.ReactNode) {
+  act(() => {
+    root?.render(ui);
+  });
+}
+
+function chartSection() {
+  const section = host?.querySelector(
+    '[data-testid="dashboard-today-activity-chart"]',
+  ) as HTMLElement | null;
+  if (!section) throw new Error("missing chart section");
+  return section;
+}
+
+function interactionLayer() {
+  const layer = host?.querySelector(
+    '[data-testid="dashboard-today-activity-chart-interaction-layer"]',
+  ) as HTMLElement | null;
+  if (!layer) throw new Error("missing chart interaction layer");
+  layer.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 1000,
+      bottom: 320,
+      left: 0,
+      width: 1000,
+      height: 320,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  layer.setPointerCapture = vi.fn();
+  layer.releasePointerCapture = vi.fn();
+  layer.hasPointerCapture = vi.fn(() => true);
+  return layer;
+}
+
+function dragLayer() {
+  const layer = host?.querySelector(
+    '[data-testid="dashboard-today-activity-chart-drag-layer"]',
+  ) as HTMLElement | null;
+  if (!layer) throw new Error("missing chart drag layer");
+  return layer;
+}
+
+function dispatchWheel(
+  element: HTMLElement,
+  init: WheelEventInit & { clientX?: number },
+) {
+  const event = new WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  if (init.clientX != null) {
+    Object.defineProperty(event, "clientX", {
+      configurable: true,
+      value: init.clientX,
+    });
+  }
+  act(() => {
+    element.dispatchEvent(event);
+  });
+  return event;
+}
+
+function dispatchPointer(
+  element: HTMLElement,
+  type: string,
+  init: MouseEventInit & { pointerId?: number },
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  Object.defineProperty(event, "pointerId", {
+    configurable: true,
+    value: init.pointerId ?? 1,
+  });
+  act(() => {
+    element.dispatchEvent(event);
+  });
+}
+
+async function flushAnimationFrame() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => resolve());
+    });
   });
 }
 
@@ -750,9 +848,363 @@ describe("DashboardTodayActivityChart", () => {
     expect(html).toContain('data-data-key="chartFailureCountNegative"');
     expect(html).toContain('data-bar-size="1"');
     expect(html).toContain('data-stack-id="positive"');
+    expect(html).toContain('data-domain="0:1439"');
     expect(html).not.toContain(
       'data-data-key="chartFailureCountNegative" data-stack-id="positive"',
     );
+  });
+
+  it("zooms horizontally around the wheel pointer and keeps the view clamped", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCount"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { ctrlKey: true, deltaY: -600, clientX: 500 });
+    await flushAnimationFrame();
+    const section = chartSection();
+
+    expect(section.dataset.zoomed).toBe("true");
+    expect(Number(section.dataset.visibleSpan)).toBeLessThan(1440);
+    expect(Number(section.dataset.visibleStartIndex)).toBeGreaterThan(0);
+    expect(Number(section.dataset.visibleEndIndex)).toBeLessThan(1439);
+    expect(Number(section.querySelector('[data-testid="bar-series"]')?.getAttribute("data-bar-size"))).toBeGreaterThan(1);
+    expect(latestChartData).toHaveLength(Number(section.dataset.visibleSpan));
+
+    dispatchWheel(layer, { ctrlKey: true, deltaY: -5000, clientX: 500 });
+    await flushAnimationFrame();
+    expect(Number(chartSection().dataset.visibleSpan)).toBe(30);
+
+    dispatchWheel(layer, { ctrlKey: true, deltaY: 5000, clientX: 500 });
+    await flushAnimationFrame();
+    expect(Number(chartSection().dataset.visibleSpan)).toBe(1440);
+    expect(chartSection().dataset.zoomed).toBe("false");
+  });
+
+  it("zooms with ordinary vertical wheel scrolling inside the chart", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCount"
+      />,
+    );
+
+    const layer = interactionLayer();
+    const event = dispatchWheel(layer, { deltaY: -600, clientX: 500 });
+
+    expect(event.defaultPrevented).toBe(true);
+    await flushAnimationFrame();
+    expect(chartSection().dataset.zoomed).toBe("true");
+    expect(Number(chartSection().dataset.visibleSpan)).toBeLessThan(1440);
+  });
+
+  it("pans horizontally with trackpad wheel deltas and pointer dragging", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCost"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { ctrlKey: true, deltaY: -700, clientX: 500 });
+    await flushAnimationFrame();
+    const zoomedStart = Number(chartSection().dataset.visibleStartIndex);
+
+    const horizontalWheel = dispatchWheel(layer, {
+      deltaX: 260,
+      deltaY: 8,
+      clientX: 500,
+    });
+    expect(horizontalWheel.defaultPrevented).toBe(true);
+    await flushAnimationFrame();
+    const wheelPannedStart = Number(chartSection().dataset.visibleStartIndex);
+    expect(wheelPannedStart).toBeGreaterThan(zoomedStart);
+
+    dispatchPointer(layer, "pointerdown", {
+      button: 0,
+      clientX: 500,
+      pointerId: 8,
+    });
+    dispatchPointer(layer, "pointermove", {
+      clientX: 220,
+      pointerId: 8,
+    });
+    await flushAnimationFrame();
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBe(
+      wheelPannedStart,
+    );
+    expect(dragLayer().style.transform).toContain("translate3d");
+
+    dispatchPointer(layer, "pointerup", {
+      clientX: 220,
+      pointerId: 8,
+    });
+    await flushAnimationFrame();
+    const draggedStart = Number(chartSection().dataset.visibleStartIndex);
+    expect(draggedStart).toBeGreaterThan(wheelPannedStart);
+
+    dispatchWheel(layer, { deltaX: -100_000, deltaY: 0, clientX: 500 });
+    await flushAnimationFrame();
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBe(0);
+  });
+
+  it("axis-locks pointer drags so vertical gestures do not pan the chart", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCost"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { deltaY: -700, clientX: 500 });
+    await flushAnimationFrame();
+    const zoomedStart = Number(chartSection().dataset.visibleStartIndex);
+
+    dispatchPointer(layer, "pointerdown", {
+      button: 0,
+      clientX: 500,
+      clientY: 100,
+      pointerId: 12,
+    });
+    dispatchPointer(layer, "pointermove", {
+      clientX: 505,
+      clientY: 180,
+      pointerId: 12,
+    });
+    await flushAnimationFrame();
+
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBe(zoomedStart);
+    expect(layer.releasePointerCapture).toHaveBeenCalledWith(12);
+  });
+
+  it("keeps horizontal pointer drags locked even with small vertical drift", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCost"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { deltaY: -700, clientX: 500 });
+    await flushAnimationFrame();
+    const zoomedStart = Number(chartSection().dataset.visibleStartIndex);
+
+    dispatchPointer(layer, "pointerdown", {
+      button: 0,
+      clientX: 500,
+      clientY: 100,
+      pointerId: 13,
+    });
+    dispatchPointer(layer, "pointermove", {
+      clientX: 220,
+      clientY: 125,
+      pointerId: 13,
+    });
+    await flushAnimationFrame();
+
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBe(zoomedStart);
+    expect(dragLayer().style.transform).toContain("translate3d");
+
+    dispatchPointer(layer, "pointerup", {
+      clientX: 220,
+      clientY: 125,
+      pointerId: 13,
+    });
+    await flushAnimationFrame();
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBeGreaterThan(
+      zoomedStart,
+    );
+  });
+
+  it("allows large diagonal pointer drags to pan with the horizontal component", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCost"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { deltaY: -700, clientX: 500 });
+    await flushAnimationFrame();
+    const zoomedStart = Number(chartSection().dataset.visibleStartIndex);
+
+    dispatchPointer(layer, "pointerdown", {
+      button: 0,
+      clientX: 500,
+      clientY: 100,
+      pointerId: 14,
+    });
+    dispatchPointer(layer, "pointermove", {
+      clientX: 240,
+      clientY: 340,
+      pointerId: 14,
+    });
+    await flushAnimationFrame();
+
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBe(zoomedStart);
+    expect(dragLayer().style.transform).toContain("translate3d");
+
+    dispatchPointer(layer, "pointerup", {
+      clientX: 240,
+      clientY: 340,
+      pointerId: 14,
+    });
+    await flushAnimationFrame();
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBeGreaterThan(
+      zoomedStart,
+    );
+  });
+
+  it("pans when horizontal wheel intent dominates vertical drift", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCount"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { ctrlKey: true, deltaY: -700, clientX: 500 });
+    await flushAnimationFrame();
+    const zoomedStart = Number(chartSection().dataset.visibleStartIndex);
+
+    const event = dispatchWheel(layer, {
+      deltaX: 120,
+      deltaY: 18,
+      clientX: 500,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    await flushAnimationFrame();
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBeGreaterThan(
+      zoomedStart,
+    );
+  });
+
+  it("widens count bars as the viewport zooms in", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCount"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { deltaY: -600, clientX: 500 });
+    await flushAnimationFrame();
+
+    const bars = host?.querySelectorAll('[data-testid="bar-series"]');
+    expect(bars?.length).toBe(3);
+    expect(Number(bars?.[0]?.getAttribute("data-bar-size"))).toBeGreaterThan(1);
+  });
+
+  it("applies the same horizontal viewport to trend mode data", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={{
+          rangeStart: "2026-04-08 00:00:00",
+          rangeEnd: "2026-04-08 00:22:00",
+          bucketSeconds: 60,
+          points: Array.from({ length: 22 }, (_, index) => ({
+            bucketStart: `2026-04-08 00:${String(index).padStart(2, "0")}:00`,
+            bucketEnd: `2026-04-08 00:${String(index).padStart(2, "0")}:59`,
+            totalCount: 2,
+            successCount: 2,
+            failureCount: 0,
+            totalTokens: 1000 + index * 10,
+            totalCost: 0.2 + index * 0.01,
+          })),
+        }}
+        loading={false}
+        error={null}
+        metric="trend"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { ctrlKey: true, deltaY: -800, clientX: 0 });
+    await flushAnimationFrame();
+    const section = chartSection();
+    const visibleStart = Number(section.dataset.visibleStartIndex);
+    const visibleEnd = Number(section.dataset.visibleEndIndex);
+
+    expect(section.dataset.chartMode).toBe("trend-area");
+    expect(latestChartData.length).toBeGreaterThan(0);
+    expect(
+      latestChartData.every(
+        (item) =>
+          typeof item.index === "number" &&
+          item.index >= visibleStart &&
+          item.index <= visibleEnd,
+      ),
+    ).toBe(true);
+  });
+
+  it("resets the horizontal viewport when the displayed day changes", async () => {
+    render(
+      <DashboardTodayActivityChart
+        response={response}
+        loading={false}
+        error={null}
+        metric="totalCount"
+      />,
+    );
+
+    const layer = interactionLayer();
+    dispatchWheel(layer, { ctrlKey: true, deltaY: -700, clientX: 500 });
+    await flushAnimationFrame();
+    expect(chartSection().dataset.zoomed).toBe("true");
+
+    rerender(
+      <DashboardTodayActivityChart
+        response={{
+          ...response,
+          rangeStart: "2026-04-09 00:00:00",
+          rangeEnd: "2026-04-09 00:03:22",
+          points: response.points.map((point) => ({
+            ...point,
+            bucketStart: String(point.bucketStart).replace(
+              "2026-04-08",
+              "2026-04-09",
+            ),
+            bucketEnd: String(point.bucketEnd).replace(
+              "2026-04-08",
+              "2026-04-09",
+            ),
+          })),
+        }}
+        loading={false}
+        error={null}
+        metric="totalCount"
+      />,
+    );
+
+    expect(chartSection().dataset.zoomed).toBe("false");
+    expect(Number(chartSection().dataset.visibleStartIndex)).toBe(0);
+    expect(Number(chartSection().dataset.visibleEndIndex)).toBe(1439);
   });
 
   it("renders cost and token modes as cumulative area charts", () => {

--- a/web/src/components/DashboardTodayActivityChart.tsx
+++ b/web/src/components/DashboardTodayActivityChart.tsx
@@ -1,4 +1,12 @@
-import { memo, useEffect, useMemo } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import {
   Area,
   AreaChart,
@@ -96,6 +104,100 @@ function formatCountValue(
   formatter: Intl.NumberFormat,
 ) {
   return `${formatter.format(value)} ${unitLabel}`;
+}
+
+const MIN_VISIBLE_MINUTES = 30;
+const HORIZONTAL_WHEEL_THRESHOLD = 2;
+const WHEEL_ZOOM_INTENSITY = 0.0018;
+const WHEEL_PAN_INTENSITY = 0.012;
+const POINTER_AXIS_LOCK_THRESHOLD_PX = 8;
+const POINTER_AXIS_LOCK_RATIO = 1.45;
+const POINTER_FREE_DIAGONAL_RATIO = 0.72;
+
+interface ChartViewport {
+  startIndex: number;
+  endIndex: number;
+}
+
+type PointerDragAxis = "pending" | "horizontal" | "vertical" | "free";
+
+function clampValue(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeViewport(
+  viewport: ChartViewport,
+  pointCount: number,
+): ChartViewport {
+  if (pointCount <= 0) {
+    return { startIndex: 0, endIndex: 0 };
+  }
+
+  const maxIndex = pointCount - 1;
+  const minSpan = Math.min(MIN_VISIBLE_MINUTES, pointCount);
+  const currentSpan = Math.max(
+    minSpan,
+    Math.min(pointCount, viewport.endIndex - viewport.startIndex + 1),
+  );
+  const startIndex = clampValue(
+    Math.round(viewport.startIndex),
+    0,
+    Math.max(0, pointCount - currentSpan),
+  );
+
+  return {
+    startIndex,
+    endIndex: Math.min(maxIndex, startIndex + currentSpan - 1),
+  };
+}
+
+function shiftViewport(
+  viewport: ChartViewport,
+  pointCount: number,
+  deltaIndexes: number,
+): ChartViewport {
+  const span = viewport.endIndex - viewport.startIndex + 1;
+  return normalizeViewport(
+    {
+      startIndex: viewport.startIndex + deltaIndexes,
+      endIndex: viewport.startIndex + deltaIndexes + span - 1,
+    },
+    pointCount,
+  );
+}
+
+function isSameViewport(left: ChartViewport, right: ChartViewport) {
+  return (
+    left.startIndex === right.startIndex &&
+    left.endIndex === right.endIndex
+  );
+}
+
+function zoomViewport(
+  viewport: ChartViewport,
+  pointCount: number,
+  zoomDelta: number,
+  anchorRatio: number,
+): ChartViewport {
+  if (pointCount <= 0) return viewport;
+
+  const currentSpan = viewport.endIndex - viewport.startIndex + 1;
+  const nextSpan = clampValue(
+    Math.round(currentSpan * Math.exp(zoomDelta)),
+    Math.min(MIN_VISIBLE_MINUTES, pointCount),
+    pointCount,
+  );
+  const safeAnchorRatio = clampValue(anchorRatio, 0, 1);
+  const anchorIndex = viewport.startIndex + (currentSpan - 1) * safeAnchorRatio;
+  const nextStart = Math.round(anchorIndex - (nextSpan - 1) * safeAnchorRatio);
+
+  return normalizeViewport(
+    {
+      startIndex: nextStart,
+      endIndex: nextStart + nextSpan - 1,
+    },
+    pointCount,
+  );
 }
 
 interface TooltipPayloadEntry {
@@ -245,6 +347,48 @@ function DashboardTodayActivityChartImpl({
     () => buildTodayMinuteChartData(response, { localeTag, closedNaturalDay }),
     [closedNaturalDay, localeTag, response],
   );
+  const [viewport, setViewport] = useState<ChartViewport>({
+    startIndex: 0,
+    endIndex: Math.max(0, data.length - 1),
+  });
+  const viewportRef = useRef<ChartViewport>(viewport);
+  const viewportIdentity = `${closedNaturalDay ? "closed" : "live"}:${response?.rangeStart ?? "empty"}:${response?.bucketSeconds ?? "none"}`;
+  const viewportIdentityRef = useRef(viewportIdentity);
+  const interactionRef = useRef<HTMLDivElement | null>(null);
+  const dragPreviewLayerRef = useRef<HTMLDivElement | null>(null);
+  const dragRef = useRef<{
+    pointerId: number;
+    startClientX: number;
+    startClientY: number;
+    currentClientX: number;
+    currentClientY: number;
+    axis: PointerDragAxis;
+    viewport: ChartViewport;
+  } | null>(null);
+  const dragPreviewOffsetRef = useRef(0);
+  const dragPreviewFrameRef = useRef<number | null>(null);
+  const wheelPanDeltaRef = useRef(0);
+  const wheelPanFrameRef = useRef<number | null>(null);
+  const wheelZoomDeltaRef = useRef(0);
+  const wheelZoomAnchorRatioRef = useRef(0.5);
+  const wheelZoomFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    viewportRef.current = viewport;
+  }, [viewport]);
+
+  useEffect(() => {
+    setViewport((current) => {
+      if (viewportIdentityRef.current !== viewportIdentity) {
+        viewportIdentityRef.current = viewportIdentity;
+        return normalizeViewport(
+          { startIndex: 0, endIndex: Math.max(0, data.length - 1) },
+          data.length,
+        );
+      }
+      return normalizeViewport(current, data.length);
+    });
+  }, [data.length, viewportIdentity]);
 
   const countUnit = t("unit.calls");
   const countSeriesNames = useMemo(
@@ -266,8 +410,39 @@ function DashboardTodayActivityChartImpl({
     }),
     [t],
   );
+  const chartData =
+    data.length > 0
+      ? data
+      : buildTodayMinuteChartData(response, { localeTag, closedNaturalDay });
+  const visibleWindow = normalizeViewport(viewport, chartData.length);
+  const visibleChartData = chartData.slice(
+    visibleWindow.startIndex,
+    visibleWindow.endIndex + 1,
+  );
+  const tenMinuteTrendData = chartData.filter(
+    (point) =>
+      point.chartTokensPerMinute != null || point.chartSpendRate != null,
+  );
+  const visibleTenMinuteTrendData = tenMinuteTrendData.filter(
+    (point) =>
+      point.index >= visibleWindow.startIndex &&
+      point.index <= visibleWindow.endIndex,
+  );
+  const viewportSpan =
+    visibleWindow.endIndex - visibleWindow.startIndex + 1;
+  const isZoomed = chartData.length > 0 && viewportSpan < chartData.length;
+  const xDomain: [number, number] = [
+    visibleWindow.startIndex,
+    visibleWindow.endIndex,
+  ];
+  const countBarSize = useMemo(() => {
+    if (chartData.length <= 0) return 1;
+    const zoomFactor = chartData.length / Math.max(1, viewportSpan);
+    return clampValue(Math.round(zoomFactor * 0.75), 1, 10);
+  }, [chartData.length, viewportSpan]);
+
   const countAxisBound = useMemo(() => {
-    const maxValue = data.reduce(
+    const maxValue = chartData.reduce(
       (current, item) =>
         Math.max(
           current,
@@ -277,7 +452,242 @@ function DashboardTodayActivityChartImpl({
       0,
     );
     return Math.max(1, maxValue);
-  }, [data]);
+  }, [chartData]);
+
+  const getAnchorRatio = useCallback((clientX: number) => {
+    const rect = interactionRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0) return 0.5;
+    return clampValue((clientX - rect.left) / rect.width, 0, 1);
+  }, []);
+
+  const scheduleWheelPan = useCallback(
+    (deltaIndexes: number) => {
+      wheelPanDeltaRef.current += deltaIndexes;
+      if (wheelPanFrameRef.current != null) return;
+
+      wheelPanFrameRef.current = window.requestAnimationFrame(() => {
+        wheelPanFrameRef.current = null;
+        const pendingDelta = wheelPanDeltaRef.current;
+        wheelPanDeltaRef.current = 0;
+        if (pendingDelta === 0) return;
+
+        const roundedDelta =
+          Math.round(pendingDelta) ||
+          Math.sign(pendingDelta) *
+            Math.max(1, Math.round(WHEEL_PAN_INTENSITY * MIN_VISIBLE_MINUTES));
+        setViewport((current) => {
+          const normalized = normalizeViewport(current, chartData.length);
+          const next = shiftViewport(
+            normalized,
+            chartData.length,
+            roundedDelta,
+          );
+          return isSameViewport(normalized, next) ? current : next;
+        });
+      });
+    },
+    [chartData.length],
+  );
+
+  const scheduleWheelZoom = useCallback(
+    (deltaY: number, anchorRatio: number) => {
+      wheelZoomDeltaRef.current += deltaY;
+      wheelZoomAnchorRatioRef.current = anchorRatio;
+      if (wheelZoomFrameRef.current != null) return;
+
+      wheelZoomFrameRef.current = window.requestAnimationFrame(() => {
+        wheelZoomFrameRef.current = null;
+        const pendingDelta = wheelZoomDeltaRef.current;
+        const pendingAnchorRatio = wheelZoomAnchorRatioRef.current;
+        wheelZoomDeltaRef.current = 0;
+        if (pendingDelta === 0) return;
+
+        setViewport((current) => {
+          const normalized = normalizeViewport(current, chartData.length);
+          const next = zoomViewport(
+            normalized,
+            chartData.length,
+            pendingDelta * WHEEL_ZOOM_INTENSITY,
+            pendingAnchorRatio,
+          );
+          return isSameViewport(normalized, next) ? current : next;
+        });
+      });
+    },
+    [chartData.length],
+  );
+
+  useEffect(
+    () => () => {
+      if (wheelPanFrameRef.current != null) {
+        window.cancelAnimationFrame(wheelPanFrameRef.current);
+      }
+      if (wheelZoomFrameRef.current != null) {
+        window.cancelAnimationFrame(wheelZoomFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (chartData.length <= MIN_VISIBLE_MINUTES) return;
+
+      const horizontalIntent =
+        Math.abs(event.deltaX) >= HORIZONTAL_WHEEL_THRESHOLD &&
+        Math.abs(event.deltaX) >= Math.abs(event.deltaY) &&
+        !event.ctrlKey;
+      const hasZoomIntent =
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        Math.abs(event.deltaY) >= HORIZONTAL_WHEEL_THRESHOLD;
+      if (!horizontalIntent && !hasZoomIntent) return;
+
+      event.preventDefault();
+      if (horizontalIntent) {
+        const normalized = normalizeViewport(viewportRef.current, chartData.length);
+        const width = interactionRef.current?.getBoundingClientRect().width ?? 1;
+        const span = normalized.endIndex - normalized.startIndex + 1;
+        scheduleWheelPan((event.deltaX / Math.max(1, width)) * span);
+        return;
+      }
+
+      scheduleWheelZoom(event.deltaY, getAnchorRatio(event.clientX));
+    },
+    [chartData.length, getAnchorRatio, scheduleWheelPan, scheduleWheelZoom],
+  );
+
+  useEffect(() => {
+    const layer = interactionRef.current;
+    if (!layer) return;
+
+    layer.addEventListener("wheel", handleWheel, { passive: false });
+    return () => {
+      layer.removeEventListener("wheel", handleWheel);
+    };
+  }, [handleWheel]);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || chartData.length <= MIN_VISIBLE_MINUTES) return;
+      dragPreviewOffsetRef.current = 0;
+      if (dragPreviewLayerRef.current) {
+        dragPreviewLayerRef.current.style.transform = "";
+      }
+      const normalized = normalizeViewport(viewport, chartData.length);
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        currentClientX: event.clientX,
+        currentClientY: event.clientY,
+        axis: "pending",
+        viewport: normalized,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [chartData.length, viewport],
+  );
+
+  const scheduleDragPreview = useCallback(() => {
+    if (dragPreviewFrameRef.current != null) return;
+
+    dragPreviewFrameRef.current = window.requestAnimationFrame(() => {
+      dragPreviewFrameRef.current = null;
+      const drag = dragRef.current;
+      if (!drag) return;
+
+      const previewOffsetPx = drag.currentClientX - drag.startClientX;
+      if (previewOffsetPx === dragPreviewOffsetRef.current) return;
+      dragPreviewOffsetRef.current = previewOffsetPx;
+      if (dragPreviewLayerRef.current) {
+        dragPreviewLayerRef.current.style.transform =
+          previewOffsetPx === 0
+            ? ""
+            : `translate3d(${previewOffsetPx}px, 0, 0)`;
+      }
+    });
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      drag.currentClientX = event.clientX;
+      drag.currentClientY = event.clientY;
+
+      if (drag.axis === "pending") {
+        const deltaX = Math.abs(drag.currentClientX - drag.startClientX);
+        const deltaY = Math.abs(drag.currentClientY - drag.startClientY);
+        const distance = Math.hypot(deltaX, deltaY);
+
+        if (distance < POINTER_AXIS_LOCK_THRESHOLD_PX) return;
+
+        if (deltaX >= deltaY * POINTER_AXIS_LOCK_RATIO) {
+          drag.axis = "horizontal";
+        } else if (deltaY >= deltaX * POINTER_AXIS_LOCK_RATIO) {
+          drag.axis = "vertical";
+          dragRef.current = null;
+          if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
+          return;
+        } else if (
+          Math.min(deltaX, deltaY) >=
+          Math.max(deltaX, deltaY) * POINTER_FREE_DIAGONAL_RATIO
+        ) {
+          drag.axis = "free";
+        } else {
+          return;
+        }
+      }
+
+      if (drag.axis === "vertical") return;
+      scheduleDragPreview();
+    },
+    [scheduleDragPreview],
+  );
+
+  const handlePointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+
+      if (drag.axis === "horizontal" || drag.axis === "free") {
+        const width = interactionRef.current?.getBoundingClientRect().width ?? 1;
+        const span = drag.viewport.endIndex - drag.viewport.startIndex + 1;
+        const deltaIndexes = Math.round(
+          ((drag.startClientX - drag.currentClientX) / Math.max(1, width)) * span,
+        );
+        setViewport((current) => {
+          const next = shiftViewport(drag.viewport, chartData.length, deltaIndexes);
+          return isSameViewport(normalizeViewport(current, chartData.length), next)
+            ? current
+            : next;
+        });
+      }
+
+      dragRef.current = null;
+      dragPreviewOffsetRef.current = 0;
+      if (dragPreviewLayerRef.current) {
+        dragPreviewLayerRef.current.style.transform = "";
+      }
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+    },
+    [chartData.length],
+  );
+
+  useEffect(
+    () => () => {
+      if (dragPreviewFrameRef.current != null) {
+        window.cancelAnimationFrame(dragPreviewFrameRef.current);
+      }
+    },
+    [],
+  );
 
   if (error) {
     return <Alert variant="error">{error}</Alert>;
@@ -293,15 +703,7 @@ function DashboardTodayActivityChartImpl({
     return <Alert>{t("chart.noDataRange")}</Alert>;
   }
 
-  const chartData =
-    data.length > 0
-      ? data
-      : buildTodayMinuteChartData(response, { localeTag, closedNaturalDay });
-  const tenMinuteTrendData = chartData.filter(
-    (point) =>
-      point.chartTokensPerMinute != null || point.chartSpendRate != null,
-  );
-  const animate = chartData.length <= 800;
+  const animate = false;
   const chartMode =
     metric === "totalCount"
       ? "count-bars"
@@ -392,16 +794,37 @@ function DashboardTodayActivityChartImpl({
 
   return (
     <section
-      className="rounded-xl border border-base-300/75 bg-base-200/40 p-4"
+      className="overscroll-x-contain rounded-xl border border-base-300/75 bg-base-200/40 p-4"
       data-testid="dashboard-today-activity-chart"
       data-chart-mode={chartMode}
       data-chart-metric={metric}
+      data-visible-start-index={visibleWindow.startIndex}
+      data-visible-end-index={visibleWindow.endIndex}
+      data-visible-span={viewportSpan}
+      data-zoomed={isZoomed ? "true" : "false"}
     >
-      <div className="h-80 w-full" data-chart-kind="dashboard-today-activity">
-        <ResponsiveContainer>
+      <div
+        ref={interactionRef}
+        className="h-80 w-full cursor-grab touch-pan-y overflow-hidden overscroll-x-contain select-none active:cursor-grabbing"
+        data-testid="dashboard-today-activity-chart-interaction-layer"
+        data-chart-kind="dashboard-today-activity"
+        data-min-visible-minutes={MIN_VISIBLE_MINUTES}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        onLostPointerCapture={handlePointerEnd}
+      >
+        <div
+          ref={dragPreviewLayerRef}
+          data-testid="dashboard-today-activity-chart-drag-layer"
+          className="h-full w-full will-change-transform"
+          style={{ transform: undefined }}
+        >
+          <ResponsiveContainer>
           {metric === "totalCount" ? (
             <ComposedChart
-              data={chartData}
+              data={visibleChartData}
               margin={{ top: 12, right: 24, left: 0, bottom: 8 }}
               barGap="-100%"
             >
@@ -412,7 +835,7 @@ function DashboardTodayActivityChartImpl({
               <XAxis
                 dataKey="index"
                 type="number"
-                domain={[0, Math.max(0, chartData.length - 1)]}
+                domain={xDomain}
                 minTickGap={28}
                 axisLine={{ stroke: chartColors.gridLine }}
                 tickLine={{ stroke: chartColors.gridLine }}
@@ -484,7 +907,7 @@ function DashboardTodayActivityChartImpl({
                 name={countSeriesNames.success}
                 stackId="positive"
                 fill={chartColors.success}
-                barSize={1}
+                barSize={countBarSize}
                 radius={[0, 0, 0, 0]}
                 isAnimationActive={animate}
               />
@@ -494,7 +917,7 @@ function DashboardTodayActivityChartImpl({
                 name={countSeriesNames.inFlight}
                 stackId="positive"
                 fill={chartColors.accent}
-                barSize={1}
+                barSize={countBarSize}
                 radius={[3, 3, 0, 0]}
                 isAnimationActive={animate}
               />
@@ -503,7 +926,7 @@ function DashboardTodayActivityChartImpl({
                 dataKey="chartFailureCountNegative"
                 name={countSeriesNames.failures}
                 fill={chartColors.failure}
-                barSize={1}
+                barSize={countBarSize}
                 radius={[0, 0, 3, 3]}
                 isAnimationActive={animate}
               />
@@ -527,7 +950,7 @@ function DashboardTodayActivityChartImpl({
             </ComposedChart>
           ) : metric === "trend" ? (
             <ComposedChart
-              data={tenMinuteTrendData}
+              data={visibleTenMinuteTrendData}
               margin={{ top: 12, right: 24, left: 0, bottom: 8 }}
             >
               <CartesianGrid
@@ -537,7 +960,7 @@ function DashboardTodayActivityChartImpl({
               <XAxis
                 dataKey="index"
                 type="number"
-                domain={[0, Math.max(0, chartData.length - 1)]}
+                domain={xDomain}
                 minTickGap={28}
                 axisLine={{ stroke: chartColors.gridLine }}
                 tickLine={{ stroke: chartColors.gridLine }}
@@ -628,7 +1051,7 @@ function DashboardTodayActivityChartImpl({
             </ComposedChart>
           ) : (
             <AreaChart
-              data={chartData}
+              data={visibleChartData}
               margin={{ top: 12, right: 24, left: 0, bottom: 8 }}
             >
               <CartesianGrid
@@ -638,7 +1061,7 @@ function DashboardTodayActivityChartImpl({
               <XAxis
                 dataKey="index"
                 type="number"
-                domain={[0, Math.max(0, chartData.length - 1)]}
+                domain={xDomain}
                 minTickGap={28}
                 axisLine={{ stroke: chartColors.gridLine }}
                 tickLine={{ stroke: chartColors.gridLine }}
@@ -709,7 +1132,8 @@ function DashboardTodayActivityChartImpl({
               />
             </AreaChart>
           )}
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Add a controlled horizontal viewport to the home `DashboardTodayActivityChart`.
- Support ctrl/meta/alt/pinch wheel zoom, horizontal wheel/trackpad panning, and pointer drag panning with clamped day bounds.
- Keep `totalCount`, `totalCost`, `totalTokens`, and `trend` on the same viewport model without backend/API changes.
- Stabilize the unrelated backend archive-read regression test that CI exposed by keeping its two archived attempts in different months.

## Validation
- `cd web && bun run test -- DashboardTodayActivityChart.test.tsx`
- `cd web && bun run lint -- src/components/DashboardTodayActivityChart.tsx src/components/DashboardTodayActivityChart.test.tsx src/components/DashboardTodayActivityChart.stories.tsx`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- `cargo test forward_proxy_timeseries_reads_pending_archived_node_health_without_materializing_cache -- --nocapture`
- `cargo fmt --check`
- `git diff --check HEAD`
- `codex review --base origin/main` clear after 4 review rounds
- Visual evidence reviewed in chat from Storybook canvas; PR body intentionally does not embed local screenshots.

## References
- Specs: `docs/specs/quhzx-ui-guidelines-system/SPEC.md`
- Spec Disposition: link
- Solutions: -
- Project Docs: -
