### PR TITLE
fix(forward-proxy): parse batch latency keys

### DIFF
--- a/src/forward_proxy/slices/manager_xray_types_and_tests.rs
+++ b/src/forward_proxy/slices/manager_xray_types_and_tests.rs
@@ -1486,4 +1486,18 @@ mod tests {
             vec![(1, 0), (1, 1), (1, 2), (2, 0), (2, 1), (2, 2)]
         );
     }
+
+    #[test]
+    fn manual_latency_batch_query_accepts_repeated_keys() {
+        assert_eq!(
+            parse_forward_proxy_nodes_latency_test_keys(
+                "key=__direct__&key=fpn_a&ignored=value&key=fpn_b"
+            ),
+            vec![
+                "__direct__".to_string(),
+                "fpn_a".to_string(),
+                "fpn_b".to_string()
+            ]
+        );
+    }
 }

--- a/src/forward_proxy/slices/storage_and_hourly_stats.rs
+++ b/src/forward_proxy/slices/storage_and_hourly_stats.rs
@@ -2358,10 +2358,10 @@ pub(crate) async fn post_forward_proxy_refresh_subscriptions(
     }))
 }
 
-#[derive(Debug, Deserialize)]
-pub(crate) struct ForwardProxyNodesLatencyTestQuery {
-    #[serde(default)]
-    key: Vec<String>,
+pub(crate) fn parse_forward_proxy_nodes_latency_test_keys(raw_query: &str) -> Vec<String> {
+    url::form_urlencoded::parse(raw_query.as_bytes())
+        .filter_map(|(key, value)| (key == "key").then(|| value.into_owned()))
+        .collect()
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2926,7 +2926,7 @@ pub(crate) async fn stream_forward_proxy_node_latency_test(
 pub(crate) async fn stream_forward_proxy_nodes_latency_test(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Query(query): Query<ForwardProxyNodesLatencyTestQuery>,
+    OriginalUri(uri): OriginalUri,
 ) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, (StatusCode, String)>
 {
     if !is_same_origin_settings_write(&headers) {
@@ -2935,7 +2935,8 @@ pub(crate) async fn stream_forward_proxy_nodes_latency_test(
             "cross-origin settings writes are forbidden".to_string(),
         ));
     }
-    let endpoints = load_forward_proxy_endpoints_for_latency_test(state.as_ref(), &query.key).await?;
+    let proxy_keys = parse_forward_proxy_nodes_latency_test_keys(uri.query().unwrap_or_default());
+    let endpoints = load_forward_proxy_endpoints_for_latency_test(state.as_ref(), &proxy_keys).await?;
     Ok(stream_forward_proxy_latency_tests(state, endpoints, false))
 }
 


### PR DESCRIPTION
## Summary
- Fix batch forward-proxy latency testing returning 400 for repeated `key` query params.
- Parse the raw query string with `url::form_urlencoded` so `?key=a&key=b` works with the existing frontend EventSource URL.

## Production Diagnosis
- Opened `https://vibe-code.ivanli.cc/#/settings` in Chrome DevTools.
- Single-node latency stream works and returns results.
- Batch latency stream currently fails with `400 Failed to deserialize query string: invalid type: string "__direct__", expected a sequence`.

## Validation
- `cargo fmt --check`
- `cargo test manual_latency -- --test-threads=1`
- pre-commit hook: `fmt`, `typecheck-web`, `check`

## References
- Follow-up to #428
