### PR TITLE
fix(upstream-accounts): preserve reset catch-up after deferred sync

### DIFF
--- a/docs/specs/a6k9p-account-maintenance-events-egress-throttle/HISTORY.md
+++ b/docs/specs/a6k9p-account-maintenance-events-egress-throttle/HISTORY.md
@@ -8,3 +8,4 @@
 - 2026-05-10: 限频粒度使用最终网络出口；无代理/direct 作为单独出口。
 - 2026-05-10: OAuth 维护流程中的后续外呼若被限频，应写入 deferred 记录并恢复账号运行状态，避免停留在 `syncing`。
 - 2026-05-11: 生产发现 reset due 的 OAuth quota exhausted 账号会被同 egress 维护批量调度反复饿死，只产生 `sync_deferred / egress_throttled` 而拿不到后续 usage snapshot。运行期维护改为在有界预算内等待同出口槽位，预算耗尽后才沿用 deferred 行为；限流进入/退出状态机保持不变。
+- 2026-05-11: `sync_deferred / egress_throttled` 不再消耗 reset catch-up 窗口；它仍作为普通维护间隔 anchor，避免非 reset-due 账号无限重排。

--- a/docs/specs/a6k9p-account-maintenance-events-egress-throttle/IMPLEMENTATION.md
+++ b/docs/specs/a6k9p-account-maintenance-events-egress-throttle/IMPLEMENTATION.md
@@ -14,6 +14,7 @@
 - 扩展 `forward_proxy_metadata_history`，通过 ipify 每 600 秒刷新一次 proxy/direct 出口 IP，维护事件写入时快照该 IP。
 - 维护外呼在真实请求前预留 10 秒出口槽位；运行期维护同步遇到同出口槽位未释放时会在有界预算内等待并重试，预算耗尽后写入 deferred 事件，且账号不保持 `syncing` 状态。
 - OAuth quota exhausted 账号不会按 reset time 自动退出限流；reset due 只触发后续 usage snapshot 维护同步，成功 snapshot 再按既有状态机保持或清除限流标记。
+- `sync_deferred / egress_throttled` 不会消耗 reset catch-up 窗口；reset due 只会被真实同步尝试清掉，而普通维护间隔仍会把 deferred 记录当作最近一次尝试。
 
 ## Quality Gates
 
@@ -21,6 +22,7 @@
 - `cargo check`
 - `cargo test account_`
 - `cargo test quota_exhausted -- --test-threads=1`
+- `cargo test maintenance_reset_due -- --test-threads=1`
 - `cargo test runtime_wait_retries_until_egress_slot_is_available -- --test-threads=1`
 - `cargo test`
 - `cd web && bun run test`
@@ -31,6 +33,7 @@
 ## Review Disposition
 
 - Earlier review noted that OAuth refresh followed by usage sync can hit the same egress slot. Runtime maintenance now queues within a bounded wait budget, so reset-due OAuth accounts are not starved by immediate `sync_deferred / egress_throttled`; budget exhaustion still preserves the deferred path.
+- `sync_deferred / egress_throttled` now preserves the post-reset catch-up window instead of consuming it, which keeps the next maintenance pass eligible to retry the real usage snapshot.
 
 ## Disposition
 

--- a/docs/specs/a6k9p-account-maintenance-events-egress-throttle/SPEC.md
+++ b/docs/specs/a6k9p-account-maintenance-events-egress-throttle/SPEC.md
@@ -90,6 +90,7 @@
 - 预留成功才允许发送真实请求。
 - 运行期维护同步遇到同出口未到 10 秒槽位时，必须在有界预算内等待并重试预留，避免 reset due 账号因同代理批量调度长期只产生 `sync_deferred / egress_throttled`。
 - 等待预算耗尽后，预留失败返回结构化 throttle error，账号维护同步路径写入 deferred 事件。
+- `sync_deferred / egress_throttled` 不代表真实 usage snapshot 已执行；它不得消耗 reset due 账号的 post-reset catch-up 窗口，但仍应作为普通维护间隔的最近一次尝试记录，避免无限重排。
 
 ### Forward proxy egress IP metadata
 
@@ -108,6 +109,7 @@
 - Given 不同出口维护外呼，When 间隔小于 10 秒，Then 不互相阻塞。
 - Given 当前代理元数据已刷新，When 维护事件写入，Then 事件快照包含可展示出口 IP。
 - Given OAuth 账号处于 quota exhausted 且 reset due，When 维护同步排到同出口槽位，Then 能实际拉取后续 usage snapshot，并继续按 snapshot 是否 exhausted 来保持或退出限流。
+- Given OAuth 账号处于 quota exhausted 且 reset due，When 本轮维护因 egress throttle 写入 `sync_deferred`，Then 下一轮维护仍视为 reset due，直到真实同步尝试产生 usage snapshot 或真实失败结果。
 
 ## Visual Evidence
 

--- a/src/upstream_accounts/maintenance_dispatch.rs
+++ b/src/upstream_accounts/maintenance_dispatch.rs
@@ -599,8 +599,20 @@ pub(crate) fn maintenance_last_attempt_recorded_after_reset(
     candidate: &MaintenanceCandidateRow,
     reset_at: DateTime<Utc>,
 ) -> bool {
-    maintenance_last_sync_attempt_at(candidate)
+    maintenance_last_reset_catchup_attempt_at(candidate)
         .is_some_and(|last_attempt_at| last_attempt_at >= reset_at)
+}
+
+fn maintenance_last_reset_catchup_attempt_at(
+    candidate: &MaintenanceCandidateRow,
+) -> Option<DateTime<Utc>> {
+    if maintenance_sync_action_is_deferred(candidate.last_action_reason_code.as_deref()) {
+        return candidate
+            .last_synced_at
+            .as_deref()
+            .and_then(parse_rfc3339_utc);
+    }
+    maintenance_last_sync_attempt_at(candidate)
 }
 
 pub(crate) fn maintenance_interval_is_due(
@@ -641,6 +653,13 @@ pub(crate) fn maintenance_reset_due(
 ) -> bool {
     maintenance_window_reset_due(candidate, candidate.primary_resets_at.as_deref(), now)
         || maintenance_window_reset_due(candidate, candidate.secondary_resets_at.as_deref(), now)
+}
+
+fn maintenance_sync_action_is_deferred(last_action_reason_code: Option<&str>) -> bool {
+    matches!(
+        last_action_reason_code,
+        Some(UPSTREAM_ACCOUNT_ACTION_REASON_EGRESS_THROTTLED)
+    )
 }
 
 pub(crate) fn maintenance_plan_is_due(

--- a/src/upstream_accounts/tests_part_2.rs
+++ b/src/upstream_accounts/tests_part_2.rs
@@ -2844,6 +2844,100 @@
         );
     }
 
+    #[test]
+    fn maintenance_reset_due_ignores_deferred_egress_throttle_after_reset() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 23, 12, 0, 0)
+            .single()
+            .expect("valid time");
+        let mut candidate = maintenance_candidates(
+            15,
+            UPSTREAM_ACCOUNT_STATUS_ACTIVE,
+            Some("2026-03-23T11:58:30Z"),
+            None,
+            Some("2026-04-23T12:00:00Z"),
+            Some(10.0),
+            Some(10.0),
+        );
+        candidate.primary_resets_at = Some("2026-03-23T11:59:00Z".to_string());
+        candidate.last_action_source =
+            Some(UPSTREAM_ACCOUNT_ACTION_SOURCE_SYNC_MAINTENANCE.to_string());
+        candidate.last_action_at = Some("2026-03-23T11:59:20Z".to_string());
+        candidate.last_action_reason_code =
+            Some(UPSTREAM_ACCOUNT_ACTION_REASON_EGRESS_THROTTLED.to_string());
+
+        assert!(
+            maintenance_reset_due(&candidate, now),
+            "egress-deferred maintenance should not consume the post-reset catch-up sync"
+        );
+    }
+
+    #[test]
+    fn maintenance_interval_is_due_respects_deferred_egress_throttle_anchor() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 23, 12, 0, 0)
+            .single()
+            .expect("valid time");
+        let mut candidate = maintenance_candidates(
+            16,
+            UPSTREAM_ACCOUNT_STATUS_ACTIVE,
+            Some("2026-03-23T11:00:00Z"),
+            None,
+            Some("2026-04-23T12:00:00Z"),
+            Some(10.0),
+            Some(10.0),
+        );
+        candidate.last_action_source =
+            Some(UPSTREAM_ACCOUNT_ACTION_SOURCE_SYNC_MAINTENANCE.to_string());
+        candidate.last_action_at = Some("2026-03-23T11:59:20Z".to_string());
+        candidate.last_action_reason_code =
+            Some(UPSTREAM_ACCOUNT_ACTION_REASON_EGRESS_THROTTLED.to_string());
+
+        assert!(
+            !maintenance_interval_is_due(&candidate, 300, now),
+            "ordinary maintenance should still use egress-deferred actions as the retry anchor"
+        );
+    }
+
+    #[test]
+    fn resolve_due_maintenance_dispatch_plans_requeues_reset_due_after_deferred_egress_throttle() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 3, 23, 12, 0, 0)
+            .single()
+            .expect("valid time");
+        let settings = PoolRoutingMaintenanceSettings {
+            primary_sync_interval_secs: 300,
+            secondary_sync_interval_secs: 1800,
+            priority_available_account_cap: 100,
+        };
+        let mut candidate = maintenance_candidates(
+            17,
+            UPSTREAM_ACCOUNT_STATUS_ACTIVE,
+            Some("2026-03-23T11:58:30Z"),
+            None,
+            Some("2026-04-23T12:00:00Z"),
+            Some(10.0),
+            Some(10.0),
+        );
+        candidate.primary_resets_at = Some("2026-03-23T11:59:00Z".to_string());
+        candidate.last_action_source =
+            Some(UPSTREAM_ACCOUNT_ACTION_SOURCE_SYNC_MAINTENANCE.to_string());
+        candidate.last_action_at = Some("2026-03-23T11:59:20Z".to_string());
+        candidate.last_action_reason_code =
+            Some(UPSTREAM_ACCOUNT_ACTION_REASON_EGRESS_THROTTLED.to_string());
+
+        let plans = resolve_due_maintenance_dispatch_plans(
+            vec![candidate],
+            settings,
+            Duration::from_secs(15 * 60),
+            now,
+        );
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].tier, MaintenanceTier::Priority);
+        assert_eq!(plans[0].sync_interval_secs, 300);
+    }
+
     fn test_routing_candidate(id: i64) -> AccountRoutingCandidateRow {
         AccountRoutingCandidateRow {
             id,


### PR DESCRIPTION
Summary
- Treat maintenance `sync_deferred / egress_throttled` as non-consuming for reset catch-up.
- Keep the quota 429 limit-state machine unchanged.
- Sync the spec/history for `a6k9p-account-maintenance-events-egress-throttle`.

Validation
- cargo fmt
- cargo test maintenance_reset_due -- --test-threads=1
- cargo test quota_exhausted -- --test-threads=1
- cargo test resolve_due_maintenance_dispatch_plans_requeues_reset_due_after_deferred_egress_throttle -- --test-threads=1
- cargo check

References
- Specs: docs/specs/a6k9p-account-maintenance-events-egress-throttle/
- Solutions: -
- Project Docs: -