### PR TITLE
fix(proxy): make follow-up subscriber-aware

### DIFF
--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -11,6 +11,7 @@
 - SQLite 单写者约束下，后台任务必须是可跳过、可退避、可重试的低优先级工作。
 - 前台关键路径不应该和 rollup/backfill/retention/maintenance 使用同等重试预算。
 - 连接池等待超时本身就是 pressure signal，应触发后台 cooldown，而不是继续并发重试。
+- `proxy capture follow-up` 也必须遵守这个分级：没有 SSE 订阅者时，不得再消耗 summary/quota 或 hourly rollup refresh 预算。
 
 ## 推荐模式
 
@@ -45,6 +46,7 @@
 - skip 必须有日志和后续 ticker，否则会变成静默丢任务。
 - 为每个后台入口单独做局部退避，容易遗漏同一压力窗口内的其他维护任务；进程级 gate 更容易统一行为。
 - `SELECT MAX(id) ... WHERE <稀疏条件>`、`NOT EXISTS` + 低选择性 phase 过滤这类查询，即使最终只返回 1 行，也可能在 SQLite 上吃掉秒级读锁预算；若它们会与前台 HTTP 共享同一数据库，必须先压成 cursor 读取或用 partial index 固定扫描面。
+- 对 proxy 收尾这类 SSE follow-up，`receiver_count()==0` 应该直接意味着“跳过 follow-up”，而不是继续排队 summary/quota 或 rollup refresh；否则会把没有任何订阅者的请求变成纯数据库放大器。
 
 ## 何时升级方案
 

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
@@ -4,6 +4,7 @@
 
 - Canonical spec: `docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md`
 - Implementation summary: 已完成
+- 最新收口：`proxy capture follow-up` 已改成 subscriber-aware，`receiver_count()==0` 且非 shutdown flush 时不会再消耗 follow-up seq 或触发 summary/quota / rollup refresh；active subscriber 与 shutdown tail flush 语义已回归验证。
 
 ## Migrated Implementation Notes
 
@@ -12,6 +13,7 @@
 - Status: 已完成
 - Note: 已移除错误的 whole-proxy admission gate，`PROXY_REQUEST_CONCURRENCY_*` 已进入 deprecated/ignored 兼容态；共享测试机 `codex-testbox` 100 并行压测通过，确认 `/v1/*` 不再因本地 admission gate 返回 `503`。
 - Note: 号池候选评分会读取最近 5 分钟的 `pool_upstream_request_attempts`，对最新仍处于 timeout/transport failure 的 `upstream_route_key + proxy_binding_key_snapshot` 组合增加短期排序惩罚；后续成功尝试会清除该短期惩罚。
+- Note: `proxy capture follow-up` 的热路径门禁前移到 subscriber-aware 调度，避免无订阅者时每次代理收尾都触发重型 summary/quota 与 rollup 预算；对应回归测试与 `cargo check --tests` 已通过。
 
 ## 验证
 
@@ -24,6 +26,8 @@
 - `cargo test resolver_does_not_demote_successful_or_non_timeout_route_proxy_history -- --nocapture`
 - `cargo test candidates_sort -- --nocapture`
 - `scripts/shared-testbox-proxy-parallel-smoke`
+- `cargo test skips_follow_up_without_subscribers -- --nocapture`
+- `cargo test persist_and_broadcast_proxy_capture -- --nocapture`
 
 ## Migrated Task-Ticket Sections
 

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
@@ -4,6 +4,7 @@
 
 - 已落地的 raw 异步旁路、records 查询收敛与 summary/quota debounce 确实缓解了 `180s first-chunk timeout`、`database is locked` 与热路径抖动。
 - 但新增的 `/v1/*` whole-proxy admission gate 把本地默认并行上限锁到了 `12`，并在高峰窗口内稳定产生日志 `proxy request concurrency wait timed out` 与本地 `503 proxy concurrency limit reached; retry later`。
+- 代理收尾的 `proxy capture follow-up` 曾在无 SSE 订阅者时仍先跑 `refresh_hourly_rollups_for_read_surfaces_best_effort(...)`，把 SQLite 写压和锁竞争放大到无用户可见收益的程度。
 - 产品硬性要求是“至少 100 个并行调用在工作”，因此该 gate 不是保护，而是新的功能性缺陷；必须回退。
 
 ## 目标 / 非目标
@@ -14,6 +15,7 @@
 - 让 request raw 与 response raw 从业务转发热路径旁路出去；资源紧张时优先丢 raw，不阻塞代理流。
 - 让大 body sticky/rewrite 不再默认整包内存物化；大体积 body 只做前缀探测，必要时回落到 file-backed replay。
 - 让 `/api/invocations` 分页主查询只对当前页记录执行重型投影，并让 summary/quota follow-up 在 burst 写入时自动合并。
+- 让 `proxy capture follow-up` 只在 active SSE subscribers 或 shutdown tail flush 时消耗 summary/quota 预算；无订阅者时不得再触发重型 rollup refresh。
 - 让号池路由在近期上游传输超时后降低同一上游端点与同一代理节点组合的选择优先级，避免短窗口内连续命中同一个坏传输组合。
 - 在共享测试机 `codex-testbox` 上完成 100 并行压测，验证本地 admission reject 已消失，且已有效的 hot-path 修复没有回退。
 
@@ -46,6 +48,7 @@
 - raw 异步旁路必须有明确截断原因，至少覆盖 `max_bytes_exceeded`、`write_failed:*`、`async_backpressure_dropped`。
 - 大 body sticky 探测只允许读取固定前缀窗口；超过窗口仍未识别时，直接回落到“无 body sticky 优化”的 replay 路径。
 - summary/quota follow-up 必须具备 burst coalesce，避免每条新记录都立即跑完整汇总。
+- `proxy capture follow-up` 必须先看 `receiver_count()`，无 SSE 订阅者且非 shutdown flush 时直接跳过，不消耗 follow-up seq，也不触发 summary/quota 查询或 rollup refresh。
 - `PROXY_REQUEST_CONCURRENCY_LIMIT` / `PROXY_REQUEST_CONCURRENCY_WAIT_TIMEOUT_MS` 只能作为弃用兼容项继续被读取与告警，不得再影响 `/v1/*` 准入。
 - 号池路由只能把近期 `transport_failure` 且 failure kind 属于 `upstream_handshake_timeout`、`failed_contact_upstream` 或 `upstream_stream_error` 的 `upstream_route_key + proxy_binding_key_snapshot` 组合纳入短期降权；同组合后续成功应清除该短期惩罚，认证、配额、402 等账号级硬失败不得混入组合降权。
 
@@ -56,6 +59,8 @@
 - 大于小体积阈值的 pool request body 不再默认整包内存物化；sticky 探测仅依赖前缀窗口或 replay snapshot 前缀。
 - `/api/invocations` 的分页主查询只先选出当前页 id，再对当前页记录执行完整投影。
 - summary/quota follow-up 在 burst 写入时能够合并，不再对每条记录立即触发一次完整汇总。
+- 无 SSE 订阅者时，`persist_and_broadcast_proxy_capture` 与 `broadcast_recovered_proxy_invocations` 不会再启动 follow-up worker，也不会触发后台 hourly rollup refresh。
+- active subscriber 场景仍保持 `records -> summary/quota` 近实时广播；shutdown tail flush 语义不回退。
 - 即使线上环境仍设置 `PROXY_REQUEST_CONCURRENCY_LIMIT` / `PROXY_REQUEST_CONCURRENCY_WAIT_TIMEOUT_MS`，它们也只会产生日志告警，不会改变 `/v1/*` 准入行为。
 - Given 某 `upstream_route_key + proxy_binding_key_snapshot` 近期发生超时/传输失败，When 号池还有其它可路由组合，Then 路由排序优先尝试其它组合；若只有该组合可用，仍允许回退使用而不是直接报无账号。
 

--- a/src/api/slices/error_distribution_and_sse.rs
+++ b/src/api/slices/error_distribution_and_sse.rs
@@ -1606,6 +1606,10 @@ pub(crate) async fn broadcast_summary_if_changed(
     window: &str,
     summary: StatsResponse,
 ) -> Result<bool, broadcast::error::SendError<BroadcastPayload>> {
+    if broadcaster.receiver_count() == 0 {
+        return Ok(false);
+    }
+
     let mut cache = cache.lock().await;
     if cache
         .summaries
@@ -1615,12 +1619,17 @@ pub(crate) async fn broadcast_summary_if_changed(
         return Ok(false);
     }
 
-    broadcaster.send(BroadcastPayload::Summary {
+    match broadcaster.send(BroadcastPayload::Summary {
         window: window.to_string(),
         summary: summary.clone(),
-    })?;
-    cache.summaries.insert(window.to_string(), summary);
-    Ok(true)
+    }) {
+        Ok(_) => {
+            cache.summaries.insert(window.to_string(), summary);
+            Ok(true)
+        }
+        Err(_err) if broadcaster.receiver_count() == 0 => Ok(false),
+        Err(err) => Err(err),
+    }
 }
 
 pub(crate) async fn broadcast_quota_if_changed(
@@ -1628,6 +1637,10 @@ pub(crate) async fn broadcast_quota_if_changed(
     cache: &Mutex<BroadcastStateCache>,
     snapshot: QuotaSnapshotResponse,
 ) -> Result<bool, broadcast::error::SendError<BroadcastPayload>> {
+    if broadcaster.receiver_count() == 0 {
+        return Ok(false);
+    }
+
     let mut cache = cache.lock().await;
     if cache
         .quota
@@ -1637,11 +1650,16 @@ pub(crate) async fn broadcast_quota_if_changed(
         return Ok(false);
     }
 
-    broadcaster.send(BroadcastPayload::Quota {
+    match broadcaster.send(BroadcastPayload::Quota {
         snapshot: Box::new(snapshot.clone()),
-    })?;
-    cache.quota = Some(snapshot);
-    Ok(true)
+    }) {
+        Ok(_) => {
+            cache.quota = Some(snapshot);
+            Ok(true)
+        }
+        Err(_err) if broadcaster.receiver_count() == 0 => Ok(false),
+        Err(err) => Err(err),
+    }
 }
 
 pub(crate) async fn sse_stream(

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -474,23 +474,25 @@ pub(crate) async fn store_raw_payload_file(
     meta
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProxyCaptureFollowUpBroadcastMode {
+    ActiveSubscribers,
+    ShutdownFlush,
+}
+
 pub(crate) async fn broadcast_proxy_capture_follow_up(
     pool: &Pool<Sqlite>,
-    hourly_rollup_sync_lock: &Mutex<()>,
+    _hourly_rollup_sync_lock: &Mutex<()>,
     broadcaster: &broadcast::Sender<BroadcastPayload>,
     broadcast_state_cache: &Mutex<BroadcastStateCache>,
     relay_config: Option<&CrsStatsConfig>,
     invocation_max_days: u64,
+    mode: ProxyCaptureFollowUpBroadcastMode,
     invoke_id: &str,
 ) {
-    refresh_hourly_rollups_for_read_surfaces_best_effort(
-        pool,
-        hourly_rollup_sync_lock,
-        "proxy capture follow-up",
-    )
-    .await;
-
-    if broadcaster.receiver_count() == 0 {
+    if matches!(mode, ProxyCaptureFollowUpBroadcastMode::ActiveSubscribers)
+        && broadcaster.receiver_count() == 0
+    {
         return;
     }
 
@@ -588,6 +590,7 @@ pub(crate) async fn finish_summary_quota_broadcast_idle(
             ctx.broadcast_state_cache,
             ctx.relay_config,
             ctx.invocation_max_days,
+            ProxyCaptureFollowUpBroadcastMode::ShutdownFlush,
             ctx.invoke_id,
         )
         .await;
@@ -615,9 +618,14 @@ pub(crate) async fn schedule_proxy_capture_follow_up_worker(
             state.broadcast_state_cache.as_ref(),
             state.config.crs_stats.as_ref(),
             state.config.invocation_max_days,
+            ProxyCaptureFollowUpBroadcastMode::ShutdownFlush,
             invoke_id,
         )
         .await;
+        return Ok(());
+    }
+
+    if state.broadcaster.receiver_count() == 0 {
         return Ok(());
     }
 
@@ -636,6 +644,7 @@ pub(crate) async fn schedule_proxy_capture_follow_up_worker(
             state.broadcast_state_cache.as_ref(),
             state.config.crs_stats.as_ref(),
             state.config.invocation_max_days,
+            ProxyCaptureFollowUpBroadcastMode::ShutdownFlush,
             invoke_id,
         )
         .await;
@@ -677,6 +686,7 @@ pub(crate) async fn schedule_proxy_capture_follow_up_worker(
                         broadcast_state_cache.as_ref(),
                         relay_config.as_ref(),
                         invocation_max_days,
+                        ProxyCaptureFollowUpBroadcastMode::ShutdownFlush,
                         &invoke_id,
                     )
                     .await;
@@ -722,6 +732,7 @@ pub(crate) async fn schedule_proxy_capture_follow_up_worker(
                         broadcast_state_cache.as_ref(),
                         relay_config.as_ref(),
                         invocation_max_days,
+                        ProxyCaptureFollowUpBroadcastMode::ShutdownFlush,
                         &invoke_id,
                     )
                     .await;
@@ -739,6 +750,7 @@ pub(crate) async fn schedule_proxy_capture_follow_up_worker(
                     broadcast_state_cache.as_ref(),
                     relay_config.as_ref(),
                     invocation_max_days,
+                    ProxyCaptureFollowUpBroadcastMode::ActiveSubscribers,
                     &invoke_id,
                 ) => {}
             };

--- a/src/tests/slices/pool_failover_window_g.rs
+++ b/src/tests/slices/pool_failover_window_g.rs
@@ -2033,10 +2033,9 @@ async fn runtime_snapshot_keeps_prompt_cache_rollups_inline_without_background_f
         .expect("terminal proxy capture should persist");
     let terminal_follow_up_handles = state.proxy_summary_quota_broadcast_handle.lock().await.len();
     assert!(
-        terminal_follow_up_handles > 0,
-        "terminal proxy captures should still schedule the summary/quota follow-up worker"
+        terminal_follow_up_handles == 0,
+        "terminal proxy captures without subscribers should not schedule the summary/quota follow-up worker"
     );
-    wait_for_summary_quota_workers(state.as_ref()).await;
 }
 
 #[tokio::test]

--- a/src/tests/slices/pool_failover_window_k.rs
+++ b/src/tests/slices/pool_failover_window_k.rs
@@ -2050,6 +2050,70 @@ async fn persist_and_broadcast_proxy_capture_skips_summary_worker_during_shutdow
 }
 
 #[tokio::test]
+async fn broadcast_recovered_proxy_invocations_skips_follow_up_without_subscribers() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let occurred_at = format_naive(Utc::now().with_timezone(&Shanghai).naive_local());
+    let invoke_id = "recovered-follow-up-no-subscribers";
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id,
+            occurred_at,
+            source,
+            status,
+            error_message,
+            raw_response,
+            payload
+        )
+        VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6)
+        "#,
+    )
+    .bind(invoke_id)
+    .bind(&occurred_at)
+    .bind(SOURCE_PROXY)
+    .bind(INVOCATION_STATUS_RUNNING)
+    .bind("{}")
+    .bind("{\"endpoint\":\"/v1/responses\"}")
+    .execute(&state.pool)
+    .await
+    .expect("insert running invocation for recovery broadcast");
+
+    let selectors = vec![InvocationRecoverySelector::new(invoke_id, occurred_at.clone())];
+    let recovered = recover_proxy_invocations_with_scope(
+        &state.pool,
+        ProxyInvocationRecoveryScope::Selectors(&selectors),
+    )
+    .await
+    .expect("recover invocation for runtime broadcast");
+    assert_eq!(recovered.len(), 1, "test setup should recover exactly one invocation");
+
+    broadcast_recovered_proxy_invocations(
+        state.as_ref(),
+        &recovered,
+    )
+    .await
+    .expect("broadcast recovered invocation without subscribers");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        state
+            .proxy_summary_quota_broadcast_seq
+            .load(Ordering::Acquire),
+        0,
+        "recovered no-subscriber path should not enqueue summary/quota follow-up work"
+    );
+    assert!(
+        !state
+            .proxy_summary_quota_broadcast_running
+            .load(Ordering::Acquire),
+        "recovered no-subscriber path should keep the summary/quota worker idle"
+    );
+}
+
+#[tokio::test]
 async fn finalize_pool_upstream_request_attempt_updates_pending_row_in_place() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),

--- a/src/tests/slices/proxy_retry_headers_and_model_settings.rs
+++ b/src/tests/slices/proxy_retry_headers_and_model_settings.rs
@@ -1259,6 +1259,40 @@ async fn proxy_capture_persist_and_broadcast_skips_duplicate_records() {
 }
 
 #[tokio::test]
+async fn proxy_capture_persist_and_broadcast_skips_follow_up_without_subscribers() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://example-upstream.invalid/").expect("valid upstream base url"),
+    )
+    .await;
+    let now_local = format_naive(Utc::now().with_timezone(&Shanghai).naive_local());
+    seed_quota_snapshot(&state.pool, &now_local).await;
+    let invoke_id = "proxy-sse-follow-up-no-subscribers";
+
+    persist_and_broadcast_proxy_capture(
+        state.as_ref(),
+        Instant::now(),
+        test_proxy_capture_record(invoke_id, &now_local),
+    )
+    .await
+    .expect("persist without subscribers should succeed");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        state
+            .proxy_summary_quota_broadcast_seq
+            .load(Ordering::Acquire),
+        0,
+        "no-subscriber path should not enqueue summary/quota follow-up work"
+    );
+    assert!(
+        !state
+            .proxy_summary_quota_broadcast_running
+            .load(Ordering::Acquire),
+        "no-subscriber path should keep the summary/quota worker idle"
+    );
+}
+
+#[tokio::test]
 async fn fetch_and_store_skips_summary_and_quota_collection_when_broadcast_state_disabled() {
     let state = test_state_with_openai_base(
         Url::parse("https://example-upstream.invalid/").expect("valid upstream base url"),


### PR DESCRIPTION
## Summary
- Skip proxy capture follow-up entirely when there are no SSE subscribers, except during shutdown flush.
- Keep active subscriber summary/quota broadcasting intact.
- Remove the eager hourly rollup refresh from the proxy hot path.

## Validation
- cargo check --tests
- cargo test skips_follow_up_without_subscribers -- --nocapture
- cargo test persist_and_broadcast_proxy_capture -- --nocapture

## Spec / Solutions / Project Docs
- Spec: docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
- Spec Disposition: update
- Specs: docs/specs/5932d-sse-proxy-live-sync/SPEC.md (preserved contract)
- Spec Sync: done
- Spec Drift: none
- Solutions: docs/solutions/performance/sqlite-write-pressure-backpressure.md
- Solutions Sync: done
- Project Docs: -
- Project Docs Sync: n/a(no project-doc change)

## Notes
- No HTTP/SSE/schema/env changes.
