### PR TITLE
fix(ci): avoid full checkout in release gates

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Configure git identity for release notes
         run: |
@@ -385,7 +383,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.release-meta.outputs.target_sha }}
-          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- Avoid full-history checkout in CI Main lint and Release jobs that do not need it.
- Keep release scripts responsible for explicit main/tag/notes fetches where history is actually required.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci-main.yml .github/workflows/release.yml`\n\n## References\n- Spec: -\n- Spec Disposition: not_needed\n- Spec Sync: n/a(spec-free)\n- Spec Drift: none\n- Solutions: -\n- Solutions Sync: n/a(no related solution)\n- Project Docs: -\n- Project Docs Sync: n/a(no project-doc changes)\n