### PR TITLE
fix(ci): retry arm64 release smoke builds

### DIFF
--- a/.github/scripts/build-smoke-image-with-retry.sh
+++ b/.github/scripts/build-smoke-image-with-retry.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_platform="${BUILD_PLATFORM:-}"
+smoke_tag="${SMOKE_TAG:-}"
+candidate_tag="${CANDIDATE_TAG:-}"
+app_effective_version="${APP_EFFECTIVE_VERSION:-}"
+cache_ref="${CACHE_REF:-}"
+build_context="${BUILD_CONTEXT:-.}"
+dockerfile_path="${DOCKERFILE_PATH:-./Dockerfile}"
+retry_attempts="${BUILD_RETRY_ATTEMPTS:-5}"
+retry_base_delay_secs="${BUILD_RETRY_BASE_DELAY_SECS:-3}"
+
+if [[ -z "${build_platform}" || -z "${smoke_tag}" || -z "${candidate_tag}" || -z "${app_effective_version}" || -z "${cache_ref}" ]]; then
+  echo "missing required build env: BUILD_PLATFORM, SMOKE_TAG, CANDIDATE_TAG, APP_EFFECTIVE_VERSION, CACHE_REF" >&2
+  exit 2
+fi
+
+is_transient_failure() {
+  local err_file="$1"
+  local patterns=(
+    "context deadline exceeded"
+    "DeadlineExceeded"
+    "TLS handshake timeout"
+    "i/o timeout"
+    "connection reset by peer"
+    "unexpected EOF"
+    "temporary failure in name resolution"
+    "no route to host"
+    "429 Too Many Requests"
+    "toomanyrequests"
+    "request canceled while waiting for connection"
+  )
+
+  for pattern in "${patterns[@]}"; do
+    if grep -Fqi "${pattern}" "${err_file}"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+for attempt in $(seq 1 "${retry_attempts}"); do
+  err_file="$(mktemp)"
+
+  if docker buildx build \
+    --progress plain \
+    --file "${dockerfile_path}" \
+    --platform "${build_platform}" \
+    --load \
+    --tag "${smoke_tag}" \
+    --tag "${candidate_tag}" \
+    --build-arg "APP_EFFECTIVE_VERSION=${app_effective_version}" \
+    --cache-from "type=registry,ref=${cache_ref}" \
+    --cache-to "type=registry,ref=${cache_ref},mode=max" \
+    "${build_context}" 2>"${err_file}"; then
+    rm -f "${err_file}"
+    exit 0
+  fi
+
+  if ! is_transient_failure "${err_file}"; then
+    echo "[buildx] non-retryable failure for ${build_platform} on attempt ${attempt}/${retry_attempts}" >&2
+    cat "${err_file}" >&2
+    rm -f "${err_file}"
+    exit 1
+  fi
+
+  if [[ "${attempt}" == "${retry_attempts}" ]]; then
+    echo "[buildx] transient failure exhausted retries for ${build_platform} after ${retry_attempts} attempts" >&2
+    cat "${err_file}" >&2
+    rm -f "${err_file}"
+    exit 1
+  fi
+
+  sleep_secs=$((attempt * retry_base_delay_secs))
+  echo "[buildx] transient failure for ${build_platform}; retry in ${sleep_secs}s (${attempt}/${retry_attempts})" >&2
+  tail -n 40 "${err_file}" >&2 || cat "${err_file}" >&2
+  rm -f "${err_file}"
+  sleep "${sleep_secs}"
+done

--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -489,7 +489,19 @@ def validate_ci_pr(path: Path, contract: ContractModel) -> None:
 
     self_tests = step_config(lint_job, "Quality gates self-tests", "ci-pr.yml.jobs.lint")
     self_tests_run = str(self_tests.get("run", ""))
-    require("test-quality-gates-contract.sh" in self_tests_run and "test-live-quality-gates.sh" in self_tests_run, "ci-pr.yml.jobs.lint: self-tests step drifted")
+    require(
+        "test-quality-gates-contract.sh" in self_tests_run
+        and "test-build-smoke-image-with-retry.sh" in self_tests_run
+        and "test-live-quality-gates.sh" in self_tests_run,
+        "ci-pr.yml.jobs.lint: self-tests step drifted",
+    )
+
+    scripts_step = step_config(lint_job, "Check quality-gates scripts", "ci-pr.yml.jobs.lint")
+    scripts_run = str(scripts_step.get("run", ""))
+    require(
+        "bash -n .github/scripts/build-smoke-image-with-retry.sh" in scripts_run,
+        "ci-pr.yml.jobs.lint: build smoke retry helper syntax check drifted",
+    )
 
     build_job = named_job_config(workflow, "build", expected_jobs, "ci-pr.yml")
     require_exact_if(build_job, "github.event_name == 'pull_request'", "ci-pr.yml.jobs.build")
@@ -520,11 +532,26 @@ def validate_ci_main(path: Path, contract: ContractModel) -> None:
     lint_job = named_job_config(workflow, "lint", expected_jobs, "ci-main.yml")
     require_no_if(lint_job, "ci-main.yml.jobs.lint")
     require_fail_closed(lint_job, "ci-main.yml.jobs.lint")
+    scripts_step = step_config(lint_job, "Check quality-gates scripts", "ci-main.yml.jobs.lint")
+    scripts_run = str(scripts_step.get("run", ""))
+    require(
+        "bash -n .github/scripts/build-smoke-image-with-retry.sh" in scripts_run,
+        "ci-main.yml.jobs.lint: build smoke retry helper syntax check drifted",
+    )
     trusted_step = step_config(lint_job, "Resolve trusted quality-gates sources", "ci-main.yml.jobs.lint")
     trusted_run = str(trusted_step.get("run", ""))
     require('source_ref="HEAD"' in trusted_run, "ci-main.yml.jobs.lint: trusted-source ref drifted")
     require('source_kind="current-branch"' in trusted_run, "ci-main.yml.jobs.lint: trusted-source kind drifted")
     require("cp \"$path\" \"$trusted_root/$path\"" in trusted_run, "ci-main.yml.jobs.lint: trusted-source copy drifted")
+
+    self_tests = step_config(lint_job, "Quality gates self-tests", "ci-main.yml.jobs.lint")
+    self_tests_run = str(self_tests.get("run", ""))
+    require(
+        "test-quality-gates-contract.sh" in self_tests_run
+        and "test-build-smoke-image-with-retry.sh" in self_tests_run
+        and "test-live-quality-gates.sh" in self_tests_run,
+        "ci-main.yml.jobs.lint: self-tests step drifted",
+    )
 
     release_snapshot = named_job_config(workflow, "release-snapshot", expected_jobs, "ci-main.yml")
     require(
@@ -817,6 +844,30 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     docker_arm = named_job_config(workflow, "docker-arm64", expected_jobs, "release.yml")
     arm_checkout = checkout_step(docker_arm, "Checkout code", "release.yml.jobs.docker-arm64")
     require(arm_checkout.get("ref") == "${{ needs.release-meta.outputs.target_sha }}", "release.yml.jobs.docker-arm64 checkout ref drifted")
+    arm_build_step = step_config(docker_arm, "Build smoke image (linux/arm64, load)", "release.yml.jobs.docker-arm64")
+    require(arm_build_step.get("shell") == "bash", "release.yml.jobs.docker-arm64: arm64 smoke build must run in bash")
+    arm_build_env = require_mapping(arm_build_step.get("env"), "release.yml.jobs.docker-arm64.steps['Build smoke image (linux/arm64, load)'].env")
+    require(
+        arm_build_env.get("BUILD_PLATFORM") == "${{ env.PLATFORM_ARM64 }}",
+        "release.yml.jobs.docker-arm64: arm64 smoke build must consume PLATFORM_ARM64",
+    )
+    require(
+        arm_build_env.get("SMOKE_TAG") == "${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64",
+        "release.yml.jobs.docker-arm64: arm64 smoke build smoke tag drifted",
+    )
+    require(
+        arm_build_env.get("CANDIDATE_TAG") == "${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64",
+        "release.yml.jobs.docker-arm64: arm64 smoke build candidate tag drifted",
+    )
+    require(
+        arm_build_env.get("CACHE_REF") == "${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64",
+        "release.yml.jobs.docker-arm64: arm64 smoke build cache ref drifted",
+    )
+    arm_build_run = str(arm_build_step.get("run", ""))
+    require(
+        "./.github/scripts/build-smoke-image-with-retry.sh" in arm_build_run,
+        "release.yml.jobs.docker-arm64: arm64 smoke build must use the retry helper",
+    )
     arm_smoke_step = step_config(docker_arm, "Smoke test image (linux/arm64)", "release.yml.jobs.docker-arm64")
     arm_smoke_env = require_mapping(arm_smoke_step.get("env"), "release.yml.jobs.docker-arm64.steps['Smoke test image (linux/arm64)'].env")
     require(

--- a/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
@@ -80,6 +80,7 @@ jobs:
             .github/scripts/check_quality_gates_contract.py \
             .github/scripts/release_snapshot.py \
             .github/scripts/verify_manifest_platforms.py
+          bash -n .github/scripts/build-smoke-image-with-retry.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -130,6 +131,7 @@ jobs:
       - name: Quality gates self-tests
         run: |
           bash .github/scripts/test-quality-gates-contract.sh
+          bash .github/scripts/test-build-smoke-image-with-retry.sh
           bash .github/scripts/test-release-snapshot.sh
           bash .github/scripts/test-live-quality-gates.sh
 

--- a/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
@@ -94,6 +94,7 @@ jobs:
             .github/scripts/check_quality_gates_contract.py \
             .github/scripts/release_snapshot.py \
             .github/scripts/verify_manifest_platforms.py
+          bash -n .github/scripts/build-smoke-image-with-retry.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -213,6 +214,7 @@ jobs:
       - name: Quality gates self-tests
         run: |
           bash .github/scripts/test-quality-gates-contract.sh
+          bash .github/scripts/test-build-smoke-image-with-retry.sh
           bash .github/scripts/test-release-snapshot.sh
           bash .github/scripts/test-live-quality-gates.sh
 

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -332,20 +332,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build smoke image (linux/arm64, load)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ env.PLATFORM_ARM64 }}
-          push: false
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
-            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
-          build-args: |
-            APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64,mode=max
+        shell: bash
+        env:
+          BUILD_PLATFORM: ${{ env.PLATFORM_ARM64 }}
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
@@ -80,6 +80,7 @@ jobs:
             .github/scripts/check_quality_gates_contract.py \
             .github/scripts/release_snapshot.py \
             .github/scripts/verify_manifest_platforms.py
+          bash -n .github/scripts/build-smoke-image-with-retry.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -130,6 +131,7 @@ jobs:
       - name: Quality gates self-tests
         run: |
           bash .github/scripts/test-quality-gates-contract.sh
+          bash .github/scripts/test-build-smoke-image-with-retry.sh
           bash .github/scripts/test-release-snapshot.sh
           bash .github/scripts/test-live-quality-gates.sh
 

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -332,20 +332,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build smoke image (linux/arm64, load)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ env.PLATFORM_ARM64 }}
-          push: false
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
-            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
-          build-args: |
-            APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64,mode=max
+        shell: bash
+        env:
+          BUILD_PLATFORM: ${{ env.PLATFORM_ARM64 }}
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash

--- a/.github/scripts/test-build-smoke-image-with-retry.sh
+++ b/.github/scripts/test-build-smoke-image-with-retry.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/.github/scripts/build-smoke-image-with-retry.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+cat >"$tmp_dir/docker-transient" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+attempt_file="${FAKE_DOCKER_ATTEMPT_FILE:?}"
+count=0
+if [[ -f "$attempt_file" ]]; then
+  count="$(cat "$attempt_file")"
+fi
+count=$((count + 1))
+printf '%s' "$count" >"$attempt_file"
+if [[ "$count" -lt 3 ]]; then
+  echo "failed to authorize: DeadlineExceeded: context deadline exceeded" >&2
+  exit 1
+fi
+exit 0
+EOF
+
+cat >"$tmp_dir/docker-permanent" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "manifest for docker.io/library/rust:1.91.0-bookworm not found" >&2
+exit 1
+EOF
+
+chmod +x "$tmp_dir/docker-transient" "$tmp_dir/docker-permanent"
+
+transient_path="$tmp_dir/transient-bin"
+mkdir -p "$transient_path"
+cp "$tmp_dir/docker-transient" "$transient_path/docker"
+
+attempt_file="$tmp_dir/transient-attempts"
+PATH="$transient_path:$PATH" \
+FAKE_DOCKER_ATTEMPT_FILE="$attempt_file" \
+BUILD_PLATFORM="linux/arm64" \
+SMOKE_TAG="ghcr.io/example/smoke:arm64" \
+CANDIDATE_TAG="ghcr.io/example/candidate:arm64" \
+APP_EFFECTIVE_VERSION="test-version" \
+CACHE_REF="ghcr.io/example/buildcache:arm64" \
+BUILD_RETRY_ATTEMPTS="5" \
+BUILD_RETRY_BASE_DELAY_SECS="0" \
+bash "$script" >"$tmp_dir/transient.out" 2>"$tmp_dir/transient.err"
+
+[[ "$(cat "$attempt_file")" == "3" ]]
+grep -q "transient failure for linux/arm64; retry in 0s (1/5)" "$tmp_dir/transient.err"
+grep -q "transient failure for linux/arm64; retry in 0s (2/5)" "$tmp_dir/transient.err"
+
+permanent_path="$tmp_dir/permanent-bin"
+mkdir -p "$permanent_path"
+cp "$tmp_dir/docker-permanent" "$permanent_path/docker"
+
+set +e
+PATH="$permanent_path:$PATH" \
+BUILD_PLATFORM="linux/arm64" \
+SMOKE_TAG="ghcr.io/example/smoke:arm64" \
+CANDIDATE_TAG="ghcr.io/example/candidate:arm64" \
+APP_EFFECTIVE_VERSION="test-version" \
+CACHE_REF="ghcr.io/example/buildcache:arm64" \
+BUILD_RETRY_ATTEMPTS="5" \
+BUILD_RETRY_BASE_DELAY_SECS="0" \
+bash "$script" >"$tmp_dir/permanent.out" 2>"$tmp_dir/permanent.err"
+rc=$?
+set -e
+
+[[ "$rc" == "1" ]]
+grep -q "non-retryable failure for linux/arm64 on attempt 1/5" "$tmp_dir/permanent.err"
+if grep -q "retry in" "$tmp_dir/permanent.err"; then
+  echo "expected permanent failure path to stop without retries" >&2
+  exit 1
+fi
+
+echo "test-build-smoke-image-with-retry: all checks passed"

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -192,6 +192,28 @@ fi
 
 grep -q "release.yml.jobs.ci-main-gate.if must stay" "$tmp_dir/release-ci-gate.log"
 
+release_arm_retry_repo="$tmp_dir/release-arm-retry-repo"
+copy_repo_snapshot "$baseline_repo" "$release_arm_retry_repo"
+python3 - <<'PY' "$release_arm_retry_repo"
+from pathlib import Path
+import sys
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/release.yml"
+text = path.read_text()
+needle = "        run: ./.github/scripts/build-smoke-image-with-retry.sh\n"
+replacement = "        run: docker buildx build --platform \"$BUILD_PLATFORM\" .\n"
+if needle not in text:
+    raise SystemExit("failed to rewrite arm64 retry helper step")
+path.write_text(text.replace(needle, replacement, 1))
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$release_arm_retry_repo" --profile final >/dev/null 2>"$tmp_dir/release-arm-retry.log"; then
+  echo "expected arm64 retry helper fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "arm64 smoke build must use the retry helper" "$tmp_dir/release-arm-retry.log"
+
 ci_main_repo="$tmp_dir/ci-main-repo"
 copy_repo_snapshot "$baseline_repo" "$ci_main_repo"
 python3 - <<'PY' "$ci_main_repo"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -81,6 +81,7 @@ jobs:
             .github/scripts/check_quality_gates_contract.py \
             .github/scripts/release_snapshot.py \
             .github/scripts/verify_manifest_platforms.py
+          bash -n .github/scripts/build-smoke-image-with-retry.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -131,6 +132,7 @@ jobs:
       - name: Quality gates self-tests
         run: |
           bash .github/scripts/test-quality-gates-contract.sh
+          bash .github/scripts/test-build-smoke-image-with-retry.sh
           bash .github/scripts/test-release-snapshot.sh
           bash .github/scripts/test-live-quality-gates.sh
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -94,6 +94,7 @@ jobs:
             .github/scripts/check_quality_gates_contract.py \
             .github/scripts/release_snapshot.py \
             .github/scripts/verify_manifest_platforms.py
+          bash -n .github/scripts/build-smoke-image-with-retry.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -213,6 +214,7 @@ jobs:
       - name: Quality gates self-tests
         run: |
           bash .github/scripts/test-quality-gates-contract.sh
+          bash .github/scripts/test-build-smoke-image-with-retry.sh
           bash .github/scripts/test-release-snapshot.sh
           bash .github/scripts/test-live-quality-gates.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,20 +338,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build smoke image (linux/arm64, load)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ env.PLATFORM_ARM64 }}
-          push: false
-          load: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
-            ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
-          build-args: |
-            APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64,mode=max
+        shell: bash
+        env:
+          BUILD_PLATFORM: ${{ env.PLATFORM_ARM64 }}
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash

--- a/docs/solutions/workflow/release-arm64-build-retry-hardening.md
+++ b/docs/solutions/workflow/release-arm64-build-retry-hardening.md
@@ -1,0 +1,62 @@
+---
+title: "Release arm64 smoke builds should retry transient registry failures"
+module: "release automation"
+problem_type: "transient registry dependency failure"
+component: "GitHub Actions multi-arch release build"
+tags:
+  - github-actions
+  - release
+  - docker-buildx
+  - arm64
+  - retry
+status: "active"
+related_specs: []
+symptoms:
+  - "Release fails in `Build + Smoke + Push Candidate (linux/arm64)` while amd64 succeeds."
+  - "The failing build dies while resolving a base image or registry metadata, often with `DeadlineExceeded` or `context deadline exceeded`."
+root_cause: "The arm64 release smoke build treated transient Docker Hub or registry metadata timeouts as terminal failures, so one flaky upstream fetch aborted the entire publish path."
+resolution_type: "retry-hardening"
+---
+
+# Release arm64 build retry hardening
+
+## Context
+
+The release workflow publishes both `linux/amd64` and `linux/arm64` images before it creates the final manifest tags. The arm64 lane runs on a native arm runner, but it still depends on external registry metadata fetches for base images and build cache layers.
+
+## Symptoms
+
+- `Release` fails even though the application code and the amd64 release lane are healthy.
+- The failing step is `Build smoke image (linux/arm64, load)`.
+- The error surface points at registry access rather than Dockerfile logic, for example `failed to authorize`, `DeadlineExceeded`, `context deadline exceeded`, or similar network timeouts.
+- Rerunning the same workflow often succeeds without any code change.
+
+## Root Cause
+
+The old arm64 smoke build used a single `docker/build-push-action` attempt. That is fine for deterministic Dockerfile failures, but it is too brittle for transient upstream registry failures. When Docker Hub or another registry stalls during metadata resolution, the release path should retry the fetch instead of treating the first timeout as a product regression.
+
+## Resolution
+
+Move the arm64 smoke build behind a repo-owned retry helper and validate that contract in CI:
+
+- Run the arm64 smoke build through `.github/scripts/build-smoke-image-with-retry.sh`.
+- Retry only known transient registry/network failures such as `DeadlineExceeded`, `context deadline exceeded`, TLS handshake timeouts, connection resets, unexpected EOF, and rate-limit style fetch failures.
+- Keep non-transient build failures fail-closed on the first attempt so real Dockerfile or packaging regressions stay loud.
+- Add a dedicated script regression test that proves both paths:
+  - transient registry failures retry and eventually succeed;
+  - permanent image-resolution failures stop immediately without looping.
+- Add workflow-contract assertions so the release topology cannot silently drift back to a non-retrying arm64 build step.
+
+## Guardrails / Reuse Notes
+
+- Keep retry classification small and explicit. A helper that retries everything will hide real build breakages.
+- Put retry policy in a repo-owned script instead of duplicating shell loops inline in workflow YAML; this keeps release, tests, and contract fixtures aligned.
+- When a release job fails in only one architecture lane, inspect whether the error happens before the real Dockerfile steps begin. If yes, suspect registry flakiness before suspecting app code.
+- For workflow-level resilience changes, update both live workflows and `quality-gates-contract` fixtures in the same patch. Otherwise CI may accept topology drift or reject the intended contract.
+
+## References
+
+- `.github/workflows/release.yml`
+- `.github/scripts/build-smoke-image-with-retry.sh`
+- `.github/scripts/test-build-smoke-image-with-retry.sh`
+- `.github/scripts/check_quality_gates_contract.py`


### PR DESCRIPTION
## Summary
- retry the arm64 release smoke build through a repo-owned buildx helper so transient registry timeouts do not fail the whole release
- add dedicated retry helper regression coverage plus quality-gates contract assertions/fixtures so the arm64 retry path cannot silently drift away
- document the release-arm64 retry-hardening pattern in docs/solutions for future workflow fixes

## Testing
- `bash .github/scripts/test-build-smoke-image-with-retry.sh`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-release-snapshot.sh`
- `bash .github/scripts/test-live-quality-gates.sh`

Spec: -
Spec Disposition: not_needed
Spec Sync: n/a(spec-free)
Spec Drift: none
Solutions: docs/solutions/workflow/release-arm64-build-retry-hardening.md
Solutions Sync: done
Project Docs: -
Project Docs Sync: n/a(no project-doc change)
Notes: Fixes the transient Docker Hub timeout class that broke Release run 27958101610 for commit 94c4bf8b769eeeca18b5f027c5fd5a196bf86c0f; after merge, manually backfill that commit via `workflow_dispatch` on `release.yml`.