### PR TITLE
fix(web): preserve compact metric suffixes in narrow dashboard tiles

### DIFF
--- a/web/src/components/AdaptiveMetricValue.test.tsx
+++ b/web/src/components/AdaptiveMetricValue.test.tsx
@@ -13,7 +13,7 @@ vi.mock('./AnimatedDigits', () => ({
 let host: HTMLDivElement | null = null
 let root: Root | null = null
 let metricContainerWidth = 320
-let metricMeasureWidth = 120
+let metricMeasureWidths = new Map<string, number>()
 
 class MockResizeObserver {
   static instances = new Set<MockResizeObserver>()
@@ -82,7 +82,11 @@ beforeAll(() => {
     configurable: true,
     get() {
       if ((this as HTMLElement).dataset.adaptiveMetricMeasure === 'true') {
-        return metricMeasureWidth
+        const key =
+          (this as HTMLElement).dataset.adaptiveMetricMeasureIndex ??
+          (this as HTMLElement).textContent ??
+          '0'
+        return metricMeasureWidths.get(key) ?? 0
       }
       return 0
     },
@@ -97,7 +101,12 @@ afterEach(() => {
   host = null
   root = null
   metricContainerWidth = 320
-  metricMeasureWidth = 120
+  metricMeasureWidths = new Map([
+    ['0', 120],
+    ['1', 88],
+    ['2', 80],
+    ['3', 72],
+  ])
   MockResizeObserver.instances.clear()
 })
 
@@ -118,6 +127,14 @@ function getMetric() {
   return metric
 }
 
+function getVisibleMetricText() {
+  const visible = host?.querySelector('[data-adaptive-metric-visible="true"]')
+  if (!(visible instanceof HTMLElement)) {
+    throw new Error('Missing visible metric element')
+  }
+  return visible.textContent ?? ''
+}
+
 function getMeasure() {
   const measure = host?.querySelector('[data-adaptive-metric-measure="true"]')
   if (!(measure instanceof HTMLElement)) {
@@ -128,6 +145,13 @@ function getMeasure() {
 
 describe('AdaptiveMetricValue', () => {
   it('switches to compact notation when the measured text widens without a container resize', () => {
+    metricMeasureWidths = new Map([
+      ['0', 120],
+      ['1', 96],
+      ['2', 88],
+      ['3', 72],
+    ])
+
     render(
       <AdaptiveMetricValue
         value={1314275579}
@@ -138,18 +162,26 @@ describe('AdaptiveMetricValue', () => {
 
     expect(getMetric().dataset.compact).toBe('false')
 
-    metricMeasureWidth = 400
+    metricMeasureWidths.set('0', 400)
     act(() => {
       MockResizeObserver.notify(getMeasure())
     })
 
     expect(getMetric().dataset.compact).toBe('true')
-    expect(getMetric().textContent).toContain('1.31B')
+    expect(getVisibleMetricText()).toContain('1.31B')
+    expect(getMetric().dataset.compactPrecision).toBe('2')
     expect(getMetric().getAttribute('title')).toBe('1,314,275,579')
     expect(host?.querySelector('[data-testid="animated-digits"]')).toBeNull()
   })
 
   it('re-evaluates overflow on window resize even when ResizeObserver is available', () => {
+    metricMeasureWidths = new Map([
+      ['0', 120],
+      ['1', 96],
+      ['2', 88],
+      ['3', 72],
+    ])
+
     render(
       <AdaptiveMetricValue
         value={1314275579}
@@ -170,7 +202,12 @@ describe('AdaptiveMetricValue', () => {
 
   it('keeps the short-scale compact suffix for zh overflow fallback', () => {
     metricContainerWidth = 100
-    metricMeasureWidth = 400
+    metricMeasureWidths = new Map([
+      ['0', 400],
+      ['1', 96],
+      ['2', 88],
+      ['3', 72],
+    ])
 
     render(
       <AdaptiveMetricValue
@@ -181,10 +218,18 @@ describe('AdaptiveMetricValue', () => {
     )
 
     expect(getMetric().dataset.compact).toBe('true')
-    expect(getMetric().textContent).toContain('1.31B')
+    expect(getVisibleMetricText()).toContain('1.3B')
+    expect(getVisibleMetricText()).toContain('B')
   })
 
   it('keeps AnimatedDigits only for non-compact number rendering', () => {
+    metricMeasureWidths = new Map([
+      ['0', 120],
+      ['1', 96],
+      ['2', 88],
+      ['3', 72],
+    ])
+
     render(
       <AdaptiveMetricValue
         value={12345}
@@ -196,12 +241,36 @@ describe('AdaptiveMetricValue', () => {
     expect(host?.querySelector('[data-testid="animated-digits"]')?.textContent).toBe('12,345')
 
     metricContainerWidth = 80
-    metricMeasureWidth = 240
+    metricMeasureWidths.set('0', 240)
     act(() => {
       MockResizeObserver.notify(getMeasure())
     })
 
     expect(getMetric().dataset.compact).toBe('true')
     expect(host?.querySelector('[data-testid="animated-digits"]')).toBeNull()
+  })
+
+  it('drops compact decimal precision to preserve the magnitude suffix when width is very tight', () => {
+    metricContainerWidth = 76
+    metricMeasureWidths = new Map([
+      ['0', 220],
+      ['1', 98],
+      ['2', 86],
+      ['3', 58],
+    ])
+
+    render(
+      <AdaptiveMetricValue
+        value={281_110_000}
+        localeTag="en-US"
+        data-testid="adaptive-metric"
+      />,
+    )
+
+    expect(getMetric().dataset.compact).toBe('true')
+    expect(getMetric().dataset.compactPrecision).toBe('0')
+    expect(getVisibleMetricText()).toContain('281M')
+    expect(getVisibleMetricText()).not.toContain('281.11M')
+    expect(getMetric().getAttribute('title')).toBe('281,110,000')
   })
 })

--- a/web/src/components/AdaptiveMetricValue.tsx
+++ b/web/src/components/AdaptiveMetricValue.tsx
@@ -6,6 +6,16 @@ export type AdaptiveMetricValueKind = 'number' | 'integer' | 'currency'
 const ADAPTIVE_METRIC_COMPACT_GUTTER_PX = 12
 const COMPACT_SUFFIX_LOCALE = 'en-US'
 
+interface MetricFormatterOptions {
+  compact: boolean
+  maximumFractionDigits?: number
+}
+
+interface CompactCandidate {
+  value: string
+  precision: number
+}
+
 interface AdaptiveMetricValueProps {
   value: number
   localeTag: string
@@ -17,7 +27,7 @@ interface AdaptiveMetricValueProps {
 function createMetricFormatter(
   localeTag: string,
   kind: AdaptiveMetricValueKind,
-  compact: boolean,
+  { compact, maximumFractionDigits }: MetricFormatterOptions,
 ) {
   // Product choice: zh dashboards use short-scale suffixes like `1.31B`
   // for overflow fallback because they are materially shorter than localized compact units.
@@ -31,14 +41,36 @@ function createMetricFormatter(
       style: 'currency',
       currency: 'USD',
       notation: compact ? 'compact' : 'standard',
-      maximumFractionDigits: 2,
+      maximumFractionDigits: maximumFractionDigits ?? 2,
     })
   }
 
   return new Intl.NumberFormat(compactLocale, {
     notation: compact ? 'compact' : 'standard',
-    maximumFractionDigits: kind === 'integer' ? 0 : 2,
+    maximumFractionDigits: maximumFractionDigits ?? (kind === 'integer' ? 0 : 2),
   })
+}
+
+function buildCompactCandidates(
+  value: number,
+  localeTag: string,
+  kind: AdaptiveMetricValueKind,
+): CompactCandidate[] {
+  const precisionCandidates = kind === 'integer' ? [0] : [2, 1, 0]
+  const uniqueValues = new Set<string>()
+  const candidates: CompactCandidate[] = []
+
+  for (const precision of precisionCandidates) {
+    const compactValue = createMetricFormatter(localeTag, kind, {
+      compact: true,
+      maximumFractionDigits: precision,
+    }).format(value)
+    if (uniqueValues.has(compactValue)) continue
+    uniqueValues.add(compactValue)
+    candidates.push({ value: compactValue, precision })
+  }
+
+  return candidates
 }
 
 export function AdaptiveMetricValue({
@@ -49,33 +81,52 @@ export function AdaptiveMetricValue({
   'data-testid': dataTestId,
 }: AdaptiveMetricValueProps) {
   const containerRef = useRef<HTMLSpanElement | null>(null)
-  const measureRef = useRef<HTMLSpanElement | null>(null)
-  const [useCompactValue, setUseCompactValue] = useState(false)
+  const measureRefs = useRef<Array<HTMLSpanElement | null>>([])
+  const [compactPrecision, setCompactPrecision] = useState<number | null>(null)
 
   const fullValue = useMemo(
-    () => createMetricFormatter(localeTag, kind, false).format(value),
+    () => createMetricFormatter(localeTag, kind, { compact: false }).format(value),
     [kind, localeTag, value],
   )
-  const compactValue = useMemo(
-    () => createMetricFormatter(localeTag, kind, true).format(value),
+  const compactCandidates = useMemo(
+    () => buildCompactCandidates(value, localeTag, kind),
     [kind, localeTag, value],
   )
 
   const evaluateOverflow = useCallback(() => {
     const container = containerRef.current
-    const measure = measureRef.current
-    if (!container || !measure) return
+    if (!container) return
 
     const availableWidth = container.clientWidth
-    const requiredWidth = measure.scrollWidth
-    if (availableWidth <= 0 || requiredWidth <= 0) return
+    if (availableWidth <= 0) return
 
-    const nextUseCompactValue =
-      requiredWidth + ADAPTIVE_METRIC_COMPACT_GUTTER_PX > availableWidth
-    setUseCompactValue((current) =>
-      current === nextUseCompactValue ? current : nextUseCompactValue,
+    const measures = measureRefs.current
+    const fullMeasure = measures[0]
+    const fullRequiredWidth = fullMeasure?.scrollWidth ?? 0
+    if (fullRequiredWidth <= 0) return
+
+    if (fullRequiredWidth + ADAPTIVE_METRIC_COMPACT_GUTTER_PX <= availableWidth) {
+      setCompactPrecision((current) => (current === null ? current : null))
+      return
+    }
+
+    let nextCompactPrecision = compactCandidates.at(-1)?.precision ?? null
+
+    for (let index = 0; index < compactCandidates.length; index += 1) {
+      const candidate = compactCandidates[index]
+      const measure = measures[index + 1]
+      const requiredWidth = measure?.scrollWidth ?? 0
+      if (requiredWidth <= 0) continue
+      if (requiredWidth + ADAPTIVE_METRIC_COMPACT_GUTTER_PX <= availableWidth) {
+        nextCompactPrecision = candidate.precision
+        break
+      }
+    }
+
+    setCompactPrecision((current) =>
+      current === nextCompactPrecision ? current : nextCompactPrecision,
     )
-  }, [])
+  }, [compactCandidates])
 
   useLayoutEffect(() => {
     evaluateOverflow()
@@ -90,7 +141,6 @@ export function AdaptiveMetricValue({
 
   useLayoutEffect(() => {
     const container = containerRef.current
-    const measure = measureRef.current
     if (!container) return undefined
 
     window.addEventListener('resize', evaluateOverflow)
@@ -105,8 +155,8 @@ export function AdaptiveMetricValue({
       evaluateOverflow()
     })
     observer.observe(container)
-    if (measure) {
-      observer.observe(measure)
+    for (const measure of measureRefs.current) {
+      if (measure) observer.observe(measure)
     }
 
     return () => {
@@ -115,27 +165,41 @@ export function AdaptiveMetricValue({
     }
   }, [evaluateOverflow])
 
-  const visibleValue = useCompactValue ? compactValue : fullValue
-  const shouldAnimateDigits = (kind === 'number' || kind === 'integer') && !useCompactValue
+  const visibleValue =
+    compactPrecision == null
+      ? fullValue
+      : compactCandidates.find((candidate) => candidate.precision === compactPrecision)?.value ?? fullValue
+  const shouldAnimateDigits = (kind === 'number' || kind === 'integer') && compactPrecision == null
 
   return (
     <span
       ref={containerRef}
       data-adaptive-metric-container="true"
-      data-compact={useCompactValue ? 'true' : 'false'}
+      data-compact={compactPrecision == null ? 'false' : 'true'}
+      data-compact-precision={compactPrecision == null ? 'full' : String(compactPrecision)}
       data-testid={dataTestId}
-      title={useCompactValue ? fullValue : undefined}
+      title={compactPrecision == null ? undefined : fullValue}
       className={`relative block min-w-0 max-w-full overflow-hidden whitespace-nowrap tabular-nums ${className ?? ''}`}
     >
+      {[fullValue, ...compactCandidates.map((candidate) => candidate.value)].map((candidateValue, index) => (
+        <span
+          key={`${index}-${candidateValue}`}
+          ref={(node) => {
+            measureRefs.current[index] = node
+          }}
+          aria-hidden
+          data-adaptive-metric-measure="true"
+          data-adaptive-metric-measure-kind={index === 0 ? 'full' : 'compact'}
+          data-adaptive-metric-measure-index={String(index)}
+          className="pointer-events-none invisible absolute left-0 top-0 whitespace-nowrap tabular-nums"
+        >
+          {candidateValue}
+        </span>
+      ))}
       <span
-        ref={measureRef}
-        aria-hidden
-        data-adaptive-metric-measure="true"
-        className="pointer-events-none invisible absolute left-0 top-0 whitespace-nowrap tabular-nums"
+        data-adaptive-metric-visible="true"
+        className="block max-w-full overflow-hidden whitespace-nowrap"
       >
-        {fullValue}
-      </span>
-      <span className="block max-w-full overflow-hidden whitespace-nowrap">
         {shouldAnimateDigits ? <AnimatedDigits value={visibleValue} /> : visibleValue}
       </span>
     </span>

--- a/web/src/components/DashboardActivityOverview.stories.tsx
+++ b/web/src/components/DashboardActivityOverview.stories.tsx
@@ -10,20 +10,28 @@ import {
 type SummaryKey = 'today' | 'yesterday' | 'previous7d' | '1d' | '7d'
 type TimeseriesKey = 'today:1m' | 'yesterday:1m' | '1d:1m' | '7d:1h' | '6mo:1d'
 type PersistedRange = 'today' | 'yesterday' | '1d' | '7d' | 'usage' | null
+type SummaryFixture = ReturnType<typeof createSummary>
+type TimeseriesFixture =
+  | ReturnType<typeof buildTodayMinutePoints>
+  | ReturnType<typeof build24HourPoints>
+  | ReturnType<typeof buildHourlyPoints>
+  | ReturnType<typeof buildDailyPoints>
 type WindowWithDashboardFetchLog = Window & {
   __dashboardOverviewFetchLog__?: string[]
 }
 type DashboardOverviewParameters = {
   persistedRange?: PersistedRange
   failTodayTimeseries?: boolean
+  summaryOverrides?: Partial<Record<SummaryKey, SummaryFixture>>
+  timeseriesOverrides?: Partial<Record<TimeseriesKey, TimeseriesFixture>>
+  delaySummaryWindows?: SummaryKey[]
+  responseDelayMs?: number
 }
 
-function StorySurface({ children }: { children: ReactNode }) {
-  return (
-    <div className="min-h-screen bg-base-200 px-6 py-6 text-base-content">
-      <div className="mx-auto w-full max-w-[1660px]">{children}</div>
-    </div>
-  )
+type AccountActivityOverviewProps = {
+  title: string
+  upstreamAccountId: number
+  testId: string
 }
 
 function jsonResponse(body: unknown) {
@@ -312,9 +320,17 @@ function distributeInteger(total: number, weights: number[]) {
 function DashboardOverviewMockApi({
   children,
   failTodayTimeseries = false,
+  summaryOverrides = {},
+  timeseriesOverrides = {},
+  delaySummaryWindows = [],
+  responseDelayMs = 0,
 }: {
   children: ReactNode
   failTodayTimeseries?: boolean
+  summaryOverrides?: Partial<Record<SummaryKey, SummaryFixture>>
+  timeseriesOverrides?: Partial<Record<TimeseriesKey, TimeseriesFixture>>
+  delaySummaryWindows?: SummaryKey[]
+  responseDelayMs?: number
 }) {
   const originalFetchRef = useRef<typeof window.fetch | null>(null)
   const originalEventSourceRef = useRef<typeof window.EventSource | null>(null)
@@ -333,7 +349,10 @@ function DashboardOverviewMockApi({
       if (url.pathname === '/api/stats/summary') {
         const windowKey = url.searchParams.get('window') as SummaryKey | null
         if (windowKey && windowKey in SUMMARY_FIXTURES) {
-          return jsonResponse(SUMMARY_FIXTURES[windowKey])
+          if (delaySummaryWindows.includes(windowKey) && responseDelayMs > 0) {
+            await new Promise((resolve) => window.setTimeout(resolve, responseDelayMs))
+          }
+          return jsonResponse(summaryOverrides[windowKey] ?? SUMMARY_FIXTURES[windowKey])
         }
       }
 
@@ -348,7 +367,7 @@ function DashboardOverviewMockApi({
           })
         }
         if (key in TIMESERIES_FIXTURES) {
-          return jsonResponse(TIMESERIES_FIXTURES[key])
+          return jsonResponse(timeseriesOverrides[key] ?? TIMESERIES_FIXTURES[key])
         }
       }
 
@@ -372,9 +391,54 @@ function DashboardOverviewMockApi({
       })
       delete windowWithFetchLog.__dashboardOverviewFetchLog__
     }
-  }, [failTodayTimeseries])
+  }, [delaySummaryWindows, failTodayTimeseries, responseDelayMs, summaryOverrides, timeseriesOverrides])
 
   return <>{children}</>
+}
+
+function DashboardOverviewStoryEnvironment({
+  children,
+  parameters,
+  maxWidth = '1660px',
+}: {
+  children: ReactNode
+  parameters: DashboardOverviewParameters
+  maxWidth?: string
+}) {
+  return (
+    <I18nProvider>
+      <DashboardOverviewMockApi
+        failTodayTimeseries={parameters.failTodayTimeseries === true}
+        summaryOverrides={(parameters.summaryOverrides ?? {}) as Partial<Record<SummaryKey, SummaryFixture>>}
+        timeseriesOverrides={(parameters.timeseriesOverrides ?? {}) as Partial<Record<TimeseriesKey, TimeseriesFixture>>}
+        delaySummaryWindows={(parameters.delaySummaryWindows ?? []) as SummaryKey[]}
+        responseDelayMs={(parameters.responseDelayMs ?? 0) as number}
+      >
+        <div className="min-h-screen bg-base-200 px-6 py-6 text-base-content">
+          <div className="mx-auto w-full" style={{ maxWidth }}>
+            <RangeStorageHarness persistedRange={(parameters.persistedRange ?? null) as PersistedRange}>
+              {children}
+            </RangeStorageHarness>
+          </div>
+        </div>
+      </DashboardOverviewMockApi>
+    </I18nProvider>
+  )
+}
+
+function EmbeddedAccountActivityOverview({
+  title = '账号活动总览',
+  upstreamAccountId = 42,
+  testId = 'upstream-account-records-activity-overview',
+}: Partial<AccountActivityOverviewProps>) {
+  return (
+    <DashboardActivityOverview
+      title={title}
+      upstreamAccountId={upstreamAccountId}
+      testId={testId}
+      storageKey={`storybook.dashboard.account-activity.${upstreamAccountId}`}
+    />
+  )
 }
 
 function RangeStorageHarness({
@@ -420,15 +484,11 @@ const meta = {
   },
   decorators: [
     (Story, context) => (
-      <I18nProvider>
-        <DashboardOverviewMockApi failTodayTimeseries={(context.parameters as DashboardOverviewParameters).failTodayTimeseries === true}>
-          <StorySurface>
-            <RangeStorageHarness persistedRange={((context.parameters as DashboardOverviewParameters).persistedRange ?? null) as PersistedRange}>
-              <Story />
-            </RangeStorageHarness>
-          </StorySurface>
-        </DashboardOverviewMockApi>
-      </I18nProvider>
+      <DashboardOverviewStoryEnvironment
+        parameters={context.parameters as DashboardOverviewParameters}
+      >
+        <Story />
+      </DashboardOverviewStoryEnvironment>
     ),
   ],
 } satisfies Meta<typeof DashboardActivityOverview>
@@ -455,17 +515,12 @@ export const TodayViewNarrowDesktop: Story = {
   },
   decorators: [
     (Story, context) => (
-      <I18nProvider>
-        <DashboardOverviewMockApi failTodayTimeseries={(context.parameters as DashboardOverviewParameters).failTodayTimeseries === true}>
-          <div className="min-h-screen bg-base-200 px-6 py-6 text-base-content">
-            <div className="mx-auto w-full max-w-[1280px]">
-              <RangeStorageHarness persistedRange={((context.parameters as DashboardOverviewParameters).persistedRange ?? null) as PersistedRange}>
-                <Story />
-              </RangeStorageHarness>
-            </div>
-          </div>
-        </DashboardOverviewMockApi>
-      </I18nProvider>
+      <DashboardOverviewStoryEnvironment
+        parameters={context.parameters as DashboardOverviewParameters}
+        maxWidth="1280px"
+      >
+        <Story />
+      </DashboardOverviewStoryEnvironment>
     ),
   ],
   play: async ({ canvasElement }) => {
@@ -475,6 +530,140 @@ export const TodayViewNarrowDesktop: Story = {
       expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact', 'true')
       expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact-precision', '0')
       expect(canvas.getByTestId('today-stats-value-total-tokens').textContent ?? '').toContain('18M')
+    })
+  },
+}
+
+const NARROW_OVERFLOW_TODAY_SUMMARY = createSummary(3428, 3296, 132, 173.3, 281110000)
+
+export const TodayViewNarrowDesktopOverflow: Story = {
+  parameters: {
+    viewport: { defaultViewport: 'desktop1280' },
+    summaryOverrides: {
+      today: NARROW_OVERFLOW_TODAY_SUMMARY,
+    },
+    timeseriesOverrides: {
+      'today:1m': buildTodayMinutePoints(NARROW_OVERFLOW_TODAY_SUMMARY),
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      <DashboardOverviewStoryEnvironment
+        parameters={context.parameters as DashboardOverviewParameters}
+        maxWidth="1280px"
+      >
+        <Story />
+      </DashboardOverviewStoryEnvironment>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() => {
+      expect(canvas.getByRole('tab', { name: /今日|today/i })).toHaveAttribute('aria-selected', 'true')
+      expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact', 'true')
+      expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact-precision', '0')
+      expect(canvas.getByTestId('today-stats-value-total-tokens').textContent ?? '').toContain('281M')
+      expect(canvas.getByTestId('dashboard-today-activity-chart')).toBeVisible()
+    })
+  },
+}
+
+export const TodayViewNarrowDesktopLoading: Story = {
+  parameters: {
+    viewport: { defaultViewport: 'desktop1280' },
+    delaySummaryWindows: ['today'],
+    responseDelayMs: 15000,
+  },
+  decorators: [
+    (Story, context) => (
+      <DashboardOverviewStoryEnvironment
+        parameters={context.parameters as DashboardOverviewParameters}
+        maxWidth="1280px"
+      >
+        <Story />
+      </DashboardOverviewStoryEnvironment>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() => {
+      expect(canvas.getByRole('tab', { name: /今日|today/i })).toHaveAttribute('aria-selected', 'true')
+      expect(canvas.getByTestId('today-stats-value-tpm-loading')).toBeVisible()
+      expect(canvas.getByTestId('today-stats-value-total-tokens-loading')).toBeVisible()
+      expect(canvas.getByTestId('dashboard-today-activity-chart')).toBeVisible()
+    })
+  },
+}
+
+export const AccountTodayNarrowDesktopOverflowDark: Story = {
+  globals: {
+    themeMode: 'dark',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'desktop1280' },
+    summaryOverrides: {
+      today: NARROW_OVERFLOW_TODAY_SUMMARY,
+    },
+    timeseriesOverrides: {
+      'today:1m': buildTodayMinutePoints(NARROW_OVERFLOW_TODAY_SUMMARY),
+    },
+  },
+  render: () => <EmbeddedAccountActivityOverview />,
+  decorators: [
+    (Story, context) => (
+      <DashboardOverviewStoryEnvironment
+        parameters={context.parameters as DashboardOverviewParameters}
+        maxWidth="1280px"
+      >
+        <Story />
+      </DashboardOverviewStoryEnvironment>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() => {
+      expect(canvas.getByTestId('upstream-account-records-activity-overview')).toBeVisible()
+      expect(canvas.getByRole('heading', { name: '账号活动总览' })).toBeVisible()
+      expect(canvas.getByRole('tab', { name: /今日|today/i })).toHaveAttribute('aria-selected', 'true')
+      expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact', 'true')
+      expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact-precision', '0')
+      expect(canvas.getByTestId('today-stats-value-total-tokens').textContent ?? '').toContain('281M')
+      expect(canvas.queryByText(/并行对话|parallel/i)).toBeNull()
+      expect(canvas.getByTestId('dashboard-today-activity-chart')).toBeVisible()
+    })
+  },
+}
+
+export const AccountTodayNarrowDesktopLoadingDark: Story = {
+  globals: {
+    themeMode: 'dark',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'desktop1280' },
+    delaySummaryWindows: ['today'],
+    responseDelayMs: 15000,
+  },
+  render: () => <EmbeddedAccountActivityOverview />,
+  decorators: [
+    (Story, context) => (
+      <DashboardOverviewStoryEnvironment
+        parameters={context.parameters as DashboardOverviewParameters}
+        maxWidth="1280px"
+      >
+        <Story />
+      </DashboardOverviewStoryEnvironment>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() => {
+      expect(canvas.getByTestId('upstream-account-records-activity-overview')).toBeVisible()
+      expect(canvas.getByRole('heading', { name: '账号活动总览' })).toBeVisible()
+      expect(canvas.getByRole('tab', { name: /今日|today/i })).toHaveAttribute('aria-selected', 'true')
+      expect(canvas.getByTestId('today-stats-value-tpm-loading')).toBeVisible()
+      expect(canvas.getByTestId('today-stats-value-total-tokens-loading')).toBeVisible()
+      expect(canvas.queryByText(/并行对话|parallel/i)).toBeNull()
+      expect(canvas.getByTestId('dashboard-today-activity-chart')).toBeVisible()
     })
   },
 }

--- a/web/src/components/DashboardActivityOverview.stories.tsx
+++ b/web/src/components/DashboardActivityOverview.stories.tsx
@@ -449,6 +449,36 @@ export const TodayView: Story = {
   },
 }
 
+export const TodayViewNarrowDesktop: Story = {
+  parameters: {
+    viewport: { defaultViewport: 'desktop1280' },
+  },
+  decorators: [
+    (Story, context) => (
+      <I18nProvider>
+        <DashboardOverviewMockApi failTodayTimeseries={(context.parameters as DashboardOverviewParameters).failTodayTimeseries === true}>
+          <div className="min-h-screen bg-base-200 px-6 py-6 text-base-content">
+            <div className="mx-auto w-full max-w-[1280px]">
+              <RangeStorageHarness persistedRange={((context.parameters as DashboardOverviewParameters).persistedRange ?? null) as PersistedRange}>
+                <Story />
+              </RangeStorageHarness>
+            </div>
+          </div>
+        </DashboardOverviewMockApi>
+      </I18nProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() => {
+      expect(canvas.getByRole('tab', { name: /今日|today/i })).toHaveAttribute('aria-selected', 'true')
+      expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact', 'true')
+      expect(canvas.getByTestId('today-stats-value-total-tokens')).toHaveAttribute('data-compact-precision', '0')
+      expect(canvas.getByTestId('today-stats-value-total-tokens').textContent ?? '').toContain('18M')
+    })
+  },
+}
+
 export const TodayRateUnavailable: Story = {
   parameters: {
     failTodayTimeseries: true,

--- a/web/src/components/TodayStatsOverview.stories.tsx
+++ b/web/src/components/TodayStatsOverview.stories.tsx
@@ -314,12 +314,83 @@ export const OverflowFallback: Story = {
   },
 }
 
+export const NarrowDesktopOverflowFallback: Story = {
+  args: {
+    stats: {
+      totalCount: 12474,
+      successCount: 9949,
+      failureCount: 2525,
+      totalCost: 539.42,
+      totalTokens: 281110000,
+    },
+    rate: sampleRate,
+    loading: false,
+    error: null,
+    showSurface: false,
+    showHeader: false,
+    showDayBadge: false,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop1280',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-[1180px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() => {
+      const totalTokensValue = canvas.getByTestId('today-stats-value-total-tokens')
+      expect(totalTokensValue).toHaveAttribute('data-compact', 'true')
+      expect(totalTokensValue).toHaveAttribute('data-compact-precision', '0')
+      expect(totalTokensValue.textContent ?? '').toContain('281M')
+    })
+  },
+}
+
 export const Loading: Story = {
   args: {
     stats: null,
     rate: null,
     loading: true,
     error: null,
+  },
+}
+
+export const NarrowDesktopLoading: Story = {
+  args: {
+    stats: null,
+    rate: null,
+    loading: true,
+    error: null,
+    showSurface: false,
+    showHeader: false,
+    showDayBadge: false,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop1280',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-[1180px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() => {
+      const loadingTile = canvas.getByTestId('today-stats-value-tpm-loading')
+      expect(loadingTile.className).toContain('w-full')
+      expect(loadingTile.className).toContain('max-w-[7.5rem]')
+    })
   },
 }
 

--- a/web/src/components/TodayStatsOverview.test.tsx
+++ b/web/src/components/TodayStatsOverview.test.tsx
@@ -461,6 +461,54 @@ describe('TodayStatsOverview', () => {
     expect(totalTokensValue?.getAttribute('title')).toBe('1,314,275,579')
   })
 
+  it('drops compact decimals before truncating the magnitude suffix in narrow tiles', () => {
+    metricContainerWidth = 76
+
+    render(
+      <TodayStatsOverview
+        stats={{
+          totalCount: 12474,
+          successCount: 9949,
+          failureCount: 2525,
+          totalCost: 539.42,
+          totalTokens: 281110000,
+        }}
+        rate={{
+          tokensPerMinute: 1000,
+          spendRate: 0.1,
+          windowMinutes: 5,
+          available: true,
+        }}
+        loading={false}
+        error={null}
+      />,
+    )
+
+    const totalTokensValue = host?.querySelector('[data-testid="today-stats-value-total-tokens"]')
+    const totalTokensVisible = totalTokensValue?.querySelector('[data-adaptive-metric-visible="true"]')
+    expect(totalTokensValue?.getAttribute('data-compact')).toBe('true')
+    expect(totalTokensValue?.getAttribute('data-compact-precision')).toBe('0')
+    expect(totalTokensVisible?.textContent).toContain('281M')
+    expect(totalTokensVisible?.textContent).not.toContain('281.11M')
+  })
+
+  it('uses a width-capped loading placeholder instead of a fixed narrow-tile width', () => {
+    render(
+      <TodayStatsOverview
+        stats={null}
+        rate={null}
+        loading
+        error={null}
+      />,
+    )
+
+    const tpmLoading = host?.querySelector('[data-testid="today-stats-value-tpm-loading"]')
+    expect(tpmLoading).toBeInstanceOf(HTMLElement)
+    expect((tpmLoading as HTMLElement | null)?.className).toContain('w-full')
+    expect((tpmLoading as HTMLElement | null)?.className).toContain('max-w-[7.5rem]')
+    expect((tpmLoading as HTMLElement | null)?.className).not.toContain('w-28')
+  })
+
   it('renders the response-time card with recent-window and day-average latency values', () => {
     const timeseries = buildTimeseriesWithLatency()
     const comparisonTimeseries = {

--- a/web/src/components/TodayStatsOverview.tsx
+++ b/web/src/components/TodayStatsOverview.tsx
@@ -106,12 +106,15 @@ function MetricTile({
         </span>
       </Tooltip>
       {loading ? (
-        <div className="mt-2 h-8 w-28 animate-pulse rounded bg-base-300/65" />
+        <div
+          data-testid={valueTestId ? `${valueTestId}-loading` : undefined}
+          className="mt-2 h-8 w-full max-w-[7.5rem] animate-pulse rounded bg-base-300/65"
+        />
       ) : displayText != null ? (
         <div
           data-testid={valueTestId}
           className={cn(
-            'mt-2 min-w-0 overflow-hidden whitespace-nowrap text-2xl font-semibold leading-tight lg:text-[1.85rem]',
+            'mt-2 min-w-0 max-w-full overflow-hidden whitespace-nowrap text-2xl font-semibold leading-tight lg:text-[1.85rem]',
             subdued ? 'text-base-content/55' : 'text-base-content',
             toneClass,
           )}
@@ -121,7 +124,7 @@ function MetricTile({
       ) : (
         <div
           className={cn(
-            'mt-2 min-w-0 overflow-hidden text-2xl font-semibold leading-tight text-base-content lg:text-[1.85rem]',
+            'mt-2 min-w-0 max-w-full overflow-hidden text-2xl font-semibold leading-tight text-base-content lg:text-[1.85rem]',
             toneClass,
           )}
         >

--- a/web/src/components/UpstreamAccountsPage.overlays.stories.tsx
+++ b/web/src/components/UpstreamAccountsPage.overlays.stories.tsx
@@ -148,8 +148,10 @@ export const DetailDrawerRecordsEmpty: Story = {
 
 function DetailDrawerStorySurface({
   initialTab,
+  maxWidth = 'none',
 }: {
   initialTab: 'records'
+  maxWidth?: string
 }) {
   return (
     <MemoryRouter initialEntries={['/account-pool/upstream-accounts?upstreamAccountId=101']}>
@@ -157,12 +159,14 @@ function DetailDrawerStorySurface({
         <I18nProvider>
           <SystemNotificationProvider>
             <StorybookUpstreamAccountsMock>
-              <SharedUpstreamAccountDetailDrawer
-                open
-                accountId={101}
-                initialTab={initialTab}
-                onClose={() => {}}
-              />
+              <div style={maxWidth === 'none' ? undefined : { maxWidth }} className="mx-auto w-full">
+                <SharedUpstreamAccountDetailDrawer
+                  open
+                  accountId={101}
+                  initialTab={initialTab}
+                  onClose={() => {}}
+                />
+              </div>
             </StorybookUpstreamAccountsMock>
           </SystemNotificationProvider>
         </I18nProvider>
@@ -195,6 +199,50 @@ export const DetailDrawerRecordsSettled: Story = {
     await expect(within(dialog).getByText(/账号活动总览|account activity overview/i)).toBeInTheDocument()
     await expect(within(dialog).getByTestId('upstream-account-records-activity-overview')).toBeInTheDocument()
     await expect(within(dialog).getByText(/gpt-5\.4/i)).toBeInTheDocument()
+  },
+}
+
+export const DetailDrawerRecordsOverflowDarkNarrow: Story = {
+  globals: {
+    themeMode: 'dark',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'desktop1280' },
+  },
+  render: () => <DetailDrawerStorySurface initialTab="records" maxWidth="1280px" />,
+  play: async ({ canvasElement }) => {
+    const documentScope = within(canvasElement.ownerDocument.body)
+    const dialog = await documentScope.findByRole('dialog', {
+      name: /Codex Pro - Tokyo/i,
+    })
+    await expect(within(dialog).getByRole('tab', { name: /调用记录|records/i })).toHaveAttribute('aria-selected', 'true')
+    await expect(within(dialog).getByText(/账号活动总览|account activity overview/i)).toBeInTheDocument()
+    const totalTokens = within(dialog).getByTestId('today-stats-value-total-tokens')
+    await expect(totalTokens).toHaveAttribute('data-compact', 'true')
+    await expect(totalTokens).toHaveAttribute('data-compact-precision', '0')
+    await expect(totalTokens).toHaveTextContent(/281M/i)
+    await expect(within(dialog).queryByText(/并行对话|parallel/i)).not.toBeInTheDocument()
+  },
+}
+
+export const DetailDrawerRecordsLoadingDarkNarrow: Story = {
+  globals: {
+    themeMode: 'dark',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'desktop1280' },
+  },
+  render: () => <DetailDrawerStorySurface initialTab="records" maxWidth="1280px" />,
+  play: async ({ canvasElement }) => {
+    const documentScope = within(canvasElement.ownerDocument.body)
+    const dialog = await documentScope.findByRole('dialog', {
+      name: /Codex Pro - Tokyo/i,
+    })
+    await expect(within(dialog).getByRole('tab', { name: /调用记录|records/i })).toHaveAttribute('aria-selected', 'true')
+    await expect(within(dialog).getByText(/账号活动总览|account activity overview/i)).toBeInTheDocument()
+    await expect(within(dialog).getByTestId('today-stats-value-tpm-loading')).toBeInTheDocument()
+    await expect(within(dialog).getByTestId('today-stats-value-total-tokens-loading')).toBeInTheDocument()
+    await expect(within(dialog).queryByText(/并行对话|parallel/i)).not.toBeInTheDocument()
   },
 }
 

--- a/web/src/components/UpstreamAccountsPage.story-helpers-runtime.tsx
+++ b/web/src/components/UpstreamAccountsPage.story-helpers-runtime.tsx
@@ -115,6 +115,10 @@ function storyAccountActivityIsEmpty(storyId: string | null) {
   return storyId?.endsWith('--detail-drawer-records-empty') === true
 }
 
+function storyAccountActivityUsesOverflowFixture(storyId: string | null) {
+  return storyId?.endsWith('--detail-drawer-records-overflow-dark-narrow') === true
+}
+
 function buildStoryAccountActivitySummary(
   accountId: number,
   storyId: string | null,
@@ -126,6 +130,15 @@ function buildStoryAccountActivitySummary(
       failureCount: 0,
       totalCost: 0,
       totalTokens: 0,
+    }
+  }
+  if (storyAccountActivityUsesOverflowFixture(storyId)) {
+    return {
+      totalCount: 2210,
+      successCount: 1836,
+      failureCount: 374,
+      totalCost: 173.3,
+      totalTokens: 281_110_000,
     }
   }
   const scale = accountId === 101 ? 1 : 0.35
@@ -149,6 +162,62 @@ function buildStoryAccountActivityTimeseries(
   const bucket = parsedUrl.searchParams.get('bucket') || '1m'
   const bucketSeconds = bucket === '1h' ? 3_600 : bucket === '1d' ? 86_400 : 60
   const rangeStart = '2026-03-13T00:00:00.000Z'
+  if (storyAccountActivityUsesOverflowFixture(storyId) && range === 'today') {
+    const overflowPoints = Array.from({ length: 12 }, (_, index) => {
+      const bucketStart = new Date(Date.parse(rangeStart) + index * bucketSeconds * 1_000)
+      const totalCount = [3, 6, 12, 4, 0, 8, 13, 7, 2, 11, 5, 9][index] ?? 0
+      const failureCount = [0, 1, 3, 0, 0, 1, 4, 2, 0, 3, 1, 2][index] ?? 0
+      const successCount = Math.max(totalCount - failureCount, 0)
+      const totalTokens = [
+        810_000,
+        1_640_000,
+        2_940_000,
+        1_120_000,
+        0,
+        1_980_000,
+        3_220_000,
+        1_760_000,
+        620_000,
+        2_880_000,
+        1_410_000,
+        2_340_000,
+      ][index] ?? 0
+      const totalCost = [
+        0.48,
+        0.96,
+        1.72,
+        0.61,
+        0,
+        1.11,
+        1.94,
+        1.03,
+        0.34,
+        1.76,
+        0.82,
+        1.39,
+      ][index] ?? 0
+      return {
+        bucketStart: bucketStart.toISOString(),
+        bucketEnd: new Date(bucketStart.getTime() + bucketSeconds * 1_000).toISOString(),
+        totalCount,
+        successCount,
+        failureCount,
+        inFlightCount: 0,
+        totalTokens,
+        totalCost,
+      }
+    })
+    return {
+      rangeStart,
+      rangeEnd: new Date(Date.parse(rangeStart) + overflowPoints.length * bucketSeconds * 1_000).toISOString(),
+      bucketSeconds,
+      snapshotId: 1,
+      effectiveBucket: bucket,
+      availableBuckets: ['1m', '10m', '1h', '1d'],
+      bucketLimitedToDaily: false,
+      points: overflowPoints,
+    }
+  }
   const points = storyAccountActivityIsEmpty(storyId)
     ? []
     : Array.from({ length: range === '7d' ? 14 : 12 }, (_, index) => {

--- a/web/src/components/UpstreamAccountsPage.story-runtime-fetch-helpers.ts
+++ b/web/src/components/UpstreamAccountsPage.story-runtime-fetch-helpers.ts
@@ -75,7 +75,10 @@ export function getWindowUsageResponseDelay(storyId: string | null) {
 }
 
 export function getAccountActivityResponseDelay(storyId: string | null) {
-  if (storyId?.endsWith('--detail-drawer-records-loading') === true) {
+  if (
+    storyId?.endsWith('--detail-drawer-records-loading') === true ||
+    storyId?.endsWith('--detail-drawer-records-loading-dark-narrow') === true
+  ) {
     return 0
   }
 
@@ -83,7 +86,10 @@ export function getAccountActivityResponseDelay(storyId: string | null) {
 }
 
 export function shouldKeepAccountActivityPending(storyId: string | null) {
-  return storyId?.endsWith('--detail-drawer-records-loading') === true
+  return (
+    storyId?.endsWith('--detail-drawer-records-loading') === true ||
+    storyId?.endsWith('--detail-drawer-records-loading-dark-narrow') === true
+  )
 }
 
 export function noContent() {


### PR DESCRIPTION
## Summary
- preserve compact metric suffixes in narrow dashboard KPI tiles by cascading compact candidates from higher to lower precision
- replace the fixed loading skeleton width with a width-capped placeholder so narrow tiles keep balanced inner gutters
- add narrow-desktop tests and Storybook stories covering overflow fallback and loading states

## Verification
- cd web && bun run test -- src/components/AdaptiveMetricValue.test.tsx src/components/TodayStatsOverview.test.tsx src/components/DashboardActivityOverview.test.tsx
- cd web && bun run build
- cd web && bun run build-storybook

## References
- Specs: -
- Solutions: -
- Project Docs: -
