### PR TITLE
fix(upstream-accounts): queue maintenance egress retries

### DIFF
--- a/docs/specs/a6k9p-account-maintenance-events-egress-throttle/HISTORY.md
+++ b/docs/specs/a6k9p-account-maintenance-events-egress-throttle/HISTORY.md
@@ -7,3 +7,4 @@
 - 2026-05-11: 限频固定间隔调整为 10 秒，仍不新增配置项。
 - 2026-05-10: 限频粒度使用最终网络出口；无代理/direct 作为单独出口。
 - 2026-05-10: OAuth 维护流程中的后续外呼若被限频，应写入 deferred 记录并恢复账号运行状态，避免停留在 `syncing`。
+- 2026-05-11: 生产发现 reset due 的 OAuth quota exhausted 账号会被同 egress 维护批量调度反复饿死，只产生 `sync_deferred / egress_throttled` 而拿不到后续 usage snapshot。运行期维护改为在有界预算内等待同出口槽位，预算耗尽后才沿用 deferred 行为；限流进入/退出状态机保持不变。

--- a/docs/specs/a6k9p-account-maintenance-events-egress-throttle/IMPLEMENTATION.md
+++ b/docs/specs/a6k9p-account-maintenance-events-egress-throttle/IMPLEMENTATION.md
@@ -12,13 +12,16 @@
 - 新增全局账号维护事件分页 API，并支持账号、分组、节点、结果筛选。
 - 账号池新增 `维护记录` 独立页，承载“非模型调用执行记录”列表，包含执行时间列、四项筛选、分页和两行记录布局。
 - 扩展 `forward_proxy_metadata_history`，通过 ipify 每 600 秒刷新一次 proxy/direct 出口 IP，维护事件写入时快照该 IP。
-- 维护外呼在真实请求前预留 10 秒出口槽位；被限频时写入 deferred 事件，且账号不保持 `syncing` 状态。
+- 维护外呼在真实请求前预留 10 秒出口槽位；运行期维护同步遇到同出口槽位未释放时会在有界预算内等待并重试，预算耗尽后写入 deferred 事件，且账号不保持 `syncing` 状态。
+- OAuth quota exhausted 账号不会按 reset time 自动退出限流；reset due 只触发后续 usage snapshot 维护同步，成功 snapshot 再按既有状态机保持或清除限流标记。
 
 ## Quality Gates
 
 - `cargo fmt --check`
 - `cargo check`
 - `cargo test account_`
+- `cargo test quota_exhausted -- --test-threads=1`
+- `cargo test runtime_wait_retries_until_egress_slot_is_available -- --test-threads=1`
 - `cargo test`
 - `cd web && bun run test`
 - `cd web && bun run build`
@@ -27,10 +30,10 @@
 
 ## Review Disposition
 
-- `codex review` raised that OAuth refresh followed by usage sync can defer the second request on the same egress. This is by design for this spec because both token refresh and usage snapshot are real non-model maintenance outbound calls, and the locked acceptance rule requires at least 10 seconds between any two real outbound calls on the same egress.
+- Earlier review noted that OAuth refresh followed by usage sync can hit the same egress slot. Runtime maintenance now queues within a bounded wait budget, so reset-due OAuth accounts are not starved by immediate `sync_deferred / egress_throttled`; budget exhaustion still preserves the deferred path.
 
 ## Disposition
 
-- `spec_disposition=create`
+- `spec_disposition=update`
 - `project_doc_disposition=none`
 - `solution_disposition=none`

--- a/docs/specs/a6k9p-account-maintenance-events-egress-throttle/SPEC.md
+++ b/docs/specs/a6k9p-account-maintenance-events-egress-throttle/SPEC.md
@@ -13,7 +13,7 @@
 - 在账号池新增 `维护记录` 独立标签页，展示全局“非模型调用执行记录”列表。
 - 列表支持按节点、结果、账号、分组筛选，并展示执行时间、账号、代理、动作、结果。
 - 扩展账号维护事件落库字段与全局分页 API，使旧账号详情 `recentActions` 保持兼容。
-- 所有账号维护类外呼按最终 forward proxy 出口或 direct 出口执行 10 秒限频；被限频任务写入 deferred/skipped 类执行记录。
+- 所有账号维护类外呼按最终 forward proxy 出口或 direct 出口执行 10 秒限频；运行期维护任务在有界预算内等待同出口槽位，预算耗尽后写入 deferred/skipped 类执行记录。
 
 ### Non-goals
 
@@ -50,7 +50,7 @@
 - 事件数据包含账号名、分组、forward proxy key/display name、出口 IP、动作、结果、结果描述。
 - 正向代理出口 IP 元数据通过 ipify 获取，按 proxy/direct 出口每 600 秒最多刷新一次。
 - 旧事件缺字段时 API 与 UI 不崩溃。
-- 同一出口连续维护真实外呼小于 10 秒时，后一次不发出网络请求，写入 deferred 记录并说明剩余等待时间。
+- 同一出口连续维护真实外呼小于 10 秒时，运行期维护 worker 必须先在有界预算内等待槽位；预算耗尽后才不发出网络请求，写入 deferred 记录并说明剩余等待时间。
 - 不同出口互不阻塞；direct 作为单独出口限频。
 
 ### SHOULD
@@ -88,7 +88,8 @@
 - 维护外呼在 forward proxy 选择完成后、真实 HTTP 请求前预留限频槽位。
 - 限频 key 使用最终选中 proxy key；无代理时使用 direct 出口 key。
 - 预留成功才允许发送真实请求。
-- 预留失败返回结构化 throttle error，账号维护同步路径写入 deferred 事件。
+- 运行期维护同步遇到同出口未到 10 秒槽位时，必须在有界预算内等待并重试预留，避免 reset due 账号因同代理批量调度长期只产生 `sync_deferred / egress_throttled`。
+- 等待预算耗尽后，预留失败返回结构化 throttle error，账号维护同步路径写入 deferred 事件。
 
 ### Forward proxy egress IP metadata
 
@@ -102,9 +103,11 @@
 - Given 多个账号维护事件，When 打开账号池 `维护记录` 标签页，Then 能看到跨账号记录列表与四个筛选项。
 - Given 事件有结果描述，When 列表渲染，Then 描述跨动作列与结果列第二行显示。
 - Given 旧事件缺账号快照或代理字段，When 列表渲染，Then 显示空态而不是报错。
-- Given 同一出口 10 秒内连续维护外呼，When 第二次执行，Then 不发出真实网络请求并写入 deferred 事件。
+- Given 同一出口 10 秒内连续维护外呼，When 第二次运行期维护执行且等待预算足够，Then 等待槽位后发送真实网络请求。
+- Given 同一出口 10 秒内连续维护外呼，When 第二次运行期维护执行且等待预算耗尽，Then 不发出真实网络请求并写入 deferred 事件。
 - Given 不同出口维护外呼，When 间隔小于 10 秒，Then 不互相阻塞。
 - Given 当前代理元数据已刷新，When 维护事件写入，Then 事件快照包含可展示出口 IP。
+- Given OAuth 账号处于 quota exhausted 且 reset due，When 维护同步排到同出口槽位，Then 能实际拉取后续 usage snapshot，并继续按 snapshot 是否 exhausted 来保持或退出限流。
 
 ## Visual Evidence
 
@@ -123,4 +126,4 @@
 ## 风险 / 假设
 
 - 出口 IP 元数据刷新是 best-effort；刷新失败保留最近成功 IP，历史旧事件仍可能显示为未记录。
-- OAuth 凭据 refresh 与 usage snapshot 可能原本在同一维护流程内连续外呼；新限频会让后续外呼 deferred，这是预期行为。
+- OAuth 凭据 refresh 与 usage snapshot 可能原本在同一维护流程内连续外呼；运行期会等待同出口槽位，只有等待预算耗尽时才 deferred，这是预期行为。

--- a/src/upstream_accounts/sync_oauth_crypto_utils.rs
+++ b/src/upstream_accounts/sync_oauth_crypto_utils.rs
@@ -1,4 +1,5 @@
 const ACCOUNT_MAINTENANCE_EGRESS_MIN_INTERVAL_SECS: i64 = 10;
+const ACCOUNT_MAINTENANCE_EGRESS_RUNTIME_WAIT_MAX_SECS: u64 = 180;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AccountMaintenanceEgressThrottleError {
@@ -226,7 +227,42 @@ async fn reserve_account_maintenance_egress_slot_for_runtime(
             return Ok(());
         }
     }
-    reserve_account_maintenance_egress_slot(pool, selected_proxy).await
+    reserve_account_maintenance_egress_slot_with_bounded_wait(
+        pool,
+        selected_proxy,
+        ACCOUNT_MAINTENANCE_EGRESS_RUNTIME_WAIT_MAX_SECS,
+    )
+    .await
+}
+
+async fn reserve_account_maintenance_egress_slot_with_bounded_wait(
+    pool: &Pool<Sqlite>,
+    selected_proxy: &SelectedForwardProxy,
+    max_wait_secs: u64,
+) -> Result<()> {
+    let mut waited_secs = 0u64;
+    loop {
+        match reserve_account_maintenance_egress_slot(pool, selected_proxy).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                let Some(throttle) =
+                    err.downcast_ref::<AccountMaintenanceEgressThrottleError>()
+                else {
+                    return Err(err);
+                };
+                if waited_secs >= max_wait_secs {
+                    return Err(err);
+                }
+                let remaining_wait_budget = max_wait_secs - waited_secs;
+                let wait_secs = throttle
+                    .retry_after_secs
+                    .min(remaining_wait_budget)
+                    .max(1);
+                sleep(Duration::from_secs(wait_secs)).await;
+                waited_secs += wait_secs;
+            }
+        }
+    }
 }
 
 async fn exchange_authorization_code_for_required_scope(
@@ -1490,5 +1526,59 @@ mod account_maintenance_egress_throttle_tests {
         reserve_account_maintenance_egress_slot(&pool, &other_proxy)
             .await
             .expect("different egress should not be throttled");
+    }
+
+    #[tokio::test]
+    async fn runtime_wait_retries_until_egress_slot_is_available() {
+        let pool = test_pool().await;
+        let proxy = selected_proxy("jp-edge-01");
+
+        reserve_account_maintenance_egress_slot(&pool, &proxy)
+            .await
+            .expect("first egress should reserve");
+        let nearly_available_at =
+            format_utc_iso(Utc::now() - ChronoDuration::seconds(9));
+        sqlx::query(
+            r#"
+            UPDATE pool_upstream_account_egress_throttle
+            SET last_sent_at = ?2, updated_at = ?2
+            WHERE egress_key = ?1
+            "#,
+        )
+        .bind(&proxy.key)
+        .bind(&nearly_available_at)
+        .execute(&pool)
+        .await
+        .expect("seed near-expired egress throttle slot");
+
+        reserve_account_maintenance_egress_slot_with_bounded_wait(&pool, &proxy, 3)
+            .await
+            .expect("runtime wait should retry once the egress slot is available");
+
+        let err = reserve_account_maintenance_egress_slot(&pool, &proxy)
+            .await
+            .expect_err("runtime wait should reserve the egress slot before returning");
+        assert!(err
+            .downcast_ref::<AccountMaintenanceEgressThrottleError>()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn runtime_wait_preserves_deferred_path_after_budget_exhaustion() {
+        let pool = test_pool().await;
+        let proxy = selected_proxy("jp-edge-01");
+
+        reserve_account_maintenance_egress_slot(&pool, &proxy)
+            .await
+            .expect("first egress should reserve");
+        let err =
+            reserve_account_maintenance_egress_slot_with_bounded_wait(&pool, &proxy, 0)
+                .await
+                .expect_err("exhausted wait budget should preserve throttle error");
+
+        let throttle = err
+            .downcast_ref::<AccountMaintenanceEgressThrottleError>()
+            .expect("throttle error");
+        assert_eq!(throttle.proxy_key, "jp-edge-01");
     }
 }


### PR DESCRIPTION
## Summary
- Queue runtime account-maintenance egress reservations with a bounded wait before falling back to deferred.
- Preserve OAuth quota state semantics: quota 429 enters rate-limited state, and later usage snapshots decide whether to clear it.
- Update the a6k9p egress throttle spec with the production starvation root cause and runtime wait behavior.

## Verification
- cargo fmt --check
- cargo test quota_exhausted -- --test-threads=1
- cargo test runtime_wait_retries_until_egress_slot_is_available -- --test-threads=1
- cargo test runtime_wait_preserves_deferred_path_after_budget_exhaustion -- --test-threads=1
- cargo test reserve_slot_enforces_ten_seconds_per_egress_key -- --test-threads=1
- cargo check
- codex review --base origin/main

## References
- Specs: docs/specs/a6k9p-account-maintenance-events-egress-throttle/
- Solutions: -
- Project Docs: -

## Notes
- No UI, API, schema, or production data cleanup changes.
- Expected production effect: reset-due OAuth accounts sharing an egress no longer repeatedly stop at sync_deferred / egress_throttled when the bounded wait can obtain a slot.