### PR TITLE
fix: restore account detail and records stats hot paths

### DIFF
--- a/docs/solutions/performance/account-detail-stats-read-model-sla.md
+++ b/docs/solutions/performance/account-detail-stats-read-model-sla.md
@@ -41,6 +41,9 @@ related_specs:
 - archive materialization 会为账号 usage / stats read-model 一并补齐 replay markers；账号 summary / timeseries 在 materialized archive 缺 marker 的旧库上，也不会再把历史批次误判成“未物化，需要在线回补”。
 - startup proxy usage backfill 改为复用共享 invocation cursor + 全表 `MAX(id)`，删除“仅扫描缺 usage 的 proxy success rows”这条生产 10 秒级热点 SQL；stale attempt recovery 同时补齐 partial index，避免后台恢复任务反复争锁。
 - 账号维度昨天视图拆掉重复 comparison fetch，避免 account-scoped yesterday 面板额外再打一次 yesterday summary / timeseries。
+- 默认账号详情接口不再同步读取 `recentActions`；事件流读取改成 health/events tab 的显式 follow-up fetch，避免 `pool_upstream_account_events` 把 overview 首屏重新拖慢。
+- 新增的 `nonSuccessCost` 重新回到 summary read-model totals；today 等开区间仍只做 bounded live tail，`yesterday` / `previous7d` 等闭区间不再因为字段补算回退到 raw live augmentation。
+- `selectedId` 暂空时不再触发 roster 级 `window-usage` 自动 hydrate；只有当前选中账号或显式手动批量 hydrate 才会命中 `/api/pool/upstream-accounts/window-usage`。
 
 ## Guardrails / Reuse Notes
 
@@ -50,6 +53,7 @@ related_specs:
 - 如果 archive batch 已经 `historical_rollups_materialized_at`，账号 usage / stats target 的 replay marker 也必须视为同一事务事实；旧库升级时先修 marker，再允许详情读路径依据“缺 marker”做 archive fallback。
 - 任何 startup / maintenance backfill 只要要扫 `codex_invocations` 或 `pool_upstream_request_attempts` 大表，都必须先证明有 cursor 或 partial index；后台慢查询同样会把详情页 SLA 拖垮。
 - 前端详情页的重型统计 hydrate 必须绑定“当前选中账号 + 当前 query key”；列表刷新不能把整个当前页账号重新拉一遍。
+- 默认详情首屏如果只需要概览信息，接口必须把非首屏字段拆成显式 opt-in 参数或 follow-up fetch；不要把事件流、审计流或其他历史列表默默塞回默认 detail 响应。
 - 若某条 SSE 只携带 invocation records，它最多只能更新 records/live 表层；不能反向触发 roster、summary、timeseries 或 `window-usage` 这类重型面。
 - 若 roster 仍需展示最新 usage/plan 快照，优先复用主表或按账号索引直取最新样本；不要再回到 `pool_upstream_account_limit_samples` 的窗口函数全表排名路径。
 

--- a/docs/specs/t6d9r-account-detail-stats-read-model/HISTORY.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/HISTORY.md
@@ -15,3 +15,6 @@
 - 2026-06-21: account-scoped `yesterday` 活动总览拆掉重复 comparison fetch，避免详情抽屉在昨天视图额外触发一轮同账号 summary / timeseries。
 - 2026-06-21: 账号详情抽屉 records tab 不再停留在一次性快照；它改为与 `Live` / `/records` 共用活动记录实时合并层，保证同账号的新记录自动出现、终态字段自动收敛，并在 SSE 重连后静默回源补齐。
 - 2026-06-23: 线上 CPU 复盘确认账号池通用 hook 仍会把 invocation `records` SSE 升级成 roster/detail/window-usage 刷新；现已切断这条链，只保留业务写入、手动 refresh 与 SSE `open` 受控补齐。
+- 2026-06-25: 线上回归确认默认 overview 首屏又被 `recentActions` 同步读取拖慢；详情接口默认改回不带 `recentActions`，仅在健康与事件 tab 按需 hydrate。
+- 2026-06-25: records 顶部卡片字段调整后，account-scoped today summary 把 `nonSuccessCost` 拖回了 live augmentation 路径并丢失 live tail；现已恢复为 read-model totals + bounded tail，闭区间默认不做 live raw 重算。
+- 2026-06-25: `selectedId` 暂空时的 roster 级 `window-usage` 自动 hydrate 被彻底移除；详情首屏只允许当前账号发 `window-usage`，手动 hydrate 才能批量取数。

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -12,6 +12,8 @@
 - Note: 前端已收紧为“仅当前选中账号”的 `window-usage` hydrate，不再因 roster 刷新批量触发详情重型统计。
 - Note: `useUpstreamAccounts(...)` 不再消费 invocation `records` SSE 来静默刷新 roster/detail/window-usage；账号池重型统计只保留手动 refresh、显式业务变更和 SSE `open` 后的受控补齐。
 - Note: 账号详情抽屉默认不再额外预取 roster / sticky conversation 统计；只有 `edit` / `routing` 这类真正依赖上下文的 tab 才会触发对应重查询。
+- Note: 账号详情默认 `overview` 首屏已改为不再同步读取 `recentActions`；健康与事件 tab 才通过显式 follow-up detail hydrate 拉取事件流。
+- Note: records 顶部卡片新增的 `nonSuccessCost` 已重新回到 read-model-first 主路径；live augmentation 只保留 `nonSuccessTokens` 与 in-progress 字段，闭区间 summary / timeseries 默认不再回退到 live raw 重算。
 
 ## 落地内容
 
@@ -29,6 +31,11 @@
 - `DashboardActivityOverview` 在 account-scoped `yesterday` 视图不再额外请求 yesterday comparison summary / timeseries，消除一个重复请求源。
 - 共享账号详情抽屉桌面壳层从 `max-w-[60rem]` 放宽到 `max-w-[90rem]`；为了让新增横向空间真实转化为概览可读性，overview 下两张 usage card 提前到 `lg` 断点进入双列，而不是继续等到 `xl`。
 - records 视图总 token 指标标题改为 `Token` 单数文案，并在 `TodayStatsOverview` 中对该标签单独保留 mixed case + `whitespace-nowrap`，避免窄卡片里出现 `今日` / `TOKENS` 断成两行的问题。
+- 账号详情接口 `get_upstream_account` 默认改为 `includeRecentActions=false`，把 `pool_upstream_account_events` 读取从 overview 首屏热路径中移出；health events tab 再按需补一次 detail hydrate。
+- `useUpstreamAccounts(...)` 在 `selectedId` 为空时不再自动对 roster 可见行批量触发 `window-usage` hydrate；只有当前选中账号或显式手动 hydrate 才会发 `window-usage` 请求。
+- account-scoped summary 将 `nonSuccessCost` 固定纳入 rollup/read-model totals，并恢复带 `full_hour_range` 的 today live tail 精确补尾，避免新增字段后 today 卡片回退成 0 或强制 raw window 重扫。
+- `fetch_summary` / `fetch_stats` 按窗口类型区分 live augmentation：闭区间默认跳过 in-progress 与 non-success token live 补算；SQLite `database is locked` 时非成功 token live 增量允许受限降级，不再整排卡片长期 skeleton。
+- Storybook 现有详情抽屉 overlay stories 继续作为 page-fallback 证据面，新增 owner-facing 首屏概览态与 records 统计卡片完成态图片，覆盖这次性能回归修复后的默认打开路径。
 
 ## Verification
 
@@ -40,11 +47,14 @@
 - `cargo test account_summary_yesterday_ignores_materialized_archive_missing_account_usage_marker -- --nocapture`
 - `cargo test materialize_historical_rollups_marks_account_replay_targets_when_only_account_targets_are_pending -- --nocapture`
 - `cargo test bootstrap_hourly_rollups_repairs_missing_materialized_account_replay_markers -- --nocapture`
+- `cargo test get_upstream_account_omits_recent_actions_by_default_and_loads_them_on_demand -- --nocapture`
+- `cargo test natural_day_summary_reports_retry_wait_and_non_success_usage -- --nocapture`
+- `cargo test account_scoped_natural_day_summary_keeps_augmentation_fields_scoped -- --nocapture`
 - `cargo test latest_usage_sample_map_keeps_latest_non_empty_sample_plan_type -- --nocapture`
 - `cargo test ensure_schema_migrates_codex_invocations_off_raw_expires_at_and_adds_retention_tables -- --nocapture`
 - `cargo check`
-- `cd web && bun run test src/hooks/useUpstreamAccounts.test.tsx src/components/DashboardActivityOverview.test.tsx`
-- `cd web && bun run test -- UpstreamAccounts.test.tsx useUpstreamStickyConversations.test.tsx`
+- `cd web && bun x vitest run --project=unit src/hooks/useUpstreamAccounts.test.tsx src/pages/account-pool/UpstreamAccounts.test.tsx src/lib/api.test.ts`
+- `cd web && bun run test-storybook`
 - `cd web && bun run build-storybook`
 
 ## Visual Evidence

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -1692,8 +1692,18 @@ pub(crate) async fn fetch_stats(
     )
     .await?;
     let mut response = totals.into_response();
-    let augmentation =
-        load_summary_live_augmentation(state.as_ref(), source_scope, None, None).await?;
+    response.non_success_cost = Some(totals.non_success_cost);
+    let augmentation = load_summary_live_augmentation(
+        state.as_ref(),
+        source_scope,
+        None,
+        None,
+        SummaryLiveAugmentationPolicy {
+            include_in_progress: true,
+            include_non_success_tokens: false,
+        },
+    )
+    .await?;
     apply_summary_live_augmentation(&mut response, augmentation);
     response.maintenance = Some(load_stats_maintenance_response(state.as_ref()).await?);
     Ok(Json(response))
@@ -1717,8 +1727,13 @@ struct SummaryLiveAugmentation {
     in_progress_conversation_count: Option<i64>,
     in_progress_retry_conversation_count: Option<i64>,
     in_progress_avg_wait_ms: Option<f64>,
-    non_success_cost: Option<f64>,
     non_success_tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SummaryLiveAugmentationPolicy {
+    include_in_progress: bool,
+    include_non_success_tokens: bool,
 }
 
 fn summary_window_range(
@@ -1746,32 +1761,37 @@ async fn load_summary_live_augmentation(
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
     range: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    policy: SummaryLiveAugmentationPolicy,
 ) -> Result<SummaryLiveAugmentation, ApiError> {
-    let in_progress = load_in_progress_summary_snapshot(
-        &state.pool,
-        source_scope,
-        upstream_account_id,
-    )
-    .await?;
-    let non_success = if let Some((start, end)) = range {
-        load_non_success_usage_snapshot(
-            &state.pool,
-            source_scope,
-            upstream_account_id,
-            start,
-            end,
-        )
-        .await?
+    let in_progress = if policy.include_in_progress {
+        let snapshot =
+            load_in_progress_summary_snapshot(&state.pool, source_scope, upstream_account_id).await?;
+        (Some(snapshot.0), Some(snapshot.1), snapshot.2)
     } else {
-        (None, None)
+        (None, None, None)
+    };
+    let non_success_tokens = if policy.include_non_success_tokens {
+        if let Some((start, end)) = range {
+            load_non_success_tokens_snapshot(
+                state,
+                source_scope,
+                upstream_account_id,
+                start,
+                end,
+            )
+            .await?
+        } else {
+            None
+        }
+    } else {
+        None
     };
 
     Ok(SummaryLiveAugmentation {
-        in_progress_conversation_count: Some(in_progress.0),
-        in_progress_retry_conversation_count: Some(in_progress.1),
+        in_progress_conversation_count: in_progress.0,
+        in_progress_retry_conversation_count: in_progress.1,
         in_progress_avg_wait_ms: in_progress.2,
-        non_success_cost: non_success.0,
-        non_success_tokens: non_success.1,
+        non_success_tokens,
     })
 }
 
@@ -1783,7 +1803,6 @@ fn apply_summary_live_augmentation(
     response.in_progress_retry_conversation_count =
         augmentation.in_progress_retry_conversation_count;
     response.in_progress_avg_wait_ms = augmentation.in_progress_avg_wait_ms;
-    response.non_success_cost = augmentation.non_success_cost;
     response.non_success_tokens = augmentation.non_success_tokens;
 }
 
@@ -1959,16 +1978,31 @@ async fn load_live_invocation_ids_in_range(
         .collect())
 }
 
-async fn load_non_success_usage_snapshot(
-    pool: &Pool<Sqlite>,
+fn summary_live_augmentation_policy(
+    window: &SummaryWindow,
+    range: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    now: DateTime<Utc>,
+) -> SummaryLiveAugmentationPolicy {
+    let closed_named_window = matches!(
+        window,
+        SummaryWindow::Calendar(_) | SummaryWindow::PreviousFullDays(_)
+    ) && range.is_some_and(|(_, end)| end < now);
+
+    SummaryLiveAugmentationPolicy {
+        include_in_progress: !closed_named_window,
+        include_non_success_tokens: !closed_named_window && range.is_some(),
+    }
+}
+
+async fn load_non_success_tokens_snapshot(
+    state: &AppState,
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
     start: DateTime<Utc>,
     end: DateTime<Utc>,
-) -> Result<(Option<f64>, Option<i64>), ApiError> {
+) -> Result<Option<i64>, ApiError> {
     let mut query = QueryBuilder::<Sqlite>::new(
         "SELECT \
-            COALESCE(SUM(COALESCE(cost, 0.0)), 0.0) AS non_success_cost, \
             COALESCE(SUM(COALESCE(total_tokens, 0)), 0) AS non_success_tokens \
          FROM codex_invocations \
          WHERE occurred_at >= ",
@@ -1992,34 +2026,101 @@ async fn load_non_success_usage_snapshot(
             .push_bind(upstream_account_id);
     }
 
-    let (non_success_cost, non_success_tokens) = query
-        .build_query_as::<(f64, i64)>()
-        .fetch_one(pool)
-        .await?;
-    let live_invocation_ids =
-        load_live_invocation_ids_in_range(pool, source_scope, upstream_account_id, start, end).await?;
-    let (archived_cost, archived_tokens) = if let Some(upstream_account_id) = upstream_account_id {
-        crate::stats::query_completed_upstream_account_archive_non_success_usage(
-            pool,
+    let live_tokens = match query
+        .build_query_scalar::<i64>()
+        .fetch_one(&state.pool)
+        .await
+    {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            let err = anyhow!(err);
+            if crate::is_sqlite_lock_error(&err) {
+                tracing::warn!(
+                    ?source_scope,
+                    upstream_account_id,
+                    start = %start,
+                    end = %end,
+                    "summary live non-success token snapshot skipped because sqlite is locked"
+                );
+                return Ok(None);
+            }
+            return Err(ApiError::from(err));
+        }
+    };
+
+    let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
+    if start >= retention_cutoff {
+        return Ok(Some(live_tokens));
+    }
+
+    let live_invocation_ids = match load_live_invocation_ids_in_range(
+        &state.pool,
+        source_scope,
+        upstream_account_id,
+        start,
+        end,
+    )
+    .await
+    {
+        Ok(ids) => ids,
+        Err(ApiError::Internal(err)) if crate::is_sqlite_lock_error(&err) => {
+            tracing::warn!(
+                ?source_scope,
+                upstream_account_id,
+                start = %start,
+                end = %end,
+                "summary archive overlap scan skipped because sqlite is locked"
+            );
+            return Ok(None);
+        }
+        Err(err) => return Err(err),
+    };
+    let archived_tokens = if let Some(upstream_account_id) = upstream_account_id {
+        match crate::stats::query_completed_upstream_account_archive_non_success_usage(
+            &state.pool,
             source_scope,
             Some((start, end)),
             Some(&live_invocation_ids),
             upstream_account_id,
         )
-        .await?
+        .await
+        {
+            Ok((_, tokens)) => tokens,
+            Err(err) if crate::is_sqlite_lock_error(&err) => {
+                tracing::warn!(
+                    ?source_scope,
+                    upstream_account_id,
+                    start = %start,
+                    end = %end,
+                    "summary archived non-success token lookup skipped because sqlite is locked"
+                );
+                return Ok(None);
+            }
+            Err(err) => return Err(ApiError::from(err)),
+        }
     } else {
-        crate::stats::query_completed_invocation_archive_non_success_usage(
-            pool,
+        match crate::stats::query_completed_invocation_archive_non_success_usage(
+            &state.pool,
             source_scope,
             Some((start, end)),
             Some(&live_invocation_ids),
         )
-        .await?
+        .await
+        {
+            Ok((_, tokens)) => tokens,
+            Err(err) if crate::is_sqlite_lock_error(&err) => {
+                tracing::warn!(
+                    ?source_scope,
+                    start = %start,
+                    end = %end,
+                    "summary archived non-success token lookup skipped because sqlite is locked"
+                );
+                return Ok(None);
+            }
+            Err(err) => return Err(ApiError::from(err)),
+        }
     };
-    Ok((
-        Some(non_success_cost + archived_cost),
-        Some(non_success_tokens + archived_tokens),
-    ))
+    Ok(Some(live_tokens + archived_tokens))
 }
 
 pub(crate) async fn build_empty_summary_response(
@@ -2036,12 +2137,21 @@ pub(crate) async fn build_empty_summary_response(
         in_progress_conversation_count: None,
         in_progress_retry_conversation_count: None,
         in_progress_avg_wait_ms: None,
-        non_success_cost: None,
+        non_success_cost: Some(0.0),
         non_success_tokens: None,
         maintenance: Some(load_stats_maintenance_response(state).await?),
     };
-    let augmentation =
-        load_summary_live_augmentation(state, source_scope, upstream_account_id, None).await?;
+    let augmentation = load_summary_live_augmentation(
+        state,
+        source_scope,
+        upstream_account_id,
+        None,
+        SummaryLiveAugmentationPolicy {
+            include_in_progress: true,
+            include_non_success_tokens: false,
+        },
+    )
+    .await?;
     apply_summary_live_augmentation(&mut response, augmentation);
     Ok(response)
 }
@@ -2174,12 +2284,15 @@ pub(crate) async fn fetch_summary(
     };
 
     let mut response = totals.into_response();
+    response.non_success_cost = Some(totals.non_success_cost);
     let range = summary_window_range(&window, reporting_tz, now)?;
+    let policy = summary_live_augmentation_policy(&window, range, now);
     let augmentation = load_summary_live_augmentation(
         state.as_ref(),
         source_scope,
         upstream_account_id,
         range,
+        policy,
     )
     .await?;
     apply_summary_live_augmentation(&mut response, augmentation);

--- a/src/api/slices/prompt_cache_and_timeseries/shared.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/shared.rs
@@ -937,6 +937,15 @@ pub(super) fn add_invocation_record_to_summary_totals(
     }
     totals.total_tokens += record.total_tokens.unwrap_or_default();
     totals.total_cost += record.cost.unwrap_or_default();
+    if invocation_counts_toward_non_success_usage(
+        record.status.as_deref(),
+        record.error_message.as_deref(),
+        record.failure_kind.as_deref(),
+        record.failure_class.as_deref(),
+        record.is_actionable,
+    ) {
+        totals.non_success_cost += record.cost.unwrap_or_default();
+    }
 }
 
 pub(crate) fn db_occurred_at_upper_bound(end_utc: DateTime<Utc>) -> String {

--- a/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
@@ -236,24 +236,6 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
             .await?,
         );
     }
-    if rollup_live_cursor < snapshot_id {
-        let tail_range_plan = HourlyRollupExactRangePlan {
-            full_hour_range: None,
-            live_exact_ranges: exact_utc_range(start, end)?.into_iter().collect(),
-        };
-        let tail_records = query_invocation_exact_records_tx_for_account(
-            tx.as_mut(),
-            &tail_range_plan,
-            source_scope,
-            snapshot_id,
-            upstream_account_id,
-            rollup_live_cursor,
-        )
-        .await?;
-        for record in &tail_records {
-            add_invocation_record_to_summary_totals(&mut totals, record);
-        }
-    }
     Ok(totals)
 }
 

--- a/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/summary_queries.rs
@@ -57,6 +57,7 @@ pub(crate) async fn query_hourly_backed_summary_range_with_config(
                 totals.failure_count += row.failure_count;
                 totals.total_tokens += row.total_tokens;
                 totals.total_cost += row.total_cost;
+                totals.non_success_cost += row.non_success_cost;
             }
             let mut exact_records = query_invocation_exact_records_tx(
                 tx.as_mut(),
@@ -157,6 +158,7 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
                 totals.failure_count += row.failure_count;
                 totals.total_tokens += row.total_tokens;
                 totals.total_cost += row.total_cost;
+                totals.non_success_cost += row.non_success_cost;
             }
             let mut exact_records = if !range_plan.live_exact_ranges.is_empty() && snapshot_id > 0 {
                 query_invocation_exact_records_for_account_tx(
@@ -233,6 +235,24 @@ pub(crate) async fn query_hourly_backed_summary_range_for_account_with_config(
             )
             .await?,
         );
+    }
+    if rollup_live_cursor < snapshot_id {
+        let tail_range_plan = HourlyRollupExactRangePlan {
+            full_hour_range: None,
+            live_exact_ranges: exact_utc_range(start, end)?.into_iter().collect(),
+        };
+        let tail_records = query_invocation_exact_records_tx_for_account(
+            tx.as_mut(),
+            &tail_range_plan,
+            source_scope,
+            snapshot_id,
+            upstream_account_id,
+            rollup_live_cursor,
+        )
+        .await?;
+        for record in &tail_records {
+            add_invocation_record_to_summary_totals(&mut totals, record);
+        }
     }
     Ok(totals)
 }

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -123,6 +123,7 @@ pub(crate) struct StatsRow {
     pub(crate) failure_count: Option<i64>,
     pub(crate) total_cost: f64,
     pub(crate) total_tokens: i64,
+    pub(crate) non_success_cost: f64,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -132,6 +133,7 @@ pub(crate) struct StatsTotals {
     pub(crate) failure_count: i64,
     pub(crate) total_cost: f64,
     pub(crate) total_tokens: i64,
+    pub(crate) non_success_cost: f64,
 }
 
 impl StatsTotals {
@@ -142,6 +144,7 @@ impl StatsTotals {
             failure_count: self.failure_count + other.failure_count,
             total_cost: self.total_cost + other.total_cost,
             total_tokens: self.total_tokens + other.total_tokens,
+            non_success_cost: self.non_success_cost + other.non_success_cost,
         }
     }
 
@@ -170,6 +173,7 @@ impl From<StatsRow> for StatsTotals {
             failure_count: value.failure_count.unwrap_or(0),
             total_cost: value.total_cost,
             total_tokens: value.total_tokens,
+            non_success_cost: value.non_success_cost,
         }
     }
 }

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -2275,6 +2275,7 @@ fn compute_crs_delta(
         failure_count: 0,
         total_tokens: delta_tokens,
         total_cost: delta_cost,
+        non_success_cost: 0.0,
     }
 }
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -23,7 +23,8 @@ pub(crate) fn stats_success_failure_select_sql() -> String {
          COALESCE(SUM(CASE WHEN {success_like} AND {resolved_failure} = 'none' THEN 1 ELSE 0 END), 0) AS success_count, \
          COALESCE(SUM(CASE WHEN {terminal_status} AND {resolved_failure} IN ('service_failure', 'client_failure', 'client_abort') THEN 1 ELSE 0 END), 0) AS failure_count, \
          COALESCE(SUM(cost), 0.0) AS total_cost, \
-         COALESCE(SUM(total_tokens), 0) AS total_tokens",
+         COALESCE(SUM(total_tokens), 0) AS total_tokens, \
+         COALESCE(SUM(CASE WHEN {terminal_status} AND {resolved_failure} IN ('service_failure', 'client_failure', 'client_abort') THEN COALESCE(cost, 0.0) ELSE 0.0 END), 0.0) AS non_success_cost",
         success_like = STATS_SUCCESS_LIKE_SQL,
         terminal_status = STATS_TERMINAL_STATUS_SQL,
         resolved_failure = crate::api::INVOCATION_RESOLVED_FAILURE_CLASS_SQL,
@@ -4222,7 +4223,8 @@ pub(crate) async fn query_crs_totals(
             COALESCE(SUM(success_count), 0) AS success_count,
             COALESCE(SUM(failure_count), 0) AS failure_count,
             COALESCE(SUM(total_cost), 0.0) AS total_cost,
-            COALESCE(SUM(total_tokens), 0) AS total_tokens
+            COALESCE(SUM(total_tokens), 0) AS total_tokens,
+            0.0 AS non_success_cost
         FROM stats_source_deltas
         WHERE source = ?1 AND period = ?2
         "#,

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -2753,6 +2753,7 @@ pub(crate) async fn query_unmaterialized_invocation_archive_totals(
         totals.failure_count += row.failure_count;
         totals.total_tokens += row.total_tokens;
         totals.total_cost += row.total_cost;
+        totals.non_success_cost += row.non_success_cost;
     }
 
     Ok(totals)
@@ -3041,6 +3042,7 @@ pub(crate) async fn query_unmaterialized_upstream_account_archive_totals(
         totals.failure_count += row.failure_count;
         totals.total_tokens += row.total_tokens;
         totals.total_cost += row.total_cost;
+        totals.non_success_cost += row.non_success_cost;
     }
 
     Ok(totals)
@@ -3952,18 +3954,25 @@ async fn query_invocation_all_time_rollup_totals(
     pool: &Pool<Sqlite>,
     source_scope: InvocationSourceScope,
 ) -> Result<AllTimeRollupTotals> {
-    let mut query = QueryBuilder::<Sqlite>::new(
+    let non_success_cost_expr =
+        if sqlite_table_has_column(pool, "invocation_rollup_hourly", "non_success_cost").await? {
+            "COALESCE(SUM(non_success_cost), 0.0) AS non_success_cost"
+        } else {
+            "0.0 AS non_success_cost"
+        };
+    let mut query = QueryBuilder::<Sqlite>::new(format!(
         r#"
         SELECT
             COALESCE(SUM(total_count), 0) AS total_count,
             COALESCE(SUM(success_count), 0) AS success_count,
             COALESCE(SUM(failure_count), 0) AS failure_count,
             COALESCE(SUM(total_cost), 0.0) AS total_cost,
-            COALESCE(SUM(total_tokens), 0) AS total_tokens
+            COALESCE(SUM(total_tokens), 0) AS total_tokens,
+            {non_success_cost_expr}
         FROM invocation_rollup_hourly
         WHERE 1 = 1
         "#,
-    );
+    ));
     if source_scope == InvocationSourceScope::ProxyOnly {
         query.push(" AND source = ").push_bind(SOURCE_PROXY);
     }

--- a/src/tests/slices/maintenance_and_raw_payload.rs
+++ b/src/tests/slices/maintenance_and_raw_payload.rs
@@ -2294,9 +2294,13 @@ async fn upstream_account_summary_and_detail_include_active_conversation_count()
         Some(2)
     );
 
-    let Json(detail_response) = get_upstream_account(State(state), axum::extract::Path(account_id))
-        .await
-        .expect("load upstream account detail");
+    let Json(detail_response) = get_upstream_account(
+        State(state),
+        axum::extract::Path(account_id),
+        axum::extract::Query(GetUpstreamAccountQuery::default()),
+    )
+    .await
+    .expect("load upstream account detail");
     let detail_json =
         serde_json::to_value(detail_response).expect("serialize upstream account detail");
     assert_eq!(
@@ -2361,6 +2365,94 @@ async fn list_upstream_accounts_keeps_generic_retry_cooldown_idle() {
         Some("normal")
     );
     assert_eq!(response_json["metrics"]["attention"].as_u64(), Some(1));
+}
+
+#[tokio::test]
+async fn get_upstream_account_omits_recent_actions_by_default_and_loads_them_on_demand() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let account_id =
+        insert_test_pool_api_key_account(&state, "Recent actions gated", "upstream-gated").await;
+
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_account_events (
+            account_id,
+            occurred_at,
+            action,
+            source,
+            account_display_name,
+            result,
+            result_description,
+            reason_code,
+            created_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        "#,
+    )
+    .bind(account_id)
+    .bind("2026-06-25 11:30:00")
+    .bind("account_updated")
+    .bind("manual")
+    .bind("Recent actions gated")
+    .bind("success")
+    .bind("settings saved")
+    .bind("account_updated")
+    .bind("2026-06-25 11:30:00")
+    .execute(&state.pool)
+    .await
+    .expect("insert upstream account event");
+
+    let Json(default_detail) = get_upstream_account(
+        State(state.clone()),
+        axum::extract::Path(account_id),
+        axum::extract::Query(GetUpstreamAccountQuery::default()),
+    )
+    .await
+    .expect("load default upstream account detail");
+    let default_detail_json =
+        serde_json::to_value(default_detail).expect("serialize default upstream account detail");
+    assert!(
+        default_detail_json["recentActions"]
+            .as_array()
+            .is_some_and(|items| items.is_empty()),
+        "default detail fetch should skip recent actions for overview first paint"
+    );
+
+    let Json(detail_with_recent_actions) = get_upstream_account(
+        State(state),
+        axum::extract::Path(account_id),
+        axum::extract::Query(GetUpstreamAccountQuery {
+            include_recent_actions: Some(true),
+        }),
+    )
+    .await
+    .expect("load upstream account detail with recent actions");
+    let detail_with_recent_actions_json = serde_json::to_value(detail_with_recent_actions)
+        .expect("serialize upstream account detail with recent actions");
+    assert_eq!(
+        detail_with_recent_actions_json["recentActions"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default()
+            >= 1,
+        true
+    );
+    assert_eq!(
+        detail_with_recent_actions_json["recentActions"]
+            .as_array()
+            .and_then(|items| {
+                items.iter().find(|item| {
+                    item.get("action").and_then(serde_json::Value::as_str)
+                        == Some("account_updated")
+                })
+            })
+            .and_then(|item| item.get("action"))
+            .and_then(serde_json::Value::as_str),
+        Some("account_updated")
+    );
 }
 
 #[tokio::test]

--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -11329,7 +11329,7 @@ async fn empty_summary_response_keeps_live_in_progress_conversation_count() {
     assert_eq!(response.in_progress_conversation_count, Some(2));
     assert_eq!(response.in_progress_retry_conversation_count, Some(0));
     assert_eq!(response.in_progress_avg_wait_ms, None);
-    assert_eq!(response.non_success_cost, None);
+    assert_eq!(response.non_success_cost, Some(0.0));
     assert_eq!(response.non_success_tokens, None);
     assert!(response.maintenance.is_some());
 }

--- a/src/tests/slices/pool_failover_window_j.rs
+++ b/src/tests/slices/pool_failover_window_j.rs
@@ -2397,7 +2397,8 @@ async fn recompute_invocation_hourly_rollups_ignores_archive_manifests_for_live_
             COALESCE(SUM(success_count), 0) AS success_count,
             COALESCE(SUM(failure_count), 0) AS failure_count,
             COALESCE(SUM(total_cost), 0.0) AS total_cost,
-            COALESCE(SUM(total_tokens), 0) AS total_tokens
+            COALESCE(SUM(total_tokens), 0) AS total_tokens,
+            COALESCE(SUM(non_success_cost), 0.0) AS non_success_cost
         FROM invocation_rollup_hourly
         WHERE bucket_start_epoch = ?1 AND source = ?2
         "#,

--- a/src/upstream_accounts/crud_group_notes.rs
+++ b/src/upstream_accounts/crud_group_notes.rs
@@ -858,10 +858,23 @@ pub(crate) async fn delete_upstream_account_group(
 pub(crate) async fn get_upstream_account(
     State(state): State<Arc<AppState>>,
     AxumPath(id): AxumPath<i64>,
+    Query(params): Query<GetUpstreamAccountQuery>,
 ) -> Result<Json<UpstreamAccountDetail>, (StatusCode, String)> {
-    let detail = load_upstream_account_detail_with_actual_usage(state.as_ref(), id)
-        .await
-        .map_err(internal_error_tuple)?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "account not found".to_string()))?;
+    let detail = load_upstream_account_detail_with_actual_usage_options(
+        state.as_ref(),
+        id,
+        LoadUpstreamAccountDetailOptions {
+            include_recent_actions: params.include_recent_actions.unwrap_or(false),
+        },
+    )
+    .await
+    .map_err(internal_error_tuple)?
+    .ok_or_else(|| (StatusCode::NOT_FOUND, "account not found".to_string()))?;
     Ok(Json(detail))
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GetUpstreamAccountQuery {
+    pub(crate) include_recent_actions: Option<bool>,
 }

--- a/src/upstream_accounts/sync_account_imports_tags.rs
+++ b/src/upstream_accounts/sync_account_imports_tags.rs
@@ -2956,6 +2956,26 @@ async fn load_upstream_account_detail(
     pool: &Pool<Sqlite>,
     id: i64,
 ) -> Result<Option<UpstreamAccountDetail>> {
+    load_upstream_account_detail_with_options(
+        pool,
+        id,
+        LoadUpstreamAccountDetailOptions {
+            include_recent_actions: true,
+        },
+    )
+    .await
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct LoadUpstreamAccountDetailOptions {
+    pub(crate) include_recent_actions: bool,
+}
+
+async fn load_upstream_account_detail_with_options(
+    pool: &Pool<Sqlite>,
+    id: i64,
+    options: LoadUpstreamAccountDetailOptions,
+) -> Result<Option<UpstreamAccountDetail>> {
     let Some(row) = load_upstream_account_row(pool, id).await? else {
         return Ok(None);
     };
@@ -2990,37 +3010,41 @@ async fn load_upstream_account_detail(
         })
         .collect::<Vec<_>>();
     history.reverse();
-    let recent_action_rows = sqlx::query_as::<_, UpstreamAccountActionEventRow>(
-        r#"
-        SELECT
-            event.id,
-            event.occurred_at,
-            event.action,
-            event.source,
-            COALESCE(event.account_display_name, account.display_name) AS account_display_name,
-            COALESCE(event.account_group_name, account.group_name) AS account_group_name,
-            event.forward_proxy_key,
-            event.forward_proxy_display_name,
-            event.forward_proxy_egress_ip,
-            event.result,
-            event.result_description,
-            event.reason_code,
-            event.reason_message,
-            event.http_status,
-            event.failure_kind,
-            event.invoke_id,
-            event.sticky_key,
-            event.created_at
-        FROM pool_upstream_account_events event
-        INNER JOIN pool_upstream_accounts account ON account.id = event.account_id
-        WHERE event.account_id = ?1
-        ORDER BY event.occurred_at DESC, event.id DESC
-        LIMIT 20
-        "#,
-    )
-    .bind(id)
-    .fetch_all(pool)
-    .await?;
+    let recent_action_rows = if options.include_recent_actions {
+        sqlx::query_as::<_, UpstreamAccountActionEventRow>(
+            r#"
+            SELECT
+                event.id,
+                event.occurred_at,
+                event.action,
+                event.source,
+                COALESCE(event.account_display_name, account.display_name) AS account_display_name,
+                COALESCE(event.account_group_name, account.group_name) AS account_group_name,
+                event.forward_proxy_key,
+                event.forward_proxy_display_name,
+                event.forward_proxy_egress_ip,
+                event.result,
+                event.result_description,
+                event.reason_code,
+                event.reason_message,
+                event.http_status,
+                event.failure_kind,
+                event.invoke_id,
+                event.sticky_key,
+                event.created_at
+            FROM pool_upstream_account_events event
+            INNER JOIN pool_upstream_accounts account ON account.id = event.account_id
+            WHERE event.account_id = ?1
+            ORDER BY event.occurred_at DESC, event.id DESC
+            LIMIT 20
+            "#,
+        )
+        .bind(id)
+        .fetch_all(pool)
+        .await?
+    } else {
+        Vec::new()
+    };
 
     let duplicate_info = load_duplicate_info_for_account(pool, row.id).await?;
     let now = Utc::now();
@@ -3058,7 +3082,23 @@ async fn load_upstream_account_detail_with_actual_usage(
     state: &AppState,
     id: i64,
 ) -> Result<Option<UpstreamAccountDetail>> {
-    let mut detail = match load_upstream_account_detail(&state.pool, id).await? {
+    load_upstream_account_detail_with_actual_usage_options(
+        state,
+        id,
+        LoadUpstreamAccountDetailOptions {
+            include_recent_actions: true,
+        },
+    )
+    .await
+}
+
+pub(crate) async fn load_upstream_account_detail_with_actual_usage_options(
+    state: &AppState,
+    id: i64,
+    options: LoadUpstreamAccountDetailOptions,
+) -> Result<Option<UpstreamAccountDetail>> {
+    let mut detail = match load_upstream_account_detail_with_options(&state.pool, id, options).await?
+    {
         Some(detail) => detail,
         None => return Ok(None),
     };

--- a/web/src/hooks/useUpstreamAccounts.test.tsx
+++ b/web/src/hooks/useUpstreamAccounts.test.tsx
@@ -1,7 +1,15 @@
 /** @vitest-environment jsdom */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type {
   FetchUpstreamAccountsQuery,
   ForwardProxyBindingNode,
@@ -18,34 +26,50 @@ import {
 } from "./useUpstreamAccounts";
 
 const apiMocks = vi.hoisted(() => ({
-  fetchUpstreamAccounts: vi.fn<
-    (query?: FetchUpstreamAccountsQuery) => Promise<UpstreamAccountListResponse>
-  >(),
-  fetchUpstreamAccountDetail: vi.fn<
-    (accountId: number, signal?: AbortSignal) => Promise<UpstreamAccountDetail>
-  >(),
-  fetchUpstreamAccountWindowUsage: vi.fn<
-    (accountIds: number[]) => Promise<UpstreamAccountWindowUsageResponse>
-  >(),
-  updateUpstreamAccountGroup: vi.fn<
-    (
-      groupName: string,
-      payload: import("../lib/api").UpdateUpstreamAccountGroupPayload,
-    ) => Promise<UpstreamAccountGroupSummary>
-  >(),
-  syncUpstreamAccount: vi.fn<(accountId: number) => Promise<UpstreamAccountDetail>>(),
-  reloginUpstreamAccount: vi.fn<(accountId: number) => Promise<{ loginId: string }>>(),
+  fetchUpstreamAccounts:
+    vi.fn<
+      (
+        query?: FetchUpstreamAccountsQuery,
+      ) => Promise<UpstreamAccountListResponse>
+    >(),
+  fetchUpstreamAccountDetail:
+    vi.fn<
+      (
+        accountId: number,
+        options?:
+          | { signal?: AbortSignal; includeRecentActions?: boolean }
+          | AbortSignal,
+      ) => Promise<UpstreamAccountDetail>
+    >(),
+  fetchUpstreamAccountWindowUsage:
+    vi.fn<
+      (accountIds: number[]) => Promise<UpstreamAccountWindowUsageResponse>
+    >(),
+  updateUpstreamAccountGroup:
+    vi.fn<
+      (
+        groupName: string,
+        payload: import("../lib/api").UpdateUpstreamAccountGroupPayload,
+      ) => Promise<UpstreamAccountGroupSummary>
+    >(),
+  syncUpstreamAccount:
+    vi.fn<(accountId: number) => Promise<UpstreamAccountDetail>>(),
+  reloginUpstreamAccount:
+    vi.fn<(accountId: number) => Promise<{ loginId: string }>>(),
   deleteUpstreamAccount: vi.fn<(accountId: number) => Promise<void>>(),
   deleteUpstreamAccountGroup: vi.fn<(groupName: string) => Promise<void>>(),
 }));
 
 const sseMocks = vi.hoisted(() => ({
-  recordListeners: [] as Array<(payload: { type: string; records?: unknown[] }) => void>,
+  recordListeners: [] as Array<
+    (payload: { type: string; records?: unknown[] }) => void
+  >,
   openListeners: [] as Array<() => void>,
 }));
 
 vi.mock("../lib/api", async () => {
-  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  const actual =
+    await vi.importActual<typeof import("../lib/api")>("../lib/api");
   return {
     ...actual,
     fetchUpstreamAccounts: apiMocks.fetchUpstreamAccounts,
@@ -98,7 +122,9 @@ beforeEach(() => {
   sseMocks.recordListeners.length = 0;
   sseMocks.openListeners.length = 0;
   apiMocks.fetchUpstreamAccounts.mockResolvedValue(createListResponse());
-  apiMocks.updateUpstreamAccountGroup.mockResolvedValue(createGroupSummary("prod"));
+  apiMocks.updateUpstreamAccountGroup.mockResolvedValue(
+    createGroupSummary("prod"),
+  );
   apiMocks.deleteUpstreamAccountGroup.mockResolvedValue();
 });
 
@@ -270,7 +296,9 @@ function createWindowedSummary(
   };
 }
 
-function createWindowUsageResponse(accountIds: number[]): UpstreamAccountWindowUsageResponse {
+function createWindowUsageResponse(
+  accountIds: number[],
+): UpstreamAccountWindowUsageResponse {
   return {
     items: accountIds.map((accountId, index) => ({
       accountId,
@@ -312,7 +340,11 @@ function createListResponse(
     groups: [],
     forwardProxyNodes: [],
     hasUngroupedAccounts: false,
-    routing: { writesEnabled: true, apiKeyConfigured: false, maskedApiKey: null },
+    routing: {
+      writesEnabled: true,
+      apiKeyConfigured: false,
+      maskedApiKey: null,
+    },
     ...overrides,
   };
 }
@@ -340,19 +372,26 @@ function Probe({
     runSync,
     refresh,
     hydrateWindowUsage,
+    loadDetail,
     beginRelogin,
     removeAccount,
     saveGroupNote,
-  } =
-    useUpstreamAccounts(query, options);
+  } = useUpstreamAccounts(query, options);
 
   return (
     <div>
       <div data-testid="selected-id">{selectedId ?? ""}</div>
-      <div data-testid="selected-name">{selectedSummary?.displayName ?? ""}</div>
+      <div data-testid="selected-name">
+        {selectedSummary?.displayName ?? ""}
+      </div>
       <div data-testid="detail-id">{detail?.id ?? ""}</div>
       <div data-testid="detail-name">{detail?.displayName ?? ""}</div>
-      <div data-testid="detail-loading">{isDetailLoading ? "true" : "false"}</div>
+      <div data-testid="detail-recent-actions-count">
+        {detail?.recentActions?.length ?? 0}
+      </div>
+      <div data-testid="detail-loading">
+        {isDetailLoading ? "true" : "false"}
+      </div>
       <div data-testid="list-error">{listError ?? ""}</div>
       <div data-testid="list-freshness">{listState.freshness}</div>
       <div data-testid="list-loading-state">{listState.loadingState}</div>
@@ -360,7 +399,9 @@ function Probe({
       <div data-testid="list-has-current-query-data">
         {listState.hasCurrentQueryData ? "true" : "false"}
       </div>
-      <div data-testid="proxy-catalog-kind">{forwardProxyCatalogState.kind}</div>
+      <div data-testid="proxy-catalog-kind">
+        {forwardProxyCatalogState.kind}
+      </div>
       <div data-testid="proxy-catalog-freshness">
         {forwardProxyCatalogState.freshness}
       </div>
@@ -392,6 +433,17 @@ function Probe({
         refresh
       </button>
       <button
+        data-testid="load-detail-recent-actions"
+        onClick={() =>
+          void loadDetail(selectedId ?? null, {
+            silent: true,
+            includeRecentActions: true,
+          })
+        }
+      >
+        load detail recent actions
+      </button>
+      <button
         data-testid="hydrate-visible"
         onClick={() => void hydrateWindowUsage(items.map((item) => item.id))}
       >
@@ -405,7 +457,11 @@ function Probe({
       </button>
       <button
         data-testid="save-prod-group"
-        onClick={() => void saveGroupNote("prod", { routingRule: { priorityTier: "fallback" } })}
+        onClick={() =>
+          void saveGroupNote("prod", {
+            routingRule: { priorityTier: "fallback" },
+          })
+        }
       >
         save prod group
       </button>
@@ -443,7 +499,9 @@ describe("useUpstreamAccounts", () => {
   });
 
   it("treats grouped includeAll queries as a distinct roster key", async () => {
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe query={{ page: 1, pageSize: 20 }} />);
     await flushAsync();
@@ -464,7 +522,10 @@ describe("useUpstreamAccounts", () => {
     const hydration = deferred<UpstreamAccountWindowUsageResponse>();
     apiMocks.fetchUpstreamAccounts.mockResolvedValueOnce(
       createListResponse({
-        items: [createWindowedSummary(1, "Alpha"), createWindowedSummary(2, "Beta")],
+        items: [
+          createWindowedSummary(1, "Alpha"),
+          createWindowedSummary(2, "Beta"),
+        ],
       }),
     );
     apiMocks.fetchUpstreamAccountWindowUsage.mockImplementationOnce(
@@ -489,7 +550,10 @@ describe("useUpstreamAccounts", () => {
   it("hydrates only the selected account for includeAll roster queries", async () => {
     apiMocks.fetchUpstreamAccounts.mockResolvedValueOnce(
       createListResponse({
-        items: [createWindowedSummary(1, "Alpha"), createWindowedSummary(2, "Beta")],
+        items: [
+          createWindowedSummary(1, "Alpha"),
+          createWindowedSummary(2, "Beta"),
+        ],
       }),
     );
     apiMocks.fetchUpstreamAccountWindowUsage.mockResolvedValueOnce(
@@ -514,13 +578,12 @@ describe("useUpstreamAccounts", () => {
   it("auto-hydrates visible roster rows when the query opts out of default selection", async () => {
     apiMocks.fetchUpstreamAccounts.mockResolvedValueOnce(
       createListResponse({
-        items: [createWindowedSummary(1, "Alpha"), createWindowedSummary(2, "Beta")],
+        items: [
+          createWindowedSummary(1, "Alpha"),
+          createWindowedSummary(2, "Beta"),
+        ],
       }),
     );
-    apiMocks.fetchUpstreamAccountWindowUsage.mockResolvedValueOnce(
-      createWindowUsageResponse([1, 2]),
-    );
-
     render(
       <Probe
         query={{ includeAll: true }}
@@ -530,8 +593,21 @@ describe("useUpstreamAccounts", () => {
     await flushAsync();
 
     expect(text("selected-id")).toBe("");
-    expect(apiMocks.fetchUpstreamAccountWindowUsage).toHaveBeenCalledWith([1, 2]);
+    expect(apiMocks.fetchUpstreamAccountWindowUsage).not.toHaveBeenCalled();
     expect(text("window-usage-pending")).toBe("false");
+    expect(text("first-item-primary-requests")).toBe("");
+    expect(text("first-item-secondary-requests")).toBe("");
+
+    apiMocks.fetchUpstreamAccountWindowUsage.mockResolvedValueOnce(
+      createWindowUsageResponse([1, 2]),
+    );
+    click("hydrate-visible");
+    await flushAsync();
+    await flushAsync();
+
+    expect(apiMocks.fetchUpstreamAccountWindowUsage).toHaveBeenCalledWith([
+      1, 2,
+    ]);
     expect(text("first-item-primary-requests")).toBe("10");
     expect(text("first-item-secondary-requests")).toBe("30");
   });
@@ -541,12 +617,18 @@ describe("useUpstreamAccounts", () => {
     apiMocks.fetchUpstreamAccounts
       .mockResolvedValueOnce(
         createListResponse({
-          items: [createWindowedSummary(1, "Alpha"), createWindowedSummary(2, "Beta")],
+          items: [
+            createWindowedSummary(1, "Alpha"),
+            createWindowedSummary(2, "Beta"),
+          ],
         }),
       )
       .mockResolvedValueOnce(
         createListResponse({
-          items: [createWindowedSummary(3, "Gamma"), createWindowedSummary(4, "Delta")],
+          items: [
+            createWindowedSummary(3, "Gamma"),
+            createWindowedSummary(4, "Delta"),
+          ],
           total: 4,
           page: 2,
           pageSize: 20,
@@ -583,12 +665,18 @@ describe("useUpstreamAccounts", () => {
     apiMocks.fetchUpstreamAccounts
       .mockResolvedValueOnce(
         createListResponse({
-          items: [createWindowedSummary(1, "Alpha"), createWindowedSummary(2, "Beta")],
+          items: [
+            createWindowedSummary(1, "Alpha"),
+            createWindowedSummary(2, "Beta"),
+          ],
         }),
       )
       .mockResolvedValueOnce(
         createListResponse({
-          items: [createWindowedSummary(1, "Alpha"), createWindowedSummary(2, "Beta")],
+          items: [
+            createWindowedSummary(1, "Alpha"),
+            createWindowedSummary(2, "Beta"),
+          ],
         }),
       );
     apiMocks.fetchUpstreamAccountWindowUsage
@@ -599,13 +687,19 @@ describe("useUpstreamAccounts", () => {
     render(<Probe query={{ page: 1, pageSize: 20 }} />);
     await flushAsync();
 
-    expect(apiMocks.fetchUpstreamAccountWindowUsage).toHaveBeenNthCalledWith(1, [1]);
+    expect(apiMocks.fetchUpstreamAccountWindowUsage).toHaveBeenNthCalledWith(
+      1,
+      [1],
+    );
     expect(text("window-usage-pending")).toBe("true");
 
     click("hydrate-visible");
     await flushAsync();
 
-    expect(apiMocks.fetchUpstreamAccountWindowUsage).toHaveBeenNthCalledWith(2, [2]);
+    expect(apiMocks.fetchUpstreamAccountWindowUsage).toHaveBeenNthCalledWith(
+      2,
+      [2],
+    );
     expect(text("window-usage-pending")).toBe("true");
 
     firstHydration.resolve(createWindowUsageResponse([1]));
@@ -627,7 +721,9 @@ describe("useUpstreamAccounts", () => {
     apiMocks.fetchUpstreamAccounts
       .mockResolvedValueOnce(createListResponse())
       .mockImplementationOnce(async () => nextPage.promise);
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe query={{ page: 1, pageSize: 20 }} />);
     await flushAsync();
@@ -664,7 +760,9 @@ describe("useUpstreamAccounts", () => {
   });
 
   it("does not refetch the roster when rerenders keep the same query key", async () => {
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe query={{ page: 1, pageSize: 20 }} />);
     await flushAsync();
@@ -723,7 +821,9 @@ describe("useUpstreamAccounts", () => {
 
     act(() => {
       (
-        host?.querySelector('[data-testid="refresh"]') as HTMLButtonElement | null
+        host?.querySelector(
+          '[data-testid="refresh"]',
+        ) as HTMLButtonElement | null
       )?.click();
     });
     await flushAsync();
@@ -755,7 +855,9 @@ describe("useUpstreamAccounts", () => {
 
     act(() => {
       (
-        host?.querySelector('[data-testid="refresh"]') as HTMLButtonElement | null
+        host?.querySelector(
+          '[data-testid="refresh"]',
+        ) as HTMLButtonElement | null
       )?.click();
     });
     await flushAsync();
@@ -782,7 +884,9 @@ describe("useUpstreamAccounts", () => {
 
     act(() => {
       (
-        host?.querySelector('[data-testid="refresh"]') as HTMLButtonElement | null
+        host?.querySelector(
+          '[data-testid="refresh"]',
+        ) as HTMLButtonElement | null
       )?.click();
     });
     await flushAsync();
@@ -797,7 +901,9 @@ describe("useUpstreamAccounts", () => {
     apiMocks.fetchUpstreamAccounts
       .mockResolvedValueOnce(createListResponse())
       .mockImplementationOnce(async () => nextPage.promise);
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe query={{ page: 1, pageSize: 20 }} />);
     await flushAsync();
@@ -896,7 +1002,9 @@ describe("useUpstreamAccounts", () => {
       .mockResolvedValueOnce(createDetail(1, "Alpha"))
       .mockResolvedValueOnce(createDetail(2, "Beta"))
       .mockResolvedValue(createDetail(2, "Beta"));
-    apiMocks.syncUpstreamAccount.mockImplementationOnce(async () => sync.promise);
+    apiMocks.syncUpstreamAccount.mockImplementationOnce(
+      async () => sync.promise,
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -927,7 +1035,9 @@ describe("useUpstreamAccounts", () => {
       .mockResolvedValueOnce(createDetail(1, "Alpha"))
       .mockResolvedValueOnce(createDetail(2, "Beta Stale"))
       .mockResolvedValueOnce(createDetail(2, "Beta Fresh"));
-    apiMocks.syncUpstreamAccount.mockImplementationOnce(async () => sync.promise);
+    apiMocks.syncUpstreamAccount.mockImplementationOnce(
+      async () => sync.promise,
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -944,7 +1054,10 @@ describe("useUpstreamAccounts", () => {
     expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(
       3,
       2,
-      expect.any(AbortSignal),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        includeRecentActions: undefined,
+      }),
     );
     expect(text("selected-id")).toBe("2");
   });
@@ -980,7 +1093,10 @@ describe("useUpstreamAccounts", () => {
     expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(
       2,
       1,
-      expect.any(AbortSignal),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        includeRecentActions: undefined,
+      }),
     );
     await flushAsync();
     await flushAsync();
@@ -994,7 +1110,9 @@ describe("useUpstreamAccounts", () => {
       .mockResolvedValueOnce(createDetail(1, "Alpha"))
       .mockImplementationOnce(async () => refreshedDetail.promise)
       .mockResolvedValue(createDetail(1, "Alpha Synced"));
-    apiMocks.syncUpstreamAccount.mockImplementationOnce(async () => sync.promise);
+    apiMocks.syncUpstreamAccount.mockImplementationOnce(
+      async () => sync.promise,
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1020,7 +1138,9 @@ describe("useUpstreamAccounts", () => {
       .mockResolvedValueOnce(createDetail(1, "Alpha"))
       .mockImplementationOnce(async () => betaFailure.promise)
       .mockImplementationOnce(async () => betaRefresh.promise);
-    apiMocks.syncUpstreamAccount.mockResolvedValueOnce(createDetail(1, "Alpha Synced"));
+    apiMocks.syncUpstreamAccount.mockResolvedValueOnce(
+      createDetail(1, "Alpha Synced"),
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1048,7 +1168,11 @@ describe("useUpstreamAccounts", () => {
         items: [createSummary(2, "Beta")],
         groups: [],
         hasUngroupedAccounts: false,
-        routing: { writesEnabled: true, apiKeyConfigured: false, maskedApiKey: null },
+        routing: {
+          writesEnabled: true,
+          apiKeyConfigured: false,
+          maskedApiKey: null,
+        },
       });
     apiMocks.fetchUpstreamAccountDetail
       .mockResolvedValueOnce(createDetail(1, "Alpha"))
@@ -1069,7 +1193,10 @@ describe("useUpstreamAccounts", () => {
     expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(
       2,
       2,
-      expect.any(AbortSignal),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        includeRecentActions: undefined,
+      }),
     );
 
     betaDetail.resolve(createDetail(2, "Beta"));
@@ -1085,7 +1212,9 @@ describe("useUpstreamAccounts", () => {
     apiMocks.fetchUpstreamAccounts
       .mockResolvedValueOnce(createListResponse())
       .mockRejectedValueOnce(new Error("List failed"));
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1152,11 +1281,15 @@ describe("useUpstreamAccounts", () => {
   });
 
   it("does not clear list errors after a non-list success", async () => {
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
     apiMocks.fetchUpstreamAccounts
       .mockResolvedValueOnce(createListResponse())
       .mockRejectedValueOnce(new Error("List failed"));
-    apiMocks.reloginUpstreamAccount.mockResolvedValueOnce({ loginId: "relogin-1" });
+    apiMocks.reloginUpstreamAccount.mockResolvedValueOnce({
+      loginId: "relogin-1",
+    });
 
     render(<Probe />);
     await flushAsync();
@@ -1175,8 +1308,12 @@ describe("useUpstreamAccounts", () => {
     apiMocks.fetchUpstreamAccountDetail
       .mockRejectedValueOnce(new Error("Alpha failed"))
       .mockResolvedValueOnce(createDetail(2, "Beta"))
-      .mockResolvedValueOnce(createDetail(2, "Beta"));
-    apiMocks.syncUpstreamAccount.mockImplementationOnce(async () => sync.promise);
+      .mockResolvedValueOnce(createDetail(2, "Beta"))
+      .mockResolvedValueOnce(createDetail(2, "Beta"))
+      .mockResolvedValueOnce(createDetail(1, "Alpha synced"));
+    apiMocks.syncUpstreamAccount.mockImplementationOnce(
+      async () => sync.promise,
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1193,6 +1330,14 @@ describe("useUpstreamAccounts", () => {
 
     click("select-alpha");
     await flushAsync();
+    expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(
+      5,
+      1,
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        includeRecentActions: undefined,
+      }),
+    );
     expect(text("selected-id")).toBe("1");
     expect(text("detail-error")).toBe("");
   });
@@ -1205,19 +1350,33 @@ describe("useUpstreamAccounts", () => {
     apiMocks.fetchUpstreamAccounts
       .mockResolvedValueOnce({
         writesEnabled: true,
-        items: [createSummary(1, "Alpha"), createSummary(3, "Gamma"), createSummary(2, "Beta")],
+        items: [
+          createSummary(1, "Alpha"),
+          createSummary(3, "Gamma"),
+          createSummary(2, "Beta"),
+        ],
         groups: [],
         hasUngroupedAccounts: false,
-        routing: { writesEnabled: true, apiKeyConfigured: false, maskedApiKey: null },
+        routing: {
+          writesEnabled: true,
+          apiKeyConfigured: false,
+          maskedApiKey: null,
+        },
       })
       .mockResolvedValueOnce({
         writesEnabled: true,
         items: [createSummary(2, "Beta"), createSummary(3, "Gamma")],
         groups: [],
         hasUngroupedAccounts: false,
-        routing: { writesEnabled: true, apiKeyConfigured: false, maskedApiKey: null },
+        routing: {
+          writesEnabled: true,
+          apiKeyConfigured: false,
+          maskedApiKey: null,
+        },
       });
-    apiMocks.deleteUpstreamAccount.mockImplementationOnce(async () => remove.promise);
+    apiMocks.deleteUpstreamAccount.mockImplementationOnce(
+      async () => remove.promise,
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1258,6 +1417,53 @@ describe("useUpstreamAccounts", () => {
     expect(text("detail-name")).not.toBe("Alpha");
   });
 
+  it("loads recent actions on demand and preserves them across a plain detail refresh", async () => {
+    apiMocks.fetchUpstreamAccounts.mockResolvedValue(createListResponse());
+    apiMocks.fetchUpstreamAccountDetail
+      .mockResolvedValueOnce(createDetail(1, "Alpha"))
+      .mockResolvedValueOnce({
+        ...createDetail(1, "Alpha"),
+        recentActions: [
+          {
+            id: 7,
+            occurredAt: "2026-03-16T02:06:00.000Z",
+            action: "route_hard_unavailable",
+            source: "call",
+            createdAt: "2026-03-16T02:06:00.000Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce(createDetail(1, "Alpha Updated"));
+
+    render(<Probe />);
+    await flushAsync();
+
+    expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(1, 1, {
+      signal: expect.any(AbortSignal),
+      includeRecentActions: undefined,
+    });
+    expect(text("detail-recent-actions-count")).toBe("0");
+
+    click("load-detail-recent-actions");
+    await flushAsync();
+
+    expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(2, 1, {
+      signal: expect.any(AbortSignal),
+      includeRecentActions: true,
+    });
+    expect(text("detail-recent-actions-count")).toBe("1");
+
+    click("refresh");
+    await flushAsync();
+
+    expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(3, 1, {
+      signal: expect.any(AbortSignal),
+      includeRecentActions: undefined,
+    });
+    expect(text("detail-name")).toBe("Alpha Updated");
+    expect(text("detail-recent-actions-count")).toBe("1");
+  });
+
   it("invalidates an older detail reload before sync refreshes the list", async () => {
     const refreshedDetail = deferred<UpstreamAccountDetail>();
     const syncedList = deferred<UpstreamAccountListResponse>();
@@ -1271,7 +1477,9 @@ describe("useUpstreamAccounts", () => {
       .mockResolvedValueOnce(createDetail(1, "Alpha"))
       .mockImplementationOnce(async () => refreshedDetail.promise)
       .mockResolvedValue(createDetail(1, "Alpha Synced"));
-    apiMocks.syncUpstreamAccount.mockImplementationOnce(async () => sync.promise);
+    apiMocks.syncUpstreamAccount.mockImplementationOnce(
+      async () => sync.promise,
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1320,7 +1528,10 @@ describe("useUpstreamAccounts", () => {
     expect(apiMocks.fetchUpstreamAccountDetail).toHaveBeenNthCalledWith(
       3,
       2,
-      expect.any(AbortSignal),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        includeRecentActions: undefined,
+      }),
     );
     expect(text("selected-id")).toBe("2");
     expect(text("detail-id")).toBe("2");
@@ -1341,12 +1552,18 @@ describe("useUpstreamAccounts", () => {
         items: [createSummary(1, "Alpha Synced"), createSummary(2, "Beta")],
         groups: [],
         hasUngroupedAccounts: false,
-        routing: { writesEnabled: true, apiKeyConfigured: false, maskedApiKey: null },
+        routing: {
+          writesEnabled: true,
+          apiKeyConfigured: false,
+          maskedApiKey: null,
+        },
       });
     apiMocks.fetchUpstreamAccountDetail
       .mockResolvedValueOnce(createDetail(1, "Alpha"))
       .mockResolvedValue(createDetail(1, "Alpha Synced"));
-    apiMocks.syncUpstreamAccount.mockImplementationOnce(async () => sync.promise);
+    apiMocks.syncUpstreamAccount.mockImplementationOnce(
+      async () => sync.promise,
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1364,7 +1581,11 @@ describe("useUpstreamAccounts", () => {
       items: [createSummary(1, "Alpha Synced"), createSummary(2, "Beta")],
       groups: [],
       hasUngroupedAccounts: false,
-      routing: { writesEnabled: true, apiKeyConfigured: false, maskedApiKey: null },
+      routing: {
+        writesEnabled: true,
+        apiKeyConfigured: false,
+        maskedApiKey: null,
+      },
     });
     await flushAsync();
     await flushAsync();
@@ -1377,7 +1598,11 @@ describe("useUpstreamAccounts", () => {
       items: [createSummary(1, "Alpha Stale"), createSummary(2, "Beta")],
       groups: [],
       hasUngroupedAccounts: false,
-      routing: { writesEnabled: true, apiKeyConfigured: false, maskedApiKey: null },
+      routing: {
+        writesEnabled: true,
+        apiKeyConfigured: false,
+        maskedApiKey: null,
+      },
     });
     await flushAsync();
 
@@ -1387,7 +1612,9 @@ describe("useUpstreamAccounts", () => {
   });
 
   it("does not refresh the roster after records SSE events", async () => {
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
     render(<Probe />);
     await flushAsync();
 
@@ -1416,7 +1643,9 @@ describe("useUpstreamAccounts", () => {
   });
 
   it("skips an immediate open resync after a fresh load, then resyncs after the cooldown", async () => {
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe />);
     await flushAsync();
@@ -1446,8 +1675,12 @@ describe("useUpstreamAccounts", () => {
 
   it("does not let records SSE preempt the first roster load before the current query hydrates", async () => {
     const pendingList = deferred<UpstreamAccountListResponse>();
-    apiMocks.fetchUpstreamAccounts.mockImplementationOnce(async () => pendingList.promise);
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccounts.mockImplementationOnce(
+      async () => pendingList.promise,
+    );
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe />);
 
@@ -1477,13 +1710,16 @@ describe("useUpstreamAccounts", () => {
 
   it("ignores same-query records SSE events even while a prior manual refresh is already running", async () => {
     const manualRefresh = deferred<UpstreamAccountListResponse>();
-    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(createDetail(1, "Alpha"));
+    apiMocks.fetchUpstreamAccountDetail.mockResolvedValue(
+      createDetail(1, "Alpha"),
+    );
 
     render(<Probe />);
     await flushAsync();
 
-    apiMocks.fetchUpstreamAccounts
-      .mockImplementationOnce(async () => manualRefresh.promise);
+    apiMocks.fetchUpstreamAccounts.mockImplementationOnce(
+      async () => manualRefresh.promise,
+    );
 
     vi.useFakeTimers();
     try {
@@ -1503,9 +1739,14 @@ describe("useUpstreamAccounts", () => {
 
       expect(apiMocks.fetchUpstreamAccounts).toHaveBeenCalledTimes(2);
 
-      manualRefresh.resolve(createListResponse({
-        items: [createSummary(1, "Alpha Refresh 1"), createSummary(2, "Beta")],
-      }));
+      manualRefresh.resolve(
+        createListResponse({
+          items: [
+            createSummary(1, "Alpha Refresh 1"),
+            createSummary(2, "Beta"),
+          ],
+        }),
+      );
       await flushAsync();
       await flushAsync();
 

--- a/web/src/hooks/useUpstreamAccounts.ts
+++ b/web/src/hooks/useUpstreamAccounts.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   bulkUpdateUpstreamAccounts,
   cancelBulkUpstreamAccountSyncJob,
@@ -54,84 +54,101 @@ import {
   type UpstreamAccountDetail,
   type UpstreamAccountSummary,
   type ValidateImportedOauthAccountsPayload,
-} from '../lib/api'
-import { upsertGroupSummary } from '../lib/upstreamAccountGroups'
-import { UPSTREAM_ACCOUNTS_CHANGED_EVENT, emitUpstreamAccountsChanged } from '../lib/upstreamAccountsEvents'
-import { isUpstreamAccountNotFoundError } from '../lib/upstreamAccountErrors'
-import { subscribeToSseOpen } from '../lib/sse'
+} from "../lib/api";
+import { upsertGroupSummary } from "../lib/upstreamAccountGroups";
+import {
+  UPSTREAM_ACCOUNTS_CHANGED_EVENT,
+  emitUpstreamAccountsChanged,
+} from "../lib/upstreamAccountsEvents";
+import { isUpstreamAccountNotFoundError } from "../lib/upstreamAccountErrors";
+import { subscribeToSseOpen } from "../lib/sse";
 
-const LOAD_LIST_FAILED = Symbol('load-list-failed')
-const DEFAULT_FETCH_UPSTREAM_ACCOUNTS_QUERY: FetchUpstreamAccountsQuery = {}
-export const UPSTREAM_ACCOUNTS_OPEN_RESYNC_COOLDOWN_MS = 3_000
+const LOAD_LIST_FAILED = Symbol("load-list-failed");
+const DEFAULT_FETCH_UPSTREAM_ACCOUNTS_QUERY: FetchUpstreamAccountsQuery = {};
+export const UPSTREAM_ACCOUNTS_OPEN_RESYNC_COOLDOWN_MS = 3_000;
 
-export type UpstreamAccountsListFreshness = 'fresh' | 'stale' | 'missing' | 'deferred'
-export type UpstreamAccountsListLoadingState = 'idle' | 'deferred' | 'initial' | 'switching' | 'refreshing'
-export type UpstreamAccountsListStatus = 'ready' | 'loading' | 'error' | 'deferred'
+export type UpstreamAccountsListFreshness =
+  | "fresh"
+  | "stale"
+  | "missing"
+  | "deferred";
+export type UpstreamAccountsListLoadingState =
+  | "idle"
+  | "deferred"
+  | "initial"
+  | "switching"
+  | "refreshing";
+export type UpstreamAccountsListStatus =
+  | "ready"
+  | "loading"
+  | "error"
+  | "deferred";
 export type ForwardProxyCatalogKind =
-  | 'ready-empty'
-  | 'ready-with-data'
-  | 'loading'
-  | 'missing'
-  | 'deferred'
+  | "ready-empty"
+  | "ready-with-data"
+  | "loading"
+  | "missing"
+  | "deferred";
 
 type UpstreamAccountsListState = {
-  queryKey: string | null
-  dataQueryKey: string | null
-  freshness: UpstreamAccountsListFreshness
-  loadingState: UpstreamAccountsListLoadingState
-  status: UpstreamAccountsListStatus
-  hasCurrentQueryData: boolean
-  isPending: boolean
-}
+  queryKey: string | null;
+  dataQueryKey: string | null;
+  freshness: UpstreamAccountsListFreshness;
+  loadingState: UpstreamAccountsListLoadingState;
+  status: UpstreamAccountsListStatus;
+  hasCurrentQueryData: boolean;
+  isPending: boolean;
+};
 
 export type ForwardProxyCatalogState = {
-  kind: ForwardProxyCatalogKind
-  freshness: UpstreamAccountsListFreshness
-  isPending: boolean
-  hasNodes: boolean
-}
+  kind: ForwardProxyCatalogKind;
+  freshness: UpstreamAccountsListFreshness;
+  isPending: boolean;
+  hasNodes: boolean;
+};
 
 type UseUpstreamAccountsOptions = {
-  allowSelectionOutsideList?: boolean
-  fallbackToFirstItem?: boolean
-}
+  allowSelectionOutsideList?: boolean;
+  fallbackToFirstItem?: boolean;
+};
 
 const DEFAULT_OPTIONS: Required<UseUpstreamAccountsOptions> = {
   allowSelectionOutsideList: false,
   fallbackToFirstItem: true,
-}
+};
 
 interface LoadOptions {
-  silent?: boolean
+  silent?: boolean;
+  includeRecentActions?: boolean;
 }
 
 type HydratedWindowUsage = {
-  primaryActualUsage: RateWindowActualUsage | null
-  secondaryActualUsage: RateWindowActualUsage | null
-}
+  primaryActualUsage: RateWindowActualUsage | null;
+  secondaryActualUsage: RateWindowActualUsage | null;
+};
 
 function normalizeQueryStringArray(values?: string[]) {
-  if (!values || values.length === 0) return undefined
+  if (!values || values.length === 0) return undefined;
   const normalized = values
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
-    .sort()
-  return normalized.length > 0 ? normalized : undefined
+    .sort();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function normalizeQueryNumberArray(values?: number[]) {
-  if (!values || values.length === 0) return undefined
+  if (!values || values.length === 0) return undefined;
   const normalized = values
     .filter((value) => Number.isFinite(value) && value > 0)
-    .sort((left, right) => left - right)
-  return normalized.length > 0 ? normalized : undefined
+    .sort((left, right) => left - right);
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function applyWindowUsageToSummary(
   item: UpstreamAccountSummary,
   usage?: HydratedWindowUsage,
 ) {
-  if (!usage) return item
+  if (!usage) return item;
   return {
     ...item,
     primaryWindow: item.primaryWindow
@@ -146,7 +163,7 @@ function applyWindowUsageToSummary(
           actualUsage: usage.secondaryActualUsage,
         }
       : item.secondaryWindow,
-  }
+  };
 }
 
 function applyWindowUsageToRoster(
@@ -154,13 +171,17 @@ function applyWindowUsageToRoster(
   usageByAccount: Record<number, HydratedWindowUsage>,
 ) {
   if (items.length === 0 || Object.keys(usageByAccount).length === 0) {
-    return items
+    return items;
   }
-  return items.map((item) => applyWindowUsageToSummary(item, usageByAccount[item.id]))
+  return items.map((item) =>
+    applyWindowUsageToSummary(item, usageByAccount[item.id]),
+  );
 }
 
-export function buildUpstreamAccountsListQueryKey(query?: FetchUpstreamAccountsQuery | null) {
-  if (query == null) return null
+export function buildUpstreamAccountsListQueryKey(
+  query?: FetchUpstreamAccountsQuery | null,
+) {
+  if (query == null) return null;
 
   return JSON.stringify({
     groupExact: normalizeQueryStringArray(query.groupExact),
@@ -174,270 +195,332 @@ export function buildUpstreamAccountsListQueryKey(query?: FetchUpstreamAccountsQ
     pageSize: query.pageSize ?? undefined,
     includeAll: query.includeAll === true ? true : undefined,
     tagIds: normalizeQueryNumberArray(query.tagIds),
-  })
+  });
 }
 
-export function shouldTriggerUpstreamAccountsOpenResync(lastResyncAt: number, now: number, force = false) {
-  if (force) return true
-  return now - lastResyncAt >= UPSTREAM_ACCOUNTS_OPEN_RESYNC_COOLDOWN_MS
+export function shouldTriggerUpstreamAccountsOpenResync(
+  lastResyncAt: number,
+  now: number,
+  force = false,
+) {
+  if (force) return true;
+  return now - lastResyncAt >= UPSTREAM_ACCOUNTS_OPEN_RESYNC_COOLDOWN_MS;
 }
 
 export function useUpstreamAccounts(
   query: FetchUpstreamAccountsQuery | null = DEFAULT_FETCH_UPSTREAM_ACCOUNTS_QUERY,
   options?: UseUpstreamAccountsOptions,
 ) {
-  const effectiveQuery = query ?? DEFAULT_FETCH_UPSTREAM_ACCOUNTS_QUERY
-  const currentListQueryKey = useMemo(() => buildUpstreamAccountsListQueryKey(query), [query])
+  const effectiveQuery = query ?? DEFAULT_FETCH_UPSTREAM_ACCOUNTS_QUERY;
+  const currentListQueryKey = useMemo(
+    () => buildUpstreamAccountsListQueryKey(query),
+    [query],
+  );
   const resolvedOptions = {
     ...DEFAULT_OPTIONS,
     ...options,
-  }
-  const [rosterItems, setRosterItems] = useState<UpstreamAccountSummary[]>([])
-  const [windowUsageByAccount, setWindowUsageByAccount] = useState<Record<number, HydratedWindowUsage>>({})
-  const [groups, setGroups] = useState<UpstreamAccountGroupSummary[]>([])
-  const [forwardProxyNodes, setForwardProxyNodes] = useState<ForwardProxyBindingNode[] | null>(null)
-  const [hasUngroupedAccounts, setHasUngroupedAccounts] = useState(false)
-  const [writesEnabled, setWritesEnabled] = useState(true)
-  const [routing, setRouting] = useState<PoolRoutingSettings | null>(null)
-  const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(effectiveQuery.page ?? 1)
-  const [pageSize, setPageSize] = useState(effectiveQuery.pageSize ?? 20)
+  };
+  const [rosterItems, setRosterItems] = useState<UpstreamAccountSummary[]>([]);
+  const [windowUsageByAccount, setWindowUsageByAccount] = useState<
+    Record<number, HydratedWindowUsage>
+  >({});
+  const [groups, setGroups] = useState<UpstreamAccountGroupSummary[]>([]);
+  const [forwardProxyNodes, setForwardProxyNodes] = useState<
+    ForwardProxyBindingNode[] | null
+  >(null);
+  const [hasUngroupedAccounts, setHasUngroupedAccounts] = useState(false);
+  const [writesEnabled, setWritesEnabled] = useState(true);
+  const [routing, setRouting] = useState<PoolRoutingSettings | null>(null);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(effectiveQuery.page ?? 1);
+  const [pageSize, setPageSize] = useState(effectiveQuery.pageSize ?? 20);
   const [metrics, setMetrics] = useState<UpstreamAccountListMetrics>({
     total: 0,
     oauth: 0,
     apiKey: 0,
     attention: 0,
-  })
-  const [selectedId, setSelectedId] = useState<number | null>(null)
-  const [detail, setDetail] = useState<UpstreamAccountDetail | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isListPending, setIsListPending] = useState(false)
-  const [isDetailLoading, setIsDetailLoading] = useState(false)
-  const [listError, setListError] = useState<string | null>(null)
-  const [listDataQueryKey, setListDataQueryKey] = useState<string | null>(null)
-  const [isWindowUsagePending, setIsWindowUsagePending] = useState(false)
-  const [detailErrors, setDetailErrors] = useState<Record<number, string>>({})
-  const [missingDetailAccountId, setMissingDetailAccountId] = useState<number | null>(null)
-  const selectedIdRef = useRef<number | null>(null)
-  const currentListQueryKeyRef = useRef<string | null>(currentListQueryKey)
-  const listDataQueryKeyRef = useRef<string | null>(null)
-  const autoLoadQueryKeyRef = useRef<string | null>(null)
-  const rosterItemsRef = useRef<UpstreamAccountSummary[]>([])
-  const listRequestSeqRef = useRef(0)
-  const listRequestInFlightSeqRef = useRef<number | null>(null)
-  const listRequestPromiseRef = useRef<Promise<number | null | typeof LOAD_LIST_FAILED> | null>(null)
-  const listRequestQueryKeyRef = useRef<string | null>(null)
+  });
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [detail, setDetail] = useState<UpstreamAccountDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isListPending, setIsListPending] = useState(false);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [listDataQueryKey, setListDataQueryKey] = useState<string | null>(null);
+  const [isWindowUsagePending, setIsWindowUsagePending] = useState(false);
+  const [detailErrors, setDetailErrors] = useState<Record<number, string>>({});
+  const [missingDetailAccountId, setMissingDetailAccountId] = useState<
+    number | null
+  >(null);
+  const selectedIdRef = useRef<number | null>(null);
+  const detailRef = useRef<UpstreamAccountDetail | null>(null);
+  const currentListQueryKeyRef = useRef<string | null>(currentListQueryKey);
+  const listDataQueryKeyRef = useRef<string | null>(null);
+  const autoLoadQueryKeyRef = useRef<string | null>(null);
+  const rosterItemsRef = useRef<UpstreamAccountSummary[]>([]);
+  const listRequestSeqRef = useRef(0);
+  const listRequestInFlightSeqRef = useRef<number | null>(null);
+  const listRequestPromiseRef = useRef<Promise<
+    number | null | typeof LOAD_LIST_FAILED
+  > | null>(null);
+  const listRequestQueryKeyRef = useRef<string | null>(null);
   const queuedSameQueryRefreshRef = useRef<{
-    preferredId?: number | null
-    options?: { respectCurrentSelection?: boolean; selectionAnchorId?: number | null; silent?: boolean }
-  } | null>(null)
-  const detailRequestSeqRef = useRef(0)
-  const detailRequestAccountIdRef = useRef<number | null>(null)
-  const detailAbortControllerRef = useRef<AbortController | null>(null)
-  const hasHydratedRef = useRef(false)
-  const detailHydratedAccountIdsRef = useRef(new Set<number>())
-  const usageHydrationGenerationRef = useRef(0)
-  const windowUsageQueryKeyRef = useRef<string | null>(null)
-  const hydratedWindowUsageIdsRef = useRef(new Set<number>())
-  const pendingWindowUsageGenerationByIdRef = useRef(new Map<number, number>())
-  const lastRefreshAtRef = useRef(0)
-  const lastOpenResyncAtRef = useRef(0)
-  const hasSeenSseOpenRef = useRef(false)
+    preferredId?: number | null;
+    options?: {
+      respectCurrentSelection?: boolean;
+      selectionAnchorId?: number | null;
+      silent?: boolean;
+    };
+  } | null>(null);
+  const detailRequestSeqRef = useRef(0);
+  const detailRequestAccountIdRef = useRef<number | null>(null);
+  const detailAbortControllerRef = useRef<AbortController | null>(null);
+  const hasHydratedRef = useRef(false);
+  const detailHydratedAccountIdsRef = useRef(new Set<number>());
+  const detailRecentActionsHydratedAccountIdRef = useRef<number | null>(null);
+  const usageHydrationGenerationRef = useRef(0);
+  const windowUsageQueryKeyRef = useRef<string | null>(null);
+  const hydratedWindowUsageIdsRef = useRef(new Set<number>());
+  const pendingWindowUsageGenerationByIdRef = useRef(new Map<number, number>());
+  const lastRefreshAtRef = useRef(0);
+  const lastOpenResyncAtRef = useRef(0);
+  const hasSeenSseOpenRef = useRef(false);
 
   useEffect(() => {
-    currentListQueryKeyRef.current = currentListQueryKey
-  }, [currentListQueryKey])
+    currentListQueryKeyRef.current = currentListQueryKey;
+  }, [currentListQueryKey]);
 
   useEffect(() => {
-    listDataQueryKeyRef.current = listDataQueryKey
-  }, [listDataQueryKey])
+    listDataQueryKeyRef.current = listDataQueryKey;
+  }, [listDataQueryKey]);
 
   useEffect(() => {
-    rosterItemsRef.current = rosterItems
-  }, [rosterItems])
+    detailRef.current = detail;
+  }, [detail]);
+
+  useEffect(() => {
+    rosterItemsRef.current = rosterItems;
+  }, [rosterItems]);
 
   const items = useMemo(
     () => applyWindowUsageToRoster(rosterItems, windowUsageByAccount),
     [rosterItems, windowUsageByAccount],
-  )
+  );
 
   const setSelectedAccount = useCallback((accountId: number | null) => {
-    selectedIdRef.current = accountId
-    setSelectedId(accountId)
+    selectedIdRef.current = accountId;
+    setSelectedId(accountId);
     setMissingDetailAccountId((current) => {
-      if (accountId == null) return null
-      return current === accountId ? null : current
-    })
-  }, [])
+      if (accountId == null) return null;
+      return current === accountId ? null : current;
+    });
+  }, []);
 
   const clearDetailError = useCallback((accountId: number) => {
     setDetailErrors((current) => {
-      if (!(accountId in current)) return current
-      const next = { ...current }
-      delete next[accountId]
-      return next
-    })
-  }, [])
+      if (!(accountId in current)) return current;
+      const next = { ...current };
+      delete next[accountId];
+      return next;
+    });
+  }, []);
+
+  const commitDetailResponse = useCallback(
+    (response: UpstreamAccountDetail, options: LoadOptions = {}) => {
+      const current = detailRef.current;
+      const preserveRecentActions =
+        options.includeRecentActions !== true &&
+        current?.id === response.id &&
+        detailRecentActionsHydratedAccountIdRef.current === response.id;
+      const nextDetail = preserveRecentActions
+        ? { ...response, recentActions: current.recentActions }
+        : response;
+      if (options.includeRecentActions) {
+        detailRecentActionsHydratedAccountIdRef.current = response.id;
+      } else if (current?.id !== response.id) {
+        detailRecentActionsHydratedAccountIdRef.current = null;
+      }
+      setDetail(nextDetail);
+      return nextDetail;
+    },
+    [],
+  );
 
   const invalidateDetailRequest = useCallback((accountId?: number | null) => {
     if (accountId != null && detailRequestAccountIdRef.current !== accountId) {
-      return
+      return;
     }
-    detailRequestSeqRef.current += 1
-    detailRequestAccountIdRef.current = null
-    detailAbortControllerRef.current?.abort()
-    detailAbortControllerRef.current = null
-    setIsDetailLoading(false)
-  }, [])
+    detailRequestSeqRef.current += 1;
+    detailRequestAccountIdRef.current = null;
+    detailAbortControllerRef.current?.abort();
+    detailAbortControllerRef.current = null;
+    setIsDetailLoading(false);
+  }, []);
 
   const resetWindowUsageHydration = useCallback(
     (queryKey: string | null, options?: { preserveData?: boolean }) => {
-      usageHydrationGenerationRef.current += 1
-      windowUsageQueryKeyRef.current = queryKey
-      hydratedWindowUsageIdsRef.current = new Set()
-      pendingWindowUsageGenerationByIdRef.current = new Map()
-      setIsWindowUsagePending(false)
+      usageHydrationGenerationRef.current += 1;
+      windowUsageQueryKeyRef.current = queryKey;
+      hydratedWindowUsageIdsRef.current = new Set();
+      pendingWindowUsageGenerationByIdRef.current = new Map();
+      setIsWindowUsagePending(false);
       if (!options?.preserveData) {
-        setWindowUsageByAccount({})
+        setWindowUsageByAccount({});
       }
     },
     [],
-  )
+  );
 
   const invalidateListRequest = useCallback(() => {
-    autoLoadQueryKeyRef.current = null
-    listRequestSeqRef.current += 1
-    listRequestInFlightSeqRef.current = null
-    listRequestPromiseRef.current = null
-    listRequestQueryKeyRef.current = null
-    queuedSameQueryRefreshRef.current = null
+    autoLoadQueryKeyRef.current = null;
+    listRequestSeqRef.current += 1;
+    listRequestInFlightSeqRef.current = null;
+    listRequestPromiseRef.current = null;
+    listRequestQueryKeyRef.current = null;
+    queuedSameQueryRefreshRef.current = null;
     resetWindowUsageHydration(currentListQueryKeyRef.current, {
       preserveData: true,
-    })
-    setIsListPending(false)
-    setIsLoading(false)
-  }, [resetWindowUsageHydration])
+    });
+    setIsListPending(false);
+    setIsLoading(false);
+  }, [resetWindowUsageHydration]);
 
   const loadList = useCallback(
     async (
       preferredId?: number | null,
-      options?: { respectCurrentSelection?: boolean; selectionAnchorId?: number | null; silent?: boolean },
+      options?: {
+        respectCurrentSelection?: boolean;
+        selectionAnchorId?: number | null;
+        silent?: boolean;
+      },
     ): Promise<number | null | typeof LOAD_LIST_FAILED> => {
-      const requestQueryKey = currentListQueryKeyRef.current
+      const requestQueryKey = currentListQueryKeyRef.current;
       if (
         listRequestPromiseRef.current &&
         listRequestQueryKeyRef.current != null &&
         listRequestQueryKeyRef.current === requestQueryKey
       ) {
         const currentQueryHydrated =
-          requestQueryKey != null && listDataQueryKeyRef.current === requestQueryKey
+          requestQueryKey != null &&
+          listDataQueryKeyRef.current === requestQueryKey;
         if (currentQueryHydrated) {
-          const queued = queuedSameQueryRefreshRef.current
+          const queued = queuedSameQueryRefreshRef.current;
           queuedSameQueryRefreshRef.current = {
             preferredId,
             options: {
               respectCurrentSelection:
-                options?.respectCurrentSelection ?? queued?.options?.respectCurrentSelection,
+                options?.respectCurrentSelection ??
+                queued?.options?.respectCurrentSelection,
               selectionAnchorId:
-                options?.selectionAnchorId ?? queued?.options?.selectionAnchorId,
-              silent: (options?.silent ?? true) && (queued?.options?.silent ?? true),
+                options?.selectionAnchorId ??
+                queued?.options?.selectionAnchorId,
+              silent:
+                (options?.silent ?? true) && (queued?.options?.silent ?? true),
             },
-          }
+          };
         }
-        return listRequestPromiseRef.current
+        return listRequestPromiseRef.current;
       }
 
-      listRequestSeqRef.current += 1
-      const requestSeq = listRequestSeqRef.current
-      const shouldShowLoading = !(options?.silent && hasHydratedRef.current)
-      listRequestInFlightSeqRef.current = requestSeq
+      listRequestSeqRef.current += 1;
+      const requestSeq = listRequestSeqRef.current;
+      const shouldShowLoading = !(options?.silent && hasHydratedRef.current);
+      listRequestInFlightSeqRef.current = requestSeq;
       const requestPromise = (async () => {
-        setIsListPending(true)
-        if (shouldShowLoading) setIsLoading(true)
-        setListError(null)
+        setIsListPending(true);
+        if (shouldShowLoading) setIsLoading(true);
+        setListError(null);
         try {
-          const response = await fetchUpstreamAccounts(effectiveQuery)
+          const response = await fetchUpstreamAccounts(effectiveQuery);
           if (requestSeq !== listRequestSeqRef.current) {
-            return LOAD_LIST_FAILED
+            return LOAD_LIST_FAILED;
           }
-          const currentSelectedId = selectedIdRef.current
-          const selectionAnchorId = options?.selectionAnchorId ?? preferredId ?? null
+          const currentSelectedId = selectedIdRef.current;
+          const selectionAnchorId =
+            options?.selectionAnchorId ?? preferredId ?? null;
           const shouldPreferRequestedId =
             preferredId != null &&
-            (!options?.respectCurrentSelection || currentSelectedId === selectionAnchorId)
-          const candidateId = shouldPreferRequestedId ? preferredId : currentSelectedId
+            (!options?.respectCurrentSelection ||
+              currentSelectedId === selectionAnchorId);
+          const candidateId = shouldPreferRequestedId
+            ? preferredId
+            : currentSelectedId;
           const hasCandidateInList =
-            candidateId != null && response.items.some((item) => item.id === candidateId)
-          const nextSelectedId =
-            hasCandidateInList
+            candidateId != null &&
+            response.items.some((item) => item.id === candidateId);
+          const nextSelectedId = hasCandidateInList
+            ? candidateId
+            : candidateId != null && resolvedOptions.allowSelectionOutsideList
               ? candidateId
-              : candidateId != null && resolvedOptions.allowSelectionOutsideList
-                ? candidateId
-                : resolvedOptions.fallbackToFirstItem
-                  ? response.items[0]?.id ?? null
-                  : null
+              : resolvedOptions.fallbackToFirstItem
+                ? (response.items[0]?.id ?? null)
+                : null;
 
           const shouldPreserveWindowUsage =
             windowUsageQueryKeyRef.current != null &&
-            windowUsageQueryKeyRef.current === requestQueryKey
-          setRosterItems(response.items)
-          setGroups(response.groups)
-          setForwardProxyNodes(response.forwardProxyNodes ?? [])
-          setHasUngroupedAccounts(response.hasUngroupedAccounts)
-          setWritesEnabled(response.writesEnabled)
-          setRouting(response.routing ?? null)
-          setTotal(response.total ?? 0)
-          setPage(response.page ?? 1)
-          setPageSize(response.pageSize ?? 20)
-          setMetrics(response.metrics ?? {
-            total: 0,
-            oauth: 0,
-            apiKey: 0,
-            attention: 0,
-          })
-          lastRefreshAtRef.current = Date.now()
-          setListDataQueryKey(requestQueryKey)
-          hasHydratedRef.current = true
+            windowUsageQueryKeyRef.current === requestQueryKey;
+          setRosterItems(response.items);
+          setGroups(response.groups);
+          setForwardProxyNodes(response.forwardProxyNodes ?? []);
+          setHasUngroupedAccounts(response.hasUngroupedAccounts);
+          setWritesEnabled(response.writesEnabled);
+          setRouting(response.routing ?? null);
+          setTotal(response.total ?? 0);
+          setPage(response.page ?? 1);
+          setPageSize(response.pageSize ?? 20);
+          setMetrics(
+            response.metrics ?? {
+              total: 0,
+              oauth: 0,
+              apiKey: 0,
+              attention: 0,
+            },
+          );
+          lastRefreshAtRef.current = Date.now();
+          setListDataQueryKey(requestQueryKey);
+          hasHydratedRef.current = true;
           resetWindowUsageHydration(requestQueryKey, {
             preserveData: shouldPreserveWindowUsage,
-          })
-          setListError(null)
-          setSelectedAccount(nextSelectedId)
-          return nextSelectedId
+          });
+          setListError(null);
+          setSelectedAccount(nextSelectedId);
+          return nextSelectedId;
         } catch (err) {
           if (requestSeq !== listRequestSeqRef.current) {
-            return LOAD_LIST_FAILED
+            return LOAD_LIST_FAILED;
           }
-          setListError(err instanceof Error ? err.message : String(err))
-          return LOAD_LIST_FAILED
+          setListError(err instanceof Error ? err.message : String(err));
+          return LOAD_LIST_FAILED;
         } finally {
           const shouldReplaySameQuery =
             requestSeq === listRequestSeqRef.current &&
             requestQueryKey != null &&
             currentListQueryKeyRef.current === requestQueryKey &&
-            queuedSameQueryRefreshRef.current != null
-          const queuedRefresh = shouldReplaySameQuery ? queuedSameQueryRefreshRef.current : null
-          queuedSameQueryRefreshRef.current = null
+            queuedSameQueryRefreshRef.current != null;
+          const queuedRefresh = shouldReplaySameQuery
+            ? queuedSameQueryRefreshRef.current
+            : null;
+          queuedSameQueryRefreshRef.current = null;
           if (listRequestInFlightSeqRef.current === requestSeq) {
-            listRequestInFlightSeqRef.current = null
-            listRequestPromiseRef.current = null
-            listRequestQueryKeyRef.current = null
+            listRequestInFlightSeqRef.current = null;
+            listRequestPromiseRef.current = null;
+            listRequestQueryKeyRef.current = null;
           }
           if (requestSeq === listRequestSeqRef.current) {
-            setIsListPending(false)
+            setIsListPending(false);
             if (shouldShowLoading) {
-              setIsLoading(false)
+              setIsLoading(false);
             }
           }
           if (queuedRefresh) {
-            void loadList(queuedRefresh.preferredId, queuedRefresh.options)
+            void loadList(queuedRefresh.preferredId, queuedRefresh.options);
           }
         }
-      })()
+      })();
 
-      listRequestPromiseRef.current = requestPromise
-      listRequestQueryKeyRef.current = requestQueryKey
-      return requestPromise
+      listRequestPromiseRef.current = requestPromise;
+      listRequestQueryKeyRef.current = requestQueryKey;
+      return requestPromise;
     },
     [
       effectiveQuery,
@@ -446,106 +529,129 @@ export function useUpstreamAccounts(
       resolvedOptions.fallbackToFirstItem,
       setSelectedAccount,
     ],
-  )
+  );
 
-  const loadDetail = useCallback(async (accountId: number | null, options: LoadOptions = {}) => {
-    detailRequestSeqRef.current += 1
-    const requestSeq = detailRequestSeqRef.current
-    detailAbortControllerRef.current?.abort()
-    detailRequestAccountIdRef.current = accountId
+  const loadDetail = useCallback(
+    async (accountId: number | null, options: LoadOptions = {}) => {
+      detailRequestSeqRef.current += 1;
+      const requestSeq = detailRequestSeqRef.current;
+      detailAbortControllerRef.current?.abort();
+      detailRequestAccountIdRef.current = accountId;
 
-    if (accountId == null) {
-      setDetail(null)
-      setIsDetailLoading(false)
-      setMissingDetailAccountId(null)
-      return null
-    }
+      if (accountId == null) {
+        detailRecentActionsHydratedAccountIdRef.current = null;
+        setDetail(null);
+        setIsDetailLoading(false);
+        setMissingDetailAccountId(null);
+        return null;
+      }
 
-    setDetail((current) => (current?.id === accountId ? current : null))
-    const shouldShowLoading =
-      !(options.silent && detailHydratedAccountIdsRef.current.has(accountId))
-    if (shouldShowLoading) setIsDetailLoading(true)
-    const controller = new AbortController()
-    detailAbortControllerRef.current = controller
-    try {
-      const response = await fetchUpstreamAccountDetail(accountId, controller.signal)
-      if (requestSeq !== detailRequestSeqRef.current || selectedIdRef.current !== accountId) {
-        return null
+      if (detailRef.current?.id !== accountId) {
+        detailRecentActionsHydratedAccountIdRef.current = null;
       }
-      setDetail(response)
-      detailHydratedAccountIdsRef.current.add(accountId)
-      clearDetailError(accountId)
-      setMissingDetailAccountId((current) => (current === accountId ? null : current))
-      return response
-    } catch (err) {
-      if (controller.signal.aborted) {
-        return null
+      setDetail((current) => (current?.id === accountId ? current : null));
+      const shouldShowLoading = !(
+        options.silent && detailHydratedAccountIdsRef.current.has(accountId)
+      );
+      if (shouldShowLoading) setIsDetailLoading(true);
+      const controller = new AbortController();
+      detailAbortControllerRef.current = controller;
+      try {
+        const response = await fetchUpstreamAccountDetail(accountId, {
+          signal: controller.signal,
+          includeRecentActions: options.includeRecentActions,
+        });
+        if (
+          requestSeq !== detailRequestSeqRef.current ||
+          selectedIdRef.current !== accountId
+        ) {
+          return null;
+        }
+        const nextDetail = commitDetailResponse(response, options);
+        detailHydratedAccountIdsRef.current.add(accountId);
+        clearDetailError(accountId);
+        setMissingDetailAccountId((current) =>
+          current === accountId ? null : current,
+        );
+        return nextDetail;
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return null;
+        }
+        if (
+          requestSeq !== detailRequestSeqRef.current ||
+          selectedIdRef.current !== accountId
+        ) {
+          return null;
+        }
+        if (isUpstreamAccountNotFoundError(err)) {
+          detailRecentActionsHydratedAccountIdRef.current = null;
+          setDetail((current) => (current?.id === accountId ? null : current));
+          clearDetailError(accountId);
+          setMissingDetailAccountId(accountId);
+          return null;
+        }
+        setDetailErrors((current) => ({
+          ...current,
+          [accountId]: err instanceof Error ? err.message : String(err),
+        }));
+        return null;
+      } finally {
+        if (requestSeq === detailRequestSeqRef.current) {
+          detailRequestAccountIdRef.current = null;
+          detailAbortControllerRef.current = null;
+          if (shouldShowLoading) setIsDetailLoading(false);
+        }
       }
-      if (requestSeq !== detailRequestSeqRef.current || selectedIdRef.current !== accountId) {
-        return null
-      }
-      if (isUpstreamAccountNotFoundError(err)) {
-        setDetail((current) => (current?.id === accountId ? null : current))
-        clearDetailError(accountId)
-        setMissingDetailAccountId(accountId)
-        return null
-      }
-      setDetailErrors((current) => ({
-        ...current,
-        [accountId]: err instanceof Error ? err.message : String(err),
-      }))
-      return null
-    } finally {
-      if (requestSeq === detailRequestSeqRef.current) {
-        detailRequestAccountIdRef.current = null
-        detailAbortControllerRef.current = null
-        if (shouldShowLoading) setIsDetailLoading(false)
-      }
-    }
-  }, [clearDetailError])
+    },
+    [clearDetailError, commitDetailResponse],
+  );
 
   useEffect(() => {
     if (query == null) {
-      autoLoadQueryKeyRef.current = null
-      resetWindowUsageHydration(null)
-      setIsLoading(true)
-      setIsListPending(false)
-      setListError(null)
-      return
+      autoLoadQueryKeyRef.current = null;
+      resetWindowUsageHydration(null);
+      setIsLoading(true);
+      setIsListPending(false);
+      setListError(null);
+      return;
     }
     if (
       autoLoadQueryKeyRef.current === currentListQueryKey &&
-      (listRequestPromiseRef.current != null || listDataQueryKeyRef.current === currentListQueryKey)
+      (listRequestPromiseRef.current != null ||
+        listDataQueryKeyRef.current === currentListQueryKey)
     ) {
-      return
+      return;
     }
-    autoLoadQueryKeyRef.current = currentListQueryKey
-    void loadList()
-  }, [currentListQueryKey, loadList, query, resetWindowUsageHydration])
+    autoLoadQueryKeyRef.current = currentListQueryKey;
+    void loadList();
+  }, [currentListQueryKey, loadList, query, resetWindowUsageHydration]);
 
   useEffect(() => {
-    void loadDetail(selectedId)
-  }, [loadDetail, selectedId])
+    void loadDetail(selectedId);
+  }, [loadDetail, selectedId]);
 
   const selectedSummary = useMemo(
     () => items.find((item) => item.id === selectedId) ?? null,
     [items, selectedId],
-  )
+  );
 
   const hydrateWindowUsage = useCallback(async (accountIds: number[]) => {
-    const requestQueryKey = currentListQueryKeyRef.current
+    const requestQueryKey = currentListQueryKeyRef.current;
     if (
       requestQueryKey == null ||
       listDataQueryKeyRef.current !== requestQueryKey
     ) {
-      return
+      return;
     }
 
     const currentRosterIdSet = new Set(
       rosterItemsRef.current
-        .filter((item) => item.primaryWindow != null || item.secondaryWindow != null)
+        .filter(
+          (item) => item.primaryWindow != null || item.secondaryWindow != null,
+        )
         .map((item) => item.id),
-    )
+    );
     const normalizedAccountIds = Array.from(
       new Set(
         accountIds.filter(
@@ -559,29 +665,30 @@ export function useUpstreamAccounts(
       (accountId) =>
         !hydratedWindowUsageIdsRef.current.has(accountId) &&
         !pendingWindowUsageGenerationByIdRef.current.has(accountId),
-    )
+    );
 
     if (normalizedAccountIds.length === 0) {
-      return
+      return;
     }
 
-    const generation = usageHydrationGenerationRef.current
+    const generation = usageHydrationGenerationRef.current;
     normalizedAccountIds.forEach((accountId) => {
-      pendingWindowUsageGenerationByIdRef.current.set(accountId, generation)
-    })
-    setIsWindowUsagePending(true)
+      pendingWindowUsageGenerationByIdRef.current.set(accountId, generation);
+    });
+    setIsWindowUsagePending(true);
 
     try {
-      const response = await fetchUpstreamAccountWindowUsage(normalizedAccountIds)
+      const response =
+        await fetchUpstreamAccountWindowUsage(normalizedAccountIds);
       if (
         generation !== usageHydrationGenerationRef.current ||
         requestQueryKey !== currentListQueryKeyRef.current ||
         listDataQueryKeyRef.current !== requestQueryKey
       ) {
-        return
+        return;
       }
       if (!response || !Array.isArray(response.items)) {
-        return
+        return;
       }
 
       const usageEntries = Object.fromEntries(
@@ -592,59 +699,56 @@ export function useUpstreamAccounts(
             secondaryActualUsage: item.secondaryActualUsage ?? null,
           } satisfies HydratedWindowUsage,
         ]),
-      ) as Record<number, HydratedWindowUsage>
+      ) as Record<number, HydratedWindowUsage>;
 
       setWindowUsageByAccount((current) => {
         if (
           generation !== usageHydrationGenerationRef.current ||
           requestQueryKey !== currentListQueryKeyRef.current
         ) {
-          return current
+          return current;
         }
-        const next = { ...current }
+        const next = { ...current };
         for (const accountId of normalizedAccountIds) {
           if (usageEntries[accountId]) {
-            next[accountId] = usageEntries[accountId]
+            next[accountId] = usageEntries[accountId];
           }
         }
-        return next
-      })
+        return next;
+      });
 
       normalizedAccountIds.forEach((accountId) => {
-        hydratedWindowUsageIdsRef.current.add(accountId)
-      })
+        hydratedWindowUsageIdsRef.current.add(accountId);
+      });
     } finally {
       const isStillCurrent =
         generation === usageHydrationGenerationRef.current &&
         requestQueryKey === currentListQueryKeyRef.current &&
-        listDataQueryKeyRef.current === requestQueryKey
+        listDataQueryKeyRef.current === requestQueryKey;
       if (isStillCurrent) {
         normalizedAccountIds.forEach((accountId) => {
-          if (pendingWindowUsageGenerationByIdRef.current.get(accountId) === generation) {
-            pendingWindowUsageGenerationByIdRef.current.delete(accountId)
+          if (
+            pendingWindowUsageGenerationByIdRef.current.get(accountId) ===
+            generation
+          ) {
+            pendingWindowUsageGenerationByIdRef.current.delete(accountId);
           }
-        })
+        });
         if (pendingWindowUsageGenerationByIdRef.current.size === 0) {
-          setIsWindowUsagePending(false)
+          setIsWindowUsagePending(false);
         }
       }
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
     if (query == null || listDataQueryKey !== currentListQueryKey) {
-      return
+      return;
     }
-    const hydrationAccountIds =
-      selectedId != null
-        ? [selectedId]
-        : rosterItems
-            .filter((item) => item.primaryWindow != null || item.secondaryWindow != null)
-            .map((item) => item.id)
-    if (hydrationAccountIds.length === 0) {
-      return
+    if (selectedId == null) {
+      return;
     }
-    void hydrateWindowUsage(hydrationAccountIds)
+    void hydrateWindowUsage([selectedId]);
   }, [
     currentListQueryKey,
     hydrateWindowUsage,
@@ -652,46 +756,52 @@ export function useUpstreamAccounts(
     query,
     rosterItems,
     selectedId,
-  ])
+  ]);
 
   const refreshCurrentSelectedDetail = useCallback(
     async (skipAccountId?: number | null, options: LoadOptions = {}) => {
-      const currentSelectedId = selectedIdRef.current
+      const currentSelectedId = selectedIdRef.current;
       if (currentSelectedId == null || currentSelectedId === skipAccountId) {
-        return
+        return;
       }
-      await loadDetail(currentSelectedId, options)
+      await loadDetail(currentSelectedId, options);
     },
     [loadDetail],
-  )
+  );
 
-  const refresh = useCallback(async (options: LoadOptions = {}) => {
-    if (query == null) {
-      return
-    }
-    const currentSelectedId = selectedIdRef.current
-    const nextSelectedId = await loadList(currentSelectedId, {
-      respectCurrentSelection: true,
-      selectionAnchorId: currentSelectedId,
-      silent: options.silent,
-    })
-    if (nextSelectedId === LOAD_LIST_FAILED) {
-      return
-    }
-    if (nextSelectedId != null && nextSelectedId === selectedIdRef.current) {
-      await loadDetail(nextSelectedId, options)
-    }
-  }, [loadDetail, loadList, query])
+  const refresh = useCallback(
+    async (options: LoadOptions = {}) => {
+      if (query == null) {
+        return;
+      }
+      const currentSelectedId = selectedIdRef.current;
+      const nextSelectedId = await loadList(currentSelectedId, {
+        respectCurrentSelection: true,
+        selectionAnchorId: currentSelectedId,
+        silent: options.silent,
+      });
+      if (nextSelectedId === LOAD_LIST_FAILED) {
+        return;
+      }
+      if (nextSelectedId != null && nextSelectedId === selectedIdRef.current) {
+        await loadDetail(nextSelectedId, options);
+      }
+    },
+    [loadDetail, loadList, query],
+  );
 
   useEffect(() => {
     const handleChanged = () => {
-      void refresh()
-    }
-    window.addEventListener(UPSTREAM_ACCOUNTS_CHANGED_EVENT, handleChanged)
+      void refresh();
+    };
+    window.addEventListener(UPSTREAM_ACCOUNTS_CHANGED_EVENT, handleChanged);
     return () => {
-      window.removeEventListener(UPSTREAM_ACCOUNTS_CHANGED_EVENT, handleChanged)
-    }
-  }, [refresh])
+      window.removeEventListener(
+        UPSTREAM_ACCOUNTS_CHANGED_EVENT,
+        handleChanged,
+      );
+    };
+  }, [refresh]);
 
   const triggerOpenResync = useCallback(
     (force = false) => {
@@ -700,51 +810,65 @@ export function useUpstreamAccounts(
         currentListQueryKeyRef.current == null ||
         listDataQueryKeyRef.current !== currentListQueryKeyRef.current
       ) {
-        return
+        return;
       }
-      const now = Date.now()
-      if (!force && now - lastRefreshAtRef.current < UPSTREAM_ACCOUNTS_OPEN_RESYNC_COOLDOWN_MS) {
-        return
+      const now = Date.now();
+      if (
+        !force &&
+        now - lastRefreshAtRef.current <
+          UPSTREAM_ACCOUNTS_OPEN_RESYNC_COOLDOWN_MS
+      ) {
+        return;
       }
-      if (!shouldTriggerUpstreamAccountsOpenResync(lastOpenResyncAtRef.current, now, force)) return
-      lastOpenResyncAtRef.current = now
-      void refresh({ silent: true })
+      if (
+        !shouldTriggerUpstreamAccountsOpenResync(
+          lastOpenResyncAtRef.current,
+          now,
+          force,
+        )
+      )
+        return;
+      lastOpenResyncAtRef.current = now;
+      void refresh({ silent: true });
     },
     [refresh],
-  )
+  );
 
   useEffect(() => {
     const unsubscribe = subscribeToSseOpen(() => {
       if (!hasSeenSseOpenRef.current) {
-        hasSeenSseOpenRef.current = true
-        return
+        hasSeenSseOpenRef.current = true;
+        return;
       }
-      triggerOpenResync()
-    })
-    return unsubscribe
-  }, [triggerOpenResync])
+      triggerOpenResync();
+    });
+    return unsubscribe;
+  }, [triggerOpenResync]);
 
-  const selectAccount = useCallback((accountId: number | null) => {
-    setSelectedAccount(accountId)
-  }, [setSelectedAccount])
+  const selectAccount = useCallback(
+    (accountId: number | null) => {
+      setSelectedAccount(accountId);
+    },
+    [setSelectedAccount],
+  );
 
   const beginOauthLogin = useCallback(
     async (payload: CreateOauthLoginSessionPayload) => {
-      return createOauthLoginSession(payload)
+      return createOauthLoginSession(payload);
     },
     [],
-  )
+  );
 
-  const beginRelogin = useCallback(
-    async (accountId: number) => {
-      return reloginUpstreamAccount(accountId)
+  const beginRelogin = useCallback(async (accountId: number) => {
+    return reloginUpstreamAccount(accountId);
+  }, []);
+
+  const getLoginSession = useCallback(
+    async (loginId: string): Promise<LoginSessionStatusResponse> => {
+      return fetchOauthLoginSession(loginId);
     },
     [],
-  )
-
-  const getLoginSession = useCallback(async (loginId: string): Promise<LoginSessionStatusResponse> => {
-    return fetchOauthLoginSession(loginId)
-  }, [])
+  );
 
   const updateOauthLogin = useCallback(
     async (
@@ -752,245 +876,304 @@ export function useUpstreamAccounts(
       payload: UpdateOauthLoginSessionPayload,
       baseUpdatedAt?: string | null,
     ): Promise<LoginSessionStatusResponse> => {
-      return updateOauthLoginSession(loginId, payload, baseUpdatedAt)
+      return updateOauthLoginSession(loginId, payload, baseUpdatedAt);
     },
     [],
-  )
+  );
 
-  const beginOauthMailboxSession = useCallback(async (): Promise<OauthMailboxSession> => {
-    const response = await createOauthMailboxSession()
-    setListError(null)
-    return response
-  }, [])
+  const beginOauthMailboxSession =
+    useCallback(async (): Promise<OauthMailboxSession> => {
+      const response = await createOauthMailboxSession();
+      setListError(null);
+      return response;
+    }, []);
 
   const beginOauthMailboxSessionForAddress = useCallback(
     async (emailAddress: string): Promise<OauthMailboxSession> => {
-      const response = await createOauthMailboxSession({ emailAddress })
-      setListError(null)
-      return response
+      const response = await createOauthMailboxSession({ emailAddress });
+      setListError(null);
+      return response;
     },
     [],
-  )
+  );
 
-  const getOauthMailboxStatuses = useCallback(async (sessionIds: string[]): Promise<OauthMailboxStatus[]> => {
-    const response = await fetchOauthMailboxStatuses({ sessionIds })
-    setListError(null)
-    return response
-  }, [])
+  const getOauthMailboxStatuses = useCallback(
+    async (sessionIds: string[]): Promise<OauthMailboxStatus[]> => {
+      const response = await fetchOauthMailboxStatuses({ sessionIds });
+      setListError(null);
+      return response;
+    },
+    [],
+  );
 
   const removeOauthMailboxSession = useCallback(async (sessionId: string) => {
-    await deleteOauthMailboxSession(sessionId)
-    setListError(null)
-  }, [])
+    await deleteOauthMailboxSession(sessionId);
+    setListError(null);
+  }, []);
 
   const completeOauthLogin = useCallback(
     async (loginId: string, payload: CompleteOauthLoginSessionPayload) => {
-      const response = await completeOauthLoginSession(loginId, payload)
-      invalidateListRequest()
-      await loadList(response.id)
-      invalidateDetailRequest()
-      setDetail(response)
-      setSelectedAccount(response.id)
-      clearDetailError(response.id)
-      emitUpstreamAccountsChanged()
-      return response
+      const response = await completeOauthLoginSession(loginId, payload);
+      invalidateListRequest();
+      await loadList(response.id);
+      invalidateDetailRequest();
+      commitDetailResponse(response, { includeRecentActions: true });
+      setSelectedAccount(response.id);
+      clearDetailError(response.id);
+      emitUpstreamAccountsChanged();
+      return response;
     },
-    [clearDetailError, invalidateDetailRequest, invalidateListRequest, loadList, setSelectedAccount],
-  )
+    [
+      clearDetailError,
+      commitDetailResponse,
+      invalidateDetailRequest,
+      invalidateListRequest,
+      loadList,
+      setSelectedAccount,
+    ],
+  );
 
   const confirmOauthOverwrite = useCallback(
     async (loginId: string) => {
-      const response = await confirmOauthIdentityOverwrite(loginId)
-      invalidateListRequest()
-      await loadList(response.id)
-      invalidateDetailRequest()
-      setDetail(response)
-      setSelectedAccount(response.id)
-      clearDetailError(response.id)
-      emitUpstreamAccountsChanged()
-      return response
+      const response = await confirmOauthIdentityOverwrite(loginId);
+      invalidateListRequest();
+      await loadList(response.id);
+      invalidateDetailRequest();
+      commitDetailResponse(response, { includeRecentActions: true });
+      setSelectedAccount(response.id);
+      clearDetailError(response.id);
+      emitUpstreamAccountsChanged();
+      return response;
     },
-    [clearDetailError, invalidateDetailRequest, invalidateListRequest, loadList, setSelectedAccount],
-  )
+    [
+      clearDetailError,
+      commitDetailResponse,
+      invalidateDetailRequest,
+      invalidateListRequest,
+      loadList,
+      setSelectedAccount,
+    ],
+  );
 
   const createApiKeyAccount = useCallback(
     async (payload: CreateApiKeyAccountPayload) => {
-      const response = await createApiKeyUpstreamAccount(payload)
-      invalidateListRequest()
-      await loadList(response.id)
-      await loadDetail(response.id)
-      setSelectedAccount(response.id)
-      clearDetailError(response.id)
-      emitUpstreamAccountsChanged()
-      return response
+      const response = await createApiKeyUpstreamAccount(payload);
+      invalidateListRequest();
+      await loadList(response.id);
+      await loadDetail(response.id);
+      setSelectedAccount(response.id);
+      clearDetailError(response.id);
+      emitUpstreamAccountsChanged();
+      return response;
     },
-    [clearDetailError, invalidateListRequest, loadDetail, loadList, setSelectedAccount],
-  )
+    [
+      clearDetailError,
+      invalidateListRequest,
+      loadDetail,
+      loadList,
+      setSelectedAccount,
+    ],
+  );
 
   const runImportedOauthValidation = useCallback(
-    async (payload: ValidateImportedOauthAccountsPayload): Promise<ImportedOauthValidationResponse> => {
-      return validateImportedOauthAccounts(payload)
+    async (
+      payload: ValidateImportedOauthAccountsPayload,
+    ): Promise<ImportedOauthValidationResponse> => {
+      return validateImportedOauthAccounts(payload);
     },
     [],
-  )
+  );
 
   const startImportedOauthValidationJob = useCallback(
-    async (payload: ValidateImportedOauthAccountsPayload): Promise<ImportedOauthValidationJobResponse> => {
-      return createImportedOauthValidationJob(payload)
+    async (
+      payload: ValidateImportedOauthAccountsPayload,
+    ): Promise<ImportedOauthValidationJobResponse> => {
+      return createImportedOauthValidationJob(payload);
     },
     [],
-  )
+  );
 
   const stopImportedOauthValidationJob = useCallback(async (jobId: string) => {
-    await cancelImportedOauthValidationJob(jobId)
-  }, [])
+    await cancelImportedOauthValidationJob(jobId);
+  }, []);
 
   const importOauthAccounts = useCallback(
-    async (payload: ImportValidatedOauthAccountsPayload): Promise<ImportedOauthImportResponse> => {
-      const response = await importValidatedOauthAccounts(payload)
-      invalidateListRequest()
+    async (
+      payload: ImportValidatedOauthAccountsPayload,
+    ): Promise<ImportedOauthImportResponse> => {
+      const response = await importValidatedOauthAccounts(payload);
+      invalidateListRequest();
       await loadList(selectedIdRef.current, {
         respectCurrentSelection: true,
         selectionAnchorId: selectedIdRef.current,
-      })
-      await refreshCurrentSelectedDetail()
-      emitUpstreamAccountsChanged()
-      return response
+      });
+      await refreshCurrentSelectedDetail();
+      emitUpstreamAccountsChanged();
+      return response;
     },
     [invalidateListRequest, loadList, refreshCurrentSelectedDetail],
-  )
+  );
 
   const saveAccount = useCallback(
     async (accountId: number, payload: UpdateUpstreamAccountPayload) => {
-      const response = await updateUpstreamAccount(accountId, payload)
-      invalidateListRequest()
-      invalidateDetailRequest(accountId)
-      await loadList(accountId, { respectCurrentSelection: true, selectionAnchorId: accountId })
-      clearDetailError(accountId)
+      const response = await updateUpstreamAccount(accountId, payload);
+      invalidateListRequest();
+      invalidateDetailRequest(accountId);
+      await loadList(accountId, {
+        respectCurrentSelection: true,
+        selectionAnchorId: accountId,
+      });
+      clearDetailError(accountId);
       if (selectedIdRef.current === accountId) {
-        setDetail(response)
+        commitDetailResponse(response, { includeRecentActions: true });
       } else {
-        await refreshCurrentSelectedDetail(accountId)
+        await refreshCurrentSelectedDetail(accountId);
       }
-      emitUpstreamAccountsChanged()
-      return response
+      emitUpstreamAccountsChanged();
+      return response;
     },
-    [clearDetailError, invalidateDetailRequest, invalidateListRequest, loadList, refreshCurrentSelectedDetail],
-  )
+    [
+      clearDetailError,
+      commitDetailResponse,
+      invalidateDetailRequest,
+      invalidateListRequest,
+      loadList,
+      refreshCurrentSelectedDetail,
+    ],
+  );
 
-  const saveRouting = useCallback(async (payload: UpdatePoolRoutingSettingsPayload) => {
-    const response = await updatePoolRoutingSettings(payload)
-    setRouting(response)
-    return response
-  }, [])
+  const saveRouting = useCallback(
+    async (payload: UpdatePoolRoutingSettingsPayload) => {
+      const response = await updatePoolRoutingSettings(payload);
+      setRouting(response);
+      return response;
+    },
+    [],
+  );
 
   const saveGroupNote = useCallback(
     async (groupName: string, payload: UpdateUpstreamAccountGroupPayload) => {
-      const response = await updateUpstreamAccountGroup(groupName, payload)
-      setGroups((current) => upsertGroupSummary(current, response))
-      invalidateListRequest()
+      const response = await updateUpstreamAccountGroup(groupName, payload);
+      setGroups((current) => upsertGroupSummary(current, response));
+      invalidateListRequest();
       await loadList(selectedIdRef.current, {
         respectCurrentSelection: true,
         selectionAnchorId: selectedIdRef.current,
-      })
-      await refreshCurrentSelectedDetail()
-      emitUpstreamAccountsChanged()
-      return response
+      });
+      await refreshCurrentSelectedDetail();
+      emitUpstreamAccountsChanged();
+      return response;
     },
     [invalidateListRequest, loadList, refreshCurrentSelectedDetail],
-  )
+  );
 
   const deleteGroupNote = useCallback(
     async (groupName: string) => {
-      await deleteUpstreamAccountGroup(groupName)
+      await deleteUpstreamAccountGroup(groupName);
       setGroups((current) =>
         current.filter((group) => group.groupName.trim() !== groupName.trim()),
-      )
-      invalidateListRequest()
+      );
+      invalidateListRequest();
       await loadList(selectedIdRef.current, {
         respectCurrentSelection: true,
         selectionAnchorId: selectedIdRef.current,
-      })
-      await refreshCurrentSelectedDetail()
-      emitUpstreamAccountsChanged()
+      });
+      await refreshCurrentSelectedDetail();
+      emitUpstreamAccountsChanged();
     },
     [invalidateListRequest, loadList, refreshCurrentSelectedDetail],
-  )
+  );
 
   const runBulkAction = useCallback(
-    async (payload: BulkUpstreamAccountActionPayload): Promise<BulkUpstreamAccountActionResponse> => {
-      const response = await bulkUpdateUpstreamAccounts(payload)
-      invalidateListRequest()
+    async (
+      payload: BulkUpstreamAccountActionPayload,
+    ): Promise<BulkUpstreamAccountActionResponse> => {
+      const response = await bulkUpdateUpstreamAccounts(payload);
+      invalidateListRequest();
       await loadList(selectedIdRef.current, {
         respectCurrentSelection: true,
         selectionAnchorId: selectedIdRef.current,
-      })
-      await refreshCurrentSelectedDetail()
-      emitUpstreamAccountsChanged()
-      return response
+      });
+      await refreshCurrentSelectedDetail();
+      emitUpstreamAccountsChanged();
+      return response;
     },
     [invalidateListRequest, loadList, refreshCurrentSelectedDetail],
-  )
+  );
 
   const startBulkSyncJob = useCallback(
-    async (payload: BulkUpstreamAccountSyncJobPayload): Promise<BulkUpstreamAccountSyncJobResponse> => {
-      return createBulkUpstreamAccountSyncJob(payload)
+    async (
+      payload: BulkUpstreamAccountSyncJobPayload,
+    ): Promise<BulkUpstreamAccountSyncJobResponse> => {
+      return createBulkUpstreamAccountSyncJob(payload);
     },
     [],
-  )
+  );
 
   const getBulkSyncJob = useCallback(
     async (jobId: string): Promise<BulkUpstreamAccountSyncJobResponse> => {
-      return fetchBulkUpstreamAccountSyncJob(jobId)
+      return fetchBulkUpstreamAccountSyncJob(jobId);
     },
     [],
-  )
+  );
 
   const stopBulkSyncJob = useCallback(async (jobId: string) => {
-    await cancelBulkUpstreamAccountSyncJob(jobId)
-  }, [])
+    await cancelBulkUpstreamAccountSyncJob(jobId);
+  }, []);
 
   const runSync = useCallback(
     async (accountId: number) => {
-      const response = await syncUpstreamAccount(accountId)
-      invalidateListRequest()
-      invalidateDetailRequest(accountId)
-      await loadList(accountId, { respectCurrentSelection: true, selectionAnchorId: accountId })
-      clearDetailError(accountId)
+      const response = await syncUpstreamAccount(accountId);
+      invalidateListRequest();
+      invalidateDetailRequest(accountId);
+      await loadList(accountId, {
+        respectCurrentSelection: true,
+        selectionAnchorId: accountId,
+      });
+      clearDetailError(accountId);
       if (selectedIdRef.current === accountId) {
-        setDetail(response)
+        commitDetailResponse(response, { includeRecentActions: true });
       } else {
-        await refreshCurrentSelectedDetail(accountId)
+        await refreshCurrentSelectedDetail(accountId);
       }
-      emitUpstreamAccountsChanged()
-      return response
+      emitUpstreamAccountsChanged();
+      return response;
     },
-    [clearDetailError, invalidateDetailRequest, invalidateListRequest, loadList, refreshCurrentSelectedDetail],
-  )
+    [
+      clearDetailError,
+      commitDetailResponse,
+      invalidateDetailRequest,
+      invalidateListRequest,
+      loadList,
+      refreshCurrentSelectedDetail,
+    ],
+  );
 
   const removeAccount = useCallback(
     async (accountId: number) => {
-      await deleteUpstreamAccount(accountId)
-      const currentSelectedId = selectedIdRef.current
-      const shouldReanchorSelection = currentSelectedId === accountId
+      await deleteUpstreamAccount(accountId);
+      const currentSelectedId = selectedIdRef.current;
+      const shouldReanchorSelection = currentSelectedId === accountId;
       const fallbackSelectedId =
         shouldReanchorSelection && resolvedOptions.fallbackToFirstItem
-          ? items.find((item) => item.id !== accountId)?.id ?? null
-          : null
-      invalidateListRequest()
+          ? (items.find((item) => item.id !== accountId)?.id ?? null)
+          : null;
+      invalidateListRequest();
       if (shouldReanchorSelection) {
-        invalidateDetailRequest(accountId)
-        setSelectedAccount(fallbackSelectedId)
-        setDetail((current) => (current?.id === accountId ? null : current))
+        invalidateDetailRequest(accountId);
+        setSelectedAccount(fallbackSelectedId);
+        setDetail((current) => (current?.id === accountId ? null : current));
       }
-      const preferredId = shouldReanchorSelection ? fallbackSelectedId : currentSelectedId
+      const preferredId = shouldReanchorSelection
+        ? fallbackSelectedId
+        : currentSelectedId;
       await loadList(preferredId, {
         respectCurrentSelection: !shouldReanchorSelection,
         selectionAnchorId: preferredId,
-      })
-      clearDetailError(accountId)
-      await refreshCurrentSelectedDetail(accountId)
-      emitUpstreamAccountsChanged()
+      });
+      clearDetailError(accountId);
+      await refreshCurrentSelectedDetail(accountId);
+      emitUpstreamAccountsChanged();
     },
     [
       clearDetailError,
@@ -1002,57 +1185,61 @@ export function useUpstreamAccounts(
       resolvedOptions.fallbackToFirstItem,
       setSelectedAccount,
     ],
-  )
+  );
 
   useEffect(
     () => () => {
-      listRequestSeqRef.current += 1
-      listRequestInFlightSeqRef.current = null
-      listRequestPromiseRef.current = null
-      listRequestQueryKeyRef.current = null
-      queuedSameQueryRefreshRef.current = null
-      detailRequestSeqRef.current += 1
-      detailRequestAccountIdRef.current = null
-      detailAbortControllerRef.current?.abort()
-      detailAbortControllerRef.current = null
-      usageHydrationGenerationRef.current += 1
-      hydratedWindowUsageIdsRef.current = new Set()
-      pendingWindowUsageGenerationByIdRef.current = new Map()
-      hasSeenSseOpenRef.current = false
-      autoLoadQueryKeyRef.current = null
+      listRequestSeqRef.current += 1;
+      listRequestInFlightSeqRef.current = null;
+      listRequestPromiseRef.current = null;
+      listRequestQueryKeyRef.current = null;
+      queuedSameQueryRefreshRef.current = null;
+      detailRequestSeqRef.current += 1;
+      detailRequestAccountIdRef.current = null;
+      detailAbortControllerRef.current?.abort();
+      detailAbortControllerRef.current = null;
+      usageHydrationGenerationRef.current += 1;
+      hydratedWindowUsageIdsRef.current = new Set();
+      pendingWindowUsageGenerationByIdRef.current = new Map();
+      hasSeenSseOpenRef.current = false;
+      autoLoadQueryKeyRef.current = null;
     },
     [],
-  )
+  );
 
-  const selectedDetailError = selectedId == null ? null : detailErrors[selectedId] ?? null
+  const selectedDetailError =
+    selectedId == null ? null : (detailErrors[selectedId] ?? null);
+  const isDetailRecentActionsHydrated =
+    detail != null &&
+    detailRecentActionsHydratedAccountIdRef.current === detail.id;
   const hasCurrentQueryData =
-    currentListQueryKey != null && listDataQueryKey === currentListQueryKey
+    currentListQueryKey != null && listDataQueryKey === currentListQueryKey;
   const listFreshness: UpstreamAccountsListFreshness =
     query == null
-      ? 'deferred'
+      ? "deferred"
       : hasCurrentQueryData
-        ? 'fresh'
+        ? "fresh"
         : listDataQueryKey != null
-          ? 'stale'
-          : 'missing'
+          ? "stale"
+          : "missing";
   const listLoadingState: UpstreamAccountsListLoadingState =
     query == null
-      ? 'deferred'
+      ? "deferred"
       : isListPending
         ? hasCurrentQueryData
-          ? 'refreshing'
+          ? "refreshing"
           : listDataQueryKey != null
-            ? 'switching'
-            : 'initial'
-        : 'idle'
+            ? "switching"
+            : "initial"
+        : "idle";
   const listStatus: UpstreamAccountsListStatus =
     query == null
-      ? 'deferred'
+      ? "deferred"
       : isListPending
-        ? 'loading'
+        ? "loading"
         : listError != null && !hasCurrentQueryData
-          ? 'error'
-          : 'ready'
+          ? "error"
+          : "ready";
   const listState: UpstreamAccountsListState = {
     queryKey: currentListQueryKey,
     dataQueryKey: listDataQueryKey,
@@ -1061,40 +1248,40 @@ export function useUpstreamAccounts(
     status: listStatus,
     hasCurrentQueryData,
     isPending: isListPending,
-  }
+  };
   const forwardProxyCatalogWaitingOnRefresh =
     query != null &&
     Array.isArray(forwardProxyNodes) &&
     forwardProxyNodes.length === 0 &&
-    isListPending
+    isListPending;
   const forwardProxyCatalogKind: ForwardProxyCatalogKind =
     query == null
-      ? 'deferred'
+      ? "deferred"
       : forwardProxyNodes == null
         ? isListPending || isLoading
-          ? 'loading'
-          : 'missing'
+          ? "loading"
+          : "missing"
         : forwardProxyCatalogWaitingOnRefresh
-          ? 'loading'
+          ? "loading"
           : forwardProxyNodes.length > 0
-            ? 'ready-with-data'
-            : 'ready-empty'
-  const forwardProxyCatalogFreshness: ForwardProxyCatalogState['freshness'] =
+            ? "ready-with-data"
+            : "ready-empty";
+  const forwardProxyCatalogFreshness: ForwardProxyCatalogState["freshness"] =
     query == null
-      ? 'deferred'
+      ? "deferred"
       : forwardProxyNodes == null
-        ? 'missing'
+        ? "missing"
         : listError != null
-          ? 'stale'
-        : forwardProxyCatalogWaitingOnRefresh
-          ? 'stale'
-          : listFreshness
+          ? "stale"
+          : forwardProxyCatalogWaitingOnRefresh
+            ? "stale"
+            : listFreshness;
   const forwardProxyCatalogState: ForwardProxyCatalogState = {
     kind: forwardProxyCatalogKind,
     freshness: forwardProxyCatalogFreshness,
     isPending: isListPending,
     hasNodes: Array.isArray(forwardProxyNodes) && forwardProxyNodes.length > 0,
-  }
+  };
 
   return {
     items,
@@ -1115,6 +1302,7 @@ export function useUpstreamAccounts(
     detailError: selectedDetailError,
     error: selectedDetailError ?? listError,
     missingDetailAccountId,
+    isDetailRecentActionsHydrated,
     selectAccount,
     refresh,
     hydrateWindowUsage,
@@ -1148,5 +1336,5 @@ export function useUpstreamAccounts(
     page,
     pageSize,
     metrics,
-  }
+  };
 }

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -340,7 +340,10 @@ describe("forward proxy manual latency API", () => {
       }
       close() {}
     }
-    vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
+    vi.stubGlobal(
+      "EventSource",
+      MockEventSource as unknown as typeof EventSource,
+    );
 
     createForwardProxyNodesLatencyTestEventSource(["node-a", "node-b"]);
     const url = new URL(MockEventSource.latestUrl, "http://localhost");
@@ -1344,14 +1347,12 @@ describe("settings normalization", () => {
     });
     vi.stubGlobal("fetch", fetchMock as typeof fetch);
 
-    const response = await fetchForwardProxyBindingNodes([
-      "fpb_jp_edge_01",
-      " ",
-      "fpb_sg_edge_02",
-      "fpb_jp_edge_01",
-    ], {
-      includeCurrent: true,
-    });
+    const response = await fetchForwardProxyBindingNodes(
+      ["fpb_jp_edge_01", " ", "fpb_sg_edge_02", "fpb_jp_edge_01"],
+      {
+        includeCurrent: true,
+      },
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response).toHaveLength(1);
@@ -1640,9 +1641,11 @@ describe("account pool frontend API helpers", () => {
   });
 
   it("normalizes active conversation counts from upstream account detail payloads", async () => {
+    let requestedUrl = "";
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => {
+      vi.fn(async (input: RequestInfo | URL) => {
+        requestedUrl = String(input);
         return new Response(
           JSON.stringify({
             id: 9,
@@ -1663,6 +1666,38 @@ describe("account pool frontend API helpers", () => {
     const response = await fetchUpstreamAccountDetail(9);
 
     expect(response.activeConversationCount).toBe(2);
+    expect(requestedUrl).toContain("/api/pool/upstream-accounts/9");
+    expect(requestedUrl).not.toContain("includeRecentActions");
+  });
+
+  it("adds includeRecentActions when requested for upstream account detail", async () => {
+    let requestedUrl = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        requestedUrl = String(input);
+        return new Response(
+          JSON.stringify({
+            id: 9,
+            kind: "oauth_codex",
+            provider: "codex",
+            displayName: "Detail OAuth",
+            isMother: false,
+            status: "active",
+            enabled: true,
+            history: [],
+            recentActions: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as typeof fetch,
+    );
+
+    await fetchUpstreamAccountDetail(9, { includeRecentActions: true });
+
+    expect(requestedUrl).toContain(
+      "/api/pool/upstream-accounts/9?includeRecentActions=1",
+    );
   });
 
   it("normalizes tag fast mode values from upstream account roster payloads", async () => {
@@ -1861,42 +1896,46 @@ describe("account pool frontend API helpers", () => {
   });
 
   it("serializes window-usage batch requests and normalizes the response", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toContain("/api/pool/upstream-accounts/window-usage");
-      expect(init?.method).toBe("POST");
-      expect(init?.body).toBe(JSON.stringify({ accountIds: [3, 7] }));
-      return new Response(
-        JSON.stringify({
-          items: [
-            {
-              accountId: 3,
-              primaryActualUsage: {
-                requestCount: 11,
-                totalTokens: 64120,
-                totalCost: 0.6123,
-                inputTokens: 38200,
-                outputTokens: 21120,
-                cacheInputTokens: 4800,
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toContain(
+          "/api/pool/upstream-accounts/window-usage",
+        );
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(JSON.stringify({ accountIds: [3, 7] }));
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                accountId: 3,
+                primaryActualUsage: {
+                  requestCount: 11,
+                  totalTokens: 64120,
+                  totalCost: 0.6123,
+                  inputTokens: 38200,
+                  outputTokens: 21120,
+                  cacheInputTokens: 4800,
+                },
+                secondaryActualUsage: null,
               },
-              secondaryActualUsage: null,
-            },
-            {
-              accountId: 7,
-              primaryActualUsage: null,
-              secondaryActualUsage: {
-                requestCount: 52,
-                totalTokens: 201440,
-                totalCost: 1.8821,
-                inputTokens: 110200,
-                outputTokens: 78240,
-                cacheInputTokens: 13000,
+              {
+                accountId: 7,
+                primaryActualUsage: null,
+                secondaryActualUsage: {
+                  requestCount: 52,
+                  totalTokens: 201440,
+                  totalCost: 1.8821,
+                  inputTokens: 110200,
+                  outputTokens: 78240,
+                  cacheInputTokens: 13000,
+                },
               },
-            },
-          ],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    });
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    );
     vi.stubGlobal("fetch", fetchMock as typeof fetch);
 
     const response = await fetchUpstreamAccountWindowUsage([3, 7]);
@@ -2431,8 +2470,7 @@ describe("account pool frontend API helpers", () => {
       "/v1/responses",
     );
     expect(
-      response.conversations[0]?.recentInvocations[0]
-        ?.upstreamAccountPlanType,
+      response.conversations[0]?.recentInvocations[0]?.upstreamAccountPlanType,
     ).toBe("enterprise");
     expect(response.conversations[0]?.recentInvocations[0]?.source).toBe(
       "proxy",
@@ -2534,55 +2572,60 @@ describe("account pool frontend API helpers", () => {
   });
 
   it("reads and updates prompt-cache conversation bindings by encoded key", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      expect(url).toContain(
-        "/api/stats/prompt-cache-conversation-bindings/pck%2Fwith%20space",
-      );
-      if (init?.method === "PATCH") {
-        expect(JSON.parse(String(init.body))).toEqual({
-          bindingKind: "upstreamAccount",
-          upstreamAccountId: 42,
-        });
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        expect(url).toContain(
+          "/api/stats/prompt-cache-conversation-bindings/pck%2Fwith%20space",
+        );
+        if (init?.method === "PATCH") {
+          expect(JSON.parse(String(init.body))).toEqual({
+            bindingKind: "upstreamAccount",
+            upstreamAccountId: 42,
+          });
+          return new Response(
+            JSON.stringify({
+              promptCacheKey: "pck/with space",
+              bindingKind: "upstreamAccount",
+              groupName: null,
+              upstreamAccountId: 42,
+              upstreamAccountName: "Pool Alpha",
+              hasEncryptedSessionOwner: true,
+              encryptedOwnerAccountId: 17,
+              encryptedOwnerAccountName: "Owner One",
+              encryptedOwnerGroupName: "prod",
+              updatedAt: "2026-03-10T23:59:00Z",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
         return new Response(
           JSON.stringify({
             promptCacheKey: "pck/with space",
-            bindingKind: "upstreamAccount",
+            bindingKind: "none",
             groupName: null,
-            upstreamAccountId: 42,
-            upstreamAccountName: "Pool Alpha",
-            hasEncryptedSessionOwner: true,
-            encryptedOwnerAccountId: 17,
-            encryptedOwnerAccountName: "Owner One",
-            encryptedOwnerGroupName: "prod",
-            updatedAt: "2026-03-10T23:59:00Z",
+            upstreamAccountId: null,
+            upstreamAccountName: null,
+            hasEncryptedSessionOwner: false,
+            encryptedOwnerAccountId: null,
+            encryptedOwnerAccountName: null,
+            encryptedOwnerGroupName: null,
+            updatedAt: null,
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         );
-      }
-      return new Response(
-        JSON.stringify({
-          promptCacheKey: "pck/with space",
-          bindingKind: "none",
-          groupName: null,
-          upstreamAccountId: null,
-          upstreamAccountName: null,
-          hasEncryptedSessionOwner: false,
-          encryptedOwnerAccountId: null,
-          encryptedOwnerAccountName: null,
-          encryptedOwnerGroupName: null,
-          updatedAt: null,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    });
+      },
+    );
     vi.stubGlobal("fetch", fetchMock as typeof fetch);
 
     const initial = await fetchPromptCacheConversationBinding("pck/with space");
-    const updated = await updatePromptCacheConversationBinding("pck/with space", {
-      bindingKind: "upstreamAccount",
-      upstreamAccountId: 42,
-    });
+    const updated = await updatePromptCacheConversationBinding(
+      "pck/with space",
+      {
+        bindingKind: "upstreamAccount",
+        upstreamAccountId: 42,
+      },
+    );
 
     expect(initial.bindingKind).toBe("none");
     expect(initial.hasEncryptedSessionOwner).toBe(false);

--- a/web/src/lib/api/core-upstream.ts
+++ b/web/src/lib/api/core-upstream.ts
@@ -92,7 +92,12 @@ export interface TagRoutingRule {
   availableModels?: string[];
 }
 
-export type EffectiveRoutingRuleSource = "root" | "group" | "tag" | "account" | string;
+export type EffectiveRoutingRuleSource =
+  | "root"
+  | "group"
+  | "tag"
+  | "account"
+  | string;
 
 export interface GroupAccountRoutingRule extends TagRoutingRule {
   imageToolRewriteMode?: ImageToolRewriteMode;
@@ -436,7 +441,13 @@ export interface BulkUpstreamAccountSyncFailedEventPayload {
 
 export interface LoginSessionStatusResponse {
   loginId: string;
-  status: "pending" | "completed" | "failed" | "expired" | "needs_identity_confirmation" | string;
+  status:
+    | "pending"
+    | "completed"
+    | "failed"
+    | "expired"
+    | "needs_identity_confirmation"
+    | string;
   authUrl?: string | null;
   redirectUri?: string | null;
   expiresAt: string;
@@ -754,7 +765,8 @@ export interface UpdateUpstreamAccountGroupPayload {
   routingRule?: UpdateGroupAccountRoutingRulePayload;
 }
 
-export type UpdateGroupAccountRoutingRulePayload = Partial<GroupAccountRoutingRule>;
+export type UpdateGroupAccountRoutingRulePayload =
+  Partial<GroupAccountRoutingRule>;
 
 function normalizeRateWindowActualUsage(
   raw: unknown,
@@ -869,19 +881,13 @@ function normalizeTagRoutingRule(raw: unknown): TagRoutingRule {
   };
 }
 
-function normalizeImageToolRewriteMode(
-  raw: unknown,
-): ImageToolRewriteMode {
-  return raw === "fill_missing" ||
-    raw === "force_add" ||
-    raw === "force_remove"
+function normalizeImageToolRewriteMode(raw: unknown): ImageToolRewriteMode {
+  return raw === "fill_missing" || raw === "force_add" || raw === "force_remove"
     ? raw
     : "keep_original";
 }
 
-function normalizeImageToolCapability(
-  raw: unknown,
-): ImageToolCapability {
+function normalizeImageToolCapability(raw: unknown): ImageToolCapability {
   return raw === "supported" || raw === "unsupported" ? raw : "unknown";
 }
 
@@ -1381,9 +1387,7 @@ function normalizeUpstreamAccountWindowUsageResponse(
         };
         return normalized;
       })
-      .filter(
-        (item): item is UpstreamAccountWindowUsageItem => item != null,
-      ),
+      .filter((item): item is UpstreamAccountWindowUsageItem => item != null),
   };
 }
 
@@ -1921,7 +1925,6 @@ function normalizeOauthMailboxStatus(raw: unknown): OauthMailboxStatus | null {
   };
 }
 
-
 export async function fetchUpstreamAccounts(
   query?: FetchUpstreamAccountsQuery,
 ): Promise<UpstreamAccountListResponse> {
@@ -1944,7 +1947,8 @@ export async function fetchUpstreamAccounts(
   }
   if (query?.page != null) search.set("page", String(query.page));
   if (query?.pageSize != null) search.set("pageSize", String(query.pageSize));
-  if (query?.includeAll != null) search.set("includeAll", String(query.includeAll));
+  if (query?.includeAll != null)
+    search.set("includeAll", String(query.includeAll));
   for (const tagId of query?.tagIds ?? []) {
     search.append("tagIds", String(tagId));
   }
@@ -1987,12 +1991,15 @@ export async function fetchUpstreamAccountWindowUsage(
   if (normalizedAccountIds.length === 0) {
     return { items: [] };
   }
-  const response = await fetchJson<unknown>("/api/pool/upstream-accounts/window-usage", {
-    method: "POST",
-    body: JSON.stringify({
-      accountIds: normalizedAccountIds,
-    }),
-  });
+  const response = await fetchJson<unknown>(
+    "/api/pool/upstream-accounts/window-usage",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        accountIds: normalizedAccountIds,
+      }),
+    },
+  );
   return normalizeUpstreamAccountWindowUsageResponse(response);
 }
 
@@ -2106,12 +2113,27 @@ export async function fetchUpstreamStickyConversations(
 
 export async function fetchUpstreamAccountDetail(
   accountId: number,
-  signal?: AbortSignal,
+  options:
+    | { signal?: AbortSignal; includeRecentActions?: boolean }
+    | AbortSignal = {},
 ): Promise<UpstreamAccountDetail> {
+  type DetailOptions = { signal?: AbortSignal; includeRecentActions?: boolean };
+  let detailOptions: DetailOptions;
+  if (typeof AbortSignal !== "undefined" && options instanceof AbortSignal) {
+    detailOptions = { signal: options };
+  } else {
+    detailOptions = options as DetailOptions;
+  }
+  const search = new URLSearchParams();
+  if (detailOptions.includeRecentActions) {
+    search.set("includeRecentActions", "1");
+  }
   const response = await fetchJson<unknown>(
-    `/api/pool/upstream-accounts/${accountId}`,
+    search.size > 0
+      ? `/api/pool/upstream-accounts/${accountId}?${search.toString()}`
+      : `/api/pool/upstream-accounts/${accountId}`,
     {
-      signal,
+      signal: detailOptions.signal,
     },
   );
   return normalizeUpstreamAccountDetail(response);

--- a/web/src/pages/account-pool/UpstreamAccounts.page-local-shared.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.page-local-shared.tsx
@@ -106,9 +106,7 @@ import {
   type RoutingDraft,
   type UpstreamAccountsLocationState,
 } from "./UpstreamAccounts.shared-types";
-import {
-  UPSTREAM_ACCOUNTS_QUERY_STALE_GRACE_MS,
-} from "./UpstreamAccounts.shared-types";
+import { UPSTREAM_ACCOUNTS_QUERY_STALE_GRACE_MS } from "./UpstreamAccounts.shared-types";
 import {
   DEFAULT_UPSTREAM_ACCOUNT_GROUP_NAME,
   formatGroupFilterValue,
@@ -506,13 +504,7 @@ function AccountDetailSkeleton() {
   );
 }
 
-function DetailField({
-  label,
-  value,
-}: {
-  label: string;
-  value: ReactNode;
-}) {
+function DetailField({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="metric-cell">
       <p className="metric-label">{label}</p>
@@ -846,7 +838,9 @@ function SharedUpstreamAccountDetailDrawerInner({
     detail,
     isDetailLoading,
     detailError = null,
+    isDetailRecentActionsHydrated,
     selectAccount,
+    loadDetail,
     saveAccount,
     runSync,
     removeAccount,
@@ -870,8 +864,7 @@ function SharedUpstreamAccountDetailDrawerInner({
     accountActions: new Set(),
   }));
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [accountPolicyEditorOpen, setAccountPolicyEditorOpen] =
-    useState(false);
+  const [accountPolicyEditorOpen, setAccountPolicyEditorOpen] = useState(false);
   const [pageCreatedTagIds, setPageCreatedTagIds] = useState<number[]>([]);
   const [
     stickyConversationSelectionValue,
@@ -954,19 +947,13 @@ function SharedUpstreamAccountDetailDrawerInner({
     draftSessionSnapshotRef.current.open !== open ||
     draftSessionSnapshotRef.current.accountId !== accountId
   ) {
-    const closedActiveSession =
-      draftSessionSnapshotRef.current.open && !open;
-    const openedVisibleSession =
-      !draftSessionSnapshotRef.current.open && open;
+    const closedActiveSession = draftSessionSnapshotRef.current.open && !open;
+    const openedVisibleSession = !draftSessionSnapshotRef.current.open && open;
     const switchedVisibleAccount =
       draftSessionSnapshotRef.current.open &&
       open &&
       draftSessionSnapshotRef.current.accountId !== accountId;
-    if (
-      closedActiveSession ||
-      openedVisibleSession ||
-      switchedVisibleAccount
-    ) {
+    if (closedActiveSession || openedVisibleSession || switchedVisibleAccount) {
       draftSessionVersion += 1;
     }
     draftSessionSnapshotRef.current = {
@@ -1123,11 +1110,7 @@ function SharedUpstreamAccountDetailDrawerInner({
         current,
         previousLatestServerDraft,
       );
-      if (
-        shouldSeedDraft ||
-        matchesSeedBaseline ||
-        matchesLatestServerDraft
-      ) {
+      if (shouldSeedDraft || matchesSeedBaseline || matchesLatestServerDraft) {
         draftBaselineRef.current = nextBaseline;
         return nextBaseline;
       }
@@ -1376,7 +1359,9 @@ function SharedUpstreamAccountDetailDrawerInner({
       if (existingGroup) {
         return existingGroup.singleAccountRotationEnabled === true;
       }
-      return groupDraftSingleAccountRotationEnabled[normalizedGroupName] === true;
+      return (
+        groupDraftSingleAccountRotationEnabled[normalizedGroupName] === true
+      );
     },
     [groupDraftSingleAccountRotationEnabled, resolveGroupSummaryForName],
   );
@@ -1483,104 +1468,103 @@ function SharedUpstreamAccountDetailDrawerInner({
     });
   }, []);
 
-  const {
-    openEditor: openGroupNoteEditor,
-    dialog: groupNoteDialog,
-  } = useUpstreamAccountGroupSettingsDialog({
-    writesEnabled,
-    container: detailDrawerPortalContainer,
-    resolveGroupState: useCallback(
-      (groupName) => {
-        const normalized = normalizeGroupName(groupName);
-        if (!normalized) return null;
-        const existingGroup = resolveGroupSummaryForName(normalized);
-        return {
-          groupName: normalized,
-          note: resolveGroupNoteForName(normalized),
-          existing: existingGroup != null,
-          accountCount: existingGroup?.accountCount ?? 0,
-          concurrencyLimit: resolveGroupConcurrencyLimitForName(normalized),
-          boundProxyKeys: resolveGroupBoundProxyKeysForName(normalized),
-          nodeShuntEnabled: resolveGroupNodeShuntEnabledForName(normalized),
-          singleAccountRotationEnabled:
-            resolveGroupSingleAccountRotationEnabledForName(normalized),
-          upstream429RetryEnabled:
-            resolveGroupUpstream429RetryEnabledForName(normalized),
-          upstream429MaxRetries:
-            resolveGroupUpstream429MaxRetriesForName(normalized),
-          routingRule: existingGroup?.routingRule,
-        };
-      },
-      [
-        resolveGroupBoundProxyKeysForName,
-        resolveGroupConcurrencyLimitForName,
-        resolveGroupNodeShuntEnabledForName,
-        resolveGroupSingleAccountRotationEnabledForName,
-        resolveGroupNoteForName,
-        resolveGroupSummaryForName,
-        resolveGroupUpstream429MaxRetriesForName,
-        resolveGroupUpstream429RetryEnabledForName,
-      ],
-    ),
-    saveGroupSettings: useCallback(
-      async (groupName, payload) => {
-        const normalizedGroupName = normalizeGroupName(groupName);
-        if (!normalizedGroupName) return;
+  const { openEditor: openGroupNoteEditor, dialog: groupNoteDialog } =
+    useUpstreamAccountGroupSettingsDialog({
+      writesEnabled,
+      container: detailDrawerPortalContainer,
+      resolveGroupState: useCallback(
+        (groupName) => {
+          const normalized = normalizeGroupName(groupName);
+          if (!normalized) return null;
+          const existingGroup = resolveGroupSummaryForName(normalized);
+          return {
+            groupName: normalized,
+            note: resolveGroupNoteForName(normalized),
+            existing: existingGroup != null,
+            accountCount: existingGroup?.accountCount ?? 0,
+            concurrencyLimit: resolveGroupConcurrencyLimitForName(normalized),
+            boundProxyKeys: resolveGroupBoundProxyKeysForName(normalized),
+            nodeShuntEnabled: resolveGroupNodeShuntEnabledForName(normalized),
+            singleAccountRotationEnabled:
+              resolveGroupSingleAccountRotationEnabledForName(normalized),
+            upstream429RetryEnabled:
+              resolveGroupUpstream429RetryEnabledForName(normalized),
+            upstream429MaxRetries:
+              resolveGroupUpstream429MaxRetriesForName(normalized),
+            routingRule: existingGroup?.routingRule,
+          };
+        },
+        [
+          resolveGroupBoundProxyKeysForName,
+          resolveGroupConcurrencyLimitForName,
+          resolveGroupNodeShuntEnabledForName,
+          resolveGroupSingleAccountRotationEnabledForName,
+          resolveGroupNoteForName,
+          resolveGroupSummaryForName,
+          resolveGroupUpstream429MaxRetriesForName,
+          resolveGroupUpstream429RetryEnabledForName,
+        ],
+      ),
+      saveGroupSettings: useCallback(
+        async (groupName, payload) => {
+          const normalizedGroupName = normalizeGroupName(groupName);
+          if (!normalizedGroupName) return;
 
-        const normalizedNote = payload.note?.trim() ?? "";
-        const normalizedBoundProxyKeys = Array.from(
-          new Set(
-            (payload.boundProxyKeys ?? [])
-              .map((value) => value.trim())
-              .filter((value) => value.length > 0),
-          ),
-        );
-        const normalizedConcurrencyLimit = payload.concurrencyLimit ?? 0;
-        const normalizedNodeShuntEnabled = payload.nodeShuntEnabled === true;
-        const normalizedSingleAccountRotationEnabled =
-          payload.singleAccountRotationEnabled === true;
-        const normalizedUpstream429RetryEnabled =
-          payload.upstream429RetryEnabled === true;
-        const normalizedUpstream429MaxRetries =
-          normalizedUpstream429RetryEnabled
-            ? normalizeEnabledGroupUpstream429MaxRetries(
-                payload.upstream429MaxRetries,
-              )
-            : normalizeGroupUpstream429MaxRetries(
-                payload.upstream429MaxRetries,
-              );
+          const normalizedNote = payload.note?.trim() ?? "";
+          const normalizedBoundProxyKeys = Array.from(
+            new Set(
+              (payload.boundProxyKeys ?? [])
+                .map((value) => value.trim())
+                .filter((value) => value.length > 0),
+            ),
+          );
+          const normalizedConcurrencyLimit = payload.concurrencyLimit ?? 0;
+          const normalizedNodeShuntEnabled = payload.nodeShuntEnabled === true;
+          const normalizedSingleAccountRotationEnabled =
+            payload.singleAccountRotationEnabled === true;
+          const normalizedUpstream429RetryEnabled =
+            payload.upstream429RetryEnabled === true;
+          const normalizedUpstream429MaxRetries =
+            normalizedUpstream429RetryEnabled
+              ? normalizeEnabledGroupUpstream429MaxRetries(
+                  payload.upstream429MaxRetries,
+                )
+              : normalizeGroupUpstream429MaxRetries(
+                  payload.upstream429MaxRetries,
+                );
 
-        await saveGroupNote(normalizedGroupName, {
-          note: normalizedNote || undefined,
-          boundProxyKeys: normalizedBoundProxyKeys,
-          concurrencyLimit: normalizedConcurrencyLimit,
-          nodeShuntEnabled: normalizedNodeShuntEnabled,
-          singleAccountRotationEnabled: normalizedSingleAccountRotationEnabled,
-          upstream429RetryEnabled: normalizedUpstream429RetryEnabled,
-          upstream429MaxRetries: normalizedUpstream429MaxRetries,
-          routingRule: payload.routingRule,
-        });
-        clearDraftGroupSettings(normalizedGroupName);
-      },
-      [clearDraftGroupSettings, saveGroupNote],
-    ),
-    deleteGroupSettings: useCallback(
-      async (groupName: string) => {
-        await deleteGroupNote(groupName);
-        clearDraftGroupSettings(groupName);
-        setDraft((current) =>
-          normalizeGroupName(current.groupName) ===
-          normalizeGroupName(groupName)
-            ? {
-                ...current,
-                groupName: "",
-              }
-            : current,
-        );
-      },
-      [clearDraftGroupSettings, deleteGroupNote],
-    ),
-  });
+          await saveGroupNote(normalizedGroupName, {
+            note: normalizedNote || undefined,
+            boundProxyKeys: normalizedBoundProxyKeys,
+            concurrencyLimit: normalizedConcurrencyLimit,
+            nodeShuntEnabled: normalizedNodeShuntEnabled,
+            singleAccountRotationEnabled:
+              normalizedSingleAccountRotationEnabled,
+            upstream429RetryEnabled: normalizedUpstream429RetryEnabled,
+            upstream429MaxRetries: normalizedUpstream429MaxRetries,
+            routingRule: payload.routingRule,
+          });
+          clearDraftGroupSettings(normalizedGroupName);
+        },
+        [clearDraftGroupSettings, saveGroupNote],
+      ),
+      deleteGroupSettings: useCallback(
+        async (groupName: string) => {
+          await deleteGroupNote(groupName);
+          clearDraftGroupSettings(groupName);
+          setDraft((current) =>
+            normalizeGroupName(current.groupName) ===
+            normalizeGroupName(groupName)
+              ? {
+                  ...current,
+                  groupName: "",
+                }
+              : current,
+          );
+        },
+        [clearDraftGroupSettings, deleteGroupNote],
+      ),
+    });
   const handleDetailGroupCreateRequest = useCallback(
     (groupName: string) => {
       openGroupNoteEditor(groupName, {
@@ -1815,6 +1799,17 @@ function SharedUpstreamAccountDetailDrawerInner({
 
   const selectedDetail = detail?.id === selectedId ? detail : null;
   const selected = selectedDetail ?? selectedSummary;
+  useEffect(() => {
+    if (
+      !open ||
+      accountId == null ||
+      detailTab !== "healthEvents" ||
+      isDetailRecentActionsHydrated
+    ) {
+      return;
+    }
+    void loadDetail(accountId, { silent: true, includeRecentActions: true });
+  }, [accountId, detailTab, isDetailRecentActionsHydrated, loadDetail, open]);
   const handleDetailDrawerClose = useCallback(() => {
     onClose();
   }, [onClose]);
@@ -1916,13 +1911,19 @@ function SharedUpstreamAccountDetailDrawerInner({
     unlimited: t("accountPool.tags.dialog.unlimited"),
     availableModels: t("accountPool.tags.dialog.availableModels"),
     availableModelsHint: t("accountPool.tags.dialog.availableModelsHint"),
-    availableModelsSearchPlaceholder: t("accountPool.tags.dialog.availableModelsSearchPlaceholder"),
+    availableModelsSearchPlaceholder: t(
+      "accountPool.tags.dialog.availableModelsSearchPlaceholder",
+    ),
     availableModelsEmpty: t("accountPool.tags.dialog.availableModelsEmpty"),
     availableModelsAll: t("accountPool.tags.dialog.availableModelsAll"),
     availableModelsCustomLabel: (value: string) =>
       t("accountPool.tags.dialog.availableModelsCustomLabel", { value }),
-    availableModelsAddCustom: t("accountPool.tags.dialog.availableModelsAddCustom"),
-    availableModelsInherited: t("accountPool.tags.dialog.availableModelsInherited"),
+    availableModelsAddCustom: t(
+      "accountPool.tags.dialog.availableModelsAddCustom",
+    ),
+    availableModelsInherited: t(
+      "accountPool.tags.dialog.availableModelsInherited",
+    ),
     availableModelsRemove: t("accountPool.tags.dialog.availableModelsRemove"),
     cancel: t("accountPool.tags.dialog.cancel"),
     save: t("accountPool.tags.dialog.save"),
@@ -2087,11 +2088,7 @@ function SharedUpstreamAccountDetailDrawerInner({
         draftBaselineRef.current = responseDraft;
         latestServerDraftRef.current = responseDraft;
         setDraft((current) =>
-          mergeDraftAfterAccountSave(
-            current,
-            saveStartedDraft,
-            responseDraft,
-          ),
+          mergeDraftAfterAccountSave(current, saveStartedDraft, responseDraft),
         );
       }
       return responseDraft;
@@ -2236,12 +2233,7 @@ function SharedUpstreamAccountDetailDrawerInner({
         });
       }
     },
-    [
-      busyAction,
-      handleNotFoundClose,
-      notifyMotherChange,
-      saveAccount,
-    ],
+    [busyAction, handleNotFoundClose, notifyMotherChange, saveAccount],
   );
 
   const handleSync = useCallback(
@@ -2794,11 +2786,11 @@ function SharedUpstreamAccountDetailDrawerInner({
                         <div className="flex flex-col gap-1">
                           <Badge
                             variant={
-                              (selectedDetail.imageToolCapability ?? "unknown") ===
-                              "supported"
+                              (selectedDetail.imageToolCapability ??
+                                "unknown") === "supported"
                                 ? "success"
-                                : (selectedDetail.imageToolCapability ?? "unknown") ===
-                                    "unsupported"
+                                : (selectedDetail.imageToolCapability ??
+                                      "unknown") === "unsupported"
                                   ? "warning"
                                   : "secondary"
                             }
@@ -3837,7 +3829,7 @@ function SharedUpstreamAccountDetailDrawerInner({
         }
         error={
           selectedDetail
-            ? actionError.accountMessages[selectedDetail.id] ?? null
+            ? (actionError.accountMessages[selectedDetail.id] ?? null)
             : null
         }
         onClose={() => setAccountPolicyEditorOpen(false)}
@@ -3846,8 +3838,12 @@ function SharedUpstreamAccountDetailDrawerInner({
           void handleSaveAccountPolicy(selectedDetail, payload);
         }}
         labels={{
-          blockNewConversations: t("accountPool.tags.dialog.blockNewConversations"),
-          forbidNewConversation: t("accountPool.tags.dialog.forbidNewConversation"),
+          blockNewConversations: t(
+            "accountPool.tags.dialog.blockNewConversations",
+          ),
+          forbidNewConversation: t(
+            "accountPool.tags.dialog.forbidNewConversation",
+          ),
           allowCutOut: t("accountPool.tags.dialog.allowCutOut"),
           allowCutIn: t("accountPool.tags.dialog.allowCutIn"),
           forbidCutOut: t("accountPool.tags.dialog.forbidCutOut"),
@@ -3857,7 +3853,9 @@ function SharedUpstreamAccountDetailDrawerInner({
           priorityNormal: t("accountPool.tags.dialog.priorityNormal"),
           priorityFallback: t("accountPool.tags.dialog.priorityFallback"),
           fastModeRewriteMode: t("accountPool.tags.dialog.fastModeRewriteMode"),
-          fastModeKeepOriginal: t("accountPool.tags.dialog.fastModeKeepOriginal"),
+          fastModeKeepOriginal: t(
+            "accountPool.tags.dialog.fastModeKeepOriginal",
+          ),
           fastModeFillMissing: t("accountPool.tags.dialog.fastModeFillMissing"),
           fastModeForceAdd: t("accountPool.tags.dialog.fastModeForceAdd"),
           fastModeForceRemove: t("accountPool.tags.dialog.fastModeForceRemove"),
@@ -3904,14 +3902,24 @@ function SharedUpstreamAccountDetailDrawerInner({
           unlimited: t("accountPool.tags.dialog.unlimited"),
           availableModels: t("accountPool.tags.dialog.availableModels"),
           availableModelsHint: t("accountPool.tags.dialog.availableModelsHint"),
-          availableModelsSearchPlaceholder: t("accountPool.tags.dialog.availableModelsSearchPlaceholder"),
-          availableModelsEmpty: t("accountPool.tags.dialog.availableModelsEmpty"),
+          availableModelsSearchPlaceholder: t(
+            "accountPool.tags.dialog.availableModelsSearchPlaceholder",
+          ),
+          availableModelsEmpty: t(
+            "accountPool.tags.dialog.availableModelsEmpty",
+          ),
           availableModelsAll: t("accountPool.tags.dialog.availableModelsAll"),
           availableModelsCustomLabel: (value) =>
             t("accountPool.tags.dialog.availableModelsCustomLabel", { value }),
-          availableModelsAddCustom: t("accountPool.tags.dialog.availableModelsAddCustom"),
-          availableModelsInherited: t("accountPool.tags.dialog.availableModelsInherited"),
-          availableModelsRemove: t("accountPool.tags.dialog.availableModelsRemove"),
+          availableModelsAddCustom: t(
+            "accountPool.tags.dialog.availableModelsAddCustom",
+          ),
+          availableModelsInherited: t(
+            "accountPool.tags.dialog.availableModelsInherited",
+          ),
+          availableModelsRemove: t(
+            "accountPool.tags.dialog.availableModelsRemove",
+          ),
           cancel: t("accountPool.tags.dialog.cancel"),
           validation: t("accountPool.tags.dialog.validation"),
         }}

--- a/web/src/pages/account-pool/UpstreamAccounts.test.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.test.tsx
@@ -140,7 +140,9 @@ vi.mock("@tanstack/react-virtual", () => ({
     estimateSize: (index: number) => number;
     scrollMargin?: number;
   }) => {
-    const sizes = Array.from({ length: count }, (_, index) => estimateSize(index));
+    const sizes = Array.from({ length: count }, (_, index) =>
+      estimateSize(index),
+    );
     const indexes =
       virtualizerMocks.visibleIndexes ??
       Array.from({ length: Math.min(count, 4) }, (_, index) => index);
@@ -180,7 +182,9 @@ vi.mock("@tanstack/react-virtual", () => ({
     estimateSize: (index: number) => number;
     scrollMargin?: number;
   }) => {
-    const sizes = Array.from({ length: count }, (_, index) => estimateSize(index));
+    const sizes = Array.from({ length: count }, (_, index) =>
+      estimateSize(index),
+    );
     const indexes =
       virtualizerMocks.visibleIndexes ??
       Array.from({ length: Math.min(count, 4) }, (_, index) => index);
@@ -1022,6 +1026,7 @@ function mockAccountsPage(options?: {
   saveRouting?: ReturnType<typeof vi.fn>;
   saveGroupNote?: ReturnType<typeof vi.fn>;
   deleteGroupNote?: ReturnType<typeof vi.fn>;
+  loadDetail?: ReturnType<typeof vi.fn>;
   groups?: Array<Record<string, unknown>>;
   routing?: {
     writesEnabled: boolean;
@@ -1039,6 +1044,7 @@ function mockAccountsPage(options?: {
   detail?: Record<string, unknown>;
 }) {
   const saveRouting = options?.saveRouting ?? vi.fn();
+  const loadDetail = options?.loadDetail ?? vi.fn();
   const groups = (
     options?.groups ?? [
       {
@@ -1071,45 +1077,47 @@ function mockAccountsPage(options?: {
   }));
   const saveGroupNote: ReturnType<typeof vi.fn> =
     options?.saveGroupNote ??
-    vi.fn().mockImplementation(
-      async (groupName: string, payload: Record<string, unknown>) => {
-        const normalizedGroupName = groupName.trim();
-        const nextSummary = {
-          groupName: normalizedGroupName,
-          accountCount:
-            groups.find((group) => group.groupName === normalizedGroupName)
-              ?.accountCount ?? 0,
-          note:
-            typeof payload.note === "string" && payload.note.trim().length > 0
-              ? payload.note
-              : null,
-          boundProxyKeys: Array.isArray(payload.boundProxyKeys)
-            ? payload.boundProxyKeys.map((value) => String(value))
-            : [],
-          nodeShuntEnabled: payload.nodeShuntEnabled === true,
-          singleAccountRotationEnabled:
-            payload.singleAccountRotationEnabled === true,
-          upstream429RetryEnabled: payload.upstream429RetryEnabled === true,
-          upstream429MaxRetries:
-            typeof payload.upstream429MaxRetries === "number"
-              ? payload.upstream429MaxRetries
-              : 0,
-          concurrencyLimit:
-            typeof payload.concurrencyLimit === "number"
-              ? payload.concurrencyLimit
-              : 0,
-        };
-        const existingIndex = groups.findIndex(
-          (group) => group.groupName === normalizedGroupName,
-        );
-        if (existingIndex >= 0) {
-          groups.splice(existingIndex, 1, nextSummary);
-        } else {
-          groups.push(nextSummary);
-        }
-        return nextSummary;
-      },
-    );
+    vi
+      .fn()
+      .mockImplementation(
+        async (groupName: string, payload: Record<string, unknown>) => {
+          const normalizedGroupName = groupName.trim();
+          const nextSummary = {
+            groupName: normalizedGroupName,
+            accountCount:
+              groups.find((group) => group.groupName === normalizedGroupName)
+                ?.accountCount ?? 0,
+            note:
+              typeof payload.note === "string" && payload.note.trim().length > 0
+                ? payload.note
+                : null,
+            boundProxyKeys: Array.isArray(payload.boundProxyKeys)
+              ? payload.boundProxyKeys.map((value) => String(value))
+              : [],
+            nodeShuntEnabled: payload.nodeShuntEnabled === true,
+            singleAccountRotationEnabled:
+              payload.singleAccountRotationEnabled === true,
+            upstream429RetryEnabled: payload.upstream429RetryEnabled === true,
+            upstream429MaxRetries:
+              typeof payload.upstream429MaxRetries === "number"
+                ? payload.upstream429MaxRetries
+                : 0,
+            concurrencyLimit:
+              typeof payload.concurrencyLimit === "number"
+                ? payload.concurrencyLimit
+                : 0,
+          };
+          const existingIndex = groups.findIndex(
+            (group) => group.groupName === normalizedGroupName,
+          );
+          if (existingIndex >= 0) {
+            groups.splice(existingIndex, 1, nextSummary);
+          } else {
+            groups.push(nextSummary);
+          }
+          return nextSummary;
+        },
+      );
   const deleteGroupNote: ReturnType<typeof vi.fn> =
     options?.deleteGroupNote ??
     vi.fn().mockImplementation(async (groupName: string) => {
@@ -1251,12 +1259,13 @@ function mockAccountsPage(options?: {
     detail,
     isLoading: false,
     isDetailLoading: false,
+    isDetailRecentActionsHydrated: false,
     listError: null,
     detailError: null,
     error: null,
     selectAccount: vi.fn(),
     refresh: vi.fn(),
-    loadDetail: vi.fn(),
+    loadDetail,
     beginOauthLogin: vi.fn(),
     beginRelogin: vi.fn(),
     beginOauthMailboxSession: vi.fn(),
@@ -1293,6 +1302,7 @@ function mockAccountsPage(options?: {
     routingTimeouts,
     saveGroupNote,
     deleteGroupNote,
+    loadDetail,
   };
 }
 
@@ -1402,19 +1412,17 @@ function mockRosterFreshnessPage(options?: {
     stopBulkSyncJob: vi.fn(),
     runSync: vi.fn(),
     removeAccount: vi.fn(),
-    groups:
-      options?.groups ??
-      [
-        {
-          groupName: "prod",
-          accountCount: 2,
-          note: "prod note",
-          boundProxyKeys: ["jp-edge-01"],
-          nodeShuntEnabled: false,
-          upstream429RetryEnabled: false,
-          upstream429MaxRetries: 0,
-        },
-      ],
+    groups: options?.groups ?? [
+      {
+        groupName: "prod",
+        accountCount: 2,
+        note: "prod note",
+        boundProxyKeys: ["jp-edge-01"],
+        nodeShuntEnabled: false,
+        upstream429RetryEnabled: false,
+        upstream429MaxRetries: 0,
+      },
+    ],
     routing: {
       writesEnabled: true,
       apiKeyConfigured: false,
@@ -1487,8 +1495,18 @@ Object.assign(scope, {
   mockRosterFreshnessPage,
 });
 Object.defineProperties(scope, {
-  host: { get: () => host, set: (value) => { host = value as typeof host; } },
-  root: { get: () => root, set: (value) => { root = value as typeof root; } },
+  host: {
+    get: () => host,
+    set: (value) => {
+      host = value as typeof host;
+    },
+  },
+  root: {
+    get: () => root,
+    set: (value) => {
+      root = value as typeof root;
+    },
+  },
 });
 const evalChunk = (chunk: string) => {
   const { outputText } = ts.transpileModule(chunk, {
@@ -1510,215 +1528,225 @@ evalChunk(suite5);
 evalChunk(suite6);
 evalChunk(suite7);
 
-describe('UpstreamAccountsPage grouped roster toggle', () => {
-  it('defaults to grid view with grid, grouped, flat selector order', async () => {
-    mockRosterFreshnessPage()
-    render()
+describe("UpstreamAccountsPage grouped roster toggle", () => {
+  it("defaults to grid view with grid, grouped, flat selector order", async () => {
+    mockRosterFreshnessPage();
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
-    const tabs = Array.from(host?.querySelectorAll('button[role="tab"]') ?? [])
-    expect(tabs[0]?.textContent ?? '').toMatch(/grid|网格/i)
-    expect(tabs[1]?.textContent ?? '').toMatch(/grouped|分组/i)
-    expect(tabs[2]?.textContent ?? '').toMatch(/flat|平铺/i)
-    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true')
-    expectRosterHookQuery({ includeAll: true })
+    const tabs = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []);
+    expect(tabs[0]?.textContent ?? "").toMatch(/grid|网格/i);
+    expect(tabs[1]?.textContent ?? "").toMatch(/grouped|分组/i);
+    expect(tabs[2]?.textContent ?? "").toMatch(/flat|平铺/i);
+    expect(tabs[0]?.getAttribute("aria-selected")).toBe("true");
+    expectRosterHookQuery({ includeAll: true });
     expect(
       host?.querySelector('[data-testid="upstream-accounts-grouped-roster"]'),
-    ).toBeTruthy()
+    ).toBeTruthy();
     expect(
-      host?.querySelector('[data-testid="upstream-accounts-pagination-footer"]'),
-    ).toBeNull()
-  })
+      host?.querySelector(
+        '[data-testid="upstream-accounts-pagination-footer"]',
+      ),
+    ).toBeNull();
+  });
 
-  it('switches to grouped view and hides the pagination footer', async () => {
-    mockRosterFreshnessPage()
-    render()
+  it("switches to grouped view and hides the pagination footer", async () => {
+    mockRosterFreshnessPage();
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
     const groupedToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ''))
-    expect(groupedToggle).toBeTruthy()
+    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ""));
+    expect(groupedToggle).toBeTruthy();
 
     act(() => {
-      groupedToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      groupedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     const groupedRoster = host?.querySelector(
       '[data-testid="upstream-accounts-grouped-roster"]',
-    ) as HTMLElement | null
-    expect(groupedRoster).toBeTruthy()
-    expect(groupedRoster?.className ?? "").not.toContain("overflow-auto")
+    ) as HTMLElement | null;
+    expect(groupedRoster).toBeTruthy();
+    expect(groupedRoster?.className ?? "").not.toContain("overflow-auto");
     expect(
       Array.from(host?.querySelectorAll('input[type="checkbox"]') ?? []).find(
         (candidate) =>
           /select filtered accounts|选择筛选结果/i.test(
-            candidate.getAttribute('aria-label') ?? '',
+            candidate.getAttribute("aria-label") ?? "",
           ),
       ),
-    ).toBeTruthy()
+    ).toBeTruthy();
     expect(
-      host?.querySelector('[data-testid="upstream-accounts-pagination-footer"]'),
-    ).toBeNull()
-  })
+      host?.querySelector(
+        '[data-testid="upstream-accounts-pagination-footer"]',
+      ),
+    ).toBeNull();
+  });
 
-  it('switches to grid view without bulk selection controls', async () => {
-    mockRosterFreshnessPage()
-    render()
+  it("switches to grid view without bulk selection controls", async () => {
+    mockRosterFreshnessPage();
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
     const gridToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /grid|网格/i.test(candidate.textContent ?? ''))
-    expect(gridToggle).toBeTruthy()
+    ).find((candidate) => /grid|网格/i.test(candidate.textContent ?? ""));
+    expect(gridToggle).toBeTruthy();
 
     act(() => {
-      gridToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      gridToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     const groupedRoster = host?.querySelector(
       '[data-testid="upstream-accounts-grouped-roster"]',
-    ) as HTMLElement | null
-    expect(groupedRoster).toBeTruthy()
-    expect(gridToggle?.getAttribute('aria-selected')).toBe('true')
-    expect(groupedRoster?.className ?? "").not.toContain("overflow-auto")
+    ) as HTMLElement | null;
+    expect(groupedRoster).toBeTruthy();
+    expect(gridToggle?.getAttribute("aria-selected")).toBe("true");
+    expect(groupedRoster?.className ?? "").not.toContain("overflow-auto");
     expect(
       Array.from(host?.querySelectorAll('input[type="checkbox"]') ?? []).find(
         (candidate) =>
           /select filtered accounts|选择筛选结果/i.test(
-            candidate.getAttribute('aria-label') ?? '',
+            candidate.getAttribute("aria-label") ?? "",
           ),
       ),
-    ).toBeFalsy()
-    expect(groupedRoster?.textContent ?? '').toMatch(/Working 2|工作中 2|工作 2/i)
+    ).toBeFalsy();
+    expect(groupedRoster?.textContent ?? "").toMatch(
+      /Working 2|工作中 2|工作 2/i,
+    );
     expect(
-      host?.querySelector('[data-testid="upstream-accounts-pagination-footer"]'),
-    ).toBeNull()
-  })
+      host?.querySelector(
+        '[data-testid="upstream-accounts-pagination-footer"]',
+      ),
+    ).toBeNull();
+  });
 
-  it('blocks grouped roster interactions while the include-all query is still switching', async () => {
+  it("blocks grouped roster interactions while the include-all query is still switching", async () => {
     mockRosterFreshnessPage({
       listState: {
         queryKey: '{"includeAll":true}',
         dataQueryKey: '{"page":2,"pageSize":20}',
-        freshness: 'stale',
-        loadingState: 'switching',
-        status: 'ready',
+        freshness: "stale",
+        loadingState: "switching",
+        status: "ready",
         hasCurrentQueryData: true,
         isPending: true,
       },
-    })
-    render()
+    });
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
     const groupedToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ''))
-    expect(groupedToggle).toBeTruthy()
+    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ""));
+    expect(groupedToggle).toBeTruthy();
 
     act(() => {
-      groupedToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      groupedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     expect(
       host?.querySelector('[data-testid="upstream-accounts-grouped-loading"]'),
-    ).toBeTruthy()
+    ).toBeTruthy();
     expect(
       host?.querySelector('[data-testid="upstream-accounts-grouped-roster"]'),
-    ).toBeNull()
+    ).toBeNull();
     expect(
       Array.from(host?.querySelectorAll('input[type="checkbox"]') ?? []).find(
         (candidate) =>
           /select filtered accounts|选择筛选结果/i.test(
-            candidate.getAttribute('aria-label') ?? '',
+            candidate.getAttribute("aria-label") ?? "",
           ),
       ),
-    ).toBeFalsy()
-  })
+    ).toBeFalsy();
+  });
 
-  it('blocks flat roster interactions while switching away from grouped include-all data', async () => {
+  it("blocks flat roster interactions while switching away from grouped include-all data", async () => {
     mockRosterFreshnessPage({
       listState: {
         queryKey: '{"page":2,"pageSize":20}',
         dataQueryKey: '{"includeAll":true}',
-        freshness: 'stale',
-        loadingState: 'switching',
-        status: 'ready',
+        freshness: "stale",
+        loadingState: "switching",
+        status: "ready",
         hasCurrentQueryData: true,
         isPending: true,
       },
-    })
-    render()
+    });
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
     const flatToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /flat|平铺/i.test(candidate.textContent ?? ''))
-    expect(flatToggle).toBeTruthy()
+    ).find((candidate) => /flat|平铺/i.test(candidate.textContent ?? ""));
+    expect(flatToggle).toBeTruthy();
     act(() => {
-      flatToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      flatToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     expect(
       host?.querySelector('[data-testid="upstream-accounts-table-loading"]'),
-    ).toBeTruthy()
+    ).toBeTruthy();
     expect(
-      host?.querySelector('[data-testid="upstream-accounts-pagination-footer"]'),
-    ).toBeTruthy()
-    expect(host?.textContent ?? '').not.toContain('Existing OAuth')
-    expect(host?.textContent ?? '').not.toContain('Another OAuth')
-  })
+      host?.querySelector(
+        '[data-testid="upstream-accounts-pagination-footer"]',
+      ),
+    ).toBeTruthy();
+    expect(host?.textContent ?? "").not.toContain("Existing OAuth");
+    expect(host?.textContent ?? "").not.toContain("Another OAuth");
+  });
 
-  it('preserves the flat page selection when toggling grouped view', async () => {
+  it("preserves the flat page selection when toggling grouped view", async () => {
     const items = [
       {
         id: 5,
-        kind: 'oauth_codex',
-        provider: 'codex',
-        displayName: 'Existing OAuth',
-        groupName: 'prod',
-        status: 'active',
-        displayStatus: 'active',
+        kind: "oauth_codex",
+        provider: "codex",
+        displayName: "Existing OAuth",
+        groupName: "prod",
+        status: "active",
+        displayStatus: "active",
         enabled: true,
         isMother: false,
         tags: [],
         effectiveRoutingRule: defaultEffectiveRoutingRule,
       },
-    ]
+    ];
     const sharedCallbacks: Pick<
       UpstreamAccountsHookValue,
-      | 'selectAccount'
-      | 'refresh'
-      | 'loadDetail'
-      | 'beginOauthLogin'
-      | 'beginRelogin'
-      | 'beginOauthMailboxSession'
-      | 'beginOauthMailboxSessionForAddress'
-      | 'getOauthMailboxStatuses'
-      | 'removeOauthMailboxSession'
-      | 'getLoginSession'
-      | 'completeOauthLogin'
-      | 'createApiKeyAccount'
-      | 'saveAccount'
-      | 'saveRouting'
-      | 'saveGroupNote'
-      | 'deleteGroupNote'
-      | 'runBulkAction'
-      | 'startBulkSyncJob'
-      | 'getBulkSyncJob'
-      | 'stopBulkSyncJob'
-      | 'runSync'
-      | 'removeAccount'
+      | "selectAccount"
+      | "refresh"
+      | "loadDetail"
+      | "beginOauthLogin"
+      | "beginRelogin"
+      | "beginOauthMailboxSession"
+      | "beginOauthMailboxSessionForAddress"
+      | "getOauthMailboxStatuses"
+      | "removeOauthMailboxSession"
+      | "getLoginSession"
+      | "completeOauthLogin"
+      | "createApiKeyAccount"
+      | "saveAccount"
+      | "saveRouting"
+      | "saveGroupNote"
+      | "deleteGroupNote"
+      | "runBulkAction"
+      | "startBulkSyncJob"
+      | "getBulkSyncJob"
+      | "stopBulkSyncJob"
+      | "runSync"
+      | "removeAccount"
     > = {
       selectAccount: vi.fn(),
       refresh: vi.fn(),
@@ -1742,15 +1770,15 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
       stopBulkSyncJob: vi.fn(),
       runSync: vi.fn(),
       removeAccount: vi.fn(),
-    }
-    const sharedRouting: UpstreamAccountsHookValue['routing'] = {
+    };
+    const sharedRouting: UpstreamAccountsHookValue["routing"] = {
       writesEnabled: true,
       apiKeyConfigured: false,
       maskedApiKey: null,
-    }
+    };
     const sharedBase: Omit<
       UpstreamAccountsHookValue,
-      'page' | 'pageSize' | 'listState'
+      "page" | "pageSize" | "listState"
     > = {
       items,
       hasUngroupedAccounts: true,
@@ -1774,15 +1802,15 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
       routing: sharedRouting,
       forwardProxyNodes: [],
       forwardProxyCatalogState: {
-        kind: 'ready-empty',
-        freshness: 'fresh',
+        kind: "ready-empty",
+        freshness: "fresh",
         isPending: false,
         hasNodes: false,
       },
       missingDetailAccountId: null,
       isWindowUsagePending: false,
       ...sharedCallbacks,
-    }
+    };
     const flatPage1: UpstreamAccountsHookValue = {
       ...sharedBase,
       page: 1,
@@ -1790,13 +1818,13 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
       listState: {
         queryKey: '{"page":1,"pageSize":20}',
         dataQueryKey: '{"page":1,"pageSize":20}',
-        freshness: 'fresh',
-        loadingState: 'idle',
-        status: 'ready',
+        freshness: "fresh",
+        loadingState: "idle",
+        status: "ready",
         hasCurrentQueryData: true,
         isPending: false,
       },
-    }
+    };
     const flatPage2: UpstreamAccountsHookValue = {
       ...sharedBase,
       page: 2,
@@ -1804,13 +1832,13 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
       listState: {
         queryKey: '{"page":2,"pageSize":20}',
         dataQueryKey: '{"page":2,"pageSize":20}',
-        freshness: 'fresh',
-        loadingState: 'idle',
-        status: 'ready',
+        freshness: "fresh",
+        loadingState: "idle",
+        status: "ready",
         hasCurrentQueryData: true,
         isPending: false,
       },
-    }
+    };
     const groupedAll: UpstreamAccountsHookValue = {
       ...sharedBase,
       page: 1,
@@ -1818,291 +1846,297 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
       listState: {
         queryKey: '{"includeAll":true}',
         dataQueryKey: '{"includeAll":true}',
-        freshness: 'fresh',
-        loadingState: 'idle',
-        status: 'ready',
+        freshness: "fresh",
+        loadingState: "idle",
+        status: "ready",
         hasCurrentQueryData: true,
         isPending: false,
       },
-    }
+    };
     hookMocks.useUpstreamAccounts.mockImplementation((query) => {
-      if (query?.includeAll) return groupedAll
-      if (query?.page === 2) return flatPage2
-      return flatPage1
-    })
+      if (query?.includeAll) return groupedAll;
+      if (query?.page === 2) return flatPage2;
+      return flatPage1;
+    });
 
-    render()
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
     const initialFlatToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /flat|平铺/i.test(candidate.textContent ?? ''))
-    expect(initialFlatToggle).toBeTruthy()
+    ).find((candidate) => /flat|平铺/i.test(candidate.textContent ?? ""));
+    expect(initialFlatToggle).toBeTruthy();
     act(() => {
-      initialFlatToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      initialFlatToggle?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
 
-    const nextButton = findButton(/next|下一页/i)
-    expect(nextButton).toBeTruthy()
+    const nextButton = findButton(/next|下一页/i);
+    expect(nextButton).toBeTruthy();
     act(() => {
-      nextButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      nextButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
-    expectRosterHookQuery({ page: 2, pageSize: 20 })
+    expectRosterHookQuery({ page: 2, pageSize: 20 });
 
     const groupedToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ''))
+    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ""));
     const flatToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /flat|平铺/i.test(candidate.textContent ?? ''))
-    expect(groupedToggle).toBeTruthy()
-    expect(flatToggle).toBeTruthy()
+    ).find((candidate) => /flat|平铺/i.test(candidate.textContent ?? ""));
+    expect(groupedToggle).toBeTruthy();
+    expect(flatToggle).toBeTruthy();
 
     act(() => {
-      groupedToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-    expectRosterHookQuery({ includeAll: true })
+      groupedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expectRosterHookQuery({ includeAll: true });
 
     act(() => {
-      flatToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      flatToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
-    expectRosterHookQuery({ page: 2, pageSize: 20 })
-  })
+    expectRosterHookQuery({ page: 2, pageSize: 20 });
+  });
 
-  it('opens the shared group settings dialog from the grouped summary action', async () => {
-    const saveGroupNote = vi.fn()
+  it("opens the shared group settings dialog from the grouped summary action", async () => {
+    const saveGroupNote = vi.fn();
     mockRosterFreshnessPage({
       saveGroupNote,
       groups: [
         {
-          groupName: '  prod  ',
-          note: 'Production routing group',
-          boundProxyKeys: ['jp-edge-01'],
+          groupName: "  prod  ",
+          note: "Production routing group",
+          boundProxyKeys: ["jp-edge-01"],
           concurrencyLimit: 3,
           nodeShuntEnabled: true,
           upstream429RetryEnabled: true,
           upstream429MaxRetries: 2,
         },
       ],
-    })
-    render()
+    });
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
     const groupedToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ''))
-    expect(groupedToggle).toBeTruthy()
+    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ""));
+    expect(groupedToggle).toBeTruthy();
 
     act(() => {
-      groupedToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      groupedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
-    const settingsButton = Array.from(host?.querySelectorAll('button') ?? []).find(
-      (candidate) =>
-        /edit group settings|编辑分组设置/i.test(
-          candidate.getAttribute('aria-label') ?? candidate.textContent ?? '',
-        ),
-    )
-    expect(settingsButton).toBeTruthy()
+    const settingsButton = Array.from(
+      host?.querySelectorAll("button") ?? [],
+    ).find((candidate) =>
+      /edit group settings|编辑分组设置/i.test(
+        candidate.getAttribute("aria-label") ?? candidate.textContent ?? "",
+      ),
+    );
+    expect(settingsButton).toBeTruthy();
 
     act(() => {
-      settingsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      settingsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
-    const dialogs = Array.from(host?.ownerDocument.querySelectorAll('[role="dialog"]') ?? [])
+    const dialogs = Array.from(
+      host?.ownerDocument.querySelectorAll('[role="dialog"]') ?? [],
+    );
     const groupSettingsDialog = dialogs.find((candidate) =>
-      /group settings|分组设置/i.test(candidate.textContent ?? ''),
-    )
-    expect(groupSettingsDialog).toBeTruthy()
-    expect(groupSettingsDialog?.textContent ?? '').toContain('prod')
-    expect(groupSettingsDialog?.textContent ?? '').toContain('JP Edge 01')
-    expect(saveGroupNote).not.toHaveBeenCalled()
-  })
+      /group settings|分组设置/i.test(candidate.textContent ?? ""),
+    );
+    expect(groupSettingsDialog).toBeTruthy();
+    expect(groupSettingsDialog?.textContent ?? "").toContain("prod");
+    expect(groupSettingsDialog?.textContent ?? "").toContain("JP Edge 01");
+    expect(saveGroupNote).not.toHaveBeenCalled();
+  });
 
-  it('treats grouped summary actions as existing groups when the catalog returns them', async () => {
-    const saveGroupNote = vi.fn()
+  it("treats grouped summary actions as existing groups when the catalog returns them", async () => {
+    const saveGroupNote = vi.fn();
     mockRosterFreshnessPage({
       saveGroupNote,
       groups: [
         {
-          groupName: 'prod',
+          groupName: "prod",
           accountCount: 2,
-          note: 'Production routing group',
-          boundProxyKeys: ['jp-edge-01'],
+          note: "Production routing group",
+          boundProxyKeys: ["jp-edge-01"],
           nodeShuntEnabled: false,
           upstream429RetryEnabled: false,
           upstream429MaxRetries: 0,
         },
       ],
-    })
-    render()
+    });
+    render();
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
     const groupedToggle = Array.from(
       host?.querySelectorAll('button[role="tab"]') ?? [],
-    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ''))
-    expect(groupedToggle).toBeTruthy()
+    ).find((candidate) => /grouped|分组/i.test(candidate.textContent ?? ""));
+    expect(groupedToggle).toBeTruthy();
 
     act(() => {
-      groupedToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      groupedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
-    const settingsButton = Array.from(host?.querySelectorAll('button') ?? []).find(
-      (candidate) =>
-        /edit group settings|编辑分组设置/i.test(
-          candidate.getAttribute('aria-label') ?? candidate.textContent ?? '',
-        ),
-    )
-    expect(settingsButton).toBeTruthy()
+    const settingsButton = Array.from(
+      host?.querySelectorAll("button") ?? [],
+    ).find((candidate) =>
+      /edit group settings|编辑分组设置/i.test(
+        candidate.getAttribute("aria-label") ?? candidate.textContent ?? "",
+      ),
+    );
+    expect(settingsButton).toBeTruthy();
 
     act(() => {
-      settingsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      settingsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
-    const dialogs = Array.from(host?.ownerDocument.querySelectorAll('[role="dialog"]') ?? [])
+    const dialogs = Array.from(
+      host?.ownerDocument.querySelectorAll('[role="dialog"]') ?? [],
+    );
     const groupSettingsDialog = dialogs.find((candidate) =>
-      /group settings|分组设置/i.test(candidate.textContent ?? ''),
-    )
-    expect(groupSettingsDialog).toBeTruthy()
-    expect(groupSettingsDialog?.textContent ?? '').toContain(
-      'already exists',
-    )
-    expect(groupSettingsDialog?.textContent ?? '').not.toContain(
-      'creates its shared settings in advance',
-    )
+      /group settings|分组设置/i.test(candidate.textContent ?? ""),
+    );
+    expect(groupSettingsDialog).toBeTruthy();
+    expect(groupSettingsDialog?.textContent ?? "").toContain("already exists");
+    expect(groupSettingsDialog?.textContent ?? "").not.toContain(
+      "creates its shared settings in advance",
+    );
 
     const saveButton = Array.from(
-      groupSettingsDialog?.querySelectorAll('button') ?? [],
-    ).find((candidate) => /save|保存/i.test(candidate.textContent ?? ''))
-    expect(saveButton).toBeTruthy()
+      groupSettingsDialog?.querySelectorAll("button") ?? [],
+    ).find((candidate) => /save|保存/i.test(candidate.textContent ?? ""));
+    expect(saveButton).toBeTruthy();
 
     act(() => {
-      saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+      saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     await act(async () => {
-      await Promise.resolve()
-    })
+      await Promise.resolve();
+    });
 
-    expect(saveGroupNote).toHaveBeenCalledTimes(1)
-  })
+    expect(saveGroupNote).toHaveBeenCalledTimes(1);
+  });
 
-  it('consumes a named presetGroupFilter from location state and clears the one-shot navigation state', async () => {
-    mockRosterFreshnessPage()
+  it("consumes a named presetGroupFilter from location state and clears the one-shot navigation state", async () => {
+    mockRosterFreshnessPage();
     writeStoredUpstreamFilters({
       workStatus: [],
       enableStatus: [],
       healthStatus: [],
       tagIds: [],
       groupFilter: {
-        mode: 'search',
-        query: 'stale-group',
+        mode: "search",
+        query: "stale-group",
       },
-    })
+    });
     render({
-      pathname: '/account-pool/upstream-accounts',
+      pathname: "/account-pool/upstream-accounts",
       state: {
         presetGroupFilter: {
-          mode: 'exact',
-          query: '  prod  ',
+          mode: "exact",
+          query: "  prod  ",
         },
       },
-    })
+    });
 
-    await flushAsync()
-    await flushAsync()
+    await flushAsync();
+    await flushAsync();
 
     expect(hookMocks.useUpstreamAccounts.mock.calls[0]?.[0]).toEqual({
       includeAll: true,
-      groupExact: ['prod'],
-    })
+      groupExact: ["prod"],
+    });
     expectRosterHookQuery({
       includeAll: true,
-      groupExact: ['prod'],
-    })
+      groupExact: ["prod"],
+    });
     expect(hookMocks.useUpstreamAccounts.mock.calls).not.toContainEqual([
       {
         page: 1,
         pageSize: 20,
-        groupExact: ['stale-group'],
+        groupExact: ["stale-group"],
       },
-    ])
-    expect(readStoredUpstreamFilters()?.groupFilters).toEqual(['stale-group'])
+    ]);
+    expect(readStoredUpstreamFilters()?.groupFilters).toEqual(["stale-group"]);
     expect(navigateMock).toHaveBeenCalledWith(
       {
-        pathname: '/account-pool/upstream-accounts',
-        search: '',
+        pathname: "/account-pool/upstream-accounts",
+        search: "",
       },
       {
         replace: true,
         state: null,
       },
-    )
-  })
+    );
+  });
 
-  it('consumes an ungrouped presetGroupFilter from location state and resets the roster to page 1', async () => {
-    mockRosterFreshnessPage()
+  it("consumes an ungrouped presetGroupFilter from location state and resets the roster to page 1", async () => {
+    mockRosterFreshnessPage();
     writeStoredUpstreamFilters({
       workStatus: [],
       enableStatus: [],
       healthStatus: [],
       tagIds: [],
       groupFilter: {
-        mode: 'search',
-        query: 'stale-group',
+        mode: "search",
+        query: "stale-group",
       },
-    })
+    });
     render({
-      pathname: '/account-pool/upstream-accounts',
+      pathname: "/account-pool/upstream-accounts",
       state: {
         presetGroupFilter: {
-          mode: 'ungrouped',
-          query: '',
+          mode: "ungrouped",
+          query: "",
         },
       },
-    })
+    });
 
-    await flushAsync()
-    await flushAsync()
+    await flushAsync();
+    await flushAsync();
 
     expectRosterHookQuery({
       includeAll: true,
-      groupExact: ['未分组'],
-    })
-    expect(readStoredUpstreamFilters()?.groupFilters).toEqual(['stale-group'])
+      groupExact: ["未分组"],
+    });
+    expect(readStoredUpstreamFilters()?.groupFilters).toEqual(["stale-group"]);
     expect(navigateMock).toHaveBeenCalledWith(
       {
-        pathname: '/account-pool/upstream-accounts',
-        search: '',
+        pathname: "/account-pool/upstream-accounts",
+        search: "",
       },
       {
         replace: true,
         state: null,
       },
-    )
-  })
+    );
+  });
 
-  it('keeps detail-drawer roster hydration disabled until a roster-dependent tab opens', async () => {
-    mockRosterFreshnessPage()
-    host = document.createElement("div")
-    document.body.appendChild(host)
-    root = createRoot(host)
+  it("keeps detail-drawer roster hydration disabled until a roster-dependent tab opens", async () => {
+    mockRosterFreshnessPage();
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
     act(() => {
       root?.render(
         <I18nProvider>
@@ -2116,18 +2150,22 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
             </MemoryRouter>
           </SystemNotificationProvider>
         </I18nProvider>,
-      )
-    })
+      );
+    });
 
-    await flushAsync()
-    await flushAsync()
+    await flushAsync();
+    await flushAsync();
 
-    expect(hookMocks.useUpstreamAccounts.mock.calls[0]?.[0]).toBeNull()
-    expect(hookMocks.useUpstreamStickyConversations.mock.calls.at(-1)?.[1]).toEqual({
-      mode: 'count',
+    expect(hookMocks.useUpstreamAccounts.mock.calls[0]?.[0]).toBeNull();
+    expect(
+      hookMocks.useUpstreamStickyConversations.mock.calls.at(-1)?.[1],
+    ).toEqual({
+      mode: "count",
       limit: 50,
-    })
-    expect(hookMocks.useUpstreamStickyConversations.mock.calls.at(-1)?.[2]).toBe(false)
+    });
+    expect(
+      hookMocks.useUpstreamStickyConversations.mock.calls.at(-1)?.[2],
+    ).toBe(false);
 
     act(() => {
       root?.render(
@@ -2143,11 +2181,11 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
             </MemoryRouter>
           </SystemNotificationProvider>
         </I18nProvider>,
-      )
-    })
-    await flushAsync()
-    hookMocks.useUpstreamAccounts.mockClear()
-    hookMocks.useUpstreamStickyConversations.mockClear()
+      );
+    });
+    await flushAsync();
+    hookMocks.useUpstreamAccounts.mockClear();
+    hookMocks.useUpstreamStickyConversations.mockClear();
     act(() => {
       root?.render(
         <I18nProvider>
@@ -2162,9 +2200,9 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
             </MemoryRouter>
           </SystemNotificationProvider>
         </I18nProvider>,
-      )
-    })
-    await flushAsync()
+      );
+    });
+    await flushAsync();
 
     expect(hookMocks.useUpstreamAccounts.mock.calls).toContainEqual([
       undefined,
@@ -2172,8 +2210,8 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
         allowSelectionOutsideList: true,
         fallbackToFirstItem: false,
       },
-    ])
-  })
+    ]);
+  });
 
   it("subscribes the records tab fetch lifecycle to the selected upstream account and reconciles on SSE open", async () => {
     mockAccountsPage();
@@ -2315,6 +2353,49 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
     });
   });
 
+  it("hydrates recent actions only after switching to the health events tab", async () => {
+    const loadDetail = vi.fn();
+    mockAccountsPage({
+      detail: {
+        recentActions: [],
+      },
+      loadDetail,
+    });
+
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    act(() => {
+      root?.render(
+        <ThemeProvider>
+          <I18nProvider>
+            <SystemNotificationProvider>
+              <MemoryRouter>
+                <SharedUpstreamAccountDetailDrawer
+                  open
+                  accountId={5}
+                  initialTab="overview"
+                  onClose={vi.fn()}
+                />
+              </MemoryRouter>
+            </SystemNotificationProvider>
+          </I18nProvider>
+        </ThemeProvider>,
+      );
+    });
+
+    await flushAsync();
+    expect(loadDetail).not.toHaveBeenCalled();
+
+    clickTab(/健康与事件|health/i);
+    await flushAsync();
+
+    expect(loadDetail).toHaveBeenCalledWith(5, {
+      silent: true,
+      includeRecentActions: true,
+    });
+  });
+
   it("clears a stale records error after an SSE-open retry succeeds", async () => {
     mockAccountsPage();
     apiMocks.fetchInvocationRecords
@@ -2367,7 +2448,9 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
       expect(apiMocks.fetchInvocationRecords).toHaveBeenCalledTimes(1);
     });
     await waitForAssertion(() => {
-      expect(document.body.textContent).toContain("initial records fetch failed");
+      expect(document.body.textContent).toContain(
+        "initial records fetch failed",
+      );
     });
 
     act(() => {
@@ -2378,17 +2461,19 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
     await waitForAssertion(() => {
       expect(apiMocks.fetchInvocationRecords).toHaveBeenCalledTimes(2);
     });
-    expect(document.body.textContent).not.toContain("initial records fetch failed");
+    expect(document.body.textContent).not.toContain(
+      "initial records fetch failed",
+    );
 
     await waitForAssertion(() => {
       expect(renderedInvocationAccountNames()).toContain("Existing OAuth");
     });
-    expect(document.body.textContent).not.toContain("initial records fetch failed");
+    expect(document.body.textContent).not.toContain(
+      "initial records fetch failed",
+    );
   });
 
-  it(
-    "clears stale rows before the records tab refetches for limit changes",
-    async () => {
+  it("clears stale rows before the records tab refetches for limit changes", async () => {
     const secondFetch = deferred<{
       snapshotId: number;
       total: number;
@@ -2491,9 +2576,7 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
     await waitForAssertion(() => {
       expect(renderedInvocationAccountNames()).toContain("Existing OAuth");
     });
-    },
-    30000,
-  );
+  }, 30000);
 
   it("clears stale rows when entering the records tab from another tab", async () => {
     const secondFetch = deferred<{
@@ -2601,4 +2684,4 @@ describe('UpstreamAccountsPage grouped roster toggle', () => {
       expect(renderedInvocationAccountNames()).toContain("Existing OAuth");
     });
   });
-})
+});


### PR DESCRIPTION
## Summary

- scope account detail overview reads to first-screen data and move `recentActions` to an opt-in follow-up fetch
- restore records summary cards to read-model-first totals with bounded live augmentation
- remove roster-level `window-usage` auto hydration when no account is selected
- avoid account-scoped natural-day summary tail double counting after rebasing onto the latest mainline summary fix

## Verification

- `cargo test get_upstream_account_omits_recent_actions_by_default_and_loads_them_on_demand -- --nocapture`
- `cargo test natural_day_summary_reports_retry_wait_and_non_success_usage -- --nocapture`
- `cargo test account_scoped_natural_day_summary_keeps_augmentation_fields_scoped -- --nocapture`
- `cd web && bun x vitest run --project=unit src/hooks/useUpstreamAccounts.test.tsx src/pages/account-pool/UpstreamAccounts.test.tsx src/lib/api.test.ts`
- `cd web && bun run test-storybook`

## Diagnostics

- read-only check on srv-101 confirmed the existing blocked hourly rollup state remains an operational signal only; this PR does not perform any online repair or write

Spec: docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md
Spec Disposition: update
Spec Sync: done
Spec Drift: none
Solutions: docs/solutions/performance/account-detail-stats-read-model-sla.md
Solutions Sync: done
Project Docs: -
Project Docs Sync: n/a(no project-doc change)

## Notes

- owner waived visual evidence for this task, so the PR body should remain image-free
