### PR TITLE
fix(dashboard): expand upstream account recent rows

### DIFF
--- a/web/src/components/DashboardWorkingConversationsSection.stories.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.stories.tsx
@@ -338,7 +338,10 @@ function createUpstreamAccountActivityStoryResponse(
         spendRate: 0.12,
         firstByteAvgMs: 420,
         avgTotalMs: 860,
-        inProgressInvocationCount: 3,
+        inProgressInvocationCount: Math.max(
+          0,
+          Math.min(recentInvocationCount, 16),
+        ),
         retryInvocationCount: 1,
         recentInvocations,
       },

--- a/web/src/components/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.test.tsx
@@ -60,6 +60,7 @@ const upstreamAccountActivityMock = vi.hoisted(() => ({
   data: null as UpstreamAccountActivityResponse | null,
   isLoading: false,
   error: null as string | null,
+  resolvedRecentInvocationLimit: null as number | null,
   calls: [] as Array<{
     range: string;
     enabled: boolean;
@@ -82,6 +83,11 @@ vi.mock("../hooks/useDashboardUpstreamAccountActivity", () => ({
       data: upstreamAccountActivityMock.data,
       isLoading: upstreamAccountActivityMock.isLoading,
       error: upstreamAccountActivityMock.error,
+      recentInvocationLimit:
+        upstreamAccountActivityMock.resolvedRecentInvocationLimit ??
+        recentInvocationLimit ??
+        upstreamAccountActivityMock.data?.accounts[0]?.recentInvocations.length ??
+        4,
       hasActivated: enabled,
       reload: vi.fn(),
     };
@@ -295,6 +301,7 @@ afterEach(() => {
   upstreamAccountActivityMock.data = null;
   upstreamAccountActivityMock.isLoading = false;
   upstreamAccountActivityMock.error = null;
+  upstreamAccountActivityMock.resolvedRecentInvocationLimit = null;
   upstreamAccountActivityMock.calls = [];
   globalThis.ResizeObserver = originalResizeObserver;
   vi.restoreAllMocks();
@@ -672,6 +679,59 @@ describe("DashboardWorkingConversationsSection", () => {
       recentInvocationLimit: 7,
     });
     expect(host?.textContent).toContain("最近 7 条调用");
+  });
+
+  it("renders upstream account cards with their own resolved recent preview limit", () => {
+    upstreamAccountActivityMock.data = {
+      ...createUpstreamAccountActivityResponse(),
+      accounts: [
+        {
+          ...createUpstreamAccountActivityResponse().accounts[0]!,
+          inProgressInvocationCount: 9,
+          recentInvocations: Array.from({ length: 9 }, (_, index) =>
+            createPreview({
+              id: 9800 + index,
+              invokeId: `acct-expanded-${index + 1}`,
+              promptCacheKey: `pck-upstream-expanded-${index + 1}`,
+              occurredAt: `2026-04-04T10:${String(59 - index).padStart(2, "0")}:00Z`,
+              status: index < 7 ? "running" : "success",
+              upstreamAccountName: "Pool Alpha",
+            }),
+          ),
+        },
+      ],
+    };
+    upstreamAccountActivityMock.resolvedRecentInvocationLimit = 9;
+
+    renderSection(
+      createResponse([
+        createConversation("pck-upstream-account-limit", [
+          createPreview({
+            id: 1,
+            invokeId: "invoke-upstream-account-limit",
+            occurredAt: "2026-04-04T10:04:00Z",
+            status: "running",
+          }),
+        ]),
+      ]),
+      { recentPreviewLimit: 4 },
+    );
+
+    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
+      (node) => node.textContent?.includes("上游账号"),
+    );
+    if (!(accountTab instanceof HTMLButtonElement)) {
+      throw new Error("missing upstream account tab");
+    }
+
+    act(() => {
+      fireEvent.click(accountTab);
+    });
+
+    expect(host?.textContent).toContain("最近 9 条调用");
+    expect(
+      host?.querySelectorAll('[data-testid="dashboard-upstream-account-recent-row"]'),
+    ).toHaveLength(9);
   });
 
   it("disables and falls back from the upstream account tab for usage range", () => {

--- a/web/src/components/DashboardWorkingConversationsSection.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.tsx
@@ -1984,6 +1984,7 @@ export function DashboardWorkingConversationsSection({
     data: upstreamAccountActivity,
     isLoading: upstreamAccountActivityLoading,
     error: upstreamAccountActivityError,
+    recentInvocationLimit: upstreamAccountRecentPreviewLimit,
   } = useDashboardUpstreamAccountActivity(
     activeRange,
     upstreamAccountActivityEnabled,
@@ -2354,7 +2355,7 @@ export function DashboardWorkingConversationsSection({
                     locale={locale}
                     localeTag={localeTag}
                     nowMs={nowMs}
-                    recentPreviewLimit={recentPreviewLimit}
+                    recentPreviewLimit={upstreamAccountRecentPreviewLimit}
                     onOpenUpstreamAccount={onOpenUpstreamAccount}
                     onOpenInvocation={onOpenInvocation}
                   />

--- a/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
+++ b/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
@@ -328,6 +328,33 @@ describe("useDashboardUpstreamAccountActivity", () => {
     expect(text("visible-limit")).toBe("9");
   });
 
+  it("does not shrink below the requested seed limit when the response resolves smaller", async () => {
+    apiMocks.fetchUpstreamAccountActivity.mockResolvedValue(
+      createAccountResponse(
+        3,
+        Array.from({ length: 7 }, (_, index) =>
+          createPreview({
+            id: 350 + index,
+            invokeId: `seed-stable-${index + 1}`,
+            occurredAt: `2026-04-04T10:${String(59 - index).padStart(2, "0")}:00Z`,
+            status: index < 3 ? "running" : "success",
+          }),
+        ),
+      ),
+    );
+
+    render(<Probe recentInvocationLimit={7} />);
+    await flushAsync();
+    await flushAsync();
+
+    expect(apiMocks.fetchUpstreamAccountActivity).toHaveBeenCalledTimes(1);
+    expect(apiMocks.fetchUpstreamAccountActivity.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ recentLimit: 7 }),
+    );
+    expect(text("visible-limit")).toBe("7");
+    expect(text("recent-count")).toBe("7");
+  });
+
   it("ignores stale smaller responses after a larger limit reload is queued", async () => {
     const first = deferred<UpstreamAccountActivityResponse>();
     const second = deferred<UpstreamAccountActivityResponse>();

--- a/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
+++ b/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
@@ -1,0 +1,375 @@
+/** @vitest-environment jsdom */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type {
+  PromptCacheConversationInvocationPreview,
+  UpstreamAccountActivityResponse,
+} from "../lib/api";
+import {
+  DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MAX,
+  DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN,
+} from "./useDashboardWorkingConversations";
+import {
+  resolveUpstreamAccountRecentPreviewLimit,
+  useDashboardUpstreamAccountActivity,
+} from "./useDashboardUpstreamAccountActivity";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchUpstreamAccountActivity:
+    vi.fn<
+      (
+        range: string,
+        options?: { recentLimit?: number; timeZone?: string; signal?: AbortSignal },
+      ) => Promise<UpstreamAccountActivityResponse>
+    >(),
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    fetchUpstreamAccountActivity: apiMocks.fetchUpstreamAccountActivity,
+  };
+});
+
+vi.mock("../lib/sse", () => ({
+  subscribeToSse: () => () => {},
+  subscribeToSseOpen: () => () => {},
+}));
+
+let host: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    writable: true,
+    value: true,
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  host?.remove();
+  host = null;
+  root = null;
+  vi.clearAllMocks();
+});
+
+function render(ui: React.ReactNode) {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root?.render(ui);
+  });
+}
+
+async function flushAsync() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function text(testId: string) {
+  const element = host?.querySelector(`[data-testid="${testId}"]`);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Missing element: ${testId}`);
+  }
+  return element.textContent ?? "";
+}
+
+function createPreview(
+  overrides: Partial<PromptCacheConversationInvocationPreview> & {
+    id: number;
+    invokeId: string;
+    occurredAt: string;
+    status: string;
+  },
+): PromptCacheConversationInvocationPreview {
+  return {
+    id: overrides.id,
+    invokeId: overrides.invokeId,
+    promptCacheKey:
+      "promptCacheKey" in overrides ? (overrides.promptCacheKey ?? null) : null,
+    occurredAt: overrides.occurredAt,
+    status: overrides.status,
+    failureClass: overrides.failureClass ?? "none",
+    routeMode: overrides.routeMode ?? "pool",
+    model: overrides.model ?? "gpt-5.4",
+    requestModel:
+      "requestModel" in overrides ? (overrides.requestModel ?? null) : "gpt-5.4",
+    responseModel:
+      "responseModel" in overrides
+        ? (overrides.responseModel ?? null)
+        : (overrides.model ?? "gpt-5.4"),
+    totalTokens: overrides.totalTokens ?? 120,
+    cost: overrides.cost ?? 0.01,
+    proxyDisplayName:
+      "proxyDisplayName" in overrides
+        ? (overrides.proxyDisplayName ?? null)
+        : "tokyo-edge-01",
+    upstreamAccountId:
+      "upstreamAccountId" in overrides
+        ? (overrides.upstreamAccountId ?? null)
+        : 42,
+    upstreamAccountName:
+      "upstreamAccountName" in overrides
+        ? (overrides.upstreamAccountName ?? null)
+        : "Pool Alpha",
+    upstreamAccountPlanType:
+      "upstreamAccountPlanType" in overrides
+        ? (overrides.upstreamAccountPlanType ?? null)
+        : null,
+    endpoint: overrides.endpoint ?? "/v1/responses",
+    compactionRequestKind: overrides.compactionRequestKind ?? null,
+    compactionResponseKind: overrides.compactionResponseKind ?? null,
+    imageIntent: overrides.imageIntent ?? null,
+    inputTokens: overrides.inputTokens ?? 70,
+    outputTokens: overrides.outputTokens ?? 50,
+    cacheInputTokens: overrides.cacheInputTokens ?? 0,
+    reasoningTokens: overrides.reasoningTokens ?? 0,
+    reasoningEffort: overrides.reasoningEffort ?? "medium",
+    errorMessage: overrides.errorMessage,
+    downstreamStatusCode: overrides.downstreamStatusCode,
+    downstreamErrorMessage: overrides.downstreamErrorMessage,
+    failureKind: overrides.failureKind,
+    transport: overrides.transport,
+    requestedServiceTier: overrides.requestedServiceTier ?? "priority",
+    serviceTier: overrides.serviceTier ?? "priority",
+    tReqReadMs: overrides.tReqReadMs ?? 10,
+    tReqParseMs: overrides.tReqParseMs ?? 8,
+    tUpstreamConnectMs: overrides.tUpstreamConnectMs ?? 40,
+    tUpstreamTtfbMs: overrides.tUpstreamTtfbMs ?? 35,
+    tUpstreamStreamMs: overrides.tUpstreamStreamMs ?? 90,
+    tRespParseMs: overrides.tRespParseMs ?? 6,
+    tPersistMs: overrides.tPersistMs ?? 4,
+    tTotalMs: overrides.tTotalMs ?? 180,
+  };
+}
+
+function createAccountResponse(
+  inProgressInvocationCount: number,
+  recentInvocations: PromptCacheConversationInvocationPreview[],
+): UpstreamAccountActivityResponse {
+  return {
+    range: "today",
+    rangeStart: "2026-04-04T10:00:00Z",
+    rangeEnd: "2026-04-04T10:05:00Z",
+    accounts: [
+      {
+        upstreamAccountId: 42,
+        displayName: "Pool Alpha",
+        groupName: "Primary",
+        planType: "enterprise",
+        requestCount: recentInvocations.length,
+        successCount: recentInvocations.filter((item) => item.status === "success")
+          .length,
+        failureCount: recentInvocations.filter((item) => item.status === "failed")
+          .length,
+        nonSuccessCount: recentInvocations.filter(
+          (item) => item.status === "failed",
+        ).length,
+        totalTokens: recentInvocations.reduce(
+          (sum, item) => sum + item.totalTokens,
+          0,
+        ),
+        successTokens: 480,
+        nonSuccessTokens: 120,
+        failureTokens: 120,
+        failureCost: 0.04,
+        totalCost: 0.12,
+        cacheHitRate: 0.15,
+        tokensPerMinute: 250,
+        spendRate: 0.03,
+        firstByteAvgMs: 320,
+        avgTotalMs: 780,
+        inProgressInvocationCount,
+        retryInvocationCount: 1,
+        recentInvocations,
+      },
+    ],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function Probe({
+  enabled = true,
+  range = "today",
+  recentInvocationLimit = DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN,
+}: {
+  enabled?: boolean;
+  range?: string;
+  recentInvocationLimit?: number;
+}) {
+  const { data, isLoading, error, recentInvocationLimit: visibleLimit } =
+    useDashboardUpstreamAccountActivity(range, enabled, recentInvocationLimit);
+
+  return (
+    <div>
+      <div data-testid="loading">{isLoading ? "true" : "false"}</div>
+      <div data-testid="error">{error ?? ""}</div>
+      <div data-testid="visible-limit">{String(visibleLimit)}</div>
+      <div data-testid="recent-count">
+        {String(data?.accounts[0]?.recentInvocations.length ?? 0)}
+      </div>
+    </div>
+  );
+}
+
+describe("resolveUpstreamAccountRecentPreviewLimit", () => {
+  it("clamps to the minimum when there is no in-flight activity", () => {
+    expect(
+      resolveUpstreamAccountRecentPreviewLimit([
+        { inProgressInvocationCount: 0 },
+        { inProgressInvocationCount: null },
+      ]),
+    ).toBe(DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN);
+  });
+
+  it("uses the highest in-progress account count", () => {
+    expect(
+      resolveUpstreamAccountRecentPreviewLimit([
+        { inProgressInvocationCount: 3 },
+        { inProgressInvocationCount: 9 },
+        { inProgressInvocationCount: 5 },
+      ]),
+    ).toBe(9);
+  });
+
+  it("clamps to the configured maximum", () => {
+    expect(
+      resolveUpstreamAccountRecentPreviewLimit([
+        { inProgressInvocationCount: 18 },
+      ]),
+    ).toBe(DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MAX);
+  });
+});
+
+describe("useDashboardUpstreamAccountActivity", () => {
+  it("expands the recent limit after hydration when an account has more in-flight invocations", async () => {
+    const first = createAccountResponse(
+      9,
+      Array.from({ length: 4 }, (_, index) =>
+        createPreview({
+          id: 100 + index,
+          invokeId: `seed-${index + 1}`,
+          occurredAt: `2026-04-04T10:0${4 - index}:00Z`,
+          status: index < 3 ? "running" : "success",
+        }),
+      ),
+    );
+    const second = createAccountResponse(
+      9,
+      Array.from({ length: 9 }, (_, index) =>
+        createPreview({
+          id: 200 + index,
+          invokeId: `expanded-${index + 1}`,
+          occurredAt: `2026-04-04T10:${String(59 - index).padStart(2, "0")}:00Z`,
+          status: index < 7 ? "running" : "success",
+        }),
+      ),
+    );
+
+    apiMocks.fetchUpstreamAccountActivity
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+
+    render(<Probe />);
+    await flushAsync();
+    await flushAsync();
+
+    expect(apiMocks.fetchUpstreamAccountActivity).toHaveBeenCalledTimes(2);
+    expect(apiMocks.fetchUpstreamAccountActivity.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ recentLimit: 4 }),
+    );
+    expect(apiMocks.fetchUpstreamAccountActivity.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({ recentLimit: 9 }),
+    );
+    expect(text("visible-limit")).toBe("9");
+    expect(text("recent-count")).toBe("9");
+    expect(text("loading")).toBe("false");
+  });
+
+  it("does not shrink below an already discovered larger account limit", async () => {
+    apiMocks.fetchUpstreamAccountActivity.mockResolvedValue(
+      createAccountResponse(
+        9,
+        Array.from({ length: 9 }, (_, index) =>
+          createPreview({
+            id: 300 + index,
+            invokeId: `stable-${index + 1}`,
+            occurredAt: `2026-04-04T10:${String(59 - index).padStart(2, "0")}:00Z`,
+            status: "running",
+          }),
+        ),
+      ),
+    );
+
+    render(<Probe recentInvocationLimit={7} />);
+    await flushAsync();
+    await flushAsync();
+
+    expect(text("visible-limit")).toBe("9");
+  });
+
+  it("ignores stale smaller responses after a larger limit reload is queued", async () => {
+    const first = deferred<UpstreamAccountActivityResponse>();
+    const second = deferred<UpstreamAccountActivityResponse>();
+    apiMocks.fetchUpstreamAccountActivity
+      .mockImplementationOnce(async () => first.promise)
+      .mockImplementationOnce(async () => second.promise);
+
+    render(<Probe />);
+    await flushAsync();
+
+    first.resolve(
+      createAccountResponse(
+        9,
+        Array.from({ length: 4 }, (_, index) =>
+          createPreview({
+            id: 400 + index,
+            invokeId: `deferred-seed-${index + 1}`,
+            occurredAt: `2026-04-04T10:0${4 - index}:00Z`,
+            status: "running",
+          }),
+        ),
+      ),
+    );
+    await flushAsync();
+
+    second.resolve(
+      createAccountResponse(
+        9,
+        Array.from({ length: 9 }, (_, index) =>
+          createPreview({
+            id: 500 + index,
+            invokeId: `deferred-expanded-${index + 1}`,
+            occurredAt: `2026-04-04T10:${String(59 - index).padStart(2, "0")}:00Z`,
+            status: "running",
+          }),
+        ),
+      ),
+    );
+    await flushAsync();
+
+    expect(text("visible-limit")).toBe("9");
+    expect(text("recent-count")).toBe("9");
+    expect(text("error")).toBe("");
+  });
+});

--- a/web/src/hooks/useDashboardUpstreamAccountActivity.ts
+++ b/web/src/hooks/useDashboardUpstreamAccountActivity.ts
@@ -143,13 +143,17 @@ export function useDashboardUpstreamAccountActivity(
       }
       const resolvedRecentInvocationLimit =
         resolveUpstreamAccountRecentPreviewLimit(response.accounts);
+      const nextRecentInvocationLimit = Math.max(
+        requestedRecentLimit,
+        resolvedRecentInvocationLimit,
+      );
       const needsExpandedReload =
-        resolvedRecentInvocationLimit > requestedRecentLimit;
-      recentInvocationLimitRef.current = resolvedRecentInvocationLimit;
+        nextRecentInvocationLimit > requestedRecentLimit;
+      recentInvocationLimitRef.current = nextRecentInvocationLimit;
       setVisibleRecentInvocationLimit(
         needsExpandedReload
           ? requestedRecentLimit
-          : resolvedRecentInvocationLimit,
+          : nextRecentInvocationLimit,
       );
       setData(response);
       hasHydratedRef.current = true;

--- a/web/src/hooks/useDashboardUpstreamAccountActivity.ts
+++ b/web/src/hooks/useDashboardUpstreamAccountActivity.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN } from "./useDashboardWorkingConversations";
+import {
+  DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MAX,
+  DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN,
+} from "./useDashboardWorkingConversations";
 import {
   fetchUpstreamAccountActivity,
+  type UpstreamAccountActivityAccount,
   type UpstreamAccountActivityResponse,
 } from "../lib/api";
 import { subscribeToSse, subscribeToSseOpen } from "../lib/sse";
@@ -17,17 +21,49 @@ function isAbortError(error: unknown) {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
+function clampRecentInvocationLimit(value: number) {
+  if (!Number.isFinite(value)) {
+    return DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN;
+  }
+  return Math.min(
+    DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MAX,
+    Math.max(
+      DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN,
+      Math.trunc(value),
+    ),
+  );
+}
+
+export function resolveUpstreamAccountRecentPreviewLimit(
+  accounts: Pick<UpstreamAccountActivityAccount, "inProgressInvocationCount">[],
+) {
+  let maxInProgressInvocationCount = 0;
+  for (const account of accounts) {
+    maxInProgressInvocationCount = Math.max(
+      maxInProgressInvocationCount,
+      account.inProgressInvocationCount ?? 0,
+    );
+  }
+  return clampRecentInvocationLimit(maxInProgressInvocationCount);
+}
+
 export function useDashboardUpstreamAccountActivity(
   range: string,
   enabled: boolean,
   recentInvocationLimit = DASHBOARD_WORKING_CONVERSATIONS_RECENT_PREVIEW_MIN,
 ) {
+  const initialRecentInvocationLimit = clampRecentInvocationLimit(
+    recentInvocationLimit,
+  );
   const [data, setData] = useState<UpstreamAccountActivityResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [visibleRecentInvocationLimit, setVisibleRecentInvocationLimit] =
+    useState(initialRecentInvocationLimit);
   const enabledRef = useRef(enabled);
   const rangeRef = useRef(range);
-  const recentInvocationLimitRef = useRef(recentInvocationLimit);
+  const recentInvocationLimitRef = useRef(initialRecentInvocationLimit);
+  const previousRangeRef = useRef(range);
   const hasActivatedRef = useRef(false);
   const hasHydratedRef = useRef(false);
   const inFlightRef = useRef(false);
@@ -47,8 +83,23 @@ export function useDashboardUpstreamAccountActivity(
   }, [range]);
 
   useEffect(() => {
-    recentInvocationLimitRef.current = recentInvocationLimit;
-  }, [recentInvocationLimit]);
+    const nextSeedRecentInvocationLimit = clampRecentInvocationLimit(
+      recentInvocationLimit,
+    );
+    const rangeChanged = previousRangeRef.current !== range;
+    previousRangeRef.current = range;
+    if (!enabled) {
+      recentInvocationLimitRef.current = nextSeedRecentInvocationLimit;
+      setVisibleRecentInvocationLimit(nextSeedRecentInvocationLimit);
+      return;
+    }
+    recentInvocationLimitRef.current = rangeChanged
+      ? nextSeedRecentInvocationLimit
+      : Math.max(
+          recentInvocationLimitRef.current,
+          nextSeedRecentInvocationLimit,
+        );
+  }, [enabled, range, recentInvocationLimit]);
 
   const clearPendingRefreshTimer = useCallback(() => {
     if (!refreshTimerRef.current) return;
@@ -90,9 +141,24 @@ export function useDashboardUpstreamAccountActivity(
       ) {
         return;
       }
+      const resolvedRecentInvocationLimit =
+        resolveUpstreamAccountRecentPreviewLimit(response.accounts);
+      const needsExpandedReload =
+        resolvedRecentInvocationLimit > requestedRecentLimit;
+      recentInvocationLimitRef.current = resolvedRecentInvocationLimit;
+      setVisibleRecentInvocationLimit(
+        needsExpandedReload
+          ? requestedRecentLimit
+          : resolvedRecentInvocationLimit,
+      );
       setData(response);
       hasHydratedRef.current = true;
       setError(null);
+      if (needsExpandedReload) {
+        pendingLoadRef.current = {
+          silent: pendingLoadRef.current?.silent ?? true,
+        };
+      }
     } catch (err) {
       if (isAbortError(err)) return;
       if (requestSeq !== requestSeqRef.current) return;
@@ -192,6 +258,7 @@ export function useDashboardUpstreamAccountActivity(
     data,
     isLoading,
     error,
+    recentInvocationLimit: visibleRecentInvocationLimit,
     hasActivated: hasActivatedRef.current,
     reload: load,
   };


### PR DESCRIPTION
## Summary
- fix upstream account recent invocation cards to expand by live in-progress account counts instead of staying pinned to the conversation-side seed limit
- add a dedicated upstream account activity hook test suite for clamp and auto-refetch behavior
- keep the existing dynamic recent row UI intact while correcting the request parameter flow

## Verification
- `cd web && bun run test -- src/hooks/useDashboardUpstreamAccountActivity.test.tsx src/components/DashboardWorkingConversationsSection.test.tsx`
- `cargo test upstream_account_activity_groups_active_accounts_and_hides_yesterday_live_counts -- --nocapture`
- `cd web && bun run build`

## References
- Specs: -
- Solutions: -
- Project Docs: -
