### PR TITLE
feat(worktree): add explicit dependency setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - `bun install` — install repo-level tooling for hooks, worktree bootstrap, and docs checks.
 - `bun run hooks:install` — install shared Git hooks for every linked worktree in this repository.
 - `bun run worktree:bootstrap` — manually rerun the copy-missing-only local config sync for the current worktree.
+- `bun run worktree:setup` — explicitly install root, `web/`, and `docs-site/` Bun dependencies for the current worktree.
 - `cd web && bun install` — install SPA dependencies once per setup.
 - `cd web && bun run dev -- --host 127.0.0.1 --port 60080` — run the front-end dev server with proxy to the backend.
 - `cd web && bun run build` — produce production assets for `web/dist`.
@@ -73,6 +74,6 @@ Use non-blocking runtime management for long-lived services, but do not require 
 ## Security & Configuration Tips
 
 - Store authentication cookies and secrets in `.env.local`; the file is ignored—never commit credentials.
-- Worktree bootstrap only copies missing resources declared in `scripts/worktree-sync.paths`; the current contract syncs `.env.local` from the primary worktree into new linked worktrees, never overwrites existing local files, and never copies dependency or runtime directories.
+- Worktree bootstrap only copies missing resources declared in `scripts/worktree-sync.paths`; the current contract syncs `.env.local` from the primary worktree into new linked worktrees, never overwrites existing local files, and never copies dependency or runtime directories. Dependency installation is explicit via `bun run worktree:setup`, not automatic from `post-checkout`.
 - SQLite files default to `codex_vibe_monitor.db` in the repo root; add alternate paths via `DATABASE_PATH` if running in containers.
 - SSE and HTTP clients depend on stable polling; monitor logs (`RUST_LOG=info cargo run`) when adjusting concurrency or timeouts.

--- a/README.md
+++ b/README.md
@@ -191,20 +191,28 @@ bun run dev
 
 ## Worktree bootstrap
 
-首次拉到包含该功能的版本后，在任一 worktree 执行一次：
+首次拉到包含该功能的版本后，在任一 worktree 执行一次，安装 shared Git hooks：
 
 ```bash
 bun install
 bun run hooks:install
 ```
 
-之后新建 linked worktree 时，shared Git `post-checkout` hook 会自动补齐缺失的 `.env.local`。如果需要手动重跑，可执行：
+之后新建 linked worktree 时，shared Git `post-checkout` hook 会自动补齐缺失的 `.env.local`。如果需要手动重跑轻量 bootstrap，可执行：
 
 ```bash
 bun run worktree:bootstrap
 ```
 
-该 bootstrap 只会复制 `scripts/worktree-sync.paths` 中声明的缺失本地资源；当前首版仅同步 `.env.local`，不会覆盖已有本地文件，也不会复制 `node_modules`、数据库文件或 `.codex/xray-forward` 一类运行态目录。
+该 bootstrap 只会复制 `scripts/worktree-sync.paths` 中声明的缺失本地资源；当前首版仅同步 `.env.local`，不会覆盖已有本地文件，也不会复制或安装 `node_modules`、数据库文件或 `.codex/xray-forward` 一类运行态目录。
+
+如果需要把当前 worktree 初始化成完整开发环境，显式执行：
+
+```bash
+bun run worktree:setup
+```
+
+`worktree:setup` 会依次安装 repo root、`web/` 与 `docs-site/` 的 Bun 依赖。依赖安装不会由 `post-checkout` 自动触发，避免 checkout 依赖网络或长时间阻塞。
 
 ## 第一次部署最该先确认的配置
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -14,6 +14,7 @@
 | q8h3n | 代理热路径并发稳定性与传输背压收口                                        | active    | `q8h3n-proxy-hot-path-streaming-stability/SPEC.md` | `q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md` | topic anchor: proxy / upstream / pool runtime     |
 | quhzx | 建立全局 UI 规范文档体系                                                  | active    | `quhzx-ui-guidelines-system/SPEC.md`               | `quhzx-ui-guidelines-system/IMPLEMENTATION.md`               | topic anchor: ui system / design standards        |
 | tr4ev | Bun-first 工具链收敛                                                      | active    | `tr4ev-bun-first-toolchain/SPEC.md`                | `tr4ev-bun-first-toolchain/IMPLEMENTATION.md`                | topic anchor: developer tooling / repo structure  |
+| v7se4 | Worktree bootstrap 与显式依赖初始化                                       | active    | `v7se4-worktree-bootstrap/SPEC.md`                 | `v7se4-worktree-bootstrap/IMPLEMENTATION.md`                 | topic anchor: developer tooling / linked worktree |
 | z9h7v | 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key） | active    | `z9h7v-invocation-log-observability/SPEC.md`       | `z9h7v-invocation-log-observability/IMPLEMENTATION.md`       | topic anchor: records / invocations observability |
 
 ## Archived Sources

--- a/docs/specs/v7se4-worktree-bootstrap/HISTORY.md
+++ b/docs/specs/v7se4-worktree-bootstrap/HISTORY.md
@@ -1,0 +1,20 @@
+# Worktree bootstrap 与显式依赖初始化 演进历史（#v7se4）
+
+> 这里记录会影响 Agent 理解“为什么一步步变成现在这样”的关键演进；单次任务流水账不放这里，规范正文仍以 `./SPEC.md` 为准。
+
+## Decision Trace
+
+- 2026-03-14: archived spec 固定 shared hooks、`post-checkout`、`.env.local` copy-missing-only 与真实 linked worktree smoke。
+- 2026-05-15: 重新建立 canonical `docs/specs/` 主题 spec，并将依赖安装明确拆到显式 `worktree:setup`，避免 checkout hook 变成联网/重型动作。
+
+## Key Reasons / Replacements
+
+- 自动 bootstrap 适合补缺失本地配置，不适合安装依赖；依赖安装失败不应阻断普通 Git checkout。
+- `worktree:setup` 是完整开发环境初始化入口，职责与 `worktree:bootstrap` 分离。
+- 本 spec 继承并取代 archived `docs/archive/specs/v7se4-worktree-bootstrap/SPEC.md` 作为当前有效规范。
+
+## References
+
+- `./SPEC.md`
+- `./IMPLEMENTATION.md`
+- `docs/archive/specs/v7se4-worktree-bootstrap/SPEC.md`

--- a/docs/specs/v7se4-worktree-bootstrap/IMPLEMENTATION.md
+++ b/docs/specs/v7se4-worktree-bootstrap/IMPLEMENTATION.md
@@ -1,0 +1,30 @@
+# Worktree bootstrap 与显式依赖初始化 实现状态（#v7se4）
+
+> 当前有效规范仍以 `./SPEC.md` 为准；这里记录实现覆盖、交付进度与 rollout 相关事实，避免这些细节散落到 PR / Git 历史里。
+
+## Current Status
+
+- Implementation: 已实现
+- Lifecycle: active
+- Catalog note: `post-checkout` bootstrap 保持轻量；依赖安装由 `worktree:setup` 显式触发。
+
+## Coverage / rollout summary
+
+- `scripts/worktree-bootstrap.sh` 继续只安装 shared hooks 并同步缺失本地资源。
+- `scripts/worktree-setup.sh` 安装 repo root、`web/`、`docs-site/` Bun 依赖。
+- `scripts/test-worktree-bootstrap.sh` 使用真实 linked worktree smoke 和 fake `bun` 验证 no-deps bootstrap 与 setup 调用链。
+- README 与 AGENTS 已说明 bootstrap/setup 的职责差异。
+
+## Remaining Gaps
+
+- None
+
+## Related Changes
+
+- 新增 `bun run worktree:setup`。
+- 扩展 worktree bootstrap smoke test。
+
+## References
+
+- `./SPEC.md`
+- `./HISTORY.md`

--- a/docs/specs/v7se4-worktree-bootstrap/SPEC.md
+++ b/docs/specs/v7se4-worktree-bootstrap/SPEC.md
@@ -1,0 +1,139 @@
+# Worktree bootstrap 与显式依赖初始化（#v7se4）
+
+> 当前有效规范以本文为准；实现覆盖与当前状态见 `./IMPLEMENTATION.md`，关键演进原因见 `./HISTORY.md`。
+
+## 背景 / 问题陈述
+
+- linked worktree 需要稳定继承本地配置，但 checkout hook 不应承担联网安装依赖等重型动作。
+- 当前仓库已经有 shared Git hooks、copy-missing-only `.env.local` 同步与真实 linked worktree smoke；本规范将“轻量 bootstrap”和“显式依赖 setup”作为长期边界固定下来。
+- archived `docs/archive/specs/v7se4-worktree-bootstrap/SPEC.md` 是历史来源；本文是当前 canonical spec。
+
+## 目标 / 非目标
+
+### Goals
+
+- 保持 `post-checkout` bootstrap 轻量、安全、幂等，只补缺失本地资源。
+- 提供显式 `bun run worktree:setup`，一次安装 repo root、`web/` 与 `docs-site/` 的 Bun 依赖。
+- 用 smoke test 锁住默认 bootstrap 不安装依赖、setup 才调用依赖安装的行为。
+
+### Non-goals
+
+- 不在 `post-checkout` 中默认执行 `bun install`。
+- 不复制 `node_modules`、SQLite DB、`.codex/xray-forward` 或其他运行态目录。
+- 不修改 HTTP API、SSE、数据库 schema 或前端业务逻辑。
+
+## 范围（Scope）
+
+### In scope
+
+- repo-local CLI：`bun run hooks:install`、`bun run worktree:bootstrap`、`bun run worktree:setup`。
+- shared Git hook wrapper、`scripts/worktree-sync.paths`、worktree bootstrap/setup smoke test。
+- README / AGENTS 中面向维护者的 bootstrap 与 setup 说明。
+
+### Out of scope
+
+- 本地 secret 内容、依赖版本升级、CI required check 名称调整。
+- 自动修复缺失系统依赖或开发机 Bun 安装。
+
+## 需求（Requirements）
+
+### MUST
+
+- `post-checkout` 自动路径不得安装依赖、不得创建或复制 `node_modules`。
+- `worktree:bootstrap` 必须继续遵守 copy-missing-only；目标文件已存在时不得覆盖。
+- `worktree:setup` 必须由开发者显式执行，并按 repo root、`web/`、`docs-site/` 覆盖 Bun 依赖安装。
+- smoke test 必须验证默认 bootstrap 的 no-deps 边界和 setup 的安装调用链，且不得真实联网安装依赖。
+
+### SHOULD
+
+- setup 脚本保持薄封装，优先复用 Bun 与现有 package manifests。
+- 文档应明确 bootstrap 与 setup 的职责差异，避免维护者误以为 checkout 会自动安装依赖。
+
+### COULD
+
+- 后续可在 setup 中增加轻量健康检查，但必须保持显式触发。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- 新 linked worktree checkout 时，shared `post-checkout` hook 调用当前 checkout 的 bootstrap runner；runner 只安装/维护 hook 链并同步 manifest 中缺失的本地资源。
+- 开发者需要完整依赖环境时，在目标 worktree 执行 `bun run worktree:setup`；脚本依次在 repo root、`web/`、`docs-site/` 运行 `bun install`。
+
+### Edge cases / errors
+
+- 当前 worktree 已存在 `.env.local` 时，bootstrap 必须跳过且不覆盖。
+- 目标依赖目录不存在时，bootstrap 不负责创建；setup 的 Bun install 负责正常依赖安装。
+- 若当前 revision 缺少 bootstrap 脚本，shared hook wrapper 继续安全 no-op。
+
+## 接口契约（Interfaces & Contracts）
+
+### 接口清单（Inventory）
+
+| 接口（Name）                 | 类型（Kind） | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner） | 使用方（Consumers） | 备注（Notes）               |
+| ---------------------------- | ------------ | ------------- | -------------- | ------------------------ | --------------- | ------------------- | --------------------------- |
+| `bun run worktree:setup`     | CLI          | internal      | New            | None                     | repo tooling    | contributors        | 显式安装 root/web/docs 依赖 |
+| `bun run worktree:bootstrap` | CLI          | internal      | Modify         | None                     | repo tooling    | contributors        | 明确保持 no-deps 轻量边界   |
+| `post-checkout` bootstrap    | Git hook     | internal      | Modify         | None                     | repo tooling    | linked worktrees    | 自动路径不得安装依赖        |
+
+### 契约文档（按 Kind 拆分）
+
+- None
+
+## 验收标准（Acceptance Criteria）
+
+- Given 新 linked worktree 缺失 `.env.local`
+  When shared `post-checkout` hook 触发
+  Then worktree 获得缺失 `.env.local`，且不会创建 root、`web/`、`docs-site/` 的 `node_modules`。
+
+- Given 开发者执行 `bun run worktree:setup`
+  When setup 脚本运行
+  Then repo root、`web/`、`docs-site/` 均执行一次 `bun install`。
+
+- Given CI 运行 `scripts/test-worktree-bootstrap.sh`
+  When fake `bun` 捕获 setup 调用链
+  Then 测试不联网且能证明 setup 覆盖三个依赖安装位置。
+
+## 验收清单（Acceptance checklist）
+
+- [x] bootstrap no-deps 边界已由 smoke test 覆盖。
+- [x] setup 显式安装路径已由 fake `bun` 覆盖。
+- [x] README / AGENTS 已区分 bootstrap 与 setup。
+- [x] archived spec 的历史语义已迁移到 canonical spec。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- `bash scripts/test-worktree-bootstrap.sh`
+- `cargo check`
+- `cd web && bun run test`
+
+### UI / Storybook (if applicable)
+
+- Not applicable.
+
+### Quality checks
+
+- 不新增 required check 名称。
+- 不改变 release label gate 或 GitHub branch protection 语义。
+
+## Visual Evidence
+
+None
+
+## Related PRs
+
+- None
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：把依赖安装放进 checkout hook 会让 Git 操作依赖网络和耗时命令；本规范固定为显式 setup。
+- 假设：Bun 是仓库唯一 JS package manager，且 root、`web/`、`docs-site/` 都由 Bun 管理。
+
+## 参考（References）
+
+- `docs/archive/specs/v7se4-worktree-bootstrap/SPEC.md`
+- `README.md`
+- `AGENTS.md`
+- `scripts/test-worktree-bootstrap.sh`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "check:bun-first": "bash .github/scripts/check-bun-first.sh",
     "hooks:install": "bash scripts/install-hooks.sh",
-    "worktree:bootstrap": "bash scripts/worktree-bootstrap.sh"
+    "worktree:bootstrap": "bash scripts/worktree-bootstrap.sh",
+    "worktree:setup": "bash scripts/worktree-setup.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",

--- a/scripts/test-worktree-bootstrap.sh
+++ b/scripts/test-worktree-bootstrap.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-vibe-monitor-worktree-bootstrap.XXXXXX")"
+tmp_dir="$(cd "$tmp_dir" && pwd)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 copy_repo() {
@@ -15,6 +16,7 @@ copy_repo() {
     --exclude 'web/.env.local' \
     --exclude 'node_modules' \
     --exclude 'web/node_modules' \
+    --exclude 'docs-site/node_modules' \
     --exclude 'target' \
     --exclude 'web/dist' \
     --exclude '.codex/logs' \
@@ -63,6 +65,17 @@ EOF_FAKE
   chmod +x "$native_dir/lefthook"
 }
 
+write_fake_bun() {
+  bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/bun" <<'EOF_FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\t%s\n' "$(pwd)" "$*" >> "${BUN_INSTALL_LOG:?}"
+EOF_FAKE
+  chmod +x "$bin_dir/bun"
+}
+
 fixture_repo="$tmp_dir/fixture"
 copy_repo "$repo_root" "$fixture_repo"
 init_repo "$fixture_repo"
@@ -96,6 +109,21 @@ assert_file_contains "$worktree_dir/.lefthook-run.log" '--no-auto-install'
 
 bash "$worktree_dir/scripts/worktree-bootstrap.sh" >/dev/null
 assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+if [ -e "$worktree_dir/node_modules" ] || [ -e "$worktree_dir/web/node_modules" ] || [ -e "$worktree_dir/docs-site/node_modules" ]; then
+  printf 'worktree bootstrap must not install dependency directories\n' >&2
+  exit 1
+fi
+
+fake_bun_dir="$tmp_dir/fake-bun"
+bun_install_log="$tmp_dir/bun-install.log"
+write_fake_bun "$fake_bun_dir"
+(
+  cd "$worktree_dir"
+  PATH="$fake_bun_dir:$PATH" BUN_INSTALL_LOG="$bun_install_log" bash scripts/worktree-setup.sh >/dev/null
+)
+assert_file_contains "$bun_install_log" "$worktree_dir"$'\t''install'
+assert_file_contains "$bun_install_log" "$worktree_dir/web"$'\t''install'
+assert_file_contains "$bun_install_log" "$worktree_dir/docs-site"$'\t''install'
 
 rm -f "$fixture_repo/scripts/run-lefthook-hook.sh" \
   "$fixture_repo/scripts/sync-worktree-resources.sh" \

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+run_install() {
+  label="$1"
+  dir="$2"
+
+  printf '[worktree-setup] installing %s dependencies\n' "$label"
+  (
+    cd "$dir"
+    bun install
+  )
+}
+
+run_install "repo" "$repo_root"
+run_install "web" "$repo_root/web"
+run_install "docs-site" "$repo_root/docs-site"
+
+printf '[worktree-setup] dependencies installed\n'


### PR DESCRIPTION
## Summary
- add `bun run worktree:setup` for explicit root, web, and docs-site dependency installation
- keep `worktree:bootstrap` and `post-checkout` lightweight/no-deps
- add canonical worktree bootstrap spec and update README/AGENTS guidance

## Verification
- `bash scripts/test-worktree-bootstrap.sh`
- `bun run worktree:setup`
- `cargo check`
- `cd web && bun run test`
- `bun run check:bun-first`
- `bash /Users/ivan/.codex/skills/spec-sync/scripts/spec_drift_check.sh --spec-path docs/specs/v7se4-worktree-bootstrap/SPEC.md`
- `codex review --base origin/main` clear after staged-file fix

## References
- Specs: `docs/specs/v7se4-worktree-bootstrap/SPEC.md`
- Solutions: -
- Project Docs: `README.md`, `AGENTS.md`

## Notes
- UI-affecting: no; visual evidence not applicable.
- Project doc disposition: update.
- Solution disposition: none.