### PR TITLE
fix(pool): demote timed-out route proxy combinations

### DIFF
--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
@@ -8,3 +8,4 @@
 ## Key Decisions
 
 - No separate historical decision record was present before this migration.
+- 号池路由使用组合级短期降权，以 `pool_upstream_request_attempts.upstream_route_key + proxy_binding_key_snapshot` 作为传输组合键；仅 timeout/transport/stream failure 触发，后续成功清除惩罚，避免把账号硬失败误当作代理组合问题。

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
@@ -11,6 +11,7 @@
 
 - Status: 已完成
 - Note: 已移除错误的 whole-proxy admission gate，`PROXY_REQUEST_CONCURRENCY_*` 已进入 deprecated/ignored 兼容态；共享测试机 `codex-testbox` 100 并行压测通过，确认 `/v1/*` 不再因本地 admission gate 返回 `503`。
+- Note: 号池候选评分会读取最近 5 分钟的 `pool_upstream_request_attempts`，对最新仍处于 timeout/transport failure 的 `upstream_route_key + proxy_binding_key_snapshot` 组合增加短期排序惩罚；后续成功尝试会清除该短期惩罚。
 
 ## 验证
 
@@ -19,6 +20,9 @@
 - `cargo test proxy_request_tracking_can_reach_100_in_flight_without_local_rejection -- --nocapture`
 - `cargo test proxy_openai_v1_via_pool_reads_request_body_without_local_admission_gate -- --nocapture`
 - `cargo test list_invocations_ -- --nocapture`
+- `cargo test resolver_demotes_recent_timeout_for_same_upstream_route_and_proxy_binding -- --nocapture`
+- `cargo test resolver_does_not_demote_successful_or_non_timeout_route_proxy_history -- --nocapture`
+- `cargo test candidates_sort -- --nocapture`
 - `scripts/shared-testbox-proxy-parallel-smoke`
 
 ## Migrated Task-Ticket Sections

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
@@ -14,6 +14,7 @@
 - 让 request raw 与 response raw 从业务转发热路径旁路出去；资源紧张时优先丢 raw，不阻塞代理流。
 - 让大 body sticky/rewrite 不再默认整包内存物化；大体积 body 只做前缀探测，必要时回落到 file-backed replay。
 - 让 `/api/invocations` 分页主查询只对当前页记录执行重型投影，并让 summary/quota follow-up 在 burst 写入时自动合并。
+- 让号池路由在近期上游传输超时后降低同一上游端点与同一代理节点组合的选择优先级，避免短窗口内连续命中同一个坏传输组合。
 - 在共享测试机 `codex-testbox` 上完成 100 并行压测，验证本地 admission reject 已消失，且已有效的 hot-path 修复没有回退。
 
 ### Non-goals
@@ -46,6 +47,7 @@
 - 大 body sticky 探测只允许读取固定前缀窗口；超过窗口仍未识别时，直接回落到“无 body sticky 优化”的 replay 路径。
 - summary/quota follow-up 必须具备 burst coalesce，避免每条新记录都立即跑完整汇总。
 - `PROXY_REQUEST_CONCURRENCY_LIMIT` / `PROXY_REQUEST_CONCURRENCY_WAIT_TIMEOUT_MS` 只能作为弃用兼容项继续被读取与告警，不得再影响 `/v1/*` 准入。
+- 号池路由只能把近期 `transport_failure` 且 failure kind 属于 `upstream_handshake_timeout`、`failed_contact_upstream` 或 `upstream_stream_error` 的 `upstream_route_key + proxy_binding_key_snapshot` 组合纳入短期降权；同组合后续成功应清除该短期惩罚，认证、配额、402 等账号级硬失败不得混入组合降权。
 
 ## 验收标准（Acceptance Criteria）
 
@@ -55,6 +57,7 @@
 - `/api/invocations` 的分页主查询只先选出当前页 id，再对当前页记录执行完整投影。
 - summary/quota follow-up 在 burst 写入时能够合并，不再对每条记录立即触发一次完整汇总。
 - 即使线上环境仍设置 `PROXY_REQUEST_CONCURRENCY_LIMIT` / `PROXY_REQUEST_CONCURRENCY_WAIT_TIMEOUT_MS`，它们也只会产生日志告警，不会改变 `/v1/*` 准入行为。
+- Given 某 `upstream_route_key + proxy_binding_key_snapshot` 近期发生超时/传输失败，When 号池还有其它可路由组合，Then 路由排序优先尝试其它组合；若只有该组合可用，仍允许回退使用而不是直接报无账号。
 
 ## 参考
 

--- a/src/upstream_accounts/routing/selection.rs
+++ b/src/upstream_accounts/routing/selection.rs
@@ -6,6 +6,8 @@ struct LivePoolCandidateEvaluation {
     blocked_message: Option<String>,
 }
 
+const POOL_ROUTE_BINDING_FAILURE_PENALTY_WINDOW_SECS: i64 = 300;
+
 pub(crate) fn compare_pool_routing_candidate_scores(
     lhs: &PoolRoutingCandidateScore,
     rhs: &PoolRoutingCandidateScore,
@@ -16,13 +18,18 @@ pub(crate) fn compare_pool_routing_candidate_scores(
         rhs.dispatch_state == PoolRoutingCandidateDispatchState::RetryOriginalNode;
     // Hard-blocked candidates are filtered before sort. Ready candidates should always beat
     // "retry original unavailable node" fallbacks. Among sendable candidates, soft-limit
-    // pressure should still demote overflow accounts before priority/scarcity tie-breakers.
+    // pressure still demotes overflow accounts first, then recent route+proxy transport
+    // failures demote a bad combination before account priority/scarcity tie-breakers.
     lhs_requires_retry_original
         .cmp(&rhs_requires_retry_original)
         .then_with(|| {
             lhs.capacity_lane
                 .rank()
                 .cmp(&rhs.capacity_lane.rank())
+                .then_with(|| {
+                    lhs.route_binding_failure_penalty
+                        .cmp(&rhs.route_binding_failure_penalty)
+                })
                 .then_with(|| lhs.routing_priority_rank.cmp(&rhs.routing_priority_rank))
                 .then_with(|| lhs.eligibility.rank().cmp(&rhs.eligibility.rank()))
                 .then_with(|| lhs.dispatch_state.rank().cmp(&rhs.dispatch_state.rank()))
@@ -47,6 +54,7 @@ fn build_pool_routing_candidate_score(
     };
     PoolRoutingCandidateScore {
         eligibility,
+        route_binding_failure_penalty: 0,
         routing_priority_rank: routing_priority_rank(Some(effective_rule)),
         capacity_lane,
         dispatch_state,
@@ -55,6 +63,111 @@ fn build_pool_routing_candidate_score(
         last_selected_at: candidate.last_selected_at.clone(),
         account_id: candidate.id,
     }
+}
+
+fn pool_route_binding_penalty_key(upstream_route_key: &str, proxy_binding_key: &str) -> String {
+    format!("{upstream_route_key}\n{proxy_binding_key}")
+}
+
+fn pool_route_binding_failure_is_penalized(status: &str, failure_kind: Option<&str>) -> bool {
+    status == POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE
+        && matches!(
+            failure_kind,
+            Some(PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT)
+                | Some(PROXY_FAILURE_FAILED_CONTACT_UPSTREAM)
+                | Some(PROXY_FAILURE_UPSTREAM_STREAM_ERROR)
+        )
+}
+
+async fn load_recent_route_binding_failure_penalties(
+    pool: &Pool<Sqlite>,
+) -> Result<HashMap<String, i64>> {
+    #[derive(Debug, FromRow)]
+    struct RouteBindingAttemptRow {
+        upstream_route_key: String,
+        proxy_binding_key_snapshot: String,
+        status: String,
+        failure_kind: Option<String>,
+    }
+
+    let rows = sqlx::query_as::<_, RouteBindingAttemptRow>(
+        r#"
+        SELECT
+            upstream_route_key,
+            proxy_binding_key_snapshot,
+            status,
+            failure_kind
+        FROM pool_upstream_request_attempts
+        WHERE upstream_route_key IS NOT NULL
+          AND proxy_binding_key_snapshot IS NOT NULL
+          AND created_at >= datetime('now', ?1)
+        ORDER BY created_at ASC, id ASC
+        "#,
+    )
+    .bind(format!(
+        "-{} seconds",
+        POOL_ROUTE_BINDING_FAILURE_PENALTY_WINDOW_SECS
+    ))
+    .fetch_all(pool)
+    .await?;
+
+    let mut penalties = HashMap::new();
+    for row in rows {
+        let key = pool_route_binding_penalty_key(
+            row.upstream_route_key.as_str(),
+            row.proxy_binding_key_snapshot.as_str(),
+        );
+        if row.status == POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS {
+            penalties.remove(&key);
+            continue;
+        }
+        if pool_route_binding_failure_is_penalized(&row.status, row.failure_kind.as_deref()) {
+            *penalties.entry(key).or_insert(0) += 1;
+        }
+    }
+    Ok(penalties)
+}
+
+async fn route_binding_keys_for_candidate_scope(
+    state: &AppState,
+    scope: &ForwardProxyRouteScope,
+) -> Vec<String> {
+    let manager = state.forward_proxy.lock().await;
+    match scope {
+        ForwardProxyRouteScope::Automatic => Vec::new(),
+        ForwardProxyRouteScope::PinnedProxyKey(proxy_key) => manager
+            .canonicalize_bound_proxy_key(proxy_key, None)
+            .into_iter()
+            .collect(),
+        ForwardProxyRouteScope::BoundGroup {
+            group_name,
+            bound_proxy_keys,
+        } => manager
+            .current_bound_group_binding_key(group_name, bound_proxy_keys)
+            .map(|key| vec![key])
+            .unwrap_or_else(|| manager.selectable_bound_proxy_keys_in_order(bound_proxy_keys)),
+    }
+}
+
+async fn route_binding_failure_penalty_for_account(
+    state: &AppState,
+    account: &PoolResolvedAccount,
+    penalties: &HashMap<String, i64>,
+) -> i64 {
+    let upstream_route_key = account.upstream_route_key();
+    route_binding_keys_for_candidate_scope(state, &account.forward_proxy_scope)
+        .await
+        .into_iter()
+        .filter_map(|proxy_binding_key| {
+            penalties
+                .get(&pool_route_binding_penalty_key(
+                    upstream_route_key.as_str(),
+                    proxy_binding_key.as_str(),
+                ))
+                .copied()
+        })
+        .max()
+        .unwrap_or(0)
 }
 
 async fn build_assigned_blocked_account(
@@ -332,6 +445,9 @@ pub(crate) async fn resolve_pool_account_for_request_with_route_requirement(
     let mut sticky_assigned_blocked = None;
     let mut group_proxy_blocked_messages = Vec::new();
     let mut node_shunt_assignments = build_upstream_account_node_shunt_assignments(state).await?;
+    let route_binding_failure_penalties =
+        load_recent_route_binding_failure_penalties(&state.pool).await?;
+    let mut resolved_candidates = Vec::new();
 
     let sticky_route = if let Some(sticky_key) = sticky_key {
         load_sticky_route(&state.pool, sticky_key).await?
@@ -389,7 +505,7 @@ pub(crate) async fn resolve_pool_account_for_request_with_route_requirement(
                 .await?
                 {
                     PoolAccountGroupProxyRoutingReadiness::Ready(group_metadata) => {
-                        let evaluation = evaluate_live_pool_candidate(
+                        let mut evaluation = evaluate_live_pool_candidate(
                             state,
                             &row,
                             sticky_candidate
@@ -421,19 +537,39 @@ pub(crate) async fn resolve_pool_account_for_request_with_route_requirement(
                             now,
                         )
                         .await?;
-                        if let Some(mut account) = evaluation.resolved_account {
+                        if let Some(mut account) = evaluation.resolved_account.take() {
                             account.routing_source = PoolRoutingSelectionSource::StickyReuse;
                             if !excluded_upstream_route_keys.contains(&account.upstream_route_key())
                             {
-                                return Ok(PoolAccountResolution::Resolved(account));
-                            }
-                            sticky_route_excluded_by_route_key = true;
-                            sticky_route_was_excluded = true;
-                            if is_account_degraded_for_routing(&row, sticky_snapshot_exhausted, now)
-                            {
-                                saw_degraded_candidate = true;
+                                let route_binding_failure_penalty =
+                                    route_binding_failure_penalty_for_account(
+                                        state,
+                                        &account,
+                                        &route_binding_failure_penalties,
+                                    )
+                                    .await;
+                                if route_binding_failure_penalty > 0 {
+                                    evaluation.score.route_binding_failure_penalty =
+                                        route_binding_failure_penalty;
+                                    evaluation.resolved_account = Some(account);
+                                    resolved_candidates.push(evaluation);
+                                    sticky_route_was_excluded = true;
+                                    saw_other_non_rate_limited_routing_candidate = true;
+                                } else {
+                                    return Ok(PoolAccountResolution::Resolved(account));
+                                }
                             } else {
-                                saw_excluded_route_candidate = true;
+                                sticky_route_excluded_by_route_key = true;
+                                sticky_route_was_excluded = true;
+                                if is_account_degraded_for_routing(
+                                    &row,
+                                    sticky_snapshot_exhausted,
+                                    now,
+                                ) {
+                                    saw_degraded_candidate = true;
+                                } else {
+                                    saw_excluded_route_candidate = true;
+                                }
                             }
                         } else if sticky_route_is_excluded_by_route_key {
                             sticky_route_excluded_by_route_key = true;
@@ -541,8 +677,6 @@ pub(crate) async fn resolve_pool_account_for_request_with_route_requirement(
             .collect::<Vec<_>>(),
     )
     .await?;
-    let mut resolved_candidates = Vec::new();
-
     for candidate in candidates {
         let Some(row) = load_upstream_account_row(&state.pool, candidate.id).await? else {
             continue;
@@ -629,7 +763,7 @@ pub(crate) async fn resolve_pool_account_for_request_with_route_requirement(
                 continue;
             }
         };
-        let evaluation = evaluate_live_pool_candidate(
+        let mut evaluation = evaluate_live_pool_candidate(
             state,
             &row,
             &candidate,
@@ -645,6 +779,15 @@ pub(crate) async fn resolve_pool_account_for_request_with_route_requirement(
             | PoolRoutingCandidateEligibility::SoftDegraded
                 if evaluation.resolved_account.is_some() =>
             {
+                if let Some(account) = evaluation.resolved_account.as_ref() {
+                    evaluation.score.route_binding_failure_penalty =
+                        route_binding_failure_penalty_for_account(
+                            state,
+                            account,
+                            &route_binding_failure_penalties,
+                        )
+                        .await;
+                }
                 resolved_candidates.push(evaluation);
             }
             PoolRoutingCandidateEligibility::HardBlocked => {

--- a/src/upstream_accounts/routing/selection.rs
+++ b/src/upstream_accounts/routing/selection.rs
@@ -100,8 +100,8 @@ async fn load_recent_route_binding_failure_penalties(
         FROM pool_upstream_request_attempts
         WHERE upstream_route_key IS NOT NULL
           AND proxy_binding_key_snapshot IS NOT NULL
-          AND created_at >= datetime('now', ?1)
-        ORDER BY created_at ASC, id ASC
+          AND occurred_at >= datetime('now', ?1)
+        ORDER BY occurred_at ASC, id ASC
         "#,
     )
     .bind(format!(

--- a/src/upstream_accounts/routing/settings_runtime.rs
+++ b/src/upstream_accounts/routing/settings_runtime.rs
@@ -543,6 +543,7 @@ impl PoolRoutingCandidateDispatchState {
 #[derive(Debug, Clone)]
 pub(crate) struct PoolRoutingCandidateScore {
     pub(crate) eligibility: PoolRoutingCandidateEligibility,
+    pub(crate) route_binding_failure_penalty: i64,
     pub(crate) routing_priority_rank: u8,
     pub(crate) capacity_lane: PoolRoutingCandidateCapacityLane,
     pub(crate) dispatch_state: PoolRoutingCandidateDispatchState,

--- a/src/upstream_accounts/tests_part_4.rs
+++ b/src/upstream_accounts/tests_part_4.rs
@@ -2988,6 +2988,7 @@ async fn resolver_keeps_higher_priority_soft_degraded_candidate_ahead_of_lower_p
 fn retry_original_node_candidates_sort_after_sendable_candidates_even_when_priority_is_higher() {
     let retry_original = PoolRoutingCandidateScore {
         eligibility: PoolRoutingCandidateEligibility::SoftDegraded,
+        route_binding_failure_penalty: 0,
         routing_priority_rank: 0,
         capacity_lane: PoolRoutingCandidateCapacityLane::Primary,
         dispatch_state: PoolRoutingCandidateDispatchState::RetryOriginalNode,
@@ -2998,6 +2999,7 @@ fn retry_original_node_candidates_sort_after_sendable_candidates_even_when_prior
     };
     let ready_after_migration = PoolRoutingCandidateScore {
         eligibility: PoolRoutingCandidateEligibility::SoftDegraded,
+        route_binding_failure_penalty: 0,
         routing_priority_rank: 2,
         capacity_lane: PoolRoutingCandidateCapacityLane::Primary,
         dispatch_state: PoolRoutingCandidateDispatchState::ReadyAfterMigration,
@@ -3021,6 +3023,7 @@ fn retry_original_node_candidates_sort_after_sendable_candidates_even_when_prior
 fn overflow_candidates_sort_after_primary_candidates_even_when_priority_is_higher() {
     let overflow = PoolRoutingCandidateScore {
         eligibility: PoolRoutingCandidateEligibility::Assignable,
+        route_binding_failure_penalty: 0,
         routing_priority_rank: 0,
         capacity_lane: PoolRoutingCandidateCapacityLane::Overflow,
         dispatch_state: PoolRoutingCandidateDispatchState::ReadyOnOwnedNode,
@@ -3031,6 +3034,7 @@ fn overflow_candidates_sort_after_primary_candidates_even_when_priority_is_highe
     };
     let primary = PoolRoutingCandidateScore {
         eligibility: PoolRoutingCandidateEligibility::Assignable,
+        route_binding_failure_penalty: 0,
         routing_priority_rank: 2,
         capacity_lane: PoolRoutingCandidateCapacityLane::Primary,
         dispatch_state: PoolRoutingCandidateDispatchState::ReadyOnOwnedNode,

--- a/src/upstream_accounts/tests_part_5.rs
+++ b/src/upstream_accounts/tests_part_5.rs
@@ -1,4 +1,163 @@
 #[tokio::test]
+async fn resolver_demotes_recent_timeout_for_same_upstream_route_and_proxy_binding() {
+    let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+    let primary_route = "https://primary-timeout.example.com/backend-api/codex";
+    let alternate_route = "https://alternate-timeout.example.com/backend-api/codex";
+    let primary = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Primary Timeout Combo",
+        "sk-primary-timeout-combo",
+        None,
+        Some(primary_route),
+    )
+    .await;
+    let alternate = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Alternate Timeout Combo",
+        "sk-alternate-timeout-combo",
+        None,
+        Some(alternate_route),
+    )
+    .await;
+    let now_iso = format_utc_iso(Utc::now());
+    insert_limit_sample_with_usage(&state.pool, primary, &now_iso, Some(1.0), Some(1.0)).await;
+    insert_limit_sample_with_usage(&state.pool, alternate, &now_iso, Some(80.0), Some(20.0)).await;
+    seed_route_binding_attempt(
+        &state.pool,
+        "route-binding-timeout",
+        primary_route,
+        FORWARD_PROXY_DIRECT_KEY,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+        Some(PROXY_FAILURE_UPSTREAM_HANDSHAKE_TIMEOUT),
+    )
+    .await;
+
+    let resolution = resolve_pool_account_for_request(&state, None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account");
+    let PoolAccountResolution::Resolved(account) = resolution else {
+        panic!("expected resolved alternate account");
+    };
+    assert_eq!(account.account_id, alternate);
+}
+
+#[tokio::test]
+async fn resolver_does_not_demote_successful_or_non_timeout_route_proxy_history() {
+    let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+    let primary_route = "https://primary-success.example.com/backend-api/codex";
+    let alternate_route = "https://alternate-success.example.com/backend-api/codex";
+    let primary = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Primary Successful Combo",
+        "sk-primary-success-combo",
+        None,
+        Some(primary_route),
+    )
+    .await;
+    let alternate = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Alternate Successful Combo",
+        "sk-alternate-success-combo",
+        None,
+        Some(alternate_route),
+    )
+    .await;
+    let now_iso = format_utc_iso(Utc::now());
+    insert_limit_sample_with_usage(&state.pool, primary, &now_iso, Some(1.0), Some(1.0)).await;
+    insert_limit_sample_with_usage(&state.pool, alternate, &now_iso, Some(80.0), Some(20.0)).await;
+    seed_route_binding_attempt(
+        &state.pool,
+        "route-binding-auth-failure",
+        primary_route,
+        FORWARD_PROXY_DIRECT_KEY,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_HTTP_FAILURE,
+        Some(PROXY_FAILURE_UPSTREAM_HTTP_AUTH),
+    )
+    .await;
+    seed_route_binding_attempt(
+        &state.pool,
+        "route-binding-success",
+        primary_route,
+        FORWARD_PROXY_DIRECT_KEY,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS,
+        None,
+    )
+    .await;
+
+    let resolution = resolve_pool_account_for_request(&state, None, &[], &HashSet::new())
+        .await
+        .expect("resolve pool account");
+    let PoolAccountResolution::Resolved(account) = resolution else {
+        panic!("expected resolved primary account");
+    };
+    assert_eq!(account.account_id, primary);
+}
+
+async fn seed_route_binding_attempt(
+    pool: &SqlitePool,
+    invoke_id: &str,
+    upstream_base_url: &str,
+    proxy_binding_key_snapshot: &str,
+    status: &str,
+    failure_kind: Option<&str>,
+) {
+    let upstream_route_key = canonical_pool_upstream_route_key(
+        &Url::parse(upstream_base_url).expect("valid upstream route"),
+    );
+    let now_iso = format_utc_iso(Utc::now());
+    let phase = if status == POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS {
+        POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_COMPLETED
+    } else {
+        POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_FAILED
+    };
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_request_attempts (
+            invoke_id,
+            occurred_at,
+            endpoint,
+            route_mode,
+            sticky_key,
+            group_name_snapshot,
+            proxy_binding_key_snapshot,
+            upstream_account_id,
+            upstream_route_key,
+            attempt_index,
+            distinct_account_index,
+            same_account_retry_index,
+            requester_ip,
+            started_at,
+            finished_at,
+            status,
+            phase,
+            http_status,
+            error_message,
+            failure_kind,
+            created_at
+        )
+        VALUES (
+            ?1, ?2, '/v1/responses', ?3, NULL, ?4, ?5, 41, ?6,
+            1, 1, 0, '203.0.113.10', ?2, ?2, ?7, ?8, ?9, ?10, ?11, datetime('now')
+        )
+        "#,
+    )
+    .bind(invoke_id)
+    .bind(&now_iso)
+    .bind(INVOCATION_ROUTE_MODE_POOL)
+    .bind(test_required_group_name())
+    .bind(proxy_binding_key_snapshot)
+    .bind(upstream_route_key)
+    .bind(status)
+    .bind(phase)
+    .bind((status == POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS).then_some(200_i64))
+    .bind((status != POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS).then_some("test failure"))
+    .bind(failure_kind)
+    .execute(pool)
+    .await
+    .expect("seed route binding attempt");
+}
+
+#[tokio::test]
 async fn resolver_returns_specific_group_proxy_error_when_only_bad_groups_remain() {
     let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
     let crypto_key = state


### PR DESCRIPTION
## Summary
- Add short-window route+proxy transport-failure demotion to pool routing candidate scoring.
- Reuse existing `pool_upstream_request_attempts.upstream_route_key` and `proxy_binding_key_snapshot` as the combination key.
- Update the hot-path stability spec with the new routing behavior and validation coverage.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `bunx dprint check docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md`
- `cargo check --tests`
- `cargo test resolver_demotes_recent_timeout_for_same_upstream_route_and_proxy_binding -- --nocapture`
- `cargo test resolver_does_not_demote_successful_or_non_timeout_route_proxy_history -- --nocapture`
- `cargo test candidates_sort -- --nocapture`
- `cargo test pool_route_oauth_responses_timeout_switches_to_alternate_route -- --nocapture`
- pre-commit hook: `fmt`, `check`, `format-markdown`, `typecheck-web`

## References
- Specs: `docs/specs/q8h3n-proxy-hot-path-streaming-stability/`
- Solutions: -
- Project Docs: -

## Notes
- `solution_disposition=none`: no reusable cross-task solution needed.
- `project_doc_disposition=none`: no human-facing project docs changed.