### PR TITLE
fix(account-stats): harden detail stats hot path

### DIFF
--- a/docs/solutions/performance/account-detail-stats-read-model-sla.md
+++ b/docs/solutions/performance/account-detail-stats-read-model-sla.md
@@ -26,6 +26,7 @@ related_specs:
 - 打开账号详情抽屉后，统计卡片和趋势图长时间空白。
 - `/api/pool/upstream-accounts/window-usage` 在多账号列表刷新时批量触发，生产日志出现单次十秒级响应。
 - 账号 summary / timeseries 在 mixed archive/live 窗口上需要重复扫描 raw invocations。
+- 读路径本身已经压到毫秒级后，详情抽屉仍会偶发卡住 10 秒以上；生产排查显示根因来自后台 SQLite 热查询占住连接与锁，前台详情请求被连带拖慢。
 
 ## Resolution
 
@@ -35,12 +36,18 @@ related_specs:
 - 前端只为当前选中账号 hydrate `window-usage`，避免 roster / SSE / 列表刷新批量打后端。
 - 详情抽屉只在真正需要时才启用重统计上下文：`routing` 才加载 sticky conversation 统计，`edit` / `routing` 才补拉 roster 上下文，避免 `overview` / `records` 首开把无关重查询叠上去。
 - 上游账号 roster 的最新 usage 样本读取已从 `ROW_NUMBER()` 窗口排序改为索引友好的“最新样本 + 最新非空 plan type”读取，去掉 `pool_upstream_account_limit_samples` 上最重的在线窗口查询。
+- summary repair 完成标记与 live cursor 分离维护：如果 repair marker 已完成但 cursor 落后于共享 invocation cursor，只刷新 cursor，不再误触发整段重修或长期读旧游标。
+- archive materialization 会为账号 usage / stats read-model 一并补齐 replay markers；账号 summary / timeseries 在 materialized archive 缺 marker 的旧库上，也不会再把历史批次误判成“未物化，需要在线回补”。
+- startup proxy usage backfill 改为复用共享 invocation cursor + 全表 `MAX(id)`，删除“仅扫描缺 usage 的 proxy success rows”这条生产 10 秒级热点 SQL；stale attempt recovery 同时补齐 partial index，避免后台恢复任务反复争锁。
+- 账号维度昨天视图拆掉重复 comparison fetch，避免 account-scoped yesterday 面板额外再打一次 yesterday summary / timeseries。
 
 ## Guardrails / Reuse Notes
 
 - 任何账号详情统计面一旦触发加载，首次展示的数据必须是准确值，不能先展示 stale 或 approximate 值。
 - 新增账号维度统计字段时，先确认 minute/hourly read-model 都能承载，再接入详情页；不要把缺失字段临时塞回 raw 在线聚合。
 - 如果 schema ensure 需要在旧库上 rebuild 账号统计，必须先确保 `hourly_rollup_live_progress` 已存在，否则 rebuild 后无法保存 cursor。
+- 如果 archive batch 已经 `historical_rollups_materialized_at`，账号 usage / stats target 的 replay marker 也必须视为同一事务事实；旧库升级时先修 marker，再允许详情读路径依据“缺 marker”做 archive fallback。
+- 任何 startup / maintenance backfill 只要要扫 `codex_invocations` 或 `pool_upstream_request_attempts` 大表，都必须先证明有 cursor 或 partial index；后台慢查询同样会把详情页 SLA 拖垮。
 - 前端详情页的重型统计 hydrate 必须绑定“当前选中账号 + 当前 query key”；列表刷新不能把整个当前页账号重新拉一遍。
 - 若 roster 仍需展示最新 usage/plan 快照，优先复用主表或按账号索引直取最新样本；不要再回到 `pool_upstream_account_limit_samples` 的窗口函数全表排名路径。
 

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -35,6 +35,7 @@
 - session cleanup 类查询使用 `(status, expires_at)`。
 - event timeline 类查询同时考虑 account scoped 与 global time scoped 两种索引。
 - 维护候选查询要把固定过滤条件前置到复合索引。
+- 启动 backfill / orphan recovery 这类后台扫描必须优先使用 progress cursor 或 partial index；不要把“只在后台跑”当成允许全表扫的理由。
 
 ## 常见坑
 
@@ -43,6 +44,7 @@
 - 后台任务拿到唯一 background slot 后再判断是否 due，会把“未到期的空跑 tick”变成对其他维护任务的饥饿源。
 - skip 必须有日志和后续 ticker，否则会变成静默丢任务。
 - 为每个后台入口单独做局部退避，容易遗漏同一压力窗口内的其他维护任务；进程级 gate 更容易统一行为。
+- `SELECT MAX(id) ... WHERE <稀疏条件>`、`NOT EXISTS` + 低选择性 phase 过滤这类查询，即使最终只返回 1 行，也可能在 SQLite 上吃掉秒级读锁预算；若它们会与前台 HTTP 共享同一数据库，必须先压成 cursor 读取或用 partial index 固定扫描面。
 
 ## 何时升级方案
 

--- a/docs/specs/t6d9r-account-detail-stats-read-model/HISTORY.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/HISTORY.md
@@ -9,3 +9,7 @@
 - 2026-06-19: schema ensure 顺序修正为先建 `hourly_rollup_live_progress` 再 rebuild 账号统计，避免旧库冷启动时 cursor 落盘失败。
 - 2026-06-20: 生产复盘确认 `window-usage` 已降到毫秒级后，剩余体感慢点来自详情抽屉自身的重复请求编排；抽屉默认 roster 预取与非 routing tab 的 `sticky-keys` 预取已被移除。
 - 2026-06-20: 生产复盘同时确认 roster `load_summaries_ms` 仍被 `pool_upstream_account_limit_samples` 的 `ranked_samples` 窗口查询拖慢；最新 usage 样本读取已切成索引友好的“最新样本 + 最新非空 plan type”组合查询。
+- 2026-06-21: 继续线上追查后确认，账号详情接口 steady-state 已降到毫秒级，但后台 proxy usage startup backfill 与 stale attempt recovery 仍会制造 SQLite 争锁，把详情抽屉体感重新拖到 10 秒级；对应热点已改成 cursor / partial-index 驱动。
+- 2026-06-21: summary repair 改为在 repair marker 已完成但 live cursor 落后时只刷新 cursor，避免详情 summary 继续绑定旧 repair cursor。
+- 2026-06-21: archive materialization 与 bootstrap 会补齐账号 usage / stats replay marker，修复旧库在 materialized archive 缺 marker 时把账号 summary / timeseries 误拉回 archive fallback 的问题。
+- 2026-06-21: account-scoped `yesterday` 活动总览拆掉重复 comparison fetch，避免详情抽屉在昨天视图额外触发一轮同账号 summary / timeseries。

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -22,13 +22,23 @@
 - 账号详情抽屉内嵌 `useUpstreamAccounts(...)` 改为按 tab 懒启用：`overview` / `records` 首开不再重复拉 roster，上下文相关 tab 才补拉。
 - `useUpstreamStickyConversations(...)` 改为仅在 `routing` tab 启用，避免详情首开时误触发 `sticky-keys` 预览重查询。
 - upstream roster 最新 usage 样本读取已改为索引友好的“每账号最新样本 + 最新非空 plan type”组合查询，移除 `pool_upstream_account_limit_samples` 上按账号 `ROW_NUMBER()` 排序的热点慢 SQL。
+- summary repair 对已完成 marker 但落后的 repair cursor 改成“只追平 cursor”，避免旧库在 readiness 通过后继续带着陈旧 summary live cursor 读详情。
+- archive materialization / bootstrap 现在会修复账号 usage、账号 stats hourly、账号 stats minute 三类 replay marker；materialized archive 不再被账号 summary / timeseries 误判成未物化历史缺口。
+- startup proxy usage backfill snapshot 改为共享 invocation cursor + `MAX(id)`，并为 proxy usage backfill 与 stale attempt recovery 补齐 partial index，减少后台恢复任务对详情接口的 SQLite 争锁。
+- `DashboardActivityOverview` 在 account-scoped `yesterday` 视图不再额外请求 yesterday comparison summary / timeseries，消除一个重复请求源。
 
 ## Verification
 
 - `cargo test account_scoped_summary_and_timeseries_filter_by_payload_upstream_account_id -- --nocapture`
 - `cargo test get_upstream_account_window_usage -- --nocapture`
 - `cargo test ensure_schema_rebuilds_account_stats_when_live_progress_table_is_missing -- --nocapture`
+- `cargo test summary_rollup_repair_refreshes_stale_repair_live_cursor_from_shared_progress -- --nocapture`
+- `cargo test summary_yesterday_ignores_missing_non_overlapping_archive_batch -- --nocapture`
+- `cargo test account_summary_yesterday_ignores_materialized_archive_missing_account_usage_marker -- --nocapture`
+- `cargo test materialize_historical_rollups_marks_account_replay_targets_when_only_account_targets_are_pending -- --nocapture`
+- `cargo test bootstrap_hourly_rollups_repairs_missing_materialized_account_replay_markers -- --nocapture`
 - `cargo test latest_usage_sample_map_keeps_latest_non_empty_sample_plan_type -- --nocapture`
+- `cargo test ensure_schema_migrates_codex_invocations_off_raw_expires_at_and_adds_retention_tables -- --nocapture`
 - `cargo check`
 - `cd web && bun run test src/hooks/useUpstreamAccounts.test.tsx src/components/DashboardActivityOverview.test.tsx`
 - `cd web && bun run test -- UpstreamAccounts.test.tsx useUpstreamStickyConversations.test.tsx`

--- a/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
@@ -204,6 +204,7 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
         totals = totals.add(
             crate::stats::query_unmaterialized_upstream_account_archive_totals(
                 pool,
+                HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
                 source_scope,
                 Some((archived_start, archived_end)),
                 Some(&archive_overlap_ids),

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -339,6 +339,7 @@ async fn fetch_timeseries_for_account(
             .ok_or_else(|| ApiError::from(anyhow!("invalid account archived timeseries end epoch")))?;
         let archived_rows = crate::stats::query_unmaterialized_upstream_account_archive_hourly_rollup_deltas(
             &state.pool,
+            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
             source_scope,
             Some((archived_start, archived_end)),
             Some(&archive_overlap_ids),

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -14,6 +14,85 @@ async fn sync_hourly_rollups_from_live_tables(pool: &Pool<Sqlite>) -> Result<()>
     Ok(())
 }
 
+async fn mark_materialized_upstream_account_archive_replayed_tx(
+    tx: &mut SqliteConnection,
+    file_path: &str,
+) -> Result<()> {
+    for target in [
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE,
+    ] {
+        mark_hourly_rollup_archive_replayed_tx(
+            tx,
+            target,
+            HOURLY_ROLLUP_DATASET_INVOCATIONS,
+            file_path,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn load_materialized_invocation_archives_missing_upstream_account_markers_tx(
+    tx: &mut SqliteConnection,
+) -> Result<Vec<String>> {
+    sqlx::query_scalar(
+        r#"
+        SELECT batches.file_path
+        FROM archive_batches AS batches
+        WHERE batches.dataset = 'codex_invocations'
+          AND batches.status = ?1
+          AND batches.historical_rollups_materialized_at IS NOT NULL
+          AND (
+                NOT EXISTS (
+                    SELECT 1
+                    FROM hourly_rollup_archive_replay AS replay
+                    WHERE replay.target = ?2
+                      AND replay.dataset = batches.dataset
+                      AND replay.file_path = batches.file_path
+                )
+                OR NOT EXISTS (
+                    SELECT 1
+                    FROM hourly_rollup_archive_replay AS replay
+                    WHERE replay.target = ?3
+                      AND replay.dataset = batches.dataset
+                      AND replay.file_path = batches.file_path
+                )
+                OR NOT EXISTS (
+                    SELECT 1
+                    FROM hourly_rollup_archive_replay AS replay
+                    WHERE replay.target = ?4
+                      AND replay.dataset = batches.dataset
+                      AND replay.file_path = batches.file_path
+                )
+          )
+        ORDER BY batches.month_key ASC, batches.created_at ASC, batches.id ASC
+        "#,
+    )
+    .bind(ARCHIVE_STATUS_COMPLETED)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(Into::into)
+}
+
+async fn repair_materialized_upstream_account_archive_markers(
+    pool: &Pool<Sqlite>,
+) -> Result<usize> {
+    let mut tx = pool.begin().await?;
+    let file_paths =
+        load_materialized_invocation_archives_missing_upstream_account_markers_tx(tx.as_mut())
+            .await?;
+    for file_path in &file_paths {
+        mark_materialized_upstream_account_archive_replayed_tx(tx.as_mut(), file_path).await?;
+    }
+    tx.commit().await?;
+    Ok(file_paths.len())
+}
+
 const HISTORICAL_ROLLUP_ARCHIVE_REPLAY_BATCH_SIZE: i64 = BACKFILL_BATCH_SIZE;
 #[cfg(test)]
 const HISTORICAL_ROLLUP_ARCHIVE_INFLATE_BUFFER_BYTES: usize = 64 * 1024;
@@ -657,6 +736,11 @@ async fn replay_invocation_archives_into_hourly_rollups_tx_with_limits(
             HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE,
         ] || pending_targets.as_slice() == [HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE]
         {
+            mark_materialized_upstream_account_archive_replayed_tx(
+                tx,
+                &archive_file.file_path,
+            )
+            .await?;
             mark_archive_batch_historical_rollups_materialized_tx(
                 tx,
                 HOURLY_ROLLUP_DATASET_INVOCATIONS,
@@ -1286,6 +1370,7 @@ async fn replay_forward_proxy_archives_into_hourly_rollups_tx(
 
 async fn bootstrap_hourly_rollups(pool: &Pool<Sqlite>) -> Result<()> {
     sync_hourly_rollups_from_live_tables(pool).await?;
+    repair_materialized_upstream_account_archive_markers(pool).await?;
     let account_stats_hourly_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM upstream_account_stats_hourly")
             .fetch_one(pool)
@@ -1296,6 +1381,7 @@ async fn bootstrap_hourly_rollups(pool: &Pool<Sqlite>) -> Result<()> {
             .await?;
     if account_stats_hourly_count == 0 || account_stats_minute_count == 0 {
         rebuild_upstream_account_stats_rollups_from_sources(pool).await?;
+        repair_materialized_upstream_account_archive_markers(pool).await?;
     }
     Ok(())
 }

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -1145,20 +1145,15 @@ pub(crate) fn decode_proxy_raw_file_bytes(path: &Path, bytes: Vec<u8>) -> io::Re
     }
 }
 
-pub(crate) async fn current_proxy_usage_backfill_snapshot_max_id(pool: &Pool<Sqlite>) -> Result<i64> {
-    Ok(sqlx::query_scalar(
-        r#"
-        SELECT COALESCE(MAX(id), 0)
-        FROM codex_invocations
-        WHERE source = ?1
-          AND status = 'success'
-          AND total_tokens IS NULL
-          AND response_raw_path IS NOT NULL
-        "#,
-    )
-    .bind(SOURCE_PROXY)
-    .fetch_one(pool)
-    .await?)
+pub(crate) async fn current_proxy_usage_backfill_snapshot_max_id(
+    pool: &Pool<Sqlite>,
+) -> Result<i64> {
+    let shared_live_cursor =
+        load_hourly_rollup_live_progress(pool, HOURLY_ROLLUP_DATASET_INVOCATIONS).await?;
+    let max_live_id = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM codex_invocations")
+        .fetch_one(pool)
+        .await?;
+    Ok(shared_live_cursor.max(max_live_id))
 }
 
 pub(crate) async fn backfill_proxy_usage_tokens_from_cursor(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -608,6 +608,18 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
 
     sqlx::query(
         r#"
+        CREATE INDEX IF NOT EXISTS idx_codex_invocations_proxy_usage_backfill_pending
+        ON codex_invocations (source, status, id)
+        WHERE total_tokens IS NULL
+          AND response_raw_path IS NOT NULL
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure index idx_codex_invocations_proxy_usage_backfill_pending")?;
+
+    sqlx::query(
+        r#"
         CREATE TABLE IF NOT EXISTS codex_quota_snapshots (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             captured_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -2012,6 +2024,21 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     .await
     .context(
         "failed to ensure index idx_pool_upstream_request_attempts_group_proxy_occurred_at",
+    )?;
+
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_pool_upstream_request_attempts_pending_early_phase_started
+        ON pool_upstream_request_attempts (status, started_at, endpoint, invoke_id, occurred_at)
+        WHERE finished_at IS NULL
+          AND COALESCE(first_byte_latency_ms, 0) <= 0
+          AND LOWER(TRIM(COALESCE(phase, ''))) IN ('connecting', 'sending_request', 'waiting_first_byte')
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context(
+        "failed to ensure index idx_pool_upstream_request_attempts_pending_early_phase_started",
     )?;
 
     sqlx::query(

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1043,8 +1043,9 @@ async fn load_completed_invocation_archive_paths(
 async fn load_invocation_archives_missing_rollup_target(
     executor: impl sqlx::Executor<'_, Database = Sqlite>,
     target: &str,
+    range: Option<(DateTime<Utc>, DateTime<Utc>)>,
 ) -> Result<Vec<ArchiveBatchPathRow>> {
-    sqlx::query_as::<_, ArchiveBatchPathRow>(
+    let mut query = QueryBuilder::<Sqlite>::new(
         r#"
         SELECT
             batches.file_path,
@@ -1056,22 +1057,83 @@ async fn load_invocation_archives_missing_rollup_target(
             NULL AS needs_failures
         FROM archive_batches AS batches
         WHERE batches.dataset = 'codex_invocations'
-          AND batches.status = ?1
+          AND batches.status =
+        "#,
+    );
+    query.push_bind(ARCHIVE_STATUS_COMPLETED);
+    query.push(
+        r#"
           AND NOT EXISTS(
             SELECT 1
             FROM hourly_rollup_archive_replay AS replay
-            WHERE replay.target = ?2
+            WHERE replay.target =
+        "#,
+    );
+    query.push_bind(target);
+    query.push(
+        r#"
               AND replay.dataset = 'codex_invocations'
               AND replay.file_path = batches.file_path
           )
-        ORDER BY batches.month_key ASC, batches.created_at ASC, batches.id ASC
         "#,
+    );
+
+    if let Some((start, end)) = range {
+        let start_bound = db_occurred_at_upper_bound(start);
+        let end_bound = db_occurred_at_lower_bound(end);
+        query.push(
+            r#"
+            AND (
+                batches.coverage_start_at IS NULL
+                OR batches.coverage_end_at IS NULL
+                OR (
+                    batches.coverage_end_at >=
+            "#,
+        );
+        query.push_bind(start_bound).push(
+            r#"
+                    AND batches.coverage_start_at <
+            "#,
+        );
+        query.push_bind(end_bound).push(
+            r#"
+                )
+            )
+            "#,
+        );
+    }
+
+    query.push(" ORDER BY batches.month_key ASC, batches.created_at ASC, batches.id ASC");
+    query
+        .build_query_as::<ArchiveBatchPathRow>()
+        .fetch_all(executor)
+        .await
+        .map_err(Into::into)
+}
+
+fn account_archive_target_treats_materialized_batch_as_replayed(target: &str) -> bool {
+    matches!(
+        target,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE
+            | HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY
+            | HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE
     )
-    .bind(ARCHIVE_STATUS_COMPLETED)
-    .bind(target)
-    .fetch_all(executor)
-    .await
-    .map_err(Into::into)
+}
+
+async fn load_invocation_archives_missing_effective_rollup_target(
+    executor: impl sqlx::Executor<'_, Database = Sqlite>,
+    target: &str,
+    range: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> Result<Vec<ArchiveBatchPathRow>> {
+    let archive_rows =
+        load_invocation_archives_missing_rollup_target(executor, target, range).await?;
+    if !account_archive_target_treats_materialized_batch_as_replayed(target) {
+        return Ok(archive_rows);
+    }
+    Ok(archive_rows
+        .into_iter()
+        .filter(|archive_row| archive_row.historical_rollups_materialized_at.is_none())
+        .collect())
 }
 
 async fn load_invocation_archives_missing_summary_rollup_markers(
@@ -1998,9 +2060,12 @@ async fn load_pending_invocation_archive_hourly_rollup_deltas(
     range: Option<(DateTime<Utc>, DateTime<Utc>)>,
     exclude_invocation_ids: Option<&HashSet<i64>>,
 ) -> Result<PendingInvocationArchiveOverallState> {
-    let archive_rows =
-        load_invocation_archives_missing_rollup_target(pool, HOURLY_ROLLUP_TARGET_INVOCATIONS)
-            .await?;
+    let archive_rows = load_invocation_archives_missing_rollup_target(
+        pool,
+        HOURLY_ROLLUP_TARGET_INVOCATIONS,
+        range,
+    )
+    .await?;
     let mut pending_state = PendingInvocationArchiveOverallState::default();
 
     for archive_row in archive_rows {
@@ -2278,9 +2343,12 @@ async fn load_proxy_perf_stage_rollups_by_materialization_state(
     end: DateTime<Utc>,
     exclude_invocation_ids: Option<&HashSet<i64>>,
 ) -> Result<PendingProxyPerfArchiveState> {
-    let archive_rows =
-        load_invocation_archives_missing_rollup_target(pool, HOURLY_ROLLUP_TARGET_PROXY_PERF)
-            .await?;
+    let archive_rows = load_invocation_archives_missing_rollup_target(
+        pool,
+        HOURLY_ROLLUP_TARGET_PROXY_PERF,
+        Some((start, end)),
+    )
+    .await?;
     let mut pending_state = PendingProxyPerfArchiveState::default();
 
     for archive_row in archive_rows {
@@ -2560,16 +2628,15 @@ fn add_account_invocation_row_to_usage_delta(
 
 pub(crate) async fn query_unmaterialized_upstream_account_archive_hourly_rollup_deltas(
     pool: &Pool<Sqlite>,
+    rollup_target: &str,
     source_scope: InvocationSourceScope,
     range: Option<(DateTime<Utc>, DateTime<Utc>)>,
     exclude_invocation_ids: Option<&HashSet<i64>>,
     upstream_account_id: i64,
 ) -> Result<Vec<UpstreamAccountUsageHourlyRollupRecord>> {
-    let archive_rows = load_invocation_archives_missing_rollup_target(
-        pool,
-        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE,
-    )
-    .await?;
+    let archive_rows =
+        load_invocation_archives_missing_effective_rollup_target(pool, rollup_target, range)
+            .await?;
     let mut archive_deltas = BTreeMap::<i64, UpstreamAccountUsageHourlyDelta>::new();
 
     for archive_row in archive_rows {
@@ -2634,6 +2701,7 @@ pub(crate) async fn query_unmaterialized_upstream_account_archive_hourly_rollup_
 
 pub(crate) async fn query_unmaterialized_upstream_account_archive_totals(
     pool: &Pool<Sqlite>,
+    rollup_target: &str,
     source_scope: InvocationSourceScope,
     range: Option<(DateTime<Utc>, DateTime<Utc>)>,
     exclude_invocation_ids: Option<&HashSet<i64>>,
@@ -2642,6 +2710,7 @@ pub(crate) async fn query_unmaterialized_upstream_account_archive_totals(
     let mut totals = StatsTotals::default();
     for row in query_unmaterialized_upstream_account_archive_hourly_rollup_deltas(
         pool,
+        rollup_target,
         source_scope,
         range,
         exclude_invocation_ids,
@@ -2692,6 +2761,7 @@ pub(crate) async fn load_unmaterialized_invocation_archive_failure_rows(
     let archive_rows = load_invocation_archives_missing_rollup_target(
         pool,
         HOURLY_ROLLUP_TARGET_INVOCATION_FAILURES,
+        Some((start, end)),
     )
     .await?;
     let mut pending_state = PendingInvocationArchiveFailureState::default();
@@ -3126,33 +3196,90 @@ async fn hourly_rollup_progress_exists(
     .is_some())
 }
 
-async fn repair_invocation_summary_rollups(pool: &Pool<Sqlite>) -> Result<()> {
-    if load_hourly_rollup_live_progress(pool, INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DATASET)
-        .await?
-        >= INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DONE
-        && hourly_rollup_progress_exists(
+async fn invocation_summary_repair_live_cursor_state(
+    pool: &Pool<Sqlite>,
+) -> Result<(bool, bool, i64, i64)> {
+    let repair_marker_done =
+        load_hourly_rollup_live_progress(pool, INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DATASET)
+            .await?
+            >= INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DONE;
+    let repair_live_cursor_exists = hourly_rollup_progress_exists(
+        pool,
+        INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_LIVE_CURSOR_DATASET,
+    )
+    .await?;
+    let shared_live_cursor =
+        load_hourly_rollup_live_progress(pool, HOURLY_ROLLUP_DATASET_INVOCATIONS).await?;
+    let repair_live_cursor = if repair_live_cursor_exists {
+        load_hourly_rollup_live_progress(
             pool,
             INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_LIVE_CURSOR_DATASET,
         )
         .await?
-    {
+    } else {
+        0
+    };
+    Ok((
+        repair_marker_done,
+        repair_live_cursor_exists,
+        shared_live_cursor,
+        repair_live_cursor,
+    ))
+}
+
+async fn invocation_summary_repair_live_cursor_state_tx(
+    tx: &mut SqliteConnection,
+) -> Result<(bool, bool, i64, i64)> {
+    let repair_marker_done =
+        load_hourly_rollup_live_progress_tx(tx, INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DATASET)
+            .await?
+            >= INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DONE;
+    let repair_live_cursor_exists = hourly_rollup_progress_exists(
+        &mut *tx,
+        INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_LIVE_CURSOR_DATASET,
+    )
+    .await?;
+    let shared_live_cursor =
+        load_hourly_rollup_live_progress_tx(tx, HOURLY_ROLLUP_DATASET_INVOCATIONS).await?;
+    let repair_live_cursor = if repair_live_cursor_exists {
+        load_hourly_rollup_live_progress_tx(
+            tx,
+            INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_LIVE_CURSOR_DATASET,
+        )
+        .await?
+    } else {
+        0
+    };
+    Ok((
+        repair_marker_done,
+        repair_live_cursor_exists,
+        shared_live_cursor,
+        repair_live_cursor,
+    ))
+}
+
+async fn repair_invocation_summary_rollups(pool: &Pool<Sqlite>) -> Result<()> {
+    let (repair_marker_done, repair_live_cursor_exists, shared_live_cursor, repair_live_cursor) =
+        invocation_summary_repair_live_cursor_state(pool).await?;
+    if repair_marker_done && repair_live_cursor_exists && repair_live_cursor >= shared_live_cursor {
         return Ok(());
     }
 
     let mut tx = pool.begin().await?;
-    if load_hourly_rollup_live_progress_tx(
-        tx.as_mut(),
-        INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DATASET,
-    )
-    .await?
-        >= INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_DONE
-        && hourly_rollup_progress_exists(
+    let (repair_marker_done, repair_live_cursor_exists, shared_live_cursor, repair_live_cursor) =
+        invocation_summary_repair_live_cursor_state_tx(tx.as_mut()).await?;
+    if repair_marker_done && repair_live_cursor_exists && repair_live_cursor >= shared_live_cursor {
+        tx.rollback().await?;
+        return Ok(());
+    }
+    if repair_marker_done && repair_live_cursor_exists && repair_live_cursor < shared_live_cursor {
+        save_hourly_rollup_live_progress_tx(
             tx.as_mut(),
             INVOCATION_SUMMARY_ROLLUP_REPAIR_MARKER_LIVE_CURSOR_DATASET,
+            shared_live_cursor,
         )
-        .await?
-    {
-        tx.rollback().await?;
+        .await?;
+        tx.commit().await?;
         return Ok(());
     }
 

--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -8292,6 +8292,100 @@ async fn all_time_summary_repair_does_not_advance_shared_live_cursor_without_hou
 }
 
 #[tokio::test]
+async fn summary_rollup_repair_refreshes_stale_repair_live_cursor_from_shared_progress() {
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.invocation_max_days = 7;
+    let state = test_state_from_config(config, true).await;
+
+    let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
+        - ChronoDuration::days(430))
+    .and_hms_opt(8, 0, 0)
+    .expect("valid archived local hour");
+    let archived_success_at = format_naive(
+        archived_hour_local
+            .checked_add_signed(ChronoDuration::minutes(5))
+            .expect("archived success time"),
+    );
+
+    seed_invocation_archive_batch(
+        &state.pool,
+        &state.config,
+        "summary-repair-stale-live-cursor",
+        &[(
+            1_i64,
+            "summary-repair-stale-live-cursor-archived-success",
+            archived_success_at.as_str(),
+            SOURCE_PROXY,
+            "success",
+            10_i64,
+            0.10_f64,
+            Some(100.0),
+        )],
+    )
+    .await;
+
+    sqlx::query(
+        r#"
+        INSERT INTO hourly_rollup_live_progress (dataset, cursor_id, updated_at)
+        VALUES (?1, ?2, datetime('now'))
+        ON CONFLICT(dataset) DO UPDATE SET
+            cursor_id = excluded.cursor_id,
+            updated_at = datetime('now')
+        "#,
+    )
+    .bind(HOURLY_ROLLUP_DATASET_INVOCATIONS)
+    .bind(25_i64)
+    .execute(&state.pool)
+    .await
+    .expect("seed shared invocation hourly rollup cursor");
+
+    sqlx::query(
+        r#"
+        INSERT INTO hourly_rollup_live_progress (dataset, cursor_id, updated_at)
+        VALUES (?1, ?2, datetime('now'))
+        ON CONFLICT(dataset) DO UPDATE SET
+            cursor_id = excluded.cursor_id,
+            updated_at = datetime('now')
+        "#,
+    )
+    .bind("codex_invocations_summary_rollup_v2")
+    .bind(1_i64)
+    .execute(&state.pool)
+    .await
+    .expect("seed summary repair completion marker");
+
+    sqlx::query(
+        r#"
+        INSERT INTO hourly_rollup_live_progress (dataset, cursor_id, updated_at)
+        VALUES (?1, ?2, datetime('now'))
+        ON CONFLICT(dataset) DO UPDATE SET
+            cursor_id = excluded.cursor_id,
+            updated_at = datetime('now')
+        "#,
+    )
+    .bind("codex_invocations_summary_rollup_v2_live_cursor")
+    .bind(10_i64)
+    .execute(&state.pool)
+    .await
+    .expect("seed stale summary repair live cursor");
+
+    crate::stats::ensure_invocation_summary_rollups_ready(&state.pool)
+        .await
+        .expect("refresh stale summary repair live cursor");
+
+    let repair_live_cursor: i64 = sqlx::query_scalar(
+        "SELECT cursor_id FROM hourly_rollup_live_progress WHERE dataset = ?1",
+    )
+    .bind("codex_invocations_summary_rollup_v2_live_cursor")
+    .fetch_one(&state.pool)
+    .await
+    .expect("load repaired summary live cursor");
+    assert_eq!(repair_live_cursor, 25);
+}
+
+#[tokio::test]
 async fn all_time_summary_rollup_repair_counts_mixed_case_success_status() {
     let mut config = test_config();
     config.openai_upstream_base_url =
@@ -9249,6 +9343,187 @@ async fn timeseries_hourly_backed_ignores_missing_exact_archive_batch() {
     assert!(response.points.iter().all(|point| point.total_count == 0));
 
     cleanup_temp_test_dir(&temp_dir);
+}
+
+#[tokio::test]
+async fn summary_yesterday_ignores_missing_non_overlapping_archive_batch() {
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.invocation_max_days = 0;
+    let state = test_state_from_config(config, true).await;
+    let temp_dir = make_temp_test_dir("summary-yesterday-missing-non-overlap-archive");
+    let missing_archive = temp_dir.join("missing-codex-invocations.sqlite.gz");
+
+    let old_day_local = (Utc::now().with_timezone(&Shanghai).date_naive()
+        - ChronoDuration::days(40))
+    .and_hms_opt(8, 0, 0)
+    .expect("valid old local day");
+    let old_month_key = old_day_local.format("%Y-%m").to_string();
+    let coverage_start_at = format_naive(old_day_local);
+    let coverage_end_at = format_naive(
+        old_day_local
+            .checked_add_signed(ChronoDuration::hours(1))
+            .expect("valid archive coverage end"),
+    );
+
+    sqlx::query(
+        r#"
+        INSERT INTO archive_batches (
+            dataset,
+            month_key,
+            file_path,
+            sha256,
+            row_count,
+            status,
+            coverage_start_at,
+            coverage_end_at,
+            created_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'))
+        "#,
+    )
+    .bind("codex_invocations")
+    .bind(&old_month_key)
+    .bind(missing_archive.to_string_lossy().to_string())
+    .bind("deadbeef")
+    .bind(1_i64)
+    .bind(ARCHIVE_STATUS_COMPLETED)
+    .bind(&coverage_start_at)
+    .bind(&coverage_end_at)
+    .execute(&state.pool)
+    .await
+    .expect("insert missing non-overlapping archive manifest");
+
+    let yesterday_local = (Utc::now().with_timezone(&Shanghai).date_naive()
+        - ChronoDuration::days(1))
+    .and_hms_opt(9, 0, 0)
+    .expect("valid yesterday local day");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id,
+            occurred_at,
+            source,
+            total_tokens,
+            cost,
+            status,
+            payload,
+            raw_response
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        "#,
+    )
+    .bind("yesterday-account-summary")
+    .bind(format_naive(yesterday_local))
+    .bind(SOURCE_PROXY)
+    .bind(33_i64)
+    .bind(0.33_f64)
+    .bind("success")
+    .bind(r#"{"upstreamAccountId":2890}"#)
+    .bind(r#"{"range":"yesterday"}"#)
+    .execute(&state.pool)
+    .await
+    .expect("insert yesterday invocation");
+
+    let Json(summary) = fetch_summary(
+        State(state),
+        Query(SummaryQuery {
+            window: Some("yesterday".to_string()),
+            limit: None,
+            time_zone: Some("Asia/Shanghai".to_string()),
+            upstream_account_id: Some(2890),
+        }),
+    )
+    .await
+    .expect("fetch yesterday account summary");
+    assert_eq!(summary.total_count, 1);
+    assert_eq!(summary.success_count, 1);
+    assert_eq!(summary.failure_count, 0);
+    assert_eq!(summary.total_tokens, 33);
+    assert_f64_close(summary.total_cost, 0.33);
+
+    cleanup_temp_test_dir(&temp_dir);
+}
+
+#[tokio::test]
+async fn account_summary_yesterday_ignores_materialized_archive_missing_account_usage_marker() {
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.invocation_max_days = 0;
+    let state = test_state_from_config(config, true).await;
+    let account_id = 2890_i64;
+
+    let yesterday_local = (Utc::now().with_timezone(&Shanghai).date_naive()
+        - ChronoDuration::days(1))
+    .and_hms_opt(9, 0, 0)
+    .expect("valid yesterday local day");
+    let occurred_at = format_naive(
+        yesterday_local
+            .checked_add_signed(ChronoDuration::minutes(10))
+            .expect("valid occurred_at"),
+    );
+    let archive_path = seed_invocation_archive_batch_with_details(
+        &state.pool,
+        &state.config,
+        "account-summary-materialized-missing-usage-marker",
+        &[SeedInvocationArchiveBatchRow {
+            id: 1_i64,
+            invoke_id: "account-summary-materialized-missing-usage-marker",
+            occurred_at: occurred_at.as_str(),
+            source: SOURCE_PROXY,
+            status: "success",
+            total_tokens: 33_i64,
+            cost: 0.33_f64,
+            ttfb_ms: Some(120.0),
+            payload: Some(r#"{"upstreamAccountId":2890}"#),
+            detail_level: DETAIL_LEVEL_FULL,
+            error_message: None,
+            failure_kind: None,
+            failure_class: Some("none"),
+            is_actionable: Some(0_i64),
+        }],
+    )
+    .await;
+
+    materialize_historical_rollups(&state.pool, &state.config, false)
+        .await
+        .expect("materialize historical rollups");
+
+    sqlx::query(
+        r#"
+        DELETE FROM hourly_rollup_archive_replay
+        WHERE dataset = 'codex_invocations'
+          AND file_path = ?1
+          AND target = ?2
+        "#,
+    )
+    .bind(archive_path.to_string_lossy().to_string())
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE)
+    .execute(&state.pool)
+    .await
+    .expect("drop upstream account usage replay marker");
+
+    fs::write(&archive_path, b"not-a-gzip-archive")
+        .expect("corrupt materialized archive after rollups exist");
+
+    let Json(summary) = fetch_summary(
+        State(state),
+        Query(SummaryQuery {
+            window: Some("yesterday".to_string()),
+            limit: None,
+            time_zone: Some("Asia/Shanghai".to_string()),
+            upstream_account_id: Some(account_id),
+        }),
+    )
+    .await
+    .expect("fetch yesterday account summary from materialized rollups");
+    assert_eq!(summary.total_count, 1);
+    assert_eq!(summary.success_count, 1);
+    assert_eq!(summary.failure_count, 0);
+    assert_eq!(summary.total_tokens, 33);
+    assert_f64_close(summary.total_cost, 0.33);
 }
 
 #[tokio::test]

--- a/src/tests/slices/pool_failover_window_i.rs
+++ b/src/tests/slices/pool_failover_window_i.rs
@@ -319,6 +319,91 @@ async fn ensure_schema_migrates_codex_invocations_off_raw_expires_at_and_adds_re
     .expect("load upstream account invocation index");
     assert!(upstream_account_index_sql.contains("$.upstreamAccountId"));
     assert!(upstream_account_index_sql.contains("occurred_at"));
+
+    let proxy_usage_backfill_index_sql = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'index'
+          AND name = 'idx_codex_invocations_proxy_usage_backfill_pending'
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load proxy usage backfill index");
+    assert!(proxy_usage_backfill_index_sql.contains("source"));
+    assert!(proxy_usage_backfill_index_sql.contains("status"));
+    assert!(proxy_usage_backfill_index_sql.contains("id"));
+    assert!(proxy_usage_backfill_index_sql.contains("total_tokens IS NULL"));
+
+    let stale_attempt_index_sql = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'index'
+          AND name = 'idx_pool_upstream_request_attempts_pending_early_phase_started'
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load stale attempt recovery index");
+    assert!(stale_attempt_index_sql.contains("status"));
+    assert!(stale_attempt_index_sql.contains("started_at"));
+    assert!(stale_attempt_index_sql.contains("invoke_id"));
+    assert!(stale_attempt_index_sql.contains("finished_at IS NULL"));
+    assert!(stale_attempt_index_sql.contains("LOWER(TRIM(COALESCE(phase, '')))"));
+
+    let proxy_usage_backfill_plan = sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT COALESCE(MAX(id), 0)
+        FROM codex_invocations
+        WHERE source = 'proxy'
+          AND status = 'success'
+          AND total_tokens IS NULL
+          AND response_raw_path IS NOT NULL
+        "#,
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("load proxy usage backfill explain plan")
+    .into_iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join(" | ");
+    assert!(
+        proxy_usage_backfill_plan.contains("idx_codex_invocations_proxy_usage_backfill_pending"),
+        "unexpected proxy usage backfill plan: {proxy_usage_backfill_plan}"
+    );
+
+    let stale_attempt_plan = sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT id, invoke_id, occurred_at, sticky_key, upstream_account_id
+        FROM pool_upstream_request_attempts
+        WHERE status = 'pending'
+          AND finished_at IS NULL
+          AND LOWER(TRIM(COALESCE(phase, ''))) IN ('connecting', 'sending_request', 'waiting_first_byte')
+          AND COALESCE(first_byte_latency_ms, 0) <= 0
+          AND (
+                started_at IS NULL
+                OR (endpoint = '/v1/responses' AND started_at <= '2026-03-09 10:00:00')
+                OR (endpoint = '/v1/responses/compact' AND started_at <= '2026-03-09 10:00:00')
+                OR (COALESCE(endpoint, '') NOT IN ('/v1/responses', '/v1/responses/compact') AND started_at <= '2026-03-09 10:00:00')
+          )
+        "#,
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("load stale attempt explain plan")
+    .into_iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join(" | ");
+    assert!(
+        stale_attempt_plan.contains("idx_pool_upstream_request_attempts_pending_early_phase_started"),
+        "unexpected stale attempt plan: {stale_attempt_plan}"
+    );
 }
 
 #[tokio::test]

--- a/src/tests/slices/pool_failover_window_j.rs
+++ b/src/tests/slices/pool_failover_window_j.rs
@@ -3924,7 +3924,7 @@ async fn bootstrap_hourly_rollups_keeps_retention_materialized_totals_unchanged(
             .fetch_one(&pool)
             .await
             .expect("count hourly rollup archive replay markers");
-    assert_eq!(replay_marker_count, 0);
+    assert_eq!(replay_marker_count, 3);
 
     cleanup_temp_test_dir(&temp_dir);
 }

--- a/src/tests/slices/pool_failover_window_j.rs
+++ b/src/tests/slices/pool_failover_window_j.rs
@@ -1896,6 +1896,172 @@ async fn materialize_historical_rollups_marks_replayed_batches_as_materialized()
 }
 
 #[tokio::test]
+async fn materialize_historical_rollups_marks_account_replay_targets_when_only_account_targets_are_pending()
+{
+    let (pool, config, temp_dir) =
+        retention_test_pool_and_config("historical-rollup-account-target-markers").await;
+    let old_invocation = shanghai_local_days_ago((config.invocation_max_days + 2) as i64, 9, 0, 0);
+
+    insert_retention_invocation(
+        &pool,
+        "historical-rollup-account-target-markers",
+        &old_invocation,
+        SOURCE_PROXY,
+        "success",
+        Some("{\"upstreamAccountId\":17,\"upstreamAccountName\":\"Replay\"}"),
+        "{\"ok\":true}",
+        None,
+        None,
+        Some(42),
+        Some(0.42),
+    )
+    .await;
+
+    sync_hourly_rollups_from_live_tables(&pool)
+        .await
+        .expect("seed live hourly rollups before retention");
+    let retention = run_data_retention_maintenance(&pool, &config, Some(false), None)
+        .await
+        .expect("archive old rows before materialize");
+    assert_eq!(retention.invocation_rows_archived, 1);
+
+    sqlx::query("UPDATE archive_batches SET historical_rollups_materialized_at = NULL")
+        .execute(&pool)
+        .await
+        .expect("clear materialized markers to mimic pre-upgrade replay state");
+
+    let invocation_archive_path: String = sqlx::query_scalar(
+        "SELECT file_path FROM archive_batches WHERE dataset = 'codex_invocations' ORDER BY id DESC LIMIT 1",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load invocation archive path");
+    for target in [
+        HOURLY_ROLLUP_TARGET_INVOCATIONS,
+        HOURLY_ROLLUP_TARGET_INVOCATION_FAILURES,
+        HOURLY_ROLLUP_TARGET_PROXY_PERF,
+        HOURLY_ROLLUP_TARGET_PROMPT_CACHE,
+        HOURLY_ROLLUP_TARGET_PROMPT_CACHE_UPSTREAM_ACCOUNTS,
+        HOURLY_ROLLUP_TARGET_STICKY_KEYS,
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, replayed_at)
+            VALUES (?1, ?2, ?3, datetime('now'))
+            "#,
+        )
+        .bind(target)
+        .bind(HOURLY_ROLLUP_DATASET_INVOCATIONS)
+        .bind(&invocation_archive_path)
+        .execute(&pool)
+        .await
+        .expect("insert invocation replay marker");
+    }
+
+    let materialize = materialize_historical_rollups(&pool, &config, false)
+        .await
+        .expect("materialize should mark account replay targets too");
+    assert_eq!(materialize.materialized_invocation_batches, 0);
+
+    let account_target_markers: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM hourly_rollup_archive_replay
+        WHERE dataset = 'codex_invocations'
+          AND file_path = ?1
+          AND target IN (?2, ?3, ?4)
+        "#,
+    )
+    .bind(&invocation_archive_path)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE)
+    .fetch_one(&pool)
+    .await
+    .expect("count account replay markers");
+    assert_eq!(account_target_markers, 3);
+
+    cleanup_temp_test_dir(&temp_dir);
+}
+
+#[tokio::test]
+async fn bootstrap_hourly_rollups_repairs_missing_materialized_account_replay_markers() {
+    let (pool, config, temp_dir) =
+        retention_test_pool_and_config("bootstrap-repairs-account-markers").await;
+    let old_invocation = shanghai_local_days_ago((config.invocation_max_days + 2) as i64, 9, 0, 0);
+
+    insert_retention_invocation(
+        &pool,
+        "bootstrap-repairs-account-markers",
+        &old_invocation,
+        SOURCE_PROXY,
+        "success",
+        Some("{\"upstreamAccountId\":17,\"upstreamAccountName\":\"Replay\"}"),
+        "{\"ok\":true}",
+        None,
+        None,
+        Some(42),
+        Some(0.42),
+    )
+    .await;
+
+    sync_hourly_rollups_from_live_tables(&pool)
+        .await
+        .expect("seed live hourly rollups before retention");
+    let retention = run_data_retention_maintenance(&pool, &config, Some(false), None)
+        .await
+        .expect("archive old rows before bootstrap repair");
+    assert_eq!(retention.invocation_rows_archived, 1);
+
+    let invocation_archive_path: String = sqlx::query_scalar(
+        "SELECT file_path FROM archive_batches WHERE dataset = 'codex_invocations' ORDER BY id DESC LIMIT 1",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load invocation archive path");
+
+    sqlx::query(
+        r#"
+        DELETE FROM hourly_rollup_archive_replay
+        WHERE dataset = 'codex_invocations'
+          AND file_path = ?1
+          AND target IN (?2, ?3, ?4)
+        "#,
+    )
+    .bind(&invocation_archive_path)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE)
+    .execute(&pool)
+    .await
+    .expect("drop account replay markers to mimic old materialized state");
+
+    bootstrap_hourly_rollups(&pool)
+        .await
+        .expect("bootstrap should repair missing account replay markers");
+
+    let account_target_markers: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM hourly_rollup_archive_replay
+        WHERE dataset = 'codex_invocations'
+          AND file_path = ?1
+          AND target IN (?2, ?3, ?4)
+        "#,
+    )
+    .bind(&invocation_archive_path)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE)
+    .fetch_one(&pool)
+    .await
+    .expect("count repaired account replay markers");
+    assert_eq!(account_target_markers, 3);
+
+    cleanup_temp_test_dir(&temp_dir);
+}
+
+#[tokio::test]
 async fn historical_rollup_backfill_stays_critical_until_legacy_invocations_materialized() {
     let (pool, config, temp_dir) =
         retention_test_pool_and_config("historical-rollup-backfill-critical").await;

--- a/src/upstream_accounts/sync_account_imports_tags.rs
+++ b/src/upstream_accounts/sync_account_imports_tags.rs
@@ -1742,6 +1742,208 @@ async fn load_duplicate_info_map(
     Ok(duplicate_info)
 }
 
+async fn load_duplicate_info_for_account(
+    pool: &Pool<Sqlite>,
+    account_id: i64,
+) -> Result<Option<DuplicateInfo>> {
+    let current_row = sqlx::query_as::<_, UpstreamAccountIdentityRow>(
+        r#"
+        SELECT
+            account.id,
+            account.chatgpt_account_id,
+            account.chatgpt_user_id,
+            account.group_name,
+            COALESCE(
+                CASE
+                    WHEN NULLIF(TRIM(account.plan_type), '') IS NOT NULL
+                         AND account.plan_type_observed_at IS NOT NULL
+                         AND julianday(account.plan_type_observed_at) >= julianday((
+                            SELECT previous_sample.captured_at
+                            FROM pool_upstream_account_limit_samples previous_sample
+                            WHERE previous_sample.account_id = account.id
+                              AND previous_sample.plan_type IS NOT NULL
+                              AND TRIM(previous_sample.plan_type) <> ''
+                            ORDER BY previous_sample.captured_at DESC
+                            LIMIT 1
+                         ))
+                        THEN NULLIF(TRIM(account.plan_type), '')
+                    ELSE (
+                        SELECT NULLIF(TRIM(previous_sample.plan_type), '')
+                        FROM pool_upstream_account_limit_samples previous_sample
+                        WHERE previous_sample.account_id = account.id
+                          AND previous_sample.plan_type IS NOT NULL
+                          AND TRIM(previous_sample.plan_type) <> ''
+                        ORDER BY previous_sample.captured_at DESC
+                        LIMIT 1
+                    )
+                END,
+                NULLIF(TRIM(account.plan_type), '')
+            ) AS plan_type
+        FROM pool_upstream_accounts account
+        WHERE account.kind = ?1
+          AND account.id = ?2
+        LIMIT 1
+        "#,
+    )
+    .bind(UPSTREAM_ACCOUNT_KIND_OAUTH_CODEX)
+    .bind(account_id)
+    .fetch_optional(pool)
+    .await?;
+    let Some(current_row) = current_row else {
+        return Ok(None);
+    };
+
+    let mut query = QueryBuilder::<Sqlite>::new(
+        r#"
+        SELECT
+            account.id,
+            account.chatgpt_account_id,
+            account.chatgpt_user_id,
+            account.group_name,
+            COALESCE(
+                CASE
+                    WHEN NULLIF(TRIM(account.plan_type), '') IS NOT NULL
+                         AND account.plan_type_observed_at IS NOT NULL
+                         AND julianday(account.plan_type_observed_at) >= julianday((
+                            SELECT previous_sample.captured_at
+                            FROM pool_upstream_account_limit_samples previous_sample
+                            WHERE previous_sample.account_id = account.id
+                              AND previous_sample.plan_type IS NOT NULL
+                              AND TRIM(previous_sample.plan_type) <> ''
+                            ORDER BY previous_sample.captured_at DESC
+                            LIMIT 1
+                         ))
+                        THEN NULLIF(TRIM(account.plan_type), '')
+                    ELSE (
+                        SELECT NULLIF(TRIM(previous_sample.plan_type), '')
+                        FROM pool_upstream_account_limit_samples previous_sample
+                        WHERE previous_sample.account_id = account.id
+                          AND previous_sample.plan_type IS NOT NULL
+                          AND TRIM(previous_sample.plan_type) <> ''
+                        ORDER BY previous_sample.captured_at DESC
+                        LIMIT 1
+                    )
+                END,
+                NULLIF(TRIM(account.plan_type), '')
+            ) AS plan_type
+        FROM pool_upstream_accounts account
+        WHERE account.kind = 
+        "#,
+    );
+    query
+        .push_bind(UPSTREAM_ACCOUNT_KIND_OAUTH_CODEX)
+        .push(" AND account.id <> ")
+        .push_bind(account_id)
+        .push(" AND (");
+    let mut has_identity_filter = false;
+    if let Some(chatgpt_account_id) = current_row.chatgpt_account_id.as_ref() {
+        query
+            .push("account.chatgpt_account_id = ")
+            .push_bind(chatgpt_account_id);
+        has_identity_filter = true;
+    }
+    if let Some(chatgpt_user_id) = current_row.chatgpt_user_id.as_ref() {
+        if has_identity_filter {
+            query.push(" OR ");
+        }
+        query
+            .push("account.chatgpt_user_id = ")
+            .push_bind(chatgpt_user_id);
+        has_identity_filter = true;
+    }
+    if !has_identity_filter {
+        return Ok(None);
+    }
+    query.push(")");
+
+    let peer_rows = query
+        .build_query_as::<UpstreamAccountIdentityRow>()
+        .fetch_all(pool)
+        .await?;
+    if peer_rows.is_empty() {
+        return Ok(None);
+    }
+
+    let current_member = UpstreamAccountIdentityClusterMember {
+        id: current_row.id,
+        chatgpt_user_id: normalize_optional_text(current_row.chatgpt_user_id.clone()),
+        group_name: normalize_legacy_ungrouped_group_name(current_row.group_name.clone()),
+        plan_type: normalize_plan_type(current_row.plan_type.as_deref()),
+    };
+    let mut peer_ids = std::collections::BTreeSet::new();
+    let mut reasons = Vec::new();
+
+    if let Some(chatgpt_account_id) = current_row.chatgpt_account_id.as_ref() {
+        let matching_peers = peer_rows
+            .iter()
+            .filter(|row| row.chatgpt_account_id.as_ref() == Some(chatgpt_account_id))
+            .collect::<Vec<_>>();
+        if matching_peers.iter().any(|row| {
+            let peer = UpstreamAccountIdentityClusterMember {
+                id: row.id,
+                chatgpt_user_id: normalize_optional_text(row.chatgpt_user_id.clone()),
+                group_name: normalize_legacy_ungrouped_group_name(row.group_name.clone()),
+                plan_type: normalize_plan_type(row.plan_type.as_deref()),
+            };
+            !is_team_shared_org_peer_pair(&current_member, &peer)
+                && should_flag_duplicate_identity_pair(
+                    current_member.plan_type.as_deref(),
+                    peer.plan_type.as_deref(),
+                )
+        }) {
+            reasons.push(DuplicateReason::SharedChatgptAccountId);
+        }
+        for row in matching_peers {
+            let peer = UpstreamAccountIdentityClusterMember {
+                id: row.id,
+                chatgpt_user_id: normalize_optional_text(row.chatgpt_user_id.clone()),
+                group_name: normalize_legacy_ungrouped_group_name(row.group_name.clone()),
+                plan_type: normalize_plan_type(row.plan_type.as_deref()),
+            };
+            if !is_team_shared_org_peer_pair(&current_member, &peer)
+                && should_flag_duplicate_identity_pair(
+                    current_member.plan_type.as_deref(),
+                    peer.plan_type.as_deref(),
+                )
+            {
+                peer_ids.insert(row.id);
+            }
+        }
+    }
+
+    if let Some(chatgpt_user_id) = current_row.chatgpt_user_id.as_ref() {
+        let matching_peers = peer_rows
+            .iter()
+            .filter(|row| row.chatgpt_user_id.as_ref() == Some(chatgpt_user_id))
+            .collect::<Vec<_>>();
+        if matching_peers.iter().any(|row| {
+            should_flag_duplicate_identity_pair(
+                current_member.plan_type.as_deref(),
+                normalize_plan_type(row.plan_type.as_deref()).as_deref(),
+            )
+        }) {
+            reasons.push(DuplicateReason::SharedChatgptUserId);
+        }
+        for row in matching_peers {
+            if should_flag_duplicate_identity_pair(
+                current_member.plan_type.as_deref(),
+                normalize_plan_type(row.plan_type.as_deref()).as_deref(),
+            ) {
+                peer_ids.insert(row.id);
+            }
+        }
+    }
+
+    if peer_ids.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(DuplicateInfo {
+        peer_account_ids: peer_ids.into_iter().collect(),
+        reasons,
+    }))
+}
+
 async fn load_account_tag_map(
     pool: &Pool<Sqlite>,
     account_ids: &[i64],
@@ -2818,7 +3020,7 @@ async fn load_upstream_account_detail(
     .fetch_all(pool)
     .await?;
 
-    let duplicate_info_map = load_duplicate_info_map(pool).await?;
+    let duplicate_info = load_duplicate_info_for_account(pool, row.id).await?;
     let now = Utc::now();
     let active_conversation_count =
         load_account_active_conversation_count_map(pool, &[row.id], now.clone())
@@ -2831,7 +3033,7 @@ async fn load_upstream_account_detail(
         latest.as_ref(),
         row.last_activity_at.clone(),
         tags,
-        duplicate_info_map.get(&row.id).cloned(),
+        duplicate_info,
         active_conversation_count,
         now,
     );
@@ -2858,7 +3060,6 @@ async fn load_upstream_account_detail_with_actual_usage(
         Some(detail) => detail,
         None => return Ok(None),
     };
-    let groups = load_canonicalized_upstream_account_groups(state).await?;
     enrich_window_actual_usage_for_summaries(state, std::slice::from_mut(&mut detail.summary))
         .await?;
     apply_effective_routing_rules_to_summaries(
@@ -2866,14 +3067,29 @@ async fn load_upstream_account_detail_with_actual_usage(
         std::slice::from_mut(&mut detail.summary),
     )
     .await?;
-    enrich_node_shunt_routing_block_reasons(state, std::slice::from_mut(&mut detail.summary))
-        .await?;
-    enrich_current_forward_proxy_for_summaries(
+    let group = load_canonicalized_upstream_account_group(
         state,
-        &groups,
-        std::slice::from_mut(&mut detail.summary),
+        detail.summary.group_name.as_deref(),
     )
     .await?;
+    if group.as_ref().is_some_and(|value| value.node_shunt_enabled) {
+        let groups = group.into_iter().collect::<Vec<_>>();
+        enrich_node_shunt_routing_block_reasons(state, std::slice::from_mut(&mut detail.summary))
+            .await?;
+        enrich_current_forward_proxy_for_summaries(
+            state,
+            &groups,
+            std::slice::from_mut(&mut detail.summary),
+        )
+        .await?;
+    } else {
+        enrich_current_forward_proxy_for_non_node_shunt_detail(
+            state,
+            group.as_ref(),
+            &mut detail.summary,
+        )
+        .await?;
+    }
     Ok(Some(detail))
 }
 
@@ -3169,6 +3385,55 @@ async fn load_canonicalized_upstream_account_groups(
     Ok(groups)
 }
 
+async fn load_canonicalized_upstream_account_group(
+    state: &AppState,
+    group_name: Option<&str>,
+) -> Result<Option<UpstreamAccountGroupSummary>> {
+    let normalized_group_name = group_name
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(group_name) = normalized_group_name else {
+        return Ok(None);
+    };
+    let metadata = load_group_metadata(&state.pool, Some(group_name)).await?;
+    let routing_rule = group_routing_rule_from_group_metadata(&metadata);
+    Ok(Some(UpstreamAccountGroupSummary {
+        group_name: group_name.to_string(),
+        account_count: sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM pool_upstream_accounts
+            WHERE TRIM(COALESCE(group_name, '')) = ?1
+            "#,
+        )
+        .bind(group_name)
+        .fetch_one(&state.pool)
+        .await?,
+        note: metadata.note.clone(),
+        bound_proxy_keys: canonicalize_forward_proxy_bound_keys(state, &metadata.bound_proxy_keys).await?,
+        node_shunt_enabled: metadata.node_shunt_enabled,
+        single_account_rotation_enabled: metadata.single_account_rotation_enabled,
+        upstream_429_retry_enabled: metadata.upstream_429_retry_enabled,
+        upstream_429_max_retries: metadata.upstream_429_max_retries,
+        concurrency_limit: metadata.concurrency_limit,
+        routing_rule,
+    }))
+}
+
+fn group_routing_rule_from_group_metadata(metadata: &UpstreamAccountGroupMetadata) -> TagRoutingRule {
+    TagRoutingRule {
+        block_new_conversations: false,
+        allow_cut_out: true,
+        allow_cut_in: true,
+        priority_tier: TagPriorityTier::Normal,
+        fast_mode_rewrite_mode: TagFastModeRewriteMode::KeepOriginal,
+        concurrency_limit: metadata.concurrency_limit,
+        upstream_429_retry_enabled: metadata.upstream_429_retry_enabled,
+        upstream_429_max_retries: metadata.upstream_429_max_retries,
+        available_models: Vec::new(),
+    }
+}
+
 fn assign_current_forward_proxy(
     item: &mut UpstreamAccountSummary,
     state: &'static str,
@@ -3310,6 +3575,58 @@ async fn enrich_current_forward_proxy_for_summaries(
         );
     }
 
+    Ok(())
+}
+
+async fn enrich_current_forward_proxy_for_non_node_shunt_detail(
+    state: &AppState,
+    group: Option<&UpstreamAccountGroupSummary>,
+    item: &mut UpstreamAccountSummary,
+) -> Result<()> {
+    assign_current_forward_proxy(
+        item,
+        UPSTREAM_ACCOUNT_FORWARD_PROXY_STATE_UNCONFIGURED,
+        None,
+        None,
+    );
+    let Some(group) = group else {
+        return Ok(());
+    };
+    if group.node_shunt_enabled {
+        return Ok(());
+    }
+    let binding_key = {
+        let manager = state.forward_proxy.lock().await;
+        manager.current_bound_group_binding_key(&group.group_name, &group.bound_proxy_keys)
+    };
+    let Some(binding_key) = binding_key else {
+        return Ok(());
+    };
+    let metadata_map = crate::forward_proxy::load_forward_proxy_metadata_history(
+        &state.pool,
+        std::slice::from_ref(&binding_key),
+    )
+    .await?;
+    let binding_display_name = {
+        let manager = state.forward_proxy.lock().await;
+        let binding_display_names = manager
+            .binding_nodes()
+            .into_iter()
+            .map(|node| (node.key, node.display_name))
+            .collect::<HashMap<_, _>>();
+        resolve_current_forward_proxy_display_name(
+            &manager,
+            &binding_display_names,
+            &metadata_map,
+            &binding_key,
+        )
+    };
+    assign_current_forward_proxy(
+        item,
+        UPSTREAM_ACCOUNT_FORWARD_PROXY_STATE_ASSIGNED,
+        Some(binding_key),
+        binding_display_name,
+    );
     Ok(())
 }
 

--- a/src/upstream_accounts/tests_part_6.rs
+++ b/src/upstream_accounts/tests_part_6.rs
@@ -710,6 +710,85 @@
     }
 
     #[tokio::test]
+    async fn load_duplicate_info_for_account_matches_global_duplicate_result() {
+        let pool = test_pool().await;
+
+        let mut tx = pool.begin().await.expect("begin tx 1");
+        ensure_display_name_available(&mut *tx, "Scoped Duplicate One", None)
+            .await
+            .expect("first name available");
+        let first_id = upsert_oauth_account(
+            &mut tx,
+            OauthAccountUpsert {
+                account_id: None,
+                display_name: "Scoped Duplicate One",
+                chosen_email: None,
+                verified_email: None,
+                group_name: None,
+                is_mother: false,
+                note: None,
+                tag_ids: vec![],
+                requested_group_metadata_changes: RequestedGroupMetadataChanges::default(),
+                claims: &test_claims("scoped-1@example.com", Some("scoped_shared_org"), Some("scoped_user_1")),
+                encrypted_credentials: "encrypted-scoped-1".to_string(),
+                has_refresh_token: true,
+                token_expires_at: "2026-03-14T00:00:00Z",
+                external_identity: None,
+            },
+        )
+        .await
+        .expect("first oauth insert");
+        tx.commit().await.expect("commit tx 1");
+
+        let mut tx = pool.begin().await.expect("begin tx 2");
+        ensure_display_name_available(&mut *tx, "Scoped Duplicate Two", None)
+            .await
+            .expect("second name available");
+        let second_id = upsert_oauth_account(
+            &mut tx,
+            OauthAccountUpsert {
+                account_id: None,
+                display_name: "Scoped Duplicate Two",
+                chosen_email: None,
+                verified_email: None,
+                group_name: None,
+                is_mother: false,
+                note: None,
+                tag_ids: vec![],
+                requested_group_metadata_changes: RequestedGroupMetadataChanges::default(),
+                claims: &test_claims("scoped-2@example.com", Some("scoped_shared_org"), Some("scoped_user_2")),
+                encrypted_credentials: "encrypted-scoped-2".to_string(),
+                has_refresh_token: true,
+                token_expires_at: "2026-03-14T00:00:00Z",
+                external_identity: None,
+            },
+        )
+        .await
+        .expect("second oauth insert");
+        tx.commit().await.expect("commit tx 2");
+
+        let all_duplicates = load_duplicate_info_map(&pool)
+            .await
+            .expect("load all duplicate info");
+        let first_scoped = load_duplicate_info_for_account(&pool, first_id)
+            .await
+            .expect("load scoped duplicate for first");
+        let second_scoped = load_duplicate_info_for_account(&pool, second_id)
+            .await
+            .expect("load scoped duplicate for second");
+
+        let first_all = all_duplicates.get(&first_id).expect("first global duplicate");
+        let first_scoped = first_scoped.expect("first scoped duplicate");
+        assert_eq!(first_scoped.peer_account_ids, first_all.peer_account_ids);
+        assert_eq!(first_scoped.reasons, first_all.reasons);
+
+        let second_all = all_duplicates.get(&second_id).expect("second global duplicate");
+        let second_scoped = second_scoped.expect("second scoped duplicate");
+        assert_eq!(second_scoped.peer_account_ids, second_all.peer_account_ids);
+        assert_eq!(second_scoped.reasons, second_all.reasons);
+    }
+
+    #[tokio::test]
     async fn same_group_team_shared_org_accounts_are_not_flagged_as_duplicates() {
         let pool = test_pool().await;
 

--- a/web/src/components/DashboardActivityOverview.test.tsx
+++ b/web/src/components/DashboardActivityOverview.test.tsx
@@ -562,6 +562,41 @@ describe('DashboardActivityOverview', () => {
     })
   })
 
+  it('does not request duplicate yesterday comparison data for account-scoped yesterday view', () => {
+    installSummaryMocks()
+    const storageKey = `${ACCOUNT_ACTIVITY_RANGE_STORAGE_KEY_PREFIX}.42`
+    window.localStorage.setItem(storageKey, 'yesterday')
+
+    render(
+      <DashboardActivityOverview
+        title="Account activity"
+        storageKey={storageKey}
+        testId="account-activity-overview"
+        upstreamAccountId={42}
+      />,
+    )
+
+    const yesterdayCalls = hookMocks.useSummary.mock.calls.filter(
+      ([window, options]) =>
+        window === 'yesterday' &&
+        options != null &&
+        typeof options === 'object' &&
+        'upstreamAccountId' in options &&
+        options.upstreamAccountId === 42,
+    )
+    expect(yesterdayCalls).toHaveLength(1)
+
+    const yesterdayTimeseriesCalls = hookMocks.useTimeseries.mock.calls.filter(
+      ([window, options]) =>
+        window === 'yesterday' &&
+        options != null &&
+        typeof options === 'object' &&
+        'upstreamAccountId' in options &&
+        options.upstreamAccountId === 42,
+    )
+    expect(yesterdayTimeseriesCalls).toHaveLength(1)
+  })
+
   it('loads each summary only after its range is selected', () => {
     installSummaryMocks()
 

--- a/web/src/components/DashboardActivityOverview.tsx
+++ b/web/src/components/DashboardActivityOverview.tsx
@@ -174,14 +174,23 @@ function DashboardNaturalDayRangePanel({
       data-testid={testId}
       data-active="true"
     >
-      <DashboardNaturalDaySummaryOverview
-        summaryWindow={summaryWindow}
-        response={data}
-        loading={isLoading}
-        error={error}
-        closedNaturalDay={timeseriesRange === 'yesterday'}
-        upstreamAccountId={upstreamAccountId}
-      />
+      {summaryWindow === 'today' ? (
+        <DashboardNaturalDayTodaySummaryOverview
+          response={data}
+          loading={isLoading}
+          error={error}
+          closedNaturalDay={timeseriesRange === 'yesterday'}
+          upstreamAccountId={upstreamAccountId}
+        />
+      ) : (
+        <DashboardNaturalDayYesterdaySummaryOverview
+          response={data}
+          loading={isLoading}
+          error={error}
+          closedNaturalDay={timeseriesRange === 'yesterday'}
+          upstreamAccountId={upstreamAccountId}
+        />
+      )}
       <DashboardNaturalDayChartSection
         response={chartResponse}
         loading={isLoading && chartResponse == null}
@@ -193,15 +202,13 @@ function DashboardNaturalDayRangePanel({
   )
 }
 
-function DashboardNaturalDaySummaryOverview({
-  summaryWindow,
+function DashboardNaturalDayTodaySummaryOverview({
   response,
   loading,
   error,
   closedNaturalDay,
   upstreamAccountId,
 }: {
-  summaryWindow: 'today' | 'yesterday'
   response: ReturnType<typeof useTimeseries>['data']
   loading: boolean
   error: ReturnType<typeof useTimeseries>['error']
@@ -212,7 +219,7 @@ function DashboardNaturalDaySummaryOverview({
     summary,
     isLoading: summaryLoading,
     error: summaryError,
-  } = useScopedSummary(summaryWindow, upstreamAccountId)
+  } = useScopedSummary('today', upstreamAccountId)
   const {
     summary: comparisonSummary,
   } = useScopedSummary('yesterday', upstreamAccountId)
@@ -231,7 +238,7 @@ function DashboardNaturalDaySummaryOverview({
     isLoading: parallelWorkLoading,
     error: parallelWorkError,
   } = useParallelWorkStats({
-    range: summaryWindow,
+    range: 'today',
     bucket: '1m',
     enabled: parallelEnabled,
   })
@@ -271,19 +278,95 @@ function DashboardNaturalDaySummaryOverview({
       rateError={error}
       now={rateNow}
       timeseries={response}
-      comparisonStats={summaryWindow === 'today' ? comparisonSummary : null}
-      comparisonTimeseries={summaryWindow === 'today' ? comparisonTimeseries : null}
+      comparisonStats={comparisonSummary}
+      comparisonTimeseries={comparisonTimeseries}
       previous7dStats={previous7dSummary}
       parallelWorkStats={parallelEnabled ? parallelWorkStats : null}
-      comparisonParallelWorkStats={
-        parallelEnabled && summaryWindow === 'today' ? comparisonParallelWorkStats : null
-      }
+      comparisonParallelWorkStats={parallelEnabled ? comparisonParallelWorkStats : null}
       parallelWorkLoading={parallelEnabled && parallelWorkLoading}
       parallelWorkError={
         parallelEnabled ? parallelWorkError : null
       }
       showParallelWork={parallelEnabled}
-      dayKind={summaryWindow}
+      dayKind="today"
+      showSurface={false}
+      showHeader={false}
+      showDayBadge={false}
+    />
+  )
+}
+
+function DashboardNaturalDayYesterdaySummaryOverview({
+  response,
+  loading,
+  error,
+  closedNaturalDay,
+  upstreamAccountId,
+}: {
+  response: ReturnType<typeof useTimeseries>['data']
+  loading: boolean
+  error: ReturnType<typeof useTimeseries>['error']
+  closedNaturalDay: boolean
+  upstreamAccountId?: number
+}) {
+  const {
+    summary,
+    isLoading: summaryLoading,
+    error: summaryError,
+  } = useScopedSummary('yesterday', upstreamAccountId)
+  const {
+    summary: previous7dSummary,
+  } = useScopedSummary('previous7d', upstreamAccountId)
+  const parallelEnabled = upstreamAccountId == null
+  const {
+    data: parallelWorkStats,
+    isLoading: parallelWorkLoading,
+    error: parallelWorkError,
+  } = useParallelWorkStats({
+    range: 'yesterday',
+    bucket: '1m',
+    enabled: parallelEnabled,
+  })
+  const [rateNow, setRateNow] = useState(() => new Date())
+
+  useEffect(() => {
+    if (closedNaturalDay) return
+    setRateNow(new Date())
+    const timer = window.setInterval(() => {
+      setRateNow(new Date())
+    }, LIVE_RATE_REFRESH_MS)
+    return () => window.clearInterval(timer)
+  }, [closedNaturalDay])
+
+  const rate = useMemo(
+    () => buildDashboardTodayRateSnapshot(response, {
+      closedNaturalDay,
+      now: rateNow,
+    }),
+    [closedNaturalDay, rateNow, response],
+  )
+
+  return (
+    <TodayStatsOverview
+      stats={summary}
+      loading={summaryLoading}
+      error={summaryError}
+      rate={rate}
+      rateLoading={loading}
+      rateError={error}
+      now={rateNow}
+      timeseries={response}
+      comparisonStats={null}
+      comparisonTimeseries={null}
+      previous7dStats={previous7dSummary}
+      parallelWorkStats={parallelEnabled ? parallelWorkStats : null}
+      comparisonParallelWorkStats={null}
+      parallelWorkLoading={parallelEnabled && parallelWorkLoading}
+      parallelWorkError={
+        parallelEnabled ? parallelWorkError : null
+      }
+      showParallelWork={parallelEnabled}
+      dayKind="yesterday"
       showSurface={false}
       showHeader={false}
       showDayBadge={false}


### PR DESCRIPTION
## Summary
- harden account detail stats summary/timeseries against stale summary repair cursors and materialized archive replay-marker gaps
- reduce detail drawer hot-path work by scoping duplicate-account/group lookups and removing duplicate yesterday account overview fetches
- remove SQLite-heavy startup/backfill scans that were intermittently stalling account detail stats in production and add partial-index coverage for background recovery queries

## Root Cause
Production verification showed the steady-state detail endpoints were already back down to millisecond latency for the affected account, but the drawer still intermittently stalled for 10s+ because background SQLite work was reclaiming locks and connections at the same time:
- startup proxy usage backfill still executed a sparse `MAX(id)` scan over `codex_invocations`
- stale attempt recovery still scanned `pool_upstream_request_attempts` through a low-selectivity predicate without a dedicated partial index
- old materialized archives that lacked account stats replay markers could still push account summary/timeseries back onto archive fallback paths
- account-scoped `yesterday` overview still duplicated one summary/timeseries fetch on the front end

## Validation
- `cargo test summary_rollup_repair_refreshes_stale_repair_live_cursor_from_shared_progress -- --nocapture`
- `cargo test account_summary_yesterday_ignores_materialized_archive_missing_account_usage_marker -- --nocapture`
- `cargo test summary_yesterday_ignores_missing_non_overlapping_archive_batch -- --nocapture`
- `cargo test materialize_historical_rollups_marks_account_replay_targets_when_only_account_targets_are_pending -- --nocapture`
- `cargo test bootstrap_hourly_rollups_repairs_missing_materialized_account_replay_markers -- --nocapture`
- `cargo test ensure_schema_migrates_codex_invocations_off_raw_expires_at_and_adds_retention_tables -- --nocapture`
- `cargo test load_duplicate_info_for_account_matches_global_duplicate_result -- --nocapture`
- `cargo test detail_preserves_group_node_shunt_unassigned_routing_block_reason -- --nocapture`
- `cargo test load_upstream_account_detail_with_actual_usage_serializes_actual_usage_camel_case -- --nocapture`
- `cargo test account_scoped_summary_and_timeseries_filter_by_payload_upstream_account_id -- --nocapture`
- `cargo test get_upstream_account_window_usage -- --nocapture`
- `cargo check`
- `cd web && bun run test src/components/DashboardActivityOverview.test.tsx`

## References
- Specs
  - `docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md`
  - `docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md`
  - `docs/specs/t6d9r-account-detail-stats-read-model/HISTORY.md`
- Solutions
  - `docs/solutions/performance/account-detail-stats-read-model-sla.md`
  - `docs/solutions/performance/sqlite-write-pressure-backpressure.md`
- Project Docs
  - `-`
