### PR TITLE
fix(stats): restore account natural-day summary live rows

### DIFF
--- a/docs/solutions/performance/rollup-backed-summary-window-consistency.md
+++ b/docs/solutions/performance/rollup-backed-summary-window-consistency.md
@@ -33,12 +33,18 @@ The summary path short-circuited to live-only aggregation whenever the requested
 - Keep natural-day summary reads on the same rollup-backed path as hourly timeseries.
 - Use hourly rollups, full-hour live tail replay, and uncovered archive fallback together.
 - Never treat `window.start >= retention_cutoff` as proof that live-only totals are complete.
+- Keep account-scoped summary variants aligned with the non-account summary path when they
+  split work between exact live reads and rollup-backed tails.
+- For windows that have no completed full hour yet, do not clamp exact live reads to the
+  rollup live cursor or add a second tail replay path just for account-scoped summaries.
 
 ## Guardrails / Reuse Notes
 
 - When a summary window is expected to match a bucketed timeseries sum, add a regression test that compares both totals on a mixed archive/live fixture.
 - Prefer the rollup-backed path for any window that can straddle archived and live days.
 - If retention settings can change over time, assume older days may already exist only in rollup/archive even when the current cutoff no longer suggests it.
+- When adding an account-scoped summary variant, compare its no-full-hour behavior against the
+  non-account path before introducing cursor-specific tail handling.
 
 ## References
 

--- a/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
@@ -140,7 +140,6 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
     let snapshot_id = resolve_invocation_snapshot_id_tx(tx.as_mut(), source_scope).await?;
     let rollup_live_cursor = load_invocation_summary_rollup_live_cursor_tx(tx.as_mut()).await?;
     let mut totals = StatsTotals::default();
-    let boundary_snapshot_id = rollup_live_cursor.min(snapshot_id);
     let archive_overlap_ids =
         if let Some((range_start_epoch, range_end_epoch)) = range_plan.full_hour_range {
             let rows = query_upstream_account_stats_rollup_range_tx(
@@ -159,19 +158,18 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
                 totals.total_tokens += row.total_tokens;
                 totals.total_cost += row.total_cost;
             }
-            let mut exact_records =
-                if !range_plan.live_exact_ranges.is_empty() && boundary_snapshot_id > 0 {
-                    query_invocation_exact_records_for_account_tx(
-                        tx.as_mut(),
-                        &range_plan,
-                        source_scope,
-                        boundary_snapshot_id,
-                        upstream_account_id,
-                    )
-                    .await?
-                } else {
-                    Vec::new()
-                };
+            let mut exact_records = if !range_plan.live_exact_ranges.is_empty() && snapshot_id > 0 {
+                query_invocation_exact_records_for_account_tx(
+                    tx.as_mut(),
+                    &range_plan,
+                    source_scope,
+                    snapshot_id,
+                    upstream_account_id,
+                )
+                .await?
+            } else {
+                Vec::new()
+            };
             let tail_records = query_invocation_full_hour_tail_records_tx_for_account(
                 tx.as_mut(),
                 &range_plan,
@@ -191,19 +189,18 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
             }
             archive_overlap_ids
         } else {
-            let exact_records =
-                if !range_plan.live_exact_ranges.is_empty() && boundary_snapshot_id > 0 {
-                    query_invocation_exact_records_for_account_tx(
-                        tx.as_mut(),
-                        &range_plan,
-                        source_scope,
-                        boundary_snapshot_id,
-                        upstream_account_id,
-                    )
-                    .await?
-                } else {
-                    Vec::new()
-                };
+            let exact_records = if !range_plan.live_exact_ranges.is_empty() && snapshot_id > 0 {
+                query_invocation_exact_records_for_account_tx(
+                    tx.as_mut(),
+                    &range_plan,
+                    source_scope,
+                    snapshot_id,
+                    upstream_account_id,
+                )
+                .await?
+            } else {
+                Vec::new()
+            };
             for record in &exact_records {
                 add_invocation_record_to_summary_totals(&mut totals, record);
             }
@@ -236,24 +233,6 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
             )
             .await?,
         );
-    }
-    if range_plan.full_hour_range.is_none() && rollup_live_cursor < snapshot_id {
-        let tail_range_plan = HourlyRollupExactRangePlan {
-            full_hour_range: None,
-            live_exact_ranges: exact_utc_range(start, end)?.into_iter().collect(),
-        };
-        let tail_records = query_invocation_exact_records_tx_for_account(
-            tx.as_mut(),
-            &tail_range_plan,
-            source_scope,
-            snapshot_id,
-            upstream_account_id,
-            rollup_live_cursor,
-        )
-        .await?;
-        for record in &tail_records {
-            add_invocation_record_to_summary_totals(&mut totals, record);
-        }
     }
     Ok(totals)
 }


### PR DESCRIPTION
Summary
- restore account-scoped natural-day summary live rows for no-full-hour windows
- remove the redundant account-scoped tail replay that dropped current live rows
- document the account-scoped tail guardrail in the rollup-backed summary solution doc

Test Plan
- cargo test 'tests::account_scoped_summary_and_timeseries_filter_by_payload_upstream_account_id' -- --exact --nocapture
- cargo test 'tests::account_scoped_natural_day_summary_keeps_augmentation_fields_scoped' -- --exact --nocapture
- cargo test 'tests::account_scoped_historical_stats_include_unmaterialized_archived_hours' -- --exact --nocapture
- cargo test

Spec: docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md
Spec Disposition: link
Solutions: docs/solutions/performance/rollup-backed-summary-window-consistency.md
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: n/a(no project-doc change)

## Visual Evidence

- Spec: docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md
- 详情抽屉记录页默认态（mock Storybook，记录页 tab 已选中；右上角请求日志证明此时只读取详情与账号 stats，不再额外预取 roster `/api/pool/upstream-accounts`` 或 sticky `/sticky-keys`）
  ![账号详情记录页请求收口](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/2021403ccc477f0f3f0ea2877e8a376ff341f4b7/docs/specs/t6d9r-account-detail-stats-read-model/assets/detail-drawer-records-request-gating.png?raw=1)
- 详情抽屉路由页按需加载（mock Storybook，从记录页切到路由页后才触发 roster、sticky keys 与 window usage 的受控请求）
  ![账号详情路由页按需加载](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/2021403ccc477f0f3f0ea2877e8a376ff341f4b7/docs/specs/t6d9r-account-detail-stats-read-model/assets/detail-drawer-routing-request-gating.png?raw=1)
- 详情抽屉 records tab 稳定态（mock Storybook；记录列表已进入 settled state，作为这次实时推送一致性修复后的 owner-facing 视觉证据）
  ![账号详情记录页实时推送稳定态](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/2021403ccc477f0f3f0ea2877e8a376ff341f4b7/docs/specs/t6d9r-account-detail-stats-read-model/assets/detail-drawer-records-live-sync-stable.png?raw=1)
- 详情抽屉 records tab 宽屏放宽态（mock Storybook；共享抽屉桌面宽度提升到 `90rem` 后，records 视图横向空间更充足，概览与记录容器不再被旧的 `60rem` 壳层过早压缩）
  ![账号详情记录页宽屏放宽态](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/2021403ccc477f0f3f0ea2877e8a376ff341f4b7/docs/specs/t6d9r-account-detail-stats-read-model/assets/detail-drawer-records-settled-wide.png?raw=1)
- 详情抽屉 records tab 窄宽度 token 标签稳定态（mock Storybook；总 token 指标标题从 `今日 Tokens` 缩短为 `今日 Token`，并保持单行显示，不再在窄卡片里被拆成两行）
  ![账号详情记录页 token 标签单行态](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/2021403ccc477f0f3f0ea2877e8a376ff341f4b7/docs/specs/t6d9r-account-detail-stats-read-model/assets/detail-drawer-records-token-label-nowrap.png?raw=1)

## Custom Notes
<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->

Notes
- Fixes the CI Main failure behind release gate for main@2bc83464a8db7a172fbac41b2ce50256fb0936bb.
