### PR TITLE
fix(ci): source arm64 retry helper from workflow checkout

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -848,6 +848,11 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     arm_helper_checkout = checkout_step(docker_arm, "Checkout workflow helpers", "release.yml.jobs.docker-arm64")
     require(arm_helper_checkout.get("ref") == "${{ github.sha }}", "release.yml.jobs.docker-arm64 helper checkout ref drifted")
     require(arm_helper_checkout.get("path") == "workflow-helpers", "release.yml.jobs.docker-arm64 helper checkout path drifted")
+    helper_install_step = step_config(docker_arm, "Install workflow helper scripts", "release.yml.jobs.docker-arm64")
+    require(helper_install_step.get("shell") == "bash", "release.yml.jobs.docker-arm64: helper install must run in bash")
+    require(helper_install_step.get("working-directory") == "target", "release.yml.jobs.docker-arm64: helper install must run from target checkout")
+    helper_install_run = str(helper_install_step.get("run", ""))
+    require("install -m 755 ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh" in helper_install_run, "release.yml.jobs.docker-arm64: helper install step must copy retry helper into target checkout")
     arm_build_step = step_config(docker_arm, "Build smoke image (linux/arm64, load)", "release.yml.jobs.docker-arm64")
     require(arm_build_step.get("shell") == "bash", "release.yml.jobs.docker-arm64: arm64 smoke build must run in bash")
     require(arm_build_step.get("working-directory") == "target", "release.yml.jobs.docker-arm64: arm64 smoke build must run from target checkout")
@@ -870,7 +875,7 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     )
     arm_build_run = str(arm_build_step.get("run", ""))
     require(
-        "../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh" in arm_build_run,
+        "./.github/scripts/build-smoke-image-with-retry.sh" in arm_build_run,
         "release.yml.jobs.docker-arm64: arm64 smoke build must use the retry helper",
     )
     arm_smoke_step = step_config(docker_arm, "Smoke test image (linux/arm64)", "release.yml.jobs.docker-arm64")

--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -844,8 +844,13 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     docker_arm = named_job_config(workflow, "docker-arm64", expected_jobs, "release.yml")
     arm_checkout = checkout_step(docker_arm, "Checkout code", "release.yml.jobs.docker-arm64")
     require(arm_checkout.get("ref") == "${{ needs.release-meta.outputs.target_sha }}", "release.yml.jobs.docker-arm64 checkout ref drifted")
+    require(arm_checkout.get("path") == "target", "release.yml.jobs.docker-arm64 checkout path drifted")
+    arm_helper_checkout = checkout_step(docker_arm, "Checkout workflow helpers", "release.yml.jobs.docker-arm64")
+    require(arm_helper_checkout.get("ref") == "${{ github.sha }}", "release.yml.jobs.docker-arm64 helper checkout ref drifted")
+    require(arm_helper_checkout.get("path") == "workflow-helpers", "release.yml.jobs.docker-arm64 helper checkout path drifted")
     arm_build_step = step_config(docker_arm, "Build smoke image (linux/arm64, load)", "release.yml.jobs.docker-arm64")
     require(arm_build_step.get("shell") == "bash", "release.yml.jobs.docker-arm64: arm64 smoke build must run in bash")
+    require(arm_build_step.get("working-directory") == "target", "release.yml.jobs.docker-arm64: arm64 smoke build must run from target checkout")
     arm_build_env = require_mapping(arm_build_step.get("env"), "release.yml.jobs.docker-arm64.steps['Build smoke image (linux/arm64, load)'].env")
     require(
         arm_build_env.get("BUILD_PLATFORM") == "${{ env.PLATFORM_ARM64 }}",
@@ -865,10 +870,11 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     )
     arm_build_run = str(arm_build_step.get("run", ""))
     require(
-        "./.github/scripts/build-smoke-image-with-retry.sh" in arm_build_run,
+        "../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh" in arm_build_run,
         "release.yml.jobs.docker-arm64: arm64 smoke build must use the retry helper",
     )
     arm_smoke_step = step_config(docker_arm, "Smoke test image (linux/arm64)", "release.yml.jobs.docker-arm64")
+    require(arm_smoke_step.get("working-directory") == "target", "release.yml.jobs.docker-arm64: arm64 smoke test must run from target checkout")
     arm_smoke_env = require_mapping(arm_smoke_step.get("env"), "release.yml.jobs.docker-arm64.steps['Smoke test image (linux/arm64)'].env")
     require(
         arm_smoke_env.get("SMOKE_TAG") == "${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64",

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -320,6 +320,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.release-meta.outputs.target_sha }}
+          path: target
+
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-helpers
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -333,16 +340,18 @@ jobs:
 
       - name: Build smoke image (linux/arm64, load)
         shell: bash
+        working-directory: target
         env:
           BUILD_PLATFORM: ${{ env.PLATFORM_ARM64 }}
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-        run: ./.github/scripts/build-smoke-image-with-retry.sh
+        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash
+        working-directory: target
         env:
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ needs.release-meta.outputs.candidate_suffix }}

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -338,6 +338,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install workflow helper scripts
+        shell: bash
+        working-directory: target
+        run: |
+          set -euo pipefail
+          install -m 755 ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh \
+            ./.github/scripts/build-smoke-image-with-retry.sh
+
       - name: Build smoke image (linux/arm64, load)
         shell: bash
         working-directory: target
@@ -347,7 +355,7 @@ jobs:
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -320,6 +320,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.release-meta.outputs.target_sha }}
+          path: target
+
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-helpers
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -333,16 +340,18 @@ jobs:
 
       - name: Build smoke image (linux/arm64, load)
         shell: bash
+        working-directory: target
         env:
           BUILD_PLATFORM: ${{ env.PLATFORM_ARM64 }}
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-        run: ./.github/scripts/build-smoke-image-with-retry.sh
+        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash
+        working-directory: target
         env:
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ needs.release-meta.outputs.candidate_suffix }}

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -338,6 +338,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install workflow helper scripts
+        shell: bash
+        working-directory: target
+        run: |
+          set -euo pipefail
+          install -m 755 ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh \
+            ./.github/scripts/build-smoke-image-with-retry.sh
+
       - name: Build smoke image (linux/arm64, load)
         shell: bash
         working-directory: target
@@ -347,7 +355,7 @@ jobs:
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -200,7 +200,7 @@ import sys
 repo = Path(sys.argv[1])
 path = repo / ".github/workflows/release.yml"
 text = path.read_text()
-needle = "        run: ./.github/scripts/build-smoke-image-with-retry.sh\n"
+needle = "        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh\n"
 replacement = "        run: docker buildx build --platform \"$BUILD_PLATFORM\" .\n"
 if needle not in text:
     raise SystemExit("failed to rewrite arm64 retry helper step")

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -200,7 +200,7 @@ import sys
 repo = Path(sys.argv[1])
 path = repo / ".github/workflows/release.yml"
 text = path.read_text()
-needle = "        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh\n"
+needle = "        run: ./.github/scripts/build-smoke-image-with-retry.sh\n"
 replacement = "        run: docker buildx build --platform \"$BUILD_PLATFORM\" .\n"
 if needle not in text:
     raise SystemExit("failed to rewrite arm64 retry helper step")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,6 +344,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install workflow helper scripts
+        shell: bash
+        working-directory: target
+        run: |
+          set -euo pipefail
+          install -m 755 ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh \
+            ./.github/scripts/build-smoke-image-with-retry.sh
+
       - name: Build smoke image (linux/arm64, load)
         shell: bash
         working-directory: target
@@ -353,7 +361,7 @@ jobs:
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.release-meta.outputs.target_sha }}
+          path: target
+
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-helpers
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -339,16 +346,18 @@ jobs:
 
       - name: Build smoke image (linux/arm64, load)
         shell: bash
+        working-directory: target
         env:
           BUILD_PLATFORM: ${{ env.PLATFORM_ARM64 }}
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
-        run: ./.github/scripts/build-smoke-image-with-retry.sh
+        run: ../workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh
 
       - name: Smoke test image (linux/arm64)
         shell: bash
+        working-directory: target
         env:
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ needs.release-meta.outputs.candidate_suffix }}

--- a/docs/solutions/workflow/release-arm64-build-retry-hardening.md
+++ b/docs/solutions/workflow/release-arm64-build-retry-hardening.md
@@ -42,7 +42,7 @@ Move the arm64 smoke build behind a repo-owned retry helper and validate that co
 - Run the arm64 smoke build through `.github/scripts/build-smoke-image-with-retry.sh`.
 - Retry only known transient registry/network failures such as `DeadlineExceeded`, `context deadline exceeded`, TLS handshake timeouts, connection resets, unexpected EOF, and rate-limit style fetch failures.
 - Keep non-transient build failures fail-closed on the first attempt so real Dockerfile or packaging regressions stay loud.
-- When the release queue can backfill older pending commits, load workflow-owned helpers from the workflow commit itself instead of the target checkout so historical targets do not fail just because the helper file was introduced later.
+- When the release queue can backfill older pending commits, stage workflow-owned helpers into the target checkout before the arm64 build so historical targets do not fail just because the helper file was introduced later.
 - Add a dedicated script regression test that proves both paths:
   - transient registry failures retry and eventually succeed;
   - permanent image-resolution failures stop immediately without looping.

--- a/docs/solutions/workflow/release-arm64-build-retry-hardening.md
+++ b/docs/solutions/workflow/release-arm64-build-retry-hardening.md
@@ -42,6 +42,7 @@ Move the arm64 smoke build behind a repo-owned retry helper and validate that co
 - Run the arm64 smoke build through `.github/scripts/build-smoke-image-with-retry.sh`.
 - Retry only known transient registry/network failures such as `DeadlineExceeded`, `context deadline exceeded`, TLS handshake timeouts, connection resets, unexpected EOF, and rate-limit style fetch failures.
 - Keep non-transient build failures fail-closed on the first attempt so real Dockerfile or packaging regressions stay loud.
+- When the release queue can backfill older pending commits, load workflow-owned helpers from the workflow commit itself instead of the target checkout so historical targets do not fail just because the helper file was introduced later.
 - Add a dedicated script regression test that proves both paths:
   - transient registry failures retry and eventually succeed;
   - permanent image-resolution failures stop immediately without looping.
@@ -51,6 +52,7 @@ Move the arm64 smoke build behind a repo-owned retry helper and validate that co
 
 - Keep retry classification small and explicit. A helper that retries everything will hide real build breakages.
 - Put retry policy in a repo-owned script instead of duplicating shell loops inline in workflow YAML; this keeps release, tests, and contract fixtures aligned.
+- If the workflow needs to run against older release targets, keep any helper files outside the target checkout or source them from the workflow revision so the queued backfill stays compatible.
 - When a release job fails in only one architecture lane, inspect whether the error happens before the real Dockerfile steps begin. If yes, suspect registry flakiness before suspecting app code.
 - For workflow-level resilience changes, update both live workflows and `quality-gates-contract` fixtures in the same patch. Otherwise CI may accept topology drift or reject the intended contract.
 


### PR DESCRIPTION
## Summary
- Keep arm64 release smoke builds compatible with older pending targets by loading the retry helper from the workflow commit checkout instead of the target checkout.
- Keep the arm64 build context isolated so historical backfills do not pick up the helper checkout directory.
- Update quality-gates contract coverage, fixtures, and solution notes accordingly.

## Tests
- `python3 .github/scripts/check_quality_gates_contract.py --repo-root . --profile final`
- `bash .github/scripts/test-build-smoke-image-with-retry.sh`
- `bash .github/scripts/test-quality-gates-contract.sh`

## References
- Solutions: `docs/solutions/workflow/release-arm64-build-retry-hardening.md`
- Specs: -
- Project Docs: -

## Note
- This unblocks backfilling the previously failed release target `94c4bf8b769eecca18b5f027c5fd5a196bf86c0f` after merge.