### PR TITLE
fix(web): route upstream short id to conversation detail

### DIFF
--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
@@ -21,6 +21,7 @@
 - 2026-06-29：线上热点复盘后，账号 tab 继续禁止逐条本地 SSE patch，并把 tab 激活态的 refresh/open-resync 统一锁到 `5s`；如果未来要恢复更高频 cadence，必须先拿到慢路径证据证明后端读路径不会再次退化成请求级热扫描。
 - 2026-06-29：补充修正 identity chip 槽位算法，明确不能直接对展示短码片段做低位 `% 8` 取槽；改为混合完整 hash 后选离散槽位，避免线上真实短码因低位偏置出现大面积同色聚集。
 - 2026-06-30：Dashboard `Working Conversations` 的 5 分钟 head/count 改读 write-side `prompt_cache_working_set_live`，并为 mixed-source 对话保留独立 `ProxyOnly` 聚合槽位，避免 UI 为了代理视图再次回扫 `codex_invocations`。
+- 2026-06-30：修正上游账号 recent 行短 ID 的热区语义，明确 identity chip 独立打开对话详情，而整行其它区域继续保留调用详情入口，避免 operator 点短 ID 时误落到 invocation drawer。
 
 ## Key Reasons / Replacements
 

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -20,6 +20,7 @@
 - 已实现：桌面宽屏账号卡固定高度收敛到更紧凑值，避免整页面板观感，同时保持 4 条 recent 记录完整可见。
 - 已实现：上游账号 recent 行改为“对话短 ID + 请求 ID”主标识布局，短 ID 基于真实 `promptCacheKey` 计算并去掉 `WC-` 前缀；点击详情时传递的 `selection.promptCacheKey` 也已修正为真实对话键。
 - 已实现：上游账号 recent 行的对话短 ID 从“连续色圆点 + 短码”收口为轻量 identity chip；chip 以短码文本为主识别，颜色降为离散辅助槽位，不再与状态徽标混淆语义。
+- 已实现：上游账号 recent 行的 identity chip 不再继承整行的调用详情点击语义；chip 现作为独立对话详情入口，点击或键盘触发时只打开对应 `promptCacheKey` 的对话抽屉，而 recent 行其余区域仍保持打开调用详情。
 - 已实现：identity chip 的离散槽位改为基于完整稳定 hash 做高低位混合后再映射，修正真实线上数据因低位 `% 8` 偏置导致的短码成片撞色问题。
 - 已实现：上游账号 recent 行不再重复显示账号名；当 `requestModel` / `responseModel` 规范化后仍不一致时，recent 行改为同时展示请求模型、切换图标与响应模型。
 - 已实现：上游账号 recent 行的 endpoint、reasoning effort 与双模型 badge 统一复用 compact 尺寸 recipe，消除同一行内 badge 高度不一致问题。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
@@ -65,6 +65,7 @@
 - 账号卡内每条 recent 调用记录的信息密度不得低于 Dashboard 对话卡片中的调用记录：至少需要覆盖状态、模型、endpoint、Token 用量摘要，以及 `RQ / UP / ED / TT` 时序摘要。
 - 账号卡 recent 调用记录的主标识行必须改为“对话短 ID + 分隔符/图标 + 请求 ID”；其中对话短 ID 固定基于真实 `promptCacheKey` 走既有 working-conversation 哈希与格式化规则，展示值去掉 `WC-` 前缀；请求 ID 显示完整 `invokeId` 并允许单行截断。
 - recent 行里的对话短 ID 必须渲染为轻量 identity chip，而不是独立彩色圆点；chip 以短码文本为主识别，颜色只作辅助 cue，不得与运行状态徽标争夺语义。
+- 上游账号 recent 行中的 identity chip 必须作为独立“对话详情”入口；点击或在 chip 上按 `Enter / Space` 时，打开对应 `promptCacheKey` 的对话详情抽屉，不得退化成调用详情。
 - identity chip 的颜色映射必须使用稳定离散槽位，而不是连续 hue；同一 `promptCacheKey` 在刷新、排序和 range 切换后应落到同一槽位，不同对话复用同一槽位可接受。
 - identity chip 的槽位计算必须混合完整稳定 hash 的高低位；不得直接对展示短码片段做低位 `% 8` 取槽，避免真实数据因为低位偏置而出现成片撞色。
 - 账号卡 recent 调用记录不得重复显示所属账号名；调用已嵌在账号大卡内时，账号名必须让位给请求标识、状态与时序摘要。
@@ -138,6 +139,7 @@
 - Given 某账号有至少 4 条范围内调用，When 查看账号卡底部，Then 只显示最近 4 条，按 `occurredAt DESC` 排序。
 - Given 某账号 recent 调用记录存在真实 `promptCacheKey`，When 查看请求标识主行，Then 可见基于该键计算出的对话短 ID、分隔图标与完整请求 ID，且短 ID 展示值不带 `WC-` 前缀。
 - Given 某账号 recent 调用记录渲染主标识行，When 查看对话短 ID，Then 它表现为轻量短码 chip，且颜色来自稳定离散辅助色槽位，而不是单独的状态样式圆点。
+- Given 用户点击某账号 recent 行里的对话短 ID identity chip，When 交互发生，Then 只打开对应 `promptCacheKey` 的对话详情抽屉，不会误打开调用详情抽屉。
 - Given 查看账号卡摘要区，When 卡片处于常驻态，Then 不出现解释性废话或状态说明条，请求数 / Token 分解只显示色点与数值，且不出现任何可见文字标签。
 - Given 查看账号卡 recent 区标题行，When 右侧存在 recent bridge 统计，Then 显示完整状态文字，并与左侧“最近 4 条调用”标题保持同一垂直对齐。
 - Given 查看账号卡内 recent 调用记录，When 与对话卡片调用记录对照，Then recent 行至少包含状态、模型、endpoint、Token 摘要与 `RQ / UP / ED / TT` 时序摘要，且 4 条记录完整留在卡内。

--- a/web/src/components/DashboardWorkingConversationsSection.stories.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.stories.tsx
@@ -2482,6 +2482,16 @@ export const UpstreamAccountTab: Story = {
     await expect(
       canvas.queryByText("最近 4 条调用里仍有活动或异常，优先从下方最近记录继续排查。"),
     ).toBeNull();
+    const identityChip = canvas.getAllByTestId(
+      "dashboard-upstream-account-recent-identity-chip",
+    )[0];
+    if (!(identityChip instanceof HTMLButtonElement)) {
+      throw new Error("expected upstream identity chip button");
+    }
+    await expect(identityChip).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("打开对话详情"),
+    );
   },
   parameters: {
     viewport: { defaultViewport: "desktop1660" },
@@ -2489,6 +2499,77 @@ export const UpstreamAccountTab: Story = {
       description: {
         story:
           "Dashboard workspace section switched to the upstream-account tab, showing one enlarged active-account card with account-level KPIs and the dynamic recent invocation window in the selected range, including lightweight short conversation identity chips and request/response model mismatch rows.",
+      },
+    },
+  },
+};
+
+export const UpstreamAccountRecentIdentityChipOpensConversation: Story = {
+  args: UpstreamAccountTab.args,
+  render: () => (
+    <DrawerPreviewStory
+      response={createResponse([
+        createConversation("pck-story-upstream-account", [
+          createPreview({
+            id: 9801,
+            invokeId: "story-working-invoke",
+            occurredAt: "2026-04-04T10:05:00Z",
+            status: "running",
+            upstreamAccountId: 42,
+            upstreamAccountName: "Pool Alpha",
+          }),
+        ]),
+      ])}
+      upstreamAccountActivity={createUpstreamAccountActivityStoryResponse()}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const accountTab = await canvas.findByRole("tab", { name: "上游账号" });
+    await userEvent.click(accountTab);
+
+    const identityChip = canvas.getAllByTestId(
+      "dashboard-upstream-account-recent-identity-chip",
+    )[0];
+    if (!(identityChip instanceof HTMLButtonElement)) {
+      throw new Error("expected upstream identity chip button");
+    }
+
+    await userEvent.click(identityChip);
+    await waitFor(() => {
+      expect(
+        document.body.querySelector(
+          '[data-testid="story-drawer-state"]',
+        )?.textContent,
+      ).toContain("conversation:pck-upstream-running");
+    });
+    await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
+      "conversation:pck-upstream-running",
+    );
+
+    const firstRow = canvas.getAllByTestId("dashboard-upstream-account-recent-row")[0];
+    if (!(firstRow instanceof HTMLButtonElement)) {
+      throw new Error("expected upstream recent row button");
+    }
+
+    await userEvent.click(firstRow);
+    await waitFor(() => {
+      expect(
+        document.body.querySelector(
+          '[data-testid="story-drawer-state"]',
+        )?.textContent,
+      ).toContain("invocation:acct-invoke-1");
+    });
+    await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
+      "invocation:acct-invoke-1",
+    );
+  },
+  parameters: {
+    viewport: { defaultViewport: "desktop1660" },
+    docs: {
+      description: {
+        story:
+          "Proves the upstream-account recent identity chip opens the conversation drawer while the surrounding recent row still opens the invocation drawer.",
       },
     },
   },

--- a/web/src/components/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.test.tsx
@@ -824,6 +824,7 @@ describe("DashboardWorkingConversationsSection", () => {
   it("shows conversation short id, full request id, mismatch models, and real prompt cache key in upstream recent rows", () => {
     upstreamAccountActivityMock.data = createUpstreamAccountActivityResponse();
     const onOpenInvocation = vi.fn();
+    const onOpenConversation = vi.fn();
 
     renderSection(
       createResponse([
@@ -836,7 +837,7 @@ describe("DashboardWorkingConversationsSection", () => {
           }),
         ]),
       ]),
-      { onOpenInvocation },
+      { onOpenConversation, onOpenInvocation },
     );
 
     const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
@@ -905,6 +906,83 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(onOpenInvocation.mock.calls[0]?.[0]?.promptCacheKey).not.toBe(
       "acct-invoke-1",
     );
+    expect(onOpenConversation).not.toHaveBeenCalled();
+  });
+
+  it("opens conversation detail from the upstream recent identity chip only", () => {
+    upstreamAccountActivityMock.data = createUpstreamAccountActivityResponse();
+    const onOpenInvocation = vi.fn();
+    const onOpenConversation = vi.fn();
+
+    renderSection(
+      createResponse([
+        createConversation("pck-upstream-anchor", [
+          createPreview({
+            id: 1,
+            invokeId: "invoke-upstream-anchor",
+            occurredAt: "2026-04-04T10:04:00Z",
+            status: "running",
+          }),
+        ]),
+      ]),
+      { onOpenConversation, onOpenInvocation },
+    );
+
+    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
+      (node) => node.textContent?.includes("上游账号"),
+    );
+    if (!(accountTab instanceof HTMLButtonElement)) {
+      throw new Error("missing upstream account tab");
+    }
+
+    act(() => {
+      fireEvent.click(accountTab);
+    });
+
+    const identityChip = host?.querySelector(
+      '[data-testid="dashboard-upstream-account-recent-identity-chip"]',
+    );
+    if (!(identityChip instanceof HTMLButtonElement)) {
+      throw new Error("missing upstream recent identity chip");
+    }
+
+    expect(identityChip.getAttribute("aria-label")).toContain("打开对话详情");
+    expect(identityChip.getAttribute("aria-label")).toContain(
+      "pck-upstream-running",
+    );
+
+    act(() => {
+      identityChip.click();
+    });
+
+    expect(onOpenConversation).toHaveBeenCalledWith({
+      conversationSequenceId: `WC-${hashDashboardWorkingConversationKey("pck-upstream-running").slice(0, 6)}`,
+      promptCacheKey: "pck-upstream-running",
+    });
+    expect(onOpenInvocation).not.toHaveBeenCalled();
+
+    onOpenConversation.mockClear();
+    onOpenInvocation.mockClear();
+
+    act(() => {
+      identityChip.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(onOpenConversation).toHaveBeenCalledTimes(1);
+    expect(onOpenInvocation).not.toHaveBeenCalled();
+
+    onOpenConversation.mockClear();
+
+    act(() => {
+      identityChip.dispatchEvent(
+        new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+      );
+    });
+
+    expect(onOpenConversation).toHaveBeenCalledTimes(1);
+    expect(onOpenInvocation).not.toHaveBeenCalled();
   });
 
   it("spreads identity chip tones for prompt cache keys that used to collide on the same low-bit slot", () => {

--- a/web/src/components/DashboardWorkingConversationsSection.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.tsx
@@ -646,12 +646,14 @@ function AccountRecentInvocationRow({
   locale,
   nowMs,
   onOpenUpstreamAccount,
+  onOpenConversation,
   onOpenInvocation,
 }: {
   invocation: DashboardWorkingConversationInvocationModel;
   locale: "zh" | "en";
   nowMs: number;
   onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+  onOpenConversation?: (selection: DashboardWorkingConversationSelection) => void;
   onOpenInvocation?: (
     selection: DashboardWorkingConversationInvocationSelection,
   ) => void;
@@ -780,6 +782,9 @@ function AccountRecentInvocationRow({
   const responseModelValue = viewModel.responseModelValue;
   const compactTimingSummary = `RQ ${formatCompactMilliseconds(invocation.record.tReqReadMs)}/${formatCompactMilliseconds(invocation.record.tReqParseMs)} · UP ${formatCompactMilliseconds(invocation.record.tUpstreamConnectMs)}/${formatCompactMilliseconds(invocation.record.tUpstreamTtfbMs)}/${formatCompactMilliseconds(invocation.record.tUpstreamStreamMs)} · ED ${formatCompactMilliseconds(invocation.record.tRespParseMs)}/${formatCompactMilliseconds(invocation.record.tPersistMs)} · TT ${typeof invocation.record.tTotalMs === "number" && Number.isFinite(invocation.record.tTotalMs) ? `${formatCompactMilliseconds(invocation.record.tTotalMs)}ms` : viewModel.totalLatencyValue}`;
   const invocationActionLabel = `${t("dashboard.workingConversations.openInvocation")} · ${invocation.record.invokeId}`;
+  const conversationActionLabel = displayPromptCacheKey
+    ? `${t("dashboard.workingConversations.openConversation")} · ${displayConversationSequenceId} · ${displayPromptCacheKey}`
+    : null;
   const fastIndicator = renderFastIndicator(viewModel.fastIndicatorState, t);
 
   const handleOpenInvocation = useCallback(() => {
@@ -794,6 +799,14 @@ function AccountRecentInvocationRow({
     });
   }, [invocation, onOpenInvocation]);
 
+  const handleOpenConversation = useCallback(() => {
+    if (!displayPromptCacheKey) return;
+    onOpenConversation?.({
+      conversationSequenceId: `WC-${hashDashboardWorkingConversationKey(displayPromptCacheKey).slice(0, 6)}`,
+      promptCacheKey: displayPromptCacheKey,
+    });
+  }, [displayPromptCacheKey, onOpenConversation]);
+
   const handleRowKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLButtonElement>) => {
       if (event.target !== event.currentTarget) return;
@@ -802,6 +815,24 @@ function AccountRecentInvocationRow({
       handleOpenInvocation();
     },
     [handleOpenInvocation],
+  );
+
+  const handleIdentityChipClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      handleOpenConversation();
+    },
+    [handleOpenConversation],
+  );
+
+  const handleIdentityChipKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      handleOpenConversation();
+    },
+    [handleOpenConversation],
   );
 
   return (
@@ -826,18 +857,23 @@ function AccountRecentInvocationRow({
             >
               {displayConversationSequenceId ? (
                 <>
-                  <span
+                  <button
+                    type="button"
                     data-testid="dashboard-upstream-account-recent-identity-chip"
                     className={cn(
                       UPSTREAM_ACCOUNT_RECENT_IDENTITY_CHIP_CLASS_NAME,
+                      "cursor-pointer transition-opacity duration-200 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
                       conversationIdentityToneClassName,
                     )}
-                    title={displayConversationSequenceId}
+                    aria-label={conversationActionLabel ?? undefined}
+                    title={conversationActionLabel ?? displayConversationSequenceId}
+                    onClick={handleIdentityChipClick}
+                    onKeyDown={handleIdentityChipKeyDown}
                   >
                     <span className="truncate whitespace-nowrap">
                       {displayConversationSequenceId}
                     </span>
-                  </span>
+                  </button>
                   <AppIcon
                     name="chevron-right"
                     className="h-3 w-3 shrink-0 text-base-content/45"
@@ -1593,6 +1629,7 @@ function DashboardUpstreamAccountActivityCard({
   nowMs,
   recentPreviewLimit,
   onOpenUpstreamAccount,
+  onOpenConversation,
   onOpenInvocation,
 }: {
   account: UpstreamAccountActivityAccount;
@@ -1601,6 +1638,7 @@ function DashboardUpstreamAccountActivityCard({
   nowMs: number;
   recentPreviewLimit: number;
   onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+  onOpenConversation?: (selection: DashboardWorkingConversationSelection) => void;
   onOpenInvocation?: (
     selection: DashboardWorkingConversationInvocationSelection,
   ) => void;
@@ -1861,6 +1899,7 @@ function DashboardUpstreamAccountActivityCard({
               locale={locale}
               nowMs={nowMs}
               onOpenUpstreamAccount={onOpenUpstreamAccount}
+              onOpenConversation={onOpenConversation}
               onOpenInvocation={onOpenInvocation}
             />
           ))}
@@ -2363,6 +2402,7 @@ export function DashboardWorkingConversationsSection({
                     nowMs={nowMs}
                     recentPreviewLimit={upstreamAccountRecentPreviewLimit}
                     onOpenUpstreamAccount={onOpenUpstreamAccount}
+                    onOpenConversation={onOpenConversation}
                     onOpenInvocation={onOpenInvocation}
                   />
                 ))}


### PR DESCRIPTION
## Summary
- fix the upstream-account recent identity chip so it opens conversation detail instead of invocation detail
- keep the surrounding recent row bound to invocation detail
- add regression coverage for chip-vs-row interaction semantics

## Verification
- `cd web && bunx vitest run src/components/DashboardWorkingConversationsSection.test.tsx src/pages/Dashboard.test.tsx`

## References
- Spec: docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
- Spec Disposition: update
- Solutions: -
- Project Docs: -
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: n/a(no solution change)
- Project Docs Sync: n/a(no project-doc change)

## Notes
- Visual evidence not required for this task per latest owner instruction.
