### PR TITLE
fix(ci): fetch main history for release backfills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,11 @@ jobs:
             exit 1
           fi
 
-          git fetch --no-tags origin main
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --prune --unshallow origin "+refs/heads/main:refs/remotes/origin/main"
+          else
+            git fetch --no-tags --prune origin "+refs/heads/main:refs/remotes/origin/main"
+          fi
           if ! git cat-file -e "${target_sha}^{commit}" 2>/dev/null; then
             git fetch --no-tags origin "${target_sha}"
           fi
@@ -191,7 +195,11 @@ jobs:
             exit 0
           fi
 
-          git fetch --no-tags origin main
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --prune --unshallow origin "+refs/heads/main:refs/remotes/origin/main"
+          else
+            git fetch --no-tags --prune origin "+refs/heads/main:refs/remotes/origin/main"
+          fi
           git fetch --tags origin
           git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}" || true
           python3 .github/scripts/release_snapshot.py next-pending \
@@ -636,7 +644,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch --no-tags origin main
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --prune --unshallow origin "+refs/heads/main:refs/remotes/origin/main"
+          else
+            git fetch --no-tags --prune origin "+refs/heads/main:refs/remotes/origin/main"
+          fi
           git fetch --tags origin
           git fetch --no-tags origin "+${RELEASE_SNAPSHOT_NOTES_REF}:${RELEASE_SNAPSHOT_NOTES_REF}" || true
           python3 .github/scripts/release_snapshot.py next-pending \


### PR DESCRIPTION
## Summary
- fetch only `main` history into `origin/main` after shallow release checkout
- keep the release checkout narrow while restoring ancestor checks for manual backfills
- update all release pending-target lookups that depend on `origin/main`

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release.yml`\n- pre-commit hook: `typecheck-web`\n\n## References\n- Specs: -\n- Solutions: -\n- Project Docs: -\n\n## Notes\n- Spec Disposition: not_needed\n- Solution Disposition: none\n- Project Doc Disposition: none\n- This follows the prior checkout-timeout hotfix and fixes the shallow-history containment check exposed by the first backfill retry.\n