### PR TITLE
fix(web): align dashboard count bars

### DIFF
--- a/web/src/components/DashboardTodayActivityChart.stories.tsx
+++ b/web/src/components/DashboardTodayActivityChart.stories.tsx
@@ -138,31 +138,29 @@ const mixedOutcomeMinuteAlignmentResponse: TimeseriesResponse = {
   rangeEnd: "2026-04-08T12:24:00+08:00",
   bucketSeconds: 60,
   points: Array.from({ length: 745 }, (_, index) => {
-    if (index >= 20 && index <= 55) {
-      const bucketStart = new Date(STORY_DAY_START);
-      bucketStart.setMinutes(bucketStart.getMinutes() + index);
-      const bucketEnd = new Date(bucketStart.getTime() + MINUTE_MS);
-      const focusMinute = index === 42;
-      const successCount = focusMinute ? 7 : index % 3 === 0 ? 2 : 1;
-      const failureCount = focusMinute ? 4 : index % 5 === 0 ? 1 : 0;
-      const inFlightCount = focusMinute ? 2 : index % 7 === 0 ? 1 : 0;
-      const completedCount = successCount + failureCount;
+    const bucketStart = new Date(STORY_DAY_START);
+    bucketStart.setMinutes(bucketStart.getMinutes() + index);
+    const bucketEnd = new Date(bucketStart.getTime() + MINUTE_MS);
+    const isAlignmentMinute = index >= 36 && index <= 48;
+    const isFocusMinute = index === 42;
+    const successCount = isAlignmentMinute ? (isFocusMinute ? 7 : 3) : 0;
+    const failureCount = isAlignmentMinute ? (isFocusMinute ? 4 : 2) : 0;
+    const inFlightCount = isFocusMinute ? 2 : 0;
+    const completedCount = successCount + failureCount;
 
-      return {
-        bucketStart: bucketStart.toISOString(),
-        bucketEnd: bucketEnd.toISOString(),
-        totalCount: successCount + failureCount + inFlightCount,
-        successCount,
-        failureCount,
-        inFlightCount,
-        totalTokens: completedCount * 920,
-        totalCost: Number((completedCount * 0.0166).toFixed(4)),
-        firstResponseByteTotalSampleCount: completedCount,
-        firstResponseByteTotalAvgMs:
-          completedCount > 0 ? 760 + (index - 42) * 18 : null,
-      };
-    }
-    return buildRealisticPoint(index, 0.4);
+    return {
+      bucketStart: bucketStart.toISOString(),
+      bucketEnd: bucketEnd.toISOString(),
+      totalCount: successCount + failureCount + inFlightCount,
+      successCount,
+      failureCount,
+      inFlightCount,
+      totalTokens: completedCount * 920,
+      totalCost: Number((completedCount * 0.0166).toFixed(4)),
+      firstResponseByteTotalSampleCount: completedCount,
+      firstResponseByteTotalAvgMs:
+        completedCount > 0 ? 760 + (index - 42) * 18 : null,
+    };
   }),
 };
 

--- a/web/src/components/DashboardTodayActivityChart.stories.tsx
+++ b/web/src/components/DashboardTodayActivityChart.stories.tsx
@@ -133,6 +133,39 @@ const latencyMinuteAlignmentResponse: TimeseriesResponse = {
   }),
 };
 
+const mixedOutcomeMinuteAlignmentResponse: TimeseriesResponse = {
+  rangeStart: "2026-04-08T00:00:00+08:00",
+  rangeEnd: "2026-04-08T12:24:00+08:00",
+  bucketSeconds: 60,
+  points: Array.from({ length: 745 }, (_, index) => {
+    if (index >= 20 && index <= 55) {
+      const bucketStart = new Date(STORY_DAY_START);
+      bucketStart.setMinutes(bucketStart.getMinutes() + index);
+      const bucketEnd = new Date(bucketStart.getTime() + MINUTE_MS);
+      const focusMinute = index === 42;
+      const successCount = focusMinute ? 7 : index % 3 === 0 ? 2 : 1;
+      const failureCount = focusMinute ? 4 : index % 5 === 0 ? 1 : 0;
+      const inFlightCount = focusMinute ? 2 : index % 7 === 0 ? 1 : 0;
+      const completedCount = successCount + failureCount;
+
+      return {
+        bucketStart: bucketStart.toISOString(),
+        bucketEnd: bucketEnd.toISOString(),
+        totalCount: successCount + failureCount + inFlightCount,
+        successCount,
+        failureCount,
+        inFlightCount,
+        totalTokens: completedCount * 920,
+        totalCost: Number((completedCount * 0.0166).toFixed(4)),
+        firstResponseByteTotalSampleCount: completedCount,
+        firstResponseByteTotalAvgMs:
+          completedCount > 0 ? 760 + (index - 42) * 18 : null,
+      };
+    }
+    return buildRealisticPoint(index, 0.4);
+  }),
+};
+
 const meta = {
   title: "Dashboard/DashboardTodayActivityChart",
   component: DashboardTodayActivityChart,
@@ -210,6 +243,27 @@ export const CountBarsLatencyMinuteAlignment: Story = {
     error: null,
     metric: "totalCount",
   },
+};
+
+export const CountBarsMixedOutcomeAlignment: Story = {
+  args: {
+    response: mixedOutcomeMinuteAlignmentResponse,
+    loading: false,
+    error: null,
+    metric: "totalCount",
+  },
+  render: () => (
+    <div className="overflow-hidden" data-testid="mixed-outcome-alignment">
+      <div className="w-[7200px] max-w-none">
+        <DashboardTodayActivityChart
+          response={mixedOutcomeMinuteAlignmentResponse}
+          loading={false}
+          error={null}
+          metric="totalCount"
+        />
+      </div>
+    </div>
+  ),
 };
 
 export const CountBarsMinuteGranularityZoom: Story = {

--- a/web/src/components/DashboardTodayActivityChart.test.tsx
+++ b/web/src/components/DashboardTodayActivityChart.test.tsx
@@ -143,16 +143,19 @@ vi.mock("recharts", () => ({
     children,
     barGap,
     data,
+    stackOffset,
   }: {
     children: ReactNode;
     barGap?: string | number;
     data?: Array<Record<string, unknown>>;
+    stackOffset?: string;
   }) => {
     latestChartData = data ?? [];
     return (
       <div
         data-testid="composed-chart"
         data-bar-gap={String(barGap ?? "")}
+        data-stack-offset={stackOffset ?? ""}
         data-data-length={String(latestChartData.length)}
       >
         {children}
@@ -841,6 +844,7 @@ describe("DashboardTodayActivityChart", () => {
     expect(html).toContain('data-chart-mode="count-bars"');
     expect(html).toContain('data-testid="composed-chart"');
     expect(html).toContain('data-bar-gap="-100%"');
+    expect(html).toContain('data-stack-offset="sign"');
     expect(html).toContain('data-data-length="1440"');
     expect(html).not.toContain('data-testid="area-chart"');
     expect(html).toContain('data-data-key="chartSuccessCount"');

--- a/web/src/components/DashboardTodayActivityChart.test.tsx
+++ b/web/src/components/DashboardTodayActivityChart.test.tsx
@@ -827,7 +827,7 @@ describe("DashboardTodayActivityChart", () => {
     expect(html).toContain('data-data-length=""');
   });
 
-  it("renders count mode as a composed chart with split success and failure bars", () => {
+  it("renders count mode with success, in-flight, and failure bars sharing one stack", () => {
     const html = renderToStaticMarkup(
       <DashboardTodayActivityChart
         response={response}
@@ -849,9 +849,10 @@ describe("DashboardTodayActivityChart", () => {
     expect(html).toContain('data-bar-size="1"');
     expect(html).toContain('data-stack-id="positive"');
     expect(html).toContain('data-domain="0:1439"');
-    expect(html).not.toContain(
-      'data-data-key="chartFailureCountNegative" data-stack-id="positive"',
+    expect(html).toContain(
+      'data-stack-id="positive" data-data-key="chartFailureCountNegative"',
     );
+    expect(html.match(/data-stack-id="positive"/g)).toHaveLength(3);
   });
 
   it("zooms horizontally around the wheel pointer and keeps the view clamped", async () => {

--- a/web/src/components/DashboardTodayActivityChart.test.tsx
+++ b/web/src/components/DashboardTodayActivityChart.test.tsx
@@ -124,16 +124,22 @@ vi.mock("recharts", () => ({
     stackId,
     dataKey,
     barSize,
+    radius,
+    shape,
   }: {
     stackId?: string;
     dataKey?: string;
     barSize?: number;
+    radius?: number[];
+    shape?: ReactNode;
   }) => (
     <div
       data-testid="bar-series"
       data-stack-id={stackId ?? ""}
       data-data-key={dataKey ?? ""}
       data-bar-size={String(barSize ?? "")}
+      data-radius={radius == null ? "" : radius.join(":")}
+      data-has-shape={shape == null ? "false" : "true"}
     />
   ),
   AreaChart: ({ children }: { children: ReactNode }) => (
@@ -854,9 +860,10 @@ describe("DashboardTodayActivityChart", () => {
     expect(html).toContain('data-stack-id="positive"');
     expect(html).toContain('data-domain="0:1439"');
     expect(html).toContain(
-      'data-stack-id="positive" data-data-key="chartFailureCountNegative"',
+      'data-stack-id="positive" data-data-key="chartFailureCountNegative" data-bar-size="1" data-radius="" data-has-shape="true"',
     );
     expect(html.match(/data-stack-id="positive"/g)).toHaveLength(3);
+    expect(html.match(/data-has-shape="true"/g)).toHaveLength(1);
   });
 
   it("zooms horizontally around the wheel pointer and keeps the view clamped", async () => {

--- a/web/src/components/DashboardTodayActivityChart.tsx
+++ b/web/src/components/DashboardTodayActivityChart.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
+  type ReactElement,
 } from "react";
 import {
   Area,
@@ -202,6 +203,63 @@ function zoomViewport(
 
 interface TooltipPayloadEntry {
   payload?: DashboardTodayMinuteDatum;
+}
+
+interface FailureBarShapeProps {
+  fill?: string;
+  x?: number | string;
+  y?: number | string;
+  width?: number | string;
+  height?: number | string;
+}
+
+function NegativeFailureBarShape({
+  fill = "currentColor",
+  x,
+  y,
+  width,
+  height,
+}: FailureBarShapeProps): ReactElement | null {
+  const rectX = Number(x);
+  const rectY = Number(y);
+  const rectWidth = Number(width);
+  const rectHeight = Number(height);
+
+  if (
+    !Number.isFinite(rectX) ||
+    !Number.isFinite(rectY) ||
+    !Number.isFinite(rectWidth) ||
+    !Number.isFinite(rectHeight) ||
+    rectWidth === 0 ||
+    rectHeight === 0
+  ) {
+    return null;
+  }
+
+  const left = Math.min(rectX, rectX + rectWidth);
+  const right = Math.max(rectX, rectX + rectWidth);
+  const top = Math.min(rectY, rectY + rectHeight);
+  const bottom = Math.max(rectY, rectY + rectHeight);
+  const normalizedWidth = right - left;
+  const normalizedHeight = bottom - top;
+  const radius = Math.min(3, normalizedWidth / 2, normalizedHeight / 2);
+
+  return (
+    <path
+      data-dashboard-failure-bar-shape="negative"
+      d={[
+        `M${left},${top}`,
+        `H${right}`,
+        `V${bottom - radius}`,
+        `Q${right},${bottom} ${right - radius},${bottom}`,
+        `H${left + radius}`,
+        `Q${left},${bottom} ${left},${bottom - radius}`,
+        "Z",
+      ].join(" ")}
+      fill={fill}
+      stroke="none"
+    />
+  );
 }
 
 interface ChartTooltipContentProps {
@@ -936,7 +994,7 @@ function DashboardTodayActivityChartImpl({
                 stackId="positive"
                 fill={chartColors.failure}
                 barSize={countBarSize}
-                radius={[0, 0, 3, 3]}
+                shape={<NegativeFailureBarShape />}
                 isAnimationActive={animate}
               />
               <Line

--- a/web/src/components/DashboardTodayActivityChart.tsx
+++ b/web/src/components/DashboardTodayActivityChart.tsx
@@ -932,6 +932,7 @@ function DashboardTodayActivityChartImpl({
                 yAxisId="count"
                 dataKey="chartFailureCountNegative"
                 name={countSeriesNames.failures}
+                stackId="positive"
                 fill={chartColors.failure}
                 barSize={countBarSize}
                 radius={[0, 0, 3, 3]}

--- a/web/src/components/DashboardTodayActivityChart.tsx
+++ b/web/src/components/DashboardTodayActivityChart.tsx
@@ -834,6 +834,7 @@ function DashboardTodayActivityChartImpl({
               data={visibleChartData}
               margin={{ top: 12, right: 24, left: 0, bottom: 8 }}
               barGap="-100%"
+              stackOffset="sign"
             >
               <CartesianGrid
                 stroke={chartColors.gridLine}


### PR DESCRIPTION
## Summary
- Align dashboard count success, in-flight, and failure bars by putting the negative failure series into the same Recharts stack.
- Use Recharts `stackOffset="sign"` so failures keep rendering below the zero axis while sharing the same X center.
- Render negative failure bars with a custom SVG shape so the zero-axis end stays square and only the far end rounds.
- Add a focused deterministic Storybook scenario where every visible failure minute also has success, so visual review directly proves red/green vertical alignment.
- Update the component regression test to require shared stack, sign-aware stack offset, and the custom failure bar shape.

## Verification
- `cd web && bun run test -- DashboardTodayActivityChart.test.tsx`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- `codex review --base origin/main`
- Storybook visual check: `CountBarsMixedOutcomeAlignment`; latest evidence shown in Codex chat, not included as PR image.
- Browser measurement after deterministic Storybook fixture: red bars `13`, green bars `13`, red-without-matching-green mismatches `0`.
- Focus-minute browser measurement: success/in-flight/failure centers all `509.165`; failure bar starts at zero-line `y=176` and extends downward.
- Failure bar SVG path starts at the zero-axis edge with `M... H...` and only uses `Q` curve commands at the lower end.

## References
- Specs: -
- Solutions: -
- Project Docs: -

## Notes
- Project doc disposition: none.
- Solution disposition: none.
- PR screenshots: omitted because screenshot submission approval has not been requested/received.