### PR TITLE
fix(ci): accept workflow baseline transition

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -46,6 +46,8 @@ LABEL_GATE_PULL_REQUEST_TYPES = {
 }
 REVIEW_POLICY_PULL_REQUEST_TYPES = {"opened", "reopened", "synchronize", "ready_for_review", "edited"}
 REVIEW_POLICY_REVIEW_TYPES = {"submitted", "dismissed", "edited"}
+ALLOWED_X64_RUNNERS = ("ubuntu-latest", "ubuntu-24.04")
+ALLOWED_CHECKOUT_ACTIONS = ("actions/checkout@v4", "actions/checkout@v7")
 
 
 def parse_args() -> argparse.Namespace:
@@ -273,7 +275,12 @@ def command_option_map(command: list[str], where: str) -> dict[str, str]:
 
 
 def checkout_step(job: dict[str, Any], step_name: str, where: str) -> dict[str, Any]:
-    step = uses_step_config(job, step_name, "actions/checkout@v4", where)
+    step = step_config(job, step_name, where)
+    actual_uses = step.get("uses")
+    require(
+        actual_uses in ALLOWED_CHECKOUT_ACTIONS,
+        f"{where}.steps[{step_name!r}].uses must stay one of {ALLOWED_CHECKOUT_ACTIONS!r}",
+    )
     return require_mapping(step.get("with"), f"{where}.steps[{step_name!r}].with")
 
 
@@ -743,7 +750,10 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     require(permissions.get("contents") == "read", "release.yml.permissions.contents must stay read")
 
     ci_main_gate = named_job_config(workflow, "ci-main-gate", expected_jobs, "release.yml")
-    require(ci_main_gate.get("runs-on") == "ubuntu-latest", "release.yml.jobs.ci-main-gate.runs-on drifted")
+    require(
+        ci_main_gate.get("runs-on") in ALLOWED_X64_RUNNERS,
+        f"release.yml.jobs.ci-main-gate.runs-on must stay one of {ALLOWED_X64_RUNNERS!r}",
+    )
     require_exact_if(
         ci_main_gate,
         "${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}",

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -51,6 +51,74 @@ done
 python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$baseline_repo" --profile final
 bash "$repo_root/.github/scripts/test-inline-metadata-workflows.sh"
 
+upgraded_baseline_repo="$tmp_dir/upgraded-baseline-repo"
+copy_repo_snapshot "$baseline_repo" "$upgraded_baseline_repo"
+python3 - <<'PY' "$upgraded_baseline_repo"
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+for path in (repo / ".github/workflows").glob("*.yml"):
+    text = path.read_text()
+    path.write_text(text.replace("actions/checkout@v4", "actions/checkout@v7"))
+
+release_path = repo / ".github/workflows/release.yml"
+release_text = release_path.read_text()
+needle = "  ci-main-gate:\n    name: CI Main Gate\n    runs-on: ubuntu-latest\n"
+replacement = "  ci-main-gate:\n    name: CI Main Gate\n    runs-on: ubuntu-24.04\n"
+if needle not in release_text:
+    raise SystemExit("failed to rewrite release ci-main-gate runner")
+release_path.write_text(release_text.replace(needle, replacement, 1))
+PY
+
+python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$upgraded_baseline_repo" --profile final
+
+checkout_action_repo="$tmp_dir/checkout-action-repo"
+copy_repo_snapshot "$upgraded_baseline_repo" "$checkout_action_repo"
+python3 - <<'PY' "$checkout_action_repo"
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/label-gate.yml"
+text = path.read_text()
+needle = "uses: actions/checkout@v7"
+replacement = "uses: actions/checkout@v6"
+if needle not in text:
+    raise SystemExit("failed to rewrite label-gate checkout action")
+path.write_text(text.replace(needle, replacement, 1))
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$checkout_action_repo" --profile final >/dev/null 2>"$tmp_dir/checkout-action.log"; then
+  echo "expected unsupported checkout action fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "must stay one of ('actions/checkout@v4', 'actions/checkout@v7')" "$tmp_dir/checkout-action.log"
+
+ci_main_gate_runner_repo="$tmp_dir/ci-main-gate-runner-repo"
+copy_repo_snapshot "$upgraded_baseline_repo" "$ci_main_gate_runner_repo"
+python3 - <<'PY' "$ci_main_gate_runner_repo"
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/release.yml"
+text = path.read_text()
+needle = "  ci-main-gate:\n    name: CI Main Gate\n    runs-on: ubuntu-24.04\n"
+replacement = "  ci-main-gate:\n    name: CI Main Gate\n    runs-on: ubuntu-22.04\n"
+if needle not in text:
+    raise SystemExit("failed to rewrite release ci-main-gate runner")
+path.write_text(text.replace(needle, replacement, 1))
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$ci_main_gate_runner_repo" --profile final >/dev/null 2>"$tmp_dir/ci-main-gate-runner.log"; then
+  echo "expected unsupported ci-main-gate runner fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "must stay one of ('ubuntu-latest', 'ubuntu-24.04')" "$tmp_dir/ci-main-gate-runner.log"
+
 simplified_topology_repo="$tmp_dir/simplified-topology-repo"
 copy_repo_snapshot "$baseline_repo" "$simplified_topology_repo"
 for workflow in ci-main.yml release.yml release-snapshot-pr.yml label-gate.yml; do


### PR DESCRIPTION
## Summary
- relax the trusted quality-gates contract checker to accept the old and new x64 workflow baselines during rollout
- cover the transition with explicit positive and negative self-tests
- keep live workflows and release semantics unchanged in this bootstrap PR

## Verification
- `python3 -m py_compile .github/scripts/check_quality_gates_contract.py`
- `bash .github/scripts/test-quality-gates-contract.sh`

## References
Spec: -
Spec Disposition: not_needed
Spec Sync: n/a(workflows-only)
Spec Drift: none
Solutions: -
Solutions Sync: n/a(no solution change)
Project Docs: -
Project Docs Sync: n/a(no project-doc change)
