### PR TITLE
fix(account-pool): allow session import into full node-shunt groups

### DIFF
--- a/src/upstream_accounts/imports_jobs_sse.rs
+++ b/src/upstream_accounts/imports_jobs_sse.rs
@@ -156,10 +156,18 @@ async fn resolve_imported_oauth_probe_scope(
             if binding.node_shunt_enabled
                 && is_group_node_shunt_unassigned_message(&err.to_string()) =>
         {
-            required_account_forward_proxy_scope(
-                Some(&binding.group_name),
-                binding.bound_proxy_keys.clone(),
-            )
+            let has_selectable_bound_proxy = {
+                let manager = state.forward_proxy.lock().await;
+                manager.has_selectable_bound_proxy_keys(&binding.bound_proxy_keys)
+            };
+            if has_selectable_bound_proxy {
+                required_account_forward_proxy_scope(
+                    Some(&binding.group_name),
+                    binding.bound_proxy_keys.clone(),
+                )
+            } else {
+                Err(err)
+            }
         }
         Err(err) => Err(err),
     }

--- a/src/upstream_accounts/imports_jobs_sse.rs
+++ b/src/upstream_accounts/imports_jobs_sse.rs
@@ -80,7 +80,7 @@ pub(crate) async fn build_imported_oauth_validation_response(
             }
         };
         let matched_account = existing_match.as_ref().map(import_match_summary_from_row);
-        let usage_scope = match resolve_group_forward_proxy_scope_for_provisioning(
+        let usage_scope = match resolve_imported_oauth_probe_scope(
             state,
             binding,
             assignments.as_ref(),
@@ -133,6 +133,36 @@ pub(crate) async fn build_imported_oauth_validation_response(
         items.len(),
         rows,
     ))
+}
+
+async fn resolve_imported_oauth_probe_scope(
+    state: &AppState,
+    binding: &ResolvedRequiredGroupProxyBinding,
+    assignments: Option<&UpstreamAccountNodeShuntAssignments>,
+    existing_match: Option<&UpstreamAccountRow>,
+    consumed_proxy_keys: &HashSet<String>,
+) -> Result<ForwardProxyRouteScope> {
+    match resolve_group_forward_proxy_scope_for_provisioning(
+        state,
+        binding,
+        assignments,
+        existing_match,
+        consumed_proxy_keys,
+    )
+    .await
+    {
+        Ok(scope) => Ok(scope),
+        Err(err)
+            if binding.node_shunt_enabled
+                && is_group_node_shunt_unassigned_message(&err.to_string()) =>
+        {
+            required_account_forward_proxy_scope(
+                Some(&binding.group_name),
+                binding.bound_proxy_keys.clone(),
+            )
+        }
+        Err(err) => Err(err),
+    }
 }
 
 pub(crate) fn build_imported_oauth_pending_response(
@@ -726,7 +756,7 @@ pub(crate) fn spawn_imported_oauth_validation_job(
                 };
                 let matched_account = existing_match.as_ref().map(import_match_summary_from_row);
 
-                let usage_scope = match resolve_group_forward_proxy_scope_for_provisioning(
+                let usage_scope = match resolve_imported_oauth_probe_scope(
                     state.as_ref(),
                     &binding,
                     Some(&assignments),
@@ -1442,7 +1472,7 @@ pub(crate) async fn import_validated_oauth_accounts(
             }
         };
         let matched_account = existing_match.as_ref().map(import_match_summary_from_row);
-        let usage_scope = match resolve_group_forward_proxy_scope_for_provisioning(
+        let usage_scope = match resolve_imported_oauth_probe_scope(
             state.as_ref(),
             &resolved_group_binding,
             Some(&assignments),

--- a/src/upstream_accounts/tests_part_1.rs
+++ b/src/upstream_accounts/tests_part_1.rs
@@ -2179,6 +2179,65 @@
     }
 
     #[tokio::test]
+    async fn imported_oauth_validation_job_keeps_node_shunt_group_blocked_without_selectable_nodes()
+    {
+        let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+
+        let Json(response) = create_imported_oauth_validation_job(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(ValidateImportedOauthAccountsRequest {
+                group_name: Some("stale-import-group".to_string()),
+                group_bound_proxy_keys: Some(vec!["stale-node".to_string()]),
+                group_node_shunt_enabled: Some(true),
+                items: vec![ImportOauthCredentialFileRequest {
+                    source_id: "source-stale".to_string(),
+                    file_name: "stale-session.json".to_string(),
+                    content: json!({
+                        "type": "codex",
+                        "email": "stale-session@example.com",
+                        "account_id": "acct_stale_session",
+                        "expired": "2099-04-20T00:00:00Z",
+                        "access_token": "access-stale-session",
+                        "id_token": test_id_token(
+                            "stale-session@example.com",
+                            Some("acct_stale_session"),
+                            Some("user_stale_session"),
+                            Some("team"),
+                        ),
+                    })
+                    .to_string(),
+                }],
+            }),
+        )
+        .await
+        .expect("start imported oauth validation job");
+        let job = state
+            .upstream_accounts
+            .get_validation_job(&response.job_id)
+            .await
+            .expect("validation job should exist");
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if job.terminal_event.lock().await.is_some() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("validation job should finish");
+
+        let rows = job.snapshot.lock().await.rows.clone();
+        let row = rows.first().expect("validation row");
+        assert_eq!(row.status, IMPORT_VALIDATION_STATUS_ERROR);
+        assert_eq!(
+            row.detail.as_deref(),
+            Some(group_node_shunt_unassigned_error_message())
+        );
+    }
+
+    #[tokio::test]
     async fn update_upstream_account_group_allows_note_only_edits_when_node_shunt_group_has_no_selectable_nodes()
      {
         let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;

--- a/src/upstream_accounts/tests_part_1.rs
+++ b/src/upstream_accounts/tests_part_1.rs
@@ -2037,6 +2037,148 @@
     }
 
     #[tokio::test]
+    async fn import_validated_oauth_accounts_persists_node_shunt_group_when_no_slot_is_available()
+    {
+        async fn usage_handler() -> (StatusCode, String) {
+            (
+                StatusCode::OK,
+                json!({
+                    "planType": "team",
+                    "rateLimit": {
+                        "primaryWindow": {
+                            "usedPercent": 12,
+                            "windowDurationMins": 300,
+                            "resetsAt": 1771322400
+                        }
+                    }
+                })
+                .to_string(),
+            )
+        }
+
+        let app = Router::new().route("/backend-api/wham/usage", get(usage_handler));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind imported validation server");
+        let addr = listener
+            .local_addr()
+            .expect("imported validation server addr");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve imported validation server");
+        });
+        let origin = format!("http://{addr}");
+
+        let state = test_app_state_with_usage_base(&format!("{origin}/backend-api")).await;
+        let crypto_key = state
+            .upstream_accounts
+            .crypto_key
+            .as_ref()
+            .expect("test crypto key");
+        let occupying_account_id = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Occupying Account",
+            "occupying@example.com",
+            "org_occupying",
+            "user_occupying",
+        )
+        .await;
+        set_test_account_group_name(&state.pool, occupying_account_id, Some("import-group")).await;
+        let mut conn = state.pool.acquire().await.expect("acquire metadata conn");
+        save_group_metadata_record_conn(
+            &mut conn,
+            "import-group",
+            UpstreamAccountGroupMetadata {
+                note: None,
+                bound_proxy_keys: test_required_group_bound_proxy_keys(),
+                node_shunt_enabled: true,
+                upstream_429_retry_enabled: false,
+                upstream_429_max_retries: 0,
+                concurrency_limit: 0,
+            },
+        )
+        .await
+        .expect("save node shunt metadata");
+        drop(conn);
+
+        let imported = ImportOauthCredentialFileRequest {
+            source_id: "source-new".to_string(),
+            file_name: "new-session.json".to_string(),
+            content: json!({
+                "type": "codex",
+                "email": "new-session@example.com",
+                "account_id": "acct_new_session",
+                "expired": "2099-04-20T00:00:00Z",
+                "access_token": "access-new-session",
+                "id_token": test_id_token(
+                    "new-session@example.com",
+                    Some("acct_new_session"),
+                    Some("user_new_session"),
+                    Some("team"),
+                ),
+            })
+            .to_string(),
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::HOST,
+            axum::http::HeaderValue::from_static("127.0.0.1:8080"),
+        );
+
+        let Json(response) = import_validated_oauth_accounts(
+            State(state.clone()),
+            headers,
+            Json(ImportValidatedOauthAccountsRequest {
+                items: vec![imported],
+                selected_source_ids: vec!["source-new".to_string()],
+                validation_job_id: None,
+                group_name: Some("import-group".to_string()),
+                group_bound_proxy_keys: Some(test_required_group_bound_proxy_keys()),
+                group_node_shunt_enabled: Some(true),
+                group_note: None,
+                concurrency_limit: None,
+                tag_ids: vec![],
+            }),
+        )
+        .await
+        .expect("import should persist even when node shunt slots are full");
+
+        assert_eq!(response.summary.created, 1);
+        assert_eq!(response.summary.failed, 0);
+        let account_id = response
+            .results
+            .first()
+            .and_then(|result| result.account_id)
+            .expect("created account id");
+        let assignments = build_upstream_account_node_shunt_assignments(state.as_ref())
+            .await
+            .expect("build node shunt assignments");
+        assert!(
+            !assignments.account_proxy_keys.contains_key(&account_id),
+            "new account should persist without stealing an occupied node shunt slot",
+        );
+        let row = load_upstream_account_row(&state.pool, account_id)
+            .await
+            .expect("load imported account")
+            .expect("imported account");
+        let metadata = load_group_metadata(&state.pool, Some("import-group"))
+            .await
+            .expect("load group metadata");
+        let err = resolve_account_forward_proxy_scope_from_assignments(
+            row.id,
+            row.group_name.as_deref(),
+            &metadata,
+            &assignments,
+        )
+        .expect_err("persisted account should remain unroutable until a node shunt slot opens");
+        assert!(is_group_node_shunt_unassigned_message(&err.to_string()));
+
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn update_upstream_account_group_allows_note_only_edits_when_node_shunt_group_has_no_selectable_nodes()
      {
         let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;

--- a/src/upstream_accounts/tests_part_1.rs
+++ b/src/upstream_accounts/tests_part_1.rs
@@ -1915,6 +1915,128 @@
     }
 
     #[tokio::test]
+    async fn imported_oauth_validation_job_probes_node_shunt_group_when_no_slot_is_available() {
+        async fn usage_handler() -> (StatusCode, String) {
+            (
+                StatusCode::OK,
+                json!({
+                    "planType": "team",
+                    "rateLimit": {
+                        "primaryWindow": {
+                            "usedPercent": 12,
+                            "windowDurationMins": 300,
+                            "resetsAt": 1771322400
+                        }
+                    }
+                })
+                .to_string(),
+            )
+        }
+
+        let app = Router::new().route("/backend-api/wham/usage", get(usage_handler));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind imported validation server");
+        let addr = listener
+            .local_addr()
+            .expect("imported validation server addr");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve imported validation server");
+        });
+        let origin = format!("http://{addr}");
+
+        let state = test_app_state_with_usage_base(&format!("{origin}/backend-api")).await;
+        let crypto_key = state
+            .upstream_accounts
+            .crypto_key
+            .as_ref()
+            .expect("test crypto key");
+        let occupying_account_id = insert_syncable_oauth_account(
+            &state.pool,
+            crypto_key,
+            "Occupying Account",
+            "occupying@example.com",
+            "org_occupying",
+            "user_occupying",
+        )
+        .await;
+        set_test_account_group_name(&state.pool, occupying_account_id, Some("import-group")).await;
+        let mut conn = state.pool.acquire().await.expect("acquire metadata conn");
+        save_group_metadata_record_conn(
+            &mut conn,
+            "import-group",
+            UpstreamAccountGroupMetadata {
+                note: None,
+                bound_proxy_keys: test_required_group_bound_proxy_keys(),
+                node_shunt_enabled: true,
+                upstream_429_retry_enabled: false,
+                upstream_429_max_retries: 0,
+                concurrency_limit: 0,
+            },
+        )
+        .await
+        .expect("save node shunt metadata");
+        drop(conn);
+
+        let Json(response) = create_imported_oauth_validation_job(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(ValidateImportedOauthAccountsRequest {
+                group_name: Some("import-group".to_string()),
+                group_bound_proxy_keys: Some(test_required_group_bound_proxy_keys()),
+                group_node_shunt_enabled: Some(true),
+                items: vec![ImportOauthCredentialFileRequest {
+                    source_id: "source-new".to_string(),
+                    file_name: "new-session.json".to_string(),
+                    content: json!({
+                        "type": "codex",
+                        "email": "new-session@example.com",
+                        "account_id": "acct_new_session",
+                        "expired": "2099-04-20T00:00:00Z",
+                        "access_token": "access-new-session",
+                        "id_token": test_id_token(
+                            "new-session@example.com",
+                            Some("acct_new_session"),
+                            Some("user_new_session"),
+                            Some("team"),
+                        ),
+                    })
+                    .to_string(),
+                }],
+            }),
+        )
+        .await
+        .expect("start imported oauth validation job");
+        let job = state
+            .upstream_accounts
+            .get_validation_job(&response.job_id)
+            .await
+            .expect("validation job should exist");
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if job.terminal_event.lock().await.is_some() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("validation job should finish");
+
+        let rows = job.snapshot.lock().await.rows.clone();
+        let row = rows.first().expect("validation row");
+        assert_eq!(row.status, IMPORT_VALIDATION_STATUS_OK);
+        assert_ne!(
+            row.detail.as_deref(),
+            Some(group_node_shunt_unassigned_error_message())
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn update_upstream_account_group_allows_note_only_edits_when_node_shunt_group_has_no_selectable_nodes()
      {
         let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;


### PR DESCRIPTION
## Summary
- Allow imported OAuth/Web Session validation to probe node-shunt groups even when no dedicated node-shunt slot is currently available.
- Keep runtime provisioning/routing behavior unchanged: accounts without assigned node-shunt slots still remain blocked from routing until a slot is available.
- Add regression coverage for validation and final import into a full node-shunt group.

## Verification
- cargo fmt --check
- cargo test node_shunt_group_when_no_slot_is_available -- --nocapture
- cargo test imported_oauth_validation_job -- --nocapture
- cargo test provisioning_scope_rejects_existing_account_without_node_shunt_slot_when_group_is_full -- --nocapture
- pre-commit: fmt, typecheck-web, cargo check --locked --all-targets --all-features

## References
Spec: -
Spec Disposition: not_needed
Spec Sync: n/a(spec-free)
Spec Drift: none
Solutions: -
Solutions Sync: n/a(no solution change)
Project Docs: -
Project Docs Sync: n/a(no project-doc change)

## Notes
<!-- CUSTOM_NOTES_START -->
Runtime diagnosis found the reported import error was caused by validation trying to reserve a node-shunt slot before the new session account existed. This PR relaxes import probing/final import so the credential can be persisted, while preserving runtime node-shunt route eligibility: the account remains unroutable with the existing unassigned-node reason until a slot opens.
<!-- CUSTOM_NOTES_END -->
