### PR TITLE
fix(perf): cut sqlite write pressure on srv-101

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -46,6 +46,7 @@ Using one cadence for all three overfits the most urgent surface and overloads t
 - Add lightweight diagnostics counters for each path: visible patch count, head fetch count, SSE summary commit count, HTTP reconcile count, chart data commit count, and conditional fetch hit count.
 - Keep `current` summary and dashboard account-activity reconcile on the same 5 second budget. A faster current-window reconcile without a matching backend live read model simply turns SQLite scan cost into a tighter request loop.
 - When an endpoint still needs strict “currently in progress” truth, move that truth into a write-side live table or read model and let the 5 second reconcile read that bounded surface instead of rescanning the historical raw table.
+- Treat dashboard working-set surfaces the same way: the 5-minute working-conversations head/count can read a write-side bounded working-set table, while exact snapshot pagination stays on its slower snapshot path because it is not part of the hot open-tab reconcile loop.
 - For future regressions, slow-path evidence needs to identify the class of work, not just that something was slow: emit endpoint/window/source-scope plus key counts or cache-hit state so operators can tell apart request-time scans, maintenance-time rebuilds, and cache hydration misses.
 
 ## Guardrails / Reuse Notes

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -12,6 +12,7 @@
 - 前台关键路径不应该和 rollup/backfill/retention/maintenance 使用同等重试预算。
 - 连接池等待超时本身就是 pressure signal，应触发后台 cooldown，而不是继续并发重试。
 - `proxy capture follow-up` 也必须遵守这个分级：没有 SSE 订阅者时，不得再消耗 summary/quota 或 hourly rollup refresh 预算。
+- 对请求收尾里的同一实体写入，要优先消除“重复唯一键探测 + 紧跟二次更新”“先重算 rollup 再补 timing 再重算一次”这类单请求内自我放大；SQLite 压力常常不是来自单条大 SQL，而是来自几条语义重复的写语句连发。
 
 ## 推荐模式
 
@@ -19,6 +20,7 @@
 
 - 前台关键写入：OAuth callback、请求路由状态、用户可见设置保存；优先拿连接，失败需返回明确业务错误。
 - 请求收尾写入：invocation 记录、usage、raw metadata；允许有界降级和异步旁路。
+- 请求收尾若已经存在对应 `running/pending` 行，优先原地更新而不是先 `INSERT OR IGNORE` 再走 repair/update；这样可以少一次唯一键冲突写尝试与后续锁竞争。
 - 后台维护写入：rollup、retention、account maintenance；pressure 下 fail-soft skip。
 - 历史回填写入：startup backfill、archive materialization；pressure 下延后，不阻塞 readiness。
 
@@ -47,6 +49,7 @@
 - 为每个后台入口单独做局部退避，容易遗漏同一压力窗口内的其他维护任务；进程级 gate 更容易统一行为。
 - `SELECT MAX(id) ... WHERE <稀疏条件>`、`NOT EXISTS` + 低选择性 phase 过滤这类查询，即使最终只返回 1 行，也可能在 SQLite 上吃掉秒级读锁预算；若它们会与前台 HTTP 共享同一数据库，必须先压成 cursor 读取或用 partial index 固定扫描面。
 - 对 proxy 收尾这类 SSE follow-up，`receiver_count()==0` 应该直接意味着“跳过 follow-up”，而不是继续排队 summary/quota 或 rollup refresh；否则会把没有任何订阅者的请求变成纯数据库放大器。
+- write-side live read model 只有在维护成本本身也受控时才值得做：前台请求内同步维护最小必要 working-set / in-progress truth，后台 rebuild 和补偿刷新则继续挂到统一 pressure gate/cooldown，避免为了止住读热点又新增一组不受控维护写入。
 
 ## 何时升级方案
 

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -12,3 +12,4 @@
 - `parallel-work` keeps its existing response JSON shape; bandwidth reduction is handled through ETag / 304 conditional HTTP rather than trimming fields.
 - 2026-06-21: 继续把“活动中的调用记录列表”统一收口到现有 `records` SSE + open 后静默回源链路，明确覆盖 `Live`、`/records` 与账号详情抽屉 records tab；历史回放类抽屉保留各自 snapshot/history 语义，不强行改造成全量实时流。
 - 2026-06-29: Dashboard current-window summary reconcile 不再保留比 calendar window 更激进的 cadence；`current summary` 与 `upstream account activity` 统一收口到 `5s` refresh/open-resync 预算，避免前端更快回源把后端请求级 SQLite 热点放大成持续 CPU 压力。
+- 2026-06-30: 第二轮 CPU 止血把 Dashboard working conversations 当前 head/count 的真相源前移到 write-side `prompt_cache_working_set_live`，接受 `<=5s` bounded freshness，但不再让 5 分钟工作集每次 reconcile 都重扫 `codex_invocations`。

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -6,6 +6,7 @@
 - Implementation summary: 已完成
 - Dashboard realtime consumption now separates SSE-fast KPI commits from 5s HTTP/chart reconcile budgets. Working conversations batch visible SSE patches for 1s and throttle head/snapshot reconcile to 5s. `/api/stats/parallel-work` keeps its response schema while supporting ETag / 304 conditional fetches.
 - Current-window summary reconcile now matches the same 5s budget as calendar windows and account-activity reconcile. The dashboard debug diagnostics also split out `current summary refresh/open-resync` and `upstream account activity refresh/open-resync`, so future regressions can distinguish SSE-fast-path churn from HTTP reconcile churn.
+- Dashboard working conversations live head/count now read from a write-side `prompt_cache_working_set_live` table that keeps the last 5 minutes of terminal activity plus any current in-flight keys. The public response shape stays unchanged, while the hot read path no longer rebuilds the working set from `codex_invocations` on every request.
 
 ## Migrated Implementation Notes
 

--- a/docs/specs/t6d9r-account-detail-stats-read-model/HISTORY.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/HISTORY.md
@@ -19,3 +19,4 @@
 - 2026-06-25: records 顶部卡片字段调整后，account-scoped today summary 把 `nonSuccessCost` 拖回了 live augmentation 路径并丢失 live tail；现已恢复为 read-model totals + bounded tail，闭区间默认不做 live raw 重算。
 - 2026-06-25: `selectedId` 暂空时的 roster 级 `window-usage` 自动 hydrate 被彻底移除；详情首屏只允许当前账号发 `window-usage`，手动 hydrate 才能批量取数。
 - 2026-06-29: 101 线上 CPU 复盘确认，剩余 summary / account-activity 热点来自请求时对 `codex_invocations` 做 in-progress correlated scan / group scan；对应 live augmentation 已切到 write-side `invocation_in_progress_live` 小表，并保留 summary 全局 retry 与 account-scoped retry 的既有语义。
+- 2026-06-30: 第二轮止血继续把 summary publish 的 distinct in-progress conversation count 也切到 live truth source，避免 maintenance 发布链路把 account detail 已经省下来的 SQLite 扫描又带回来。

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -36,6 +36,7 @@
 - account-scoped summary 将 `nonSuccessCost` 固定纳入 rollup/read-model totals，并恢复带 `full_hour_range` 的 today live tail 精确补尾，避免新增字段后 today 卡片回退成 0 或强制 raw window 重扫。
 - `fetch_summary` / `fetch_stats` 按窗口类型区分 live augmentation：闭区间默认跳过 in-progress 与 non-success token live 补算；SQLite `database is locked` 时非成功 token live 增量允许受限降级，不再整排卡片长期 skeleton。
 - summary / account-activity 的 in-progress augmentation 已从请求时扫描 `codex_invocations` 改成 `invocation_in_progress_live` 小表读取。该 live read model 由 `codex_invocations` trigger 与 startup rebuild 同步维护，并分别保留 summary 全局 retry 与 account-scoped retry 语义，避免 Dashboard/account detail 的当前窗口 reconcile 把 read-model 节省下来的 CPU 再吃回去。
+- summary publish 当前窗口里的 `inProgressConversationCount` distinct-count 现在也直接复用 live table truth source，而不是在 maintenance 路径里对 `codex_invocations` 再做一次 `COUNT(DISTINCT prompt_cache_key)`；这让 summary 广播与账号详情共用同一份 bounded in-progress truth。
 - Storybook 现有详情抽屉 overlay stories 继续作为 page-fallback 证据面，新增 owner-facing 首屏概览态与 records 统计卡片完成态图片，覆盖这次性能回归修复后的默认打开路径。
 
 ## Verification

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
@@ -20,6 +20,7 @@
 - 2026-06-29：生产诊断确认账号卡“首字用时”误接成阶段级上游首字节时延，导致真实秒级总耗时在 owner-facing 卡面被渲染成 `0ms`；因此冻结该卡主值必须回到首字总耗时口径，并要求前后端同时保留显式字段用于平滑兼容。
 - 2026-06-29：线上热点复盘后，账号 tab 继续禁止逐条本地 SSE patch，并把 tab 激活态的 refresh/open-resync 统一锁到 `5s`；如果未来要恢复更高频 cadence，必须先拿到慢路径证据证明后端读路径不会再次退化成请求级热扫描。
 - 2026-06-29：补充修正 identity chip 槽位算法，明确不能直接对展示短码片段做低位 `% 8` 取槽；改为混合完整 hash 后选离散槽位，避免线上真实短码因低位偏置出现大面积同色聚集。
+- 2026-06-30：Dashboard `Working Conversations` 的 5 分钟 head/count 改读 write-side `prompt_cache_working_set_live`，并为 mixed-source 对话保留独立 `ProxyOnly` 聚合槽位，避免 UI 为了代理视图再次回扫 `codex_invocations`。
 
 ## Key Reasons / Replacements
 

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -27,6 +27,7 @@
 - 已实现：账号活动接口补出 `avgTotalMs`、`totalCost`、严格失败 `failureCost` 与 `failureTokens`；失败比率由前端按 `failureCount / requestCount` 计算，`其他` 按 `nonSuccessCount - failureCount` 下限归零。
 - 已实现：账号卡列表按 `totalTokens` 倒序排列，并用最近调用时间与账号 ID 作稳定排序兜底。
 - 已实现：账号卡“首字用时”从阶段级 `t_upstream_ttfb_ms` 纠偏为 owner-facing 的首字总耗时口径；后端聚合现在复用 `resolve_first_response_byte_total_ms(...)`，并额外暴露显式 `firstResponseByteTotalAvgMs` 供前端优先消费，避免真实秒级总耗时被渲染成 `0ms`。
+- 已实现：工作区 `对话` tab 当前 5 分钟 working-set 的 head/count 改读 write-side `prompt_cache_working_set_live`，并为 mixed-source key 保留 `All / ProxyOnly` 两套聚合列，避免换源后 `ProxyOnly` 视角丢 key 或排序漂移。
 
 ## Remaining Gaps
 

--- a/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/aggregate_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/aggregate_queries.rs
@@ -74,67 +74,17 @@ pub(crate) async fn query_active_prompt_cache_conversation_count(
 
 pub(crate) async fn query_working_prompt_cache_conversation_count(
     pool: &Pool<Sqlite>,
-    range_start_bound: &str,
+    _range_start_bound: &str,
     source_scope: InvocationSourceScope,
 ) -> Result<i64> {
-    const KEY_EXPR: &str = "CASE WHEN json_valid(payload) THEN TRIM(CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)) END";
-
     let mut query = QueryBuilder::<Sqlite>::new(
-        "WITH recent_terminal AS (\
-            SELECT ",
+        "SELECT COUNT(*) AS count \
+         FROM prompt_cache_working_set_live \
+         WHERE source_scope_all = 1",
     );
-    query
-        .push(KEY_EXPR)
-        .push(
-            " AS prompt_cache_key \
-             FROM codex_invocations \
-             WHERE occurred_at >= ",
-        )
-        .push_bind(range_start_bound)
-        .push(" AND ")
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) NOT IN ('running', 'pending')");
-
     if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
+        query.push(" AND source_scope_proxy_only = 1");
     }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), in_flight AS (\
-            SELECT ",
-    );
-    query
-        .push(KEY_EXPR)
-        .push(
-            " AS prompt_cache_key \
-             FROM codex_invocations \
-             WHERE ",
-        )
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) IN ('running', 'pending')");
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), working AS (\
-            SELECT prompt_cache_key FROM recent_terminal \
-            UNION \
-            SELECT prompt_cache_key FROM in_flight\
-         ) \
-         SELECT COUNT(*) AS count FROM working",
-    );
 
     let (count,) = query.build_query_as::<(i64,)>().fetch_one(pool).await?;
     Ok(count)
@@ -145,38 +95,20 @@ pub(crate) async fn query_in_progress_prompt_cache_conversation_count(
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
 ) -> Result<i64> {
-    const KEY_EXPR: &str = "CASE WHEN json_valid(payload) THEN TRIM(CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)) END";
-
     let mut query = QueryBuilder::<Sqlite>::new(
         "SELECT COUNT(DISTINCT prompt_cache_key) AS count \
-         FROM (\
-             SELECT ",
+         FROM invocation_in_progress_live \
+         WHERE prompt_cache_key IS NOT NULL \
+           AND prompt_cache_key <> ''",
     );
-    query.push(KEY_EXPR).push(
-        " AS prompt_cache_key \
-         FROM codex_invocations \
-         WHERE ",
-    );
-    query
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) IN ('running', 'pending')");
-
     if source_scope == InvocationSourceScope::ProxyOnly {
         query.push(" AND source = ").push_bind(SOURCE_PROXY);
     }
     if let Some(upstream_account_id) = upstream_account_id {
         query
-            .push(" AND ")
-            .push(crate::api::INVOCATION_UPSTREAM_ACCOUNT_ID_SQL)
-            .push(" = ")
+            .push(" AND upstream_account_id = ")
             .push_bind(upstream_account_id);
     }
-
-    query.push(")");
 
     let (count,) = query.build_query_as::<(i64,)>().fetch_one(pool).await?;
     Ok(count)
@@ -339,104 +271,47 @@ pub(crate) async fn query_prompt_cache_conversation_hidden_count(
 
 pub(crate) async fn query_prompt_cache_working_conversation_aggregates(
     pool: &Pool<Sqlite>,
-    range_start_bound: &str,
+    _range_start_bound: &str,
     source_scope: InvocationSourceScope,
     limit: i64,
 ) -> Result<Vec<PromptCacheConversationAggregateRow>> {
-    const KEY_EXPR: &str = "CASE WHEN json_valid(payload) THEN TRIM(CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)) END";
-
     let mut query = QueryBuilder::<Sqlite>::new(
-        "WITH recent_terminal AS (\
-            SELECT ",
+        "SELECT \
+            prompt_cache_key, \
+            ",
     );
-    query
-        .push(KEY_EXPR)
-        .push(
-            " AS prompt_cache_key, MAX(occurred_at) AS last_terminal_at \
-             FROM codex_invocations \
-             WHERE occurred_at >= ",
-        )
-        .push_bind(range_start_bound)
-        .push(" AND ")
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) NOT IN ('running', 'pending')");
-
     if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
+        query.push(
+            "proxy_request_count AS request_count, \
+             proxy_total_tokens AS total_tokens, \
+             proxy_total_cost AS total_cost, \
+             COALESCE(proxy_created_at, created_at) AS created_at, \
+             COALESCE(proxy_last_activity_at, last_activity_at) AS last_activity_at, \
+             proxy_sort_anchor_at AS sort_anchor_at, \
+             proxy_last_terminal_at AS last_terminal_at, \
+             proxy_last_in_flight_at AS last_in_flight_at \
+         FROM prompt_cache_working_set_live \
+         WHERE source_scope_proxy_only = 1 \
+           AND proxy_sort_anchor_at IS NOT NULL",
+        );
+    } else {
+        query.push(
+            "request_count, \
+             total_tokens, \
+             total_cost, \
+             created_at, \
+             last_activity_at, \
+             sort_anchor_at, \
+             last_terminal_at, \
+             last_in_flight_at \
+         FROM prompt_cache_working_set_live \
+         WHERE source_scope_all = 1",
+        );
     }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), in_flight AS (\
-            SELECT ",
-    );
-    query
-        .push(KEY_EXPR)
-        .push(
-            " AS prompt_cache_key, MAX(occurred_at) AS last_in_flight_at \
-             FROM codex_invocations \
-             WHERE ",
-        )
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) IN ('running', 'pending')");
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), working AS (\
-            SELECT prompt_cache_key, last_terminal_at, NULL AS last_in_flight_at \
-              FROM recent_terminal \
-            UNION ALL \
-            SELECT prompt_cache_key, NULL AS last_terminal_at, last_in_flight_at \
-              FROM in_flight \
-         ), collapsed_working AS (\
-            SELECT prompt_cache_key, \
-                   MAX(last_terminal_at) AS last_terminal_at, \
-                   MAX(last_in_flight_at) AS last_in_flight_at, \
-                   CASE \
-                       WHEN MAX(last_terminal_at) IS NULL THEN MAX(last_in_flight_at) \
-                       WHEN MAX(last_in_flight_at) IS NULL THEN MAX(last_terminal_at) \
-                       WHEN MAX(last_terminal_at) >= MAX(last_in_flight_at) THEN MAX(last_terminal_at) \
-                       ELSE MAX(last_in_flight_at) \
-                   END AS sort_anchor_at \
-              FROM working \
-              GROUP BY prompt_cache_key\
-         ), aggregates AS (\
-            SELECT prompt_cache_key, \
-                   SUM(request_count) AS request_count, \
-                   SUM(total_tokens) AS total_tokens, \
-                   SUM(total_cost) AS total_cost, \
-                   MIN(first_seen_at) AS created_at, \
-                   MAX(last_seen_at) AS last_activity_at \
-              FROM prompt_cache_rollup_hourly \
-             WHERE prompt_cache_key IN (SELECT prompt_cache_key FROM collapsed_working)",
-    );
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-
     query
         .push(
-            " GROUP BY prompt_cache_key\
-         ) \
-         SELECT aggregates.prompt_cache_key, aggregates.request_count, aggregates.total_tokens, \
-                aggregates.total_cost, aggregates.created_at, aggregates.last_activity_at \
-           FROM aggregates \
-           INNER JOIN collapsed_working ON collapsed_working.prompt_cache_key = aggregates.prompt_cache_key \
-          ORDER BY collapsed_working.sort_anchor_at DESC, aggregates.created_at DESC, aggregates.prompt_cache_key DESC \
-          LIMIT ",
+            " ORDER BY sort_anchor_at DESC, created_at DESC, prompt_cache_key DESC \
+              LIMIT ",
         )
         .push_bind(limit);
 

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -934,8 +934,8 @@ pub(crate) async fn persist_proxy_capture_record(
     .execute(tx.as_mut())
     .await?;
 
-    let (invocation_id, inserted_new_row) = if insert_result.rows_affected() > 0 {
-        (insert_result.last_insert_rowid(), true)
+    let invocation_id = if insert_result.rows_affected() > 0 {
+        insert_result.last_insert_rowid()
     } else {
         let Some(existing) = load_persisted_invocation_identity_tx(
             tx.as_mut(),
@@ -947,12 +947,11 @@ pub(crate) async fn persist_proxy_capture_record(
             tx.commit().await?;
             return Ok(None);
         };
-        let allow_terminal_repair = !invocation_status_is_in_flight(Some(record.status.as_str()))
-            && invocation_status_is_recoverable_proxy_interrupted(
-                existing.status.as_deref(),
-                existing.failure_kind.as_deref(),
-            );
-        if !invocation_status_is_in_flight(existing.status.as_deref()) && !allow_terminal_repair {
+        if !persisted_invocation_allows_proxy_record_update(
+            existing.status.as_deref(),
+            existing.failure_kind.as_deref(),
+            &record.status,
+        ) {
             tx.commit().await?;
             return Ok(None);
         }
@@ -1048,56 +1047,13 @@ pub(crate) async fn persist_proxy_capture_record(
             tx.commit().await?;
             return Ok(None);
         }
-
-        (existing.id, false)
+        existing.id
     };
 
     touch_invocation_upstream_account_last_activity_tx(
         tx.as_mut(),
         &record.occurred_at,
         record.payload.as_deref(),
-    )
-    .await?;
-
-    if inserted_new_row {
-        upsert_invocation_hourly_rollups_tx(
-            tx.as_mut(),
-            &[InvocationHourlySourceRecord {
-                id: invocation_id,
-                occurred_at: record.occurred_at.clone(),
-                source: SOURCE_PROXY.to_string(),
-                status: Some(record.status.clone()),
-                detail_level: DETAIL_LEVEL_FULL.to_string(),
-                input_tokens: record.usage.input_tokens,
-                output_tokens: record.usage.output_tokens,
-                cache_input_tokens: record.usage.cache_input_tokens,
-                total_tokens: record.usage.total_tokens,
-                cost: record.cost,
-                error_message: record.error_message.clone(),
-                failure_kind: failure_kind.clone(),
-                failure_class: Some(failure.failure_class.as_str().to_string()),
-                is_actionable: Some(failure.is_actionable as i64),
-                payload: record.payload.clone(),
-                t_total_ms: None,
-                t_req_read_ms: Some(record.timings.t_req_read_ms),
-                t_req_parse_ms: Some(record.timings.t_req_parse_ms),
-                t_upstream_connect_ms: Some(record.timings.t_upstream_connect_ms),
-                t_upstream_ttfb_ms: Some(record.timings.t_upstream_ttfb_ms),
-                t_upstream_stream_ms: Some(record.timings.t_upstream_stream_ms),
-                t_resp_parse_ms: Some(record.timings.t_resp_parse_ms),
-                t_persist_ms: None,
-            }],
-            &INVOCATION_HOURLY_ROLLUP_TARGETS,
-        )
-        .await?;
-    } else {
-        recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[invocation_id]).await?;
-    }
-
-    save_hourly_rollup_live_progress_tx(
-        tx.as_mut(),
-        HOURLY_ROLLUP_DATASET_INVOCATIONS,
-        invocation_id,
     )
     .await?;
 
@@ -1119,6 +1075,12 @@ pub(crate) async fn persist_proxy_capture_record(
     .await?;
 
     recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[invocation_id]).await?;
+    save_hourly_rollup_live_progress_tx(
+        tx.as_mut(),
+        HOURLY_ROLLUP_DATASET_INVOCATIONS,
+        invocation_id,
+    )
+    .await?;
 
     let persisted =
         load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -1830,6 +1830,19 @@ pub(crate) async fn load_persisted_invocation_identity_tx(
     .map_err(Into::into)
 }
 
+pub(crate) fn persisted_invocation_allows_proxy_record_update(
+    existing_status: Option<&str>,
+    existing_failure_kind: Option<&str>,
+    incoming_status: &str,
+) -> bool {
+    invocation_status_is_in_flight(existing_status)
+        || (!invocation_status_is_in_flight(Some(incoming_status))
+            && invocation_status_is_recoverable_proxy_interrupted(
+                existing_status,
+                existing_failure_kind,
+            ))
+}
+
 pub(crate) async fn load_persisted_api_invocation_tx(
     tx: &mut SqliteConnection,
     invoke_id: &str,
@@ -2024,158 +2037,20 @@ pub(crate) async fn persist_proxy_capture_runtime_record(
     let t_upstream_ttfb_ms = nullable_runtime_timing_value(record.timings.t_upstream_ttfb_ms);
     let created_at = format_utc_iso_millis(Utc::now());
     let mut tx = pool.begin().await?;
-    let insert_result = sqlx::query(
-        r#"
-        INSERT OR IGNORE INTO codex_invocations (
-            invoke_id,
-            occurred_at,
-            source,
-            model,
-            input_tokens,
-            output_tokens,
-            cache_input_tokens,
-            reasoning_tokens,
-            total_tokens,
-            cost,
-            cost_estimated,
-            price_version,
-            status,
-            error_message,
-            failure_kind,
-            failure_class,
-            is_actionable,
-            payload,
-            raw_response,
-            request_raw_path,
-            request_raw_codec,
-            request_raw_size,
-            request_raw_truncated,
-            request_raw_truncated_reason,
-            response_raw_path,
-            response_raw_codec,
-            response_raw_size,
-            response_raw_truncated,
-            response_raw_truncated_reason,
-            t_total_ms,
-            t_req_read_ms,
-            t_req_parse_ms,
-            t_upstream_connect_ms,
-            t_upstream_ttfb_ms,
-            t_upstream_stream_ms,
-            t_resp_parse_ms,
-            t_persist_ms,
-            created_at
-        )
-        VALUES (
-            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
-            ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
-            ?37, ?38
-        )
-        "#,
-    )
-    .bind(&record.invoke_id)
-    .bind(&record.occurred_at)
-    .bind(SOURCE_PROXY)
-    .bind(&record.model)
-    .bind(record.usage.input_tokens)
-    .bind(record.usage.output_tokens)
-    .bind(record.usage.cache_input_tokens)
-    .bind(record.usage.reasoning_tokens)
-    .bind(record.usage.total_tokens)
-    .bind(record.cost)
-    .bind(record.cost_estimated as i64)
-    .bind(record.price_version.as_deref())
-    .bind(&record.status)
-    .bind(record.error_message.as_deref())
-    .bind(failure_kind.as_deref())
-    .bind(failure.failure_class.as_str())
-    .bind(failure.is_actionable as i64)
-    .bind(record.payload.as_deref())
-    .bind(&raw_response)
-    .bind(record.req_raw.path.as_deref())
-    .bind(raw_payload_meta_codec(&record.req_raw))
-    .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
-    .bind(record.req_raw.truncated as i64)
-    .bind(record.req_raw.truncated_reason.as_deref())
-    .bind(resp_raw.path.as_deref())
-    .bind(raw_payload_meta_codec(&resp_raw))
-    .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
-    .bind(resp_raw.truncated as i64)
-    .bind(resp_raw.truncated_reason.as_deref())
-    .bind(None::<f64>)
-    .bind(t_req_read_ms)
-    .bind(t_req_parse_ms)
-    .bind(t_upstream_connect_ms)
-    .bind(t_upstream_ttfb_ms)
-    .bind(None::<f64>)
-    .bind(None::<f64>)
-    .bind(None::<f64>)
-    .bind(created_at)
-    .execute(tx.as_mut())
-    .await?;
-
-    let invocation_id = if insert_result.rows_affected() > 0 {
-        let inserted_id = insert_result.last_insert_rowid();
-        upsert_invocation_hourly_rollups_tx(
-            tx.as_mut(),
-            &[InvocationHourlySourceRecord {
-                id: inserted_id,
-                occurred_at: record.occurred_at.clone(),
-                source: SOURCE_PROXY.to_string(),
-                status: Some(record.status.clone()),
-                detail_level: DETAIL_LEVEL_FULL.to_string(),
-                input_tokens: record.usage.input_tokens,
-                output_tokens: record.usage.output_tokens,
-                cache_input_tokens: record.usage.cache_input_tokens,
-                total_tokens: record.usage.total_tokens,
-                cost: record.cost,
-                error_message: record.error_message.clone(),
-                failure_kind: failure_kind.clone(),
-                failure_class: Some(failure.failure_class.as_str().to_string()),
-                is_actionable: Some(failure.is_actionable as i64),
-                payload: record.payload.clone(),
-                t_total_ms: None,
-                t_req_read_ms,
-                t_req_parse_ms,
-                t_upstream_connect_ms,
-                t_upstream_ttfb_ms,
-                t_upstream_stream_ms: None,
-                t_resp_parse_ms: None,
-                t_persist_ms: None,
-            }],
-            &INVOCATION_HOURLY_ROLLUP_TARGETS,
-        )
-        .await?;
-        save_hourly_rollup_live_progress_tx(
-            tx.as_mut(),
-            HOURLY_ROLLUP_DATASET_INVOCATIONS,
-            inserted_id,
-        )
-        .await?;
-        touch_invocation_upstream_account_last_activity_tx(
-            tx.as_mut(),
-            &record.occurred_at,
-            record.payload.as_deref(),
-        )
-        .await?;
-        inserted_id
-    } else {
-        let Some(existing) = load_persisted_invocation_identity_tx(
-            tx.as_mut(),
-            &record.invoke_id,
-            &record.occurred_at,
-        )
-        .await?
-        else {
-            tx.commit().await?;
-            return Ok(None);
+    let existing_identity =
+        if invocation_status_is_in_flight(Some(record.status.as_str())) {
+            None
+        } else {
+            load_persisted_invocation_identity_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
+                .await?
         };
-        let allow_terminal_repair = !invocation_status_is_in_flight(Some(record.status.as_str()))
-            && invocation_status_is_recoverable_proxy_interrupted(
-                existing.status.as_deref(),
-                existing.failure_kind.as_deref(),
-            );
-        if !invocation_status_is_in_flight(existing.status.as_deref()) && !allow_terminal_repair {
+
+    if let Some(existing) = existing_identity {
+        if !persisted_invocation_allows_proxy_record_update(
+            existing.status.as_deref(),
+            existing.failure_kind.as_deref(),
+            &record.status,
+        ) {
             tx.commit().await?;
             return Ok(None);
         }
@@ -2284,17 +2159,270 @@ pub(crate) async fn persist_proxy_capture_runtime_record(
             record.payload.as_deref(),
         )
         .await?;
-        existing.id
-    };
+    } else {
+        let insert_result = sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO codex_invocations (
+                invoke_id,
+                occurred_at,
+                source,
+                model,
+                input_tokens,
+                output_tokens,
+                cache_input_tokens,
+                reasoning_tokens,
+                total_tokens,
+                cost,
+                cost_estimated,
+                price_version,
+                status,
+                error_message,
+                failure_kind,
+                failure_class,
+                is_actionable,
+                payload,
+                raw_response,
+                request_raw_path,
+                request_raw_codec,
+                request_raw_size,
+                request_raw_truncated,
+                request_raw_truncated_reason,
+                response_raw_path,
+                response_raw_codec,
+                response_raw_size,
+                response_raw_truncated,
+                response_raw_truncated_reason,
+                t_total_ms,
+                t_req_read_ms,
+                t_req_parse_ms,
+                t_upstream_connect_ms,
+                t_upstream_ttfb_ms,
+                t_upstream_stream_ms,
+                t_resp_parse_ms,
+                t_persist_ms,
+                created_at
+            )
+            VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
+                ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
+                ?37, ?38
+            )
+            "#,
+        )
+        .bind(&record.invoke_id)
+        .bind(&record.occurred_at)
+        .bind(SOURCE_PROXY)
+        .bind(&record.model)
+        .bind(record.usage.input_tokens)
+        .bind(record.usage.output_tokens)
+        .bind(record.usage.cache_input_tokens)
+        .bind(record.usage.reasoning_tokens)
+        .bind(record.usage.total_tokens)
+        .bind(record.cost)
+        .bind(record.cost_estimated as i64)
+        .bind(record.price_version.as_deref())
+        .bind(&record.status)
+        .bind(record.error_message.as_deref())
+        .bind(failure_kind.as_deref())
+        .bind(failure.failure_class.as_str())
+        .bind(failure.is_actionable as i64)
+        .bind(record.payload.as_deref())
+        .bind(&raw_response)
+        .bind(record.req_raw.path.as_deref())
+        .bind(raw_payload_meta_codec(&record.req_raw))
+        .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
+        .bind(record.req_raw.truncated as i64)
+        .bind(record.req_raw.truncated_reason.as_deref())
+        .bind(resp_raw.path.as_deref())
+        .bind(raw_payload_meta_codec(&resp_raw))
+        .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
+        .bind(resp_raw.truncated as i64)
+        .bind(resp_raw.truncated_reason.as_deref())
+        .bind(None::<f64>)
+        .bind(t_req_read_ms)
+        .bind(t_req_parse_ms)
+        .bind(t_upstream_connect_ms)
+        .bind(t_upstream_ttfb_ms)
+        .bind(None::<f64>)
+        .bind(None::<f64>)
+        .bind(None::<f64>)
+        .bind(created_at)
+        .execute(tx.as_mut())
+        .await?;
+
+        if insert_result.rows_affected() > 0 {
+            let inserted_id = insert_result.last_insert_rowid();
+            upsert_invocation_hourly_rollups_tx(
+                tx.as_mut(),
+                &[InvocationHourlySourceRecord {
+                    id: inserted_id,
+                    occurred_at: record.occurred_at.clone(),
+                    source: SOURCE_PROXY.to_string(),
+                    status: Some(record.status.clone()),
+                    detail_level: DETAIL_LEVEL_FULL.to_string(),
+                    input_tokens: record.usage.input_tokens,
+                    output_tokens: record.usage.output_tokens,
+                    cache_input_tokens: record.usage.cache_input_tokens,
+                    total_tokens: record.usage.total_tokens,
+                    cost: record.cost,
+                    error_message: record.error_message.clone(),
+                    failure_kind: failure_kind.clone(),
+                    failure_class: Some(failure.failure_class.as_str().to_string()),
+                    is_actionable: Some(failure.is_actionable as i64),
+                    payload: record.payload.clone(),
+                    t_total_ms: None,
+                    t_req_read_ms,
+                    t_req_parse_ms,
+                    t_upstream_connect_ms,
+                    t_upstream_ttfb_ms,
+                    t_upstream_stream_ms: None,
+                    t_resp_parse_ms: None,
+                    t_persist_ms: None,
+                }],
+                &INVOCATION_HOURLY_ROLLUP_TARGETS,
+            )
+            .await?;
+            save_hourly_rollup_live_progress_tx(
+                tx.as_mut(),
+                HOURLY_ROLLUP_DATASET_INVOCATIONS,
+                inserted_id,
+            )
+            .await?;
+            touch_invocation_upstream_account_last_activity_tx(
+                tx.as_mut(),
+                &record.occurred_at,
+                record.payload.as_deref(),
+            )
+            .await?;
+        } else {
+            let Some(existing) = load_persisted_invocation_identity_tx(
+                tx.as_mut(),
+                &record.invoke_id,
+                &record.occurred_at,
+            )
+            .await?
+            else {
+                tx.commit().await?;
+                return Ok(None);
+            };
+            if !persisted_invocation_allows_proxy_record_update(
+                existing.status.as_deref(),
+                existing.failure_kind.as_deref(),
+                &record.status,
+            ) {
+                tx.commit().await?;
+                return Ok(None);
+            }
+
+            let affected = sqlx::query(
+                r#"
+                UPDATE codex_invocations
+                SET source = ?2,
+                    model = ?3,
+                    input_tokens = ?4,
+                    output_tokens = ?5,
+                    cache_input_tokens = ?6,
+                    reasoning_tokens = ?7,
+                    total_tokens = ?8,
+                    cost = ?9,
+                    cost_estimated = ?10,
+                    price_version = ?11,
+                    status = ?12,
+                    error_message = ?13,
+                    failure_kind = ?14,
+                    failure_class = ?15,
+                    is_actionable = ?16,
+                    payload = ?17,
+                    raw_response = ?18,
+                    request_raw_path = ?19,
+                    request_raw_codec = ?20,
+                    request_raw_size = ?21,
+                    request_raw_truncated = ?22,
+                    request_raw_truncated_reason = ?23,
+                    response_raw_path = ?24,
+                    response_raw_codec = ?25,
+                    response_raw_size = ?26,
+                    response_raw_truncated = ?27,
+                    response_raw_truncated_reason = ?28,
+                    t_total_ms = ?29,
+                    t_req_read_ms = ?30,
+                    t_req_parse_ms = ?31,
+                    t_upstream_connect_ms = ?32,
+                    t_upstream_ttfb_ms = ?33,
+                    t_upstream_stream_ms = ?34,
+                    t_resp_parse_ms = ?35,
+                    t_persist_ms = ?36
+                WHERE id = ?1
+                  AND (
+                        LOWER(TRIM(COALESCE(status, ''))) IN ('running', 'pending')
+                        OR (
+                            LOWER(TRIM(COALESCE(status, ''))) = 'interrupted'
+                            AND LOWER(TRIM(COALESCE(failure_kind, ''))) = 'proxy_interrupted'
+                        )
+                  )
+                "#,
+            )
+            .bind(existing.id)
+            .bind(SOURCE_PROXY)
+            .bind(&record.model)
+            .bind(record.usage.input_tokens)
+            .bind(record.usage.output_tokens)
+            .bind(record.usage.cache_input_tokens)
+            .bind(record.usage.reasoning_tokens)
+            .bind(record.usage.total_tokens)
+            .bind(record.cost)
+            .bind(record.cost_estimated as i64)
+            .bind(record.price_version.as_deref())
+            .bind(&record.status)
+            .bind(record.error_message.as_deref())
+            .bind(failure_kind.as_deref())
+            .bind(failure.failure_class.as_str())
+            .bind(failure.is_actionable as i64)
+            .bind(record.payload.as_deref())
+            .bind(&raw_response)
+            .bind(record.req_raw.path.as_deref())
+            .bind(raw_payload_meta_codec(&record.req_raw))
+            .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
+            .bind(record.req_raw.truncated as i64)
+            .bind(record.req_raw.truncated_reason.as_deref())
+            .bind(resp_raw.path.as_deref())
+            .bind(raw_payload_meta_codec(&resp_raw))
+            .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
+            .bind(resp_raw.truncated as i64)
+            .bind(resp_raw.truncated_reason.as_deref())
+            .bind(None::<f64>)
+            .bind(t_req_read_ms)
+            .bind(t_req_parse_ms)
+            .bind(t_upstream_connect_ms)
+            .bind(t_upstream_ttfb_ms)
+            .bind(None::<f64>)
+            .bind(None::<f64>)
+            .bind(None::<f64>)
+            .execute(tx.as_mut())
+            .await?
+            .rows_affected();
+            if affected == 0 {
+                tx.commit().await?;
+                return Ok(None);
+            }
+            recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[existing.id]).await?;
+            save_hourly_rollup_live_progress_tx(
+                tx.as_mut(),
+                HOURLY_ROLLUP_DATASET_INVOCATIONS,
+                existing.id,
+            )
+            .await?;
+            touch_invocation_upstream_account_last_activity_tx(
+                tx.as_mut(),
+                &record.occurred_at,
+                record.payload.as_deref(),
+            )
+            .await?;
+        }
+    }
 
     let persisted = load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
         .await?;
-    save_hourly_rollup_live_progress_tx(
-        tx.as_mut(),
-        HOURLY_ROLLUP_DATASET_INVOCATIONS,
-        invocation_id,
-    )
-    .await?;
     tx.commit().await?;
 
     Ok(Some(persisted))

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,6 +6,8 @@ const INVOCATION_PROMPT_CACHE_KEY_EXPR_SQL: &str =
     "CASE WHEN json_valid(payload) THEN TRIM(CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)) END";
 const INVOCATION_UPSTREAM_ACCOUNT_ID_EXPR_SQL: &str =
     "CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.upstreamAccountId') AS INTEGER) END";
+const PROMPT_CACHE_WORKING_SET_WINDOW_SECONDS: i64 = 300;
+const SHANGHAI_NOW_SQL: &str = "datetime('now', '+8 hours')";
 
 fn ensure_schema_lock_key(pool: &Pool<Sqlite>) -> String {
     let connect_options = pool.connect_options();
@@ -322,6 +324,258 @@ async fn rebuild_invocation_in_progress_live_triggers(pool: &Pool<Sqlite>) -> Re
     tx.commit()
         .await
         .context("failed to commit invocation_in_progress_live trigger rebuild")?;
+
+    Ok(())
+}
+
+fn prompt_cache_working_set_live_refresh_sql_for_key(key_expr: &str) -> String {
+    let display_status_sql = crate::api::invocation_display_status_sql();
+    format!(
+        r#"
+        INSERT INTO prompt_cache_working_set_live (
+            prompt_cache_key,
+            source_scope_all,
+            source_scope_proxy_only,
+            created_at,
+            last_activity_at,
+            last_terminal_at,
+            last_in_flight_at,
+            sort_anchor_at,
+            request_count,
+            total_tokens,
+            total_cost,
+            proxy_created_at,
+            proxy_last_activity_at,
+            proxy_last_terminal_at,
+            proxy_last_in_flight_at,
+            proxy_sort_anchor_at,
+            proxy_request_count,
+            proxy_total_tokens,
+            proxy_total_cost,
+            updated_at
+        )
+        SELECT
+            candidate.prompt_cache_key,
+            1,
+            candidate.source_scope_proxy_only,
+            candidate.created_at,
+            candidate.last_activity_at,
+            candidate.last_terminal_at,
+            candidate.last_in_flight_at,
+            candidate.sort_anchor_at,
+            candidate.request_count,
+            candidate.total_tokens,
+            candidate.total_cost,
+            candidate.proxy_created_at,
+            candidate.proxy_last_activity_at,
+            candidate.proxy_last_terminal_at,
+            candidate.proxy_last_in_flight_at,
+            candidate.proxy_sort_anchor_at,
+            candidate.proxy_request_count,
+            candidate.proxy_total_tokens,
+            candidate.proxy_total_cost,
+            datetime('now')
+        FROM (
+            SELECT
+                keyed.prompt_cache_key AS prompt_cache_key,
+                CASE WHEN MAX(CASE WHEN keyed.source = '{source_proxy}' THEN 1 ELSE 0 END) = 1 THEN 1 ELSE 0 END AS source_scope_proxy_only,
+                MIN(keyed.occurred_at) AS created_at,
+                MAX(keyed.occurred_at) AS last_activity_at,
+                MAX(CASE WHEN keyed.is_in_flight = 0 THEN keyed.occurred_at END) AS last_terminal_at,
+                MAX(CASE WHEN keyed.is_in_flight = 1 THEN keyed.occurred_at END) AS last_in_flight_at,
+                MAX(
+                    CASE
+                        WHEN keyed.is_in_flight = 1 THEN keyed.occurred_at
+                        WHEN keyed.occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds') THEN keyed.occurred_at
+                        ELSE NULL
+                    END
+                ) AS sort_anchor_at,
+                COUNT(*) AS request_count,
+                COALESCE(SUM(COALESCE(keyed.total_tokens, 0)), 0) AS total_tokens,
+                COALESCE(SUM(COALESCE(keyed.cost, 0.0)), 0.0) AS total_cost,
+                MIN(CASE WHEN keyed.source = '{source_proxy}' THEN keyed.occurred_at END) AS proxy_created_at,
+                MAX(CASE WHEN keyed.source = '{source_proxy}' THEN keyed.occurred_at END) AS proxy_last_activity_at,
+                MAX(CASE WHEN keyed.source = '{source_proxy}' AND keyed.is_in_flight = 0 THEN keyed.occurred_at END) AS proxy_last_terminal_at,
+                MAX(CASE WHEN keyed.source = '{source_proxy}' AND keyed.is_in_flight = 1 THEN keyed.occurred_at END) AS proxy_last_in_flight_at,
+                MAX(
+                    CASE
+                        WHEN keyed.source = '{source_proxy}' AND keyed.is_in_flight = 1 THEN keyed.occurred_at
+                        WHEN keyed.source = '{source_proxy}' AND keyed.occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds') THEN keyed.occurred_at
+                        ELSE NULL
+                    END
+                ) AS proxy_sort_anchor_at,
+                COALESCE(SUM(CASE WHEN keyed.source = '{source_proxy}' THEN 1 ELSE 0 END), 0) AS proxy_request_count,
+                COALESCE(SUM(CASE WHEN keyed.source = '{source_proxy}' THEN COALESCE(keyed.total_tokens, 0) ELSE 0 END), 0) AS proxy_total_tokens,
+                COALESCE(SUM(CASE WHEN keyed.source = '{source_proxy}' THEN COALESCE(keyed.cost, 0.0) ELSE 0.0 END), 0.0) AS proxy_total_cost
+            FROM (
+                SELECT
+                    {prompt_cache_key_sql} AS prompt_cache_key,
+                    source,
+                    occurred_at,
+                    total_tokens,
+                    cost,
+                    CASE
+                        WHEN LOWER(TRIM({display_status_sql})) IN ('running', 'pending') THEN 1
+                        ELSE 0
+                    END AS is_in_flight
+                FROM codex_invocations
+                WHERE {prompt_cache_key_sql} = {key_expr}
+                  AND {prompt_cache_key_sql} IS NOT NULL
+                  AND {prompt_cache_key_sql} <> ''
+                  AND (
+                        LOWER(TRIM({display_status_sql})) IN ('running', 'pending')
+                        OR occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds')
+                  )
+            ) AS keyed
+            GROUP BY keyed.prompt_cache_key
+        ) AS candidate
+        WHERE candidate.sort_anchor_at IS NOT NULL
+        ON CONFLICT(prompt_cache_key) DO UPDATE SET
+            source_scope_all = excluded.source_scope_all,
+            source_scope_proxy_only = excluded.source_scope_proxy_only,
+            created_at = excluded.created_at,
+            last_activity_at = excluded.last_activity_at,
+            last_terminal_at = excluded.last_terminal_at,
+            last_in_flight_at = excluded.last_in_flight_at,
+            sort_anchor_at = excluded.sort_anchor_at,
+            request_count = excluded.request_count,
+            total_tokens = excluded.total_tokens,
+            total_cost = excluded.total_cost,
+            proxy_created_at = excluded.proxy_created_at,
+            proxy_last_activity_at = excluded.proxy_last_activity_at,
+            proxy_last_terminal_at = excluded.proxy_last_terminal_at,
+            proxy_last_in_flight_at = excluded.proxy_last_in_flight_at,
+            proxy_sort_anchor_at = excluded.proxy_sort_anchor_at,
+            proxy_request_count = excluded.proxy_request_count,
+            proxy_total_tokens = excluded.proxy_total_tokens,
+            proxy_total_cost = excluded.proxy_total_cost,
+            updated_at = excluded.updated_at;
+        DELETE FROM prompt_cache_working_set_live
+        WHERE prompt_cache_key = {key_expr}
+          AND prompt_cache_key IS NOT NULL
+          AND prompt_cache_key <> ''
+          AND NOT EXISTS (
+              SELECT 1
+              FROM codex_invocations
+              WHERE {prompt_cache_key_sql} = {key_expr}
+                AND {prompt_cache_key_sql} IS NOT NULL
+                AND {prompt_cache_key_sql} <> ''
+                AND (
+                    LOWER(TRIM({display_status_sql})) IN ('running', 'pending')
+                    OR occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds')
+                )
+          )
+        "#,
+        prompt_cache_key_sql = INVOCATION_PROMPT_CACHE_KEY_EXPR_SQL,
+        display_status_sql = display_status_sql,
+        key_expr = key_expr,
+        source_proxy = SOURCE_PROXY,
+        window_seconds = PROMPT_CACHE_WORKING_SET_WINDOW_SECONDS,
+    )
+}
+
+async fn rebuild_prompt_cache_working_set_live_table(pool: &Pool<Sqlite>) -> Result<()> {
+    sqlx::query("DELETE FROM prompt_cache_working_set_live")
+        .execute(pool)
+        .await
+        .context("failed to clear prompt_cache_working_set_live before rebuild")?;
+
+    let display_status_sql = crate::api::invocation_display_status_sql();
+    let rebuild_sql = format!(
+        r#"
+        INSERT INTO prompt_cache_working_set_live (
+            prompt_cache_key,
+            source_scope_all,
+            source_scope_proxy_only,
+            created_at,
+            last_activity_at,
+            last_terminal_at,
+            last_in_flight_at,
+            sort_anchor_at,
+            request_count,
+            total_tokens,
+            total_cost,
+            proxy_created_at,
+            proxy_last_activity_at,
+            proxy_last_terminal_at,
+            proxy_last_in_flight_at,
+            proxy_sort_anchor_at,
+            proxy_request_count,
+            proxy_total_tokens,
+            proxy_total_cost,
+            updated_at
+        )
+        SELECT
+            keyed.prompt_cache_key,
+            1,
+            CASE WHEN MAX(CASE WHEN keyed.source = '{source_proxy}' THEN 1 ELSE 0 END) = 1 THEN 1 ELSE 0 END AS source_scope_proxy_only,
+            MIN(keyed.occurred_at) AS created_at,
+            MAX(keyed.occurred_at) AS last_activity_at,
+            MAX(CASE WHEN keyed.is_in_flight = 0 THEN keyed.occurred_at END) AS last_terminal_at,
+            MAX(CASE WHEN keyed.is_in_flight = 1 THEN keyed.occurred_at END) AS last_in_flight_at,
+            MAX(
+                CASE
+                    WHEN keyed.is_in_flight = 1 THEN keyed.occurred_at
+                    WHEN keyed.occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds') THEN keyed.occurred_at
+                    ELSE NULL
+                END
+            ) AS sort_anchor_at,
+            COUNT(*) AS request_count,
+            COALESCE(SUM(COALESCE(keyed.total_tokens, 0)), 0) AS total_tokens,
+            COALESCE(SUM(COALESCE(keyed.cost, 0.0)), 0.0) AS total_cost,
+            MIN(CASE WHEN keyed.source = '{source_proxy}' THEN keyed.occurred_at END) AS proxy_created_at,
+            MAX(CASE WHEN keyed.source = '{source_proxy}' THEN keyed.occurred_at END) AS proxy_last_activity_at,
+            MAX(CASE WHEN keyed.source = '{source_proxy}' AND keyed.is_in_flight = 0 THEN keyed.occurred_at END) AS proxy_last_terminal_at,
+            MAX(CASE WHEN keyed.source = '{source_proxy}' AND keyed.is_in_flight = 1 THEN keyed.occurred_at END) AS proxy_last_in_flight_at,
+            MAX(
+                CASE
+                    WHEN keyed.source = '{source_proxy}' AND keyed.is_in_flight = 1 THEN keyed.occurred_at
+                    WHEN keyed.source = '{source_proxy}' AND keyed.occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds') THEN keyed.occurred_at
+                    ELSE NULL
+                END
+            ) AS proxy_sort_anchor_at,
+            COALESCE(SUM(CASE WHEN keyed.source = '{source_proxy}' THEN 1 ELSE 0 END), 0) AS proxy_request_count,
+            COALESCE(SUM(CASE WHEN keyed.source = '{source_proxy}' THEN COALESCE(keyed.total_tokens, 0) ELSE 0 END), 0) AS proxy_total_tokens,
+            COALESCE(SUM(CASE WHEN keyed.source = '{source_proxy}' THEN COALESCE(keyed.cost, 0.0) ELSE 0.0 END), 0.0) AS proxy_total_cost,
+            {shanghai_now_sql}
+        FROM (
+            SELECT
+                {prompt_cache_key_sql} AS prompt_cache_key,
+                source,
+                occurred_at,
+                total_tokens,
+                cost,
+                CASE
+                    WHEN LOWER(TRIM({display_status_sql})) IN ('running', 'pending') THEN 1
+                    ELSE 0
+                END AS is_in_flight
+            FROM codex_invocations
+            WHERE {prompt_cache_key_sql} IS NOT NULL
+              AND {prompt_cache_key_sql} <> ''
+              AND (
+                    LOWER(TRIM({display_status_sql})) IN ('running', 'pending')
+                    OR occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds')
+              )
+        ) AS keyed
+        GROUP BY keyed.prompt_cache_key
+        HAVING MAX(
+            CASE
+                WHEN keyed.is_in_flight = 1 THEN keyed.occurred_at
+                WHEN keyed.occurred_at >= datetime('now', '+8 hours', '-{window_seconds} seconds') THEN keyed.occurred_at
+                ELSE NULL
+            END
+        ) IS NOT NULL
+        "#,
+        prompt_cache_key_sql = INVOCATION_PROMPT_CACHE_KEY_EXPR_SQL,
+        display_status_sql = display_status_sql,
+        source_proxy = SOURCE_PROXY,
+        window_seconds = PROMPT_CACHE_WORKING_SET_WINDOW_SECONDS,
+        shanghai_now_sql = SHANGHAI_NOW_SQL,
+    );
+    sqlx::query(&rebuild_sql)
+        .execute(pool)
+        .await
+        .context("failed to rebuild prompt_cache_working_set_live rows")?;
 
     Ok(())
 }
@@ -1017,13 +1271,135 @@ async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     .await
     .context("failed to ensure index idx_invocation_in_progress_live_prompt_cache_key")?;
 
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS prompt_cache_working_set_live (
+            prompt_cache_key TEXT PRIMARY KEY,
+            source_scope_all INTEGER NOT NULL DEFAULT 1,
+            source_scope_proxy_only INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            last_activity_at TEXT NOT NULL,
+            last_terminal_at TEXT,
+            last_in_flight_at TEXT,
+            sort_anchor_at TEXT NOT NULL,
+            request_count INTEGER NOT NULL DEFAULT 0,
+            total_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cost REAL NOT NULL DEFAULT 0.0,
+            proxy_created_at TEXT,
+            proxy_last_activity_at TEXT,
+            proxy_last_terminal_at TEXT,
+            proxy_last_in_flight_at TEXT,
+            proxy_sort_anchor_at TEXT,
+            proxy_request_count INTEGER NOT NULL DEFAULT 0,
+            proxy_total_tokens INTEGER NOT NULL DEFAULT 0,
+            proxy_total_cost REAL NOT NULL DEFAULT 0.0,
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure prompt_cache_working_set_live table existence")?;
+
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_prompt_cache_working_set_live_sort_anchor
+        ON prompt_cache_working_set_live (sort_anchor_at DESC, created_at DESC, prompt_cache_key DESC)
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure idx_prompt_cache_working_set_live_sort_anchor")?;
+
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_prompt_cache_working_set_live_proxy_sort_anchor
+        ON prompt_cache_working_set_live (source_scope_proxy_only, sort_anchor_at DESC, created_at DESC, prompt_cache_key DESC)
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure idx_prompt_cache_working_set_live_proxy_sort_anchor")?;
+
+    for trigger_name in [
+        "trg_codex_invocations_live_insert",
+        "trg_codex_invocations_live_update",
+        "trg_codex_invocations_live_delete",
+        "trg_codex_invocations_prompt_cache_working_set_insert",
+        "trg_codex_invocations_prompt_cache_working_set_update",
+        "trg_codex_invocations_prompt_cache_working_set_delete",
+    ] {
+        sqlx::query(&format!("DROP TRIGGER IF EXISTS {trigger_name}"))
+            .execute(pool)
+            .await
+            .with_context(|| format!("failed to drop stale trigger {trigger_name}"))?;
+    }
+
     rebuild_invocation_in_progress_live_triggers(pool)
         .await
         .context("failed to rebuild invocation_in_progress_live triggers at startup")?;
 
+    let prompt_cache_insert_trigger_sql = format!(
+        r#"
+        CREATE TRIGGER trg_codex_invocations_prompt_cache_working_set_insert
+        AFTER INSERT ON codex_invocations
+        BEGIN
+            {refresh_sql};
+        END
+        "#,
+        refresh_sql = prompt_cache_working_set_live_refresh_sql_for_key(
+            &invocation_in_progress_live_prompt_cache_key_expr("NEW")
+        ),
+    );
+    sqlx::query(&prompt_cache_insert_trigger_sql)
+        .execute(pool)
+        .await
+        .context("failed to ensure trigger trg_codex_invocations_prompt_cache_working_set_insert")?;
+
+    let prompt_cache_update_trigger_sql = format!(
+        r#"
+        CREATE TRIGGER trg_codex_invocations_prompt_cache_working_set_update
+        AFTER UPDATE ON codex_invocations
+        BEGIN
+            {refresh_old_sql};
+            {refresh_new_sql};
+        END
+        "#,
+        refresh_old_sql = prompt_cache_working_set_live_refresh_sql_for_key(
+            &invocation_in_progress_live_prompt_cache_key_expr("OLD")
+        ),
+        refresh_new_sql = prompt_cache_working_set_live_refresh_sql_for_key(
+            &invocation_in_progress_live_prompt_cache_key_expr("NEW")
+        ),
+    );
+    sqlx::query(&prompt_cache_update_trigger_sql)
+        .execute(pool)
+        .await
+        .context("failed to ensure trigger trg_codex_invocations_prompt_cache_working_set_update")?;
+
+    let prompt_cache_delete_trigger_sql = format!(
+        r#"
+        CREATE TRIGGER trg_codex_invocations_prompt_cache_working_set_delete
+        AFTER DELETE ON codex_invocations
+        BEGIN
+            {refresh_sql};
+        END
+        "#,
+        refresh_sql = prompt_cache_working_set_live_refresh_sql_for_key(
+            &invocation_in_progress_live_prompt_cache_key_expr("OLD")
+        ),
+    );
+    sqlx::query(&prompt_cache_delete_trigger_sql)
+        .execute(pool)
+        .await
+        .context("failed to ensure trigger trg_codex_invocations_prompt_cache_working_set_delete")?;
+
     rebuild_invocation_in_progress_live_table(pool)
         .await
         .context("failed to rebuild invocation_in_progress_live table at startup")?;
+    rebuild_prompt_cache_working_set_live_table(pool)
+        .await
+        .context("failed to rebuild prompt_cache_working_set_live table at startup")?;
 
     sqlx::query(
         r#"

--- a/src/tests/slices/pool_failover_window_i.rs
+++ b/src/tests/slices/pool_failover_window_i.rs
@@ -650,6 +650,201 @@ async fn ensure_schema_serializes_live_trigger_rebuild_under_concurrent_reentry(
 }
 
 #[tokio::test]
+async fn ensure_schema_rebuilds_prompt_cache_working_set_live_from_existing_invocations() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let now = Utc::now();
+
+    for trigger_name in [
+        "trg_codex_invocations_prompt_cache_working_set_insert",
+        "trg_codex_invocations_prompt_cache_working_set_update",
+        "trg_codex_invocations_prompt_cache_working_set_delete",
+    ] {
+        sqlx::query(&format!("DROP TRIGGER IF EXISTS {trigger_name}"))
+            .execute(&state.pool)
+            .await
+            .expect("drop prompt cache working-set trigger before rebuild test");
+    }
+    sqlx::query("DROP TABLE IF EXISTS prompt_cache_working_set_live")
+        .execute(&state.pool)
+        .await
+        .expect("drop prompt cache working-set table before rebuild test");
+
+    for (invoke_id, source, status, prompt_cache_key, seconds_ago, total_tokens, cost) in [
+        (
+            "working-live-recent-success",
+            SOURCE_PROXY,
+            "success",
+            "working-live-key-a",
+            30_i64,
+            120_i64,
+            0.12_f64,
+        ),
+        (
+            "working-live-recent-running",
+            SOURCE_PROXY,
+            "running",
+            "working-live-key-a",
+            15_i64,
+            140_i64,
+            0.14_f64,
+        ),
+        (
+            "working-live-recent-cross-source",
+            SOURCE_XY,
+            "success",
+            "working-live-key-b",
+            40_i64,
+            220_i64,
+            0.22_f64,
+        ),
+        (
+            "working-live-old-terminal",
+            SOURCE_PROXY,
+            "success",
+            "working-live-key-old",
+            720_i64,
+            320_i64,
+            0.32_f64,
+        ),
+    ] {
+        let occurred_at = format_naive((now - ChronoDuration::seconds(seconds_ago)).with_timezone(&Shanghai).naive_local());
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                invoke_id,
+                occurred_at,
+                source,
+                status,
+                total_tokens,
+                cost,
+                payload,
+                raw_response
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            "#,
+        )
+        .bind(invoke_id)
+        .bind(occurred_at)
+        .bind(source)
+        .bind(status)
+        .bind(total_tokens)
+        .bind(cost)
+        .bind(json!({ "promptCacheKey": prompt_cache_key }).to_string())
+        .bind("{}")
+        .execute(&state.pool)
+        .await
+        .expect("insert prompt cache working-set rebuild source row");
+    }
+
+    ensure_schema(&state.pool)
+        .await
+        .expect("rebuild prompt_cache_working_set_live on ensure_schema");
+
+    let rows = sqlx::query_as::<
+        _,
+        (String, i64, i64, String, String, Option<String>, Option<String>, i64, i64, f64),
+    >(
+        r#"
+        SELECT
+            prompt_cache_key,
+            source_scope_all,
+            source_scope_proxy_only,
+            created_at,
+            last_activity_at,
+            last_terminal_at,
+            last_in_flight_at,
+            request_count,
+            total_tokens,
+            total_cost
+        FROM prompt_cache_working_set_live
+        ORDER BY prompt_cache_key
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load rebuilt working-set rows");
+
+    assert_eq!(rows.len(), 2, "only recent or in-flight keys should survive rebuild");
+
+    let key_a = rows
+        .iter()
+        .find(|row| row.0 == "working-live-key-a")
+        .expect("working-live-key-a should survive rebuild");
+    assert_eq!(key_a.1, 1);
+    assert_eq!(key_a.2, 1);
+    assert_eq!(key_a.7, 2);
+    assert_eq!(key_a.8, 260);
+    assert!((key_a.9 - 0.26).abs() < 1e-9);
+    assert!(key_a.5.is_some());
+    assert!(key_a.6.is_some());
+
+    let key_b = rows
+        .iter()
+        .find(|row| row.0 == "working-live-key-b")
+        .expect("working-live-key-b should survive rebuild");
+    assert_eq!(key_b.1, 1);
+    assert_eq!(key_b.2, 0);
+    assert_eq!(key_b.7, 1);
+    assert_eq!(key_b.8, 220);
+    assert!((key_b.9 - 0.22).abs() < 1e-9);
+    assert!(key_b.5.is_some());
+    assert!(key_b.6.is_none());
+}
+
+#[tokio::test]
+async fn proxy_only_working_conversation_live_aggregate_keeps_mixed_source_proxy_slice() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let now = Utc::now();
+
+    for (invoke_id, source, seconds_ago, total_tokens, cost) in [
+        ("mixed-proxy", SOURCE_PROXY, 30_i64, 120_i64, 0.12_f64),
+        ("mixed-crs", SOURCE_CRS, 20_i64, 220_i64, 0.22_f64),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            "#,
+        )
+        .bind(invoke_id)
+        .bind(format_naive((now - ChronoDuration::seconds(seconds_ago)).with_timezone(&Shanghai).naive_local()))
+        .bind(source)
+        .bind("success")
+        .bind(total_tokens)
+        .bind(cost)
+        .bind(json!({ "promptCacheKey": "mixed-working-key" }).to_string())
+        .bind("{}")
+        .execute(&state.pool)
+        .await
+        .expect("insert mixed-source working conversation row");
+    }
+
+    let rows = query_prompt_cache_working_conversation_aggregates(
+        &state.pool,
+        &db_occurred_at_lower_bound(now - ChronoDuration::minutes(5)),
+        InvocationSourceScope::ProxyOnly,
+        10,
+    )
+    .await
+    .expect("proxy-only working conversation aggregate should succeed");
+
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.prompt_cache_key, "mixed-working-key");
+    assert_eq!(row.request_count, 1);
+    assert_eq!(row.total_tokens, 120);
+    assert!((row.total_cost - 0.12).abs() < 1e-9);
+}
+
+#[tokio::test]
 async fn health_check_reports_starting_until_startup_is_ready() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18080").expect("valid upstream url"),


### PR DESCRIPTION
Summary
- Move Dashboard working-conversation and summary in-progress conversation truth sources onto write-side live tables so these paths stop scanning `codex_invocations` on request and publish hot paths.
- Reduce proxy capture SQLite write amplification by finalizing existing invocation rows in place and removing duplicate rollup recomputation from the runtime persistence path.
- Keep the existing API/UI schema and `<=5s` reconcile budget semantics while extending the pressure/backpressure docs for the new maintenance paths.

Specs:
- docs/specs/5932d-sse-proxy-live-sync/SPEC.md
- docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md
- docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
Spec Disposition: update
Solutions:
- docs/solutions/performance/realtime-dashboard-reconcile-budget.md
- docs/solutions/performance/sqlite-write-pressure-backpressure.md
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: n/a(no project-doc change)

Test Plan
- cargo test ensure_schema_rebuilds_prompt_cache_working_set_live_from_existing_invocations -- --nocapture
- cargo test prompt_cache_conversations_activity_minutes -- --nocapture
- cargo test summary_reports_invocation_based_in_progress_counts -- --nocapture
- cargo test persist_proxy_capture_record_finalizes_existing_running_row_in_place -- --nocapture
- cargo test proxy_only_working_conversation_live_aggregate_keeps_mixed_source_proxy_slice -- --nocapture
- cargo test persist_proxy_capture_record_repairs_proxy_interrupted_recovery_row_with_terminal_result -- --nocapture
- cd web && bun run test -- --run src/hooks/useDashboardWorkingConversations.test.tsx src/lib/api.test.ts

## Visual Evidence
- No UI-facing visual change. Existing spec evidence remains valid.

## Custom Notes
<!-- CUSTOM_NOTES_START -->
- `#492` is already merged and deployed; this PR is the second-round CPU stopgap focused on remaining write pressure and working-set read-model hotspots observed on srv-101 on June 30, 2026.
- Production before/after CPU proof still depends on deploying this PR to 101.
<!-- CUSTOM_NOTES_END -->
