### PR TITLE
fix(perf): stop snapshot scans on srv-101

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -46,7 +46,7 @@ Using one cadence for all three overfits the most urgent surface and overloads t
 - Add lightweight diagnostics counters for each path: visible patch count, head fetch count, SSE summary commit count, HTTP reconcile count, chart data commit count, and conditional fetch hit count.
 - Keep `current` summary and dashboard account-activity reconcile on the same 5 second budget. A faster current-window reconcile without a matching backend live read model simply turns SQLite scan cost into a tighter request loop.
 - When an endpoint still needs strict “currently in progress” truth, move that truth into a write-side live table or read model and let the 5 second reconcile read that bounded surface instead of rescanning the historical raw table.
-- Treat dashboard working-set surfaces the same way: the 5-minute working-conversations head/count can read a write-side bounded working-set table, while exact snapshot pagination stays on its slower snapshot path because it is not part of the hot open-tab reconcile loop.
+- Treat dashboard working-set surfaces the same way: the 5-minute working-conversations head/count and snapshot pagination/count can both read a write-side bounded working-set table. Keep the response shape and main ordering stable, but accept `<=5s` bounded freshness instead of strict historical snapshot recomputation from the raw invocation table.
 - For future regressions, slow-path evidence needs to identify the class of work, not just that something was slow: emit endpoint/window/source-scope plus key counts or cache-hit state so operators can tell apart request-time scans, maintenance-time rebuilds, and cache hydration misses.
 
 ## Guardrails / Reuse Notes

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -21,6 +21,7 @@
 - 前台关键写入：OAuth callback、请求路由状态、用户可见设置保存；优先拿连接，失败需返回明确业务错误。
 - 请求收尾写入：invocation 记录、usage、raw metadata；允许有界降级和异步旁路。
 - 请求收尾若已经存在对应 `running/pending` 行，优先原地更新而不是先 `INSERT OR IGNORE` 再走 repair/update；这样可以少一次唯一键冲突写尝试与后续锁竞争。
+- 对同一 attempt 的 phase、latency、capability/compact-support 等进度字段，优先并入同一条前台更新，而不是拆成 `phase bump -> latency patch -> finalize` 的多段慢写；减少单请求尾部把 SQLite 单写者预算切碎。
 - 后台维护写入：rollup、retention、account maintenance；pressure 下 fail-soft skip。
 - 历史回填写入：startup backfill、archive materialization；pressure 下延后，不阻塞 readiness。
 

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -13,3 +13,4 @@
 - 2026-06-21: 继续把“活动中的调用记录列表”统一收口到现有 `records` SSE + open 后静默回源链路，明确覆盖 `Live`、`/records` 与账号详情抽屉 records tab；历史回放类抽屉保留各自 snapshot/history 语义，不强行改造成全量实时流。
 - 2026-06-29: Dashboard current-window summary reconcile 不再保留比 calendar window 更激进的 cadence；`current summary` 与 `upstream account activity` 统一收口到 `5s` refresh/open-resync 预算，避免前端更快回源把后端请求级 SQLite 热点放大成持续 CPU 压力。
 - 2026-06-30: 第二轮 CPU 止血把 Dashboard working conversations 当前 head/count 的真相源前移到 write-side `prompt_cache_working_set_live`，接受 `<=5s` bounded freshness，但不再让 5 分钟工作集每次 reconcile 都重扫 `codex_invocations`。
+- 2026-06-30: 第三轮 CPU 止血继续把 working conversations 的 snapshot count/page 从 `WITH recent_terminal` 历史重算收口到 live working-set truth。接口继续保留 `snapshot_at`、cursor 与字段 shape，但 snapshot 聚合不再承诺严格历史时点重算，只承诺 `<=5s` bounded freshness。

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -7,6 +7,7 @@
 - Dashboard realtime consumption now separates SSE-fast KPI commits from 5s HTTP/chart reconcile budgets. Working conversations batch visible SSE patches for 1s and throttle head/snapshot reconcile to 5s. `/api/stats/parallel-work` keeps its response schema while supporting ETag / 304 conditional fetches.
 - Current-window summary reconcile now matches the same 5s budget as calendar windows and account-activity reconcile. The dashboard debug diagnostics also split out `current summary refresh/open-resync` and `upstream account activity refresh/open-resync`, so future regressions can distinguish SSE-fast-path churn from HTTP reconcile churn.
 - Dashboard working conversations live head/count now read from a write-side `prompt_cache_working_set_live` table that keeps the last 5 minutes of terminal activity plus any current in-flight keys. The public response shape stays unchanged, while the hot read path no longer rebuilds the working set from `codex_invocations` on every request.
+- Working-conversations snapshot count/page now also accept the same `<=5s` bounded-freshness contract. Instead of strict historical recomputation from `codex_invocations`, snapshot aggregates read the live working-set truth directly and keep the existing response fields, cursor shape, and main ordering semantics.
 
 ## Migrated Implementation Notes
 

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -37,6 +37,8 @@
 - `fetch_summary` / `fetch_stats` 按窗口类型区分 live augmentation：闭区间默认跳过 in-progress 与 non-success token live 补算；SQLite `database is locked` 时非成功 token live 增量允许受限降级，不再整排卡片长期 skeleton。
 - summary / account-activity 的 in-progress augmentation 已从请求时扫描 `codex_invocations` 改成 `invocation_in_progress_live` 小表读取。该 live read model 由 `codex_invocations` trigger 与 startup rebuild 同步维护，并分别保留 summary 全局 retry 与 account-scoped retry 语义，避免 Dashboard/account detail 的当前窗口 reconcile 把 read-model 节省下来的 CPU 再吃回去。
 - summary publish 当前窗口里的 `inProgressConversationCount` distinct-count 现在也直接复用 live table truth source，而不是在 maintenance 路径里对 `codex_invocations` 再做一次 `COUNT(DISTINCT prompt_cache_key)`；这让 summary 广播与账号详情共用同一份 bounded in-progress truth。
+- 第三轮 SQLite 止血进一步把 prompt cache working-conversation 的 snapshot count/page 从 `codex_invocations` 热表扫描切到 write-side working-set truth；虽然公开 API shape 不变，但相关详情/工作区入口现在统一接受 `<=5s` bounded freshness，而不再为严格 snapshot membership 付出请求级扫表代价。
+- proxy capture 请求尾写路径也继续收敛：`codex_invocations` 终态持久化改为单路径 upsert/finalize，`pool_upstream_request_attempts` 的 phase / latency / compact-support 进度尽量并入同一条更新，减少账号详情和 Dashboard 与请求尾写争用 SQLite 单写者预算。
 - Storybook 现有详情抽屉 overlay stories 继续作为 page-fallback 证据面，新增 owner-facing 首屏概览态与 records 统计卡片完成态图片，覆盖这次性能回归修复后的默认打开路径。
 
 ## Verification

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -30,6 +30,7 @@
 - 已实现：账号卡列表按 `totalTokens` 倒序排列，并用最近调用时间与账号 ID 作稳定排序兜底。
 - 已实现：账号卡“首字用时”从阶段级 `t_upstream_ttfb_ms` 纠偏为 owner-facing 的首字总耗时口径；后端聚合现在复用 `resolve_first_response_byte_total_ms(...)`，并额外暴露显式 `firstResponseByteTotalAvgMs` 供前端优先消费，避免真实秒级总耗时被渲染成 `0ms`。
 - 已实现：工作区 `对话` tab 当前 5 分钟 working-set 的 head/count 改读 write-side `prompt_cache_working_set_live`，并为 mixed-source key 保留 `All / ProxyOnly` 两套聚合列，避免换源后 `ProxyOnly` 视角丢 key 或排序漂移。
+- 已实现：工作区 `对话` tab 的 snapshot count/page 也收口到同一份 live working-set truth，不再通过 `WITH recent_terminal` 对 `codex_invocations` 做严格历史重算。公开字段、cursor 形态、recent preview 与主排序语义保持不变，但 snapshot membership 明确接受 `<=5s` bounded freshness。
 
 ## Remaining Gaps
 

--- a/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/aggregate_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/aggregate_queries.rs
@@ -116,84 +116,15 @@ pub(crate) async fn query_in_progress_prompt_cache_conversation_count(
 
 pub(crate) async fn query_working_prompt_cache_conversation_count_at_snapshot(
     pool: &Pool<Sqlite>,
-    range_start_bound: &str,
-    snapshot: &PromptCacheConversationSnapshotFilter,
+    _range_start_bound: &str,
+    _snapshot: &PromptCacheConversationSnapshotFilter,
     source_scope: InvocationSourceScope,
 ) -> Result<i64> {
-    const KEY_EXPR: &str = "CASE WHEN json_valid(payload) THEN TRIM(CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)) END";
-
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "WITH recent_terminal AS (\
-            SELECT ",
-    );
-    query
-        .push(KEY_EXPR)
-        .push(
-            " AS prompt_cache_key \
-             FROM codex_invocations \
-             WHERE occurred_at >= ",
-        )
-        .push_bind(range_start_bound)
-        .push(" AND ");
-    push_snapshot_invocation_visibility_clause(
-        &mut query,
-        "occurred_at",
-        "id",
-        "created_at",
-        Some(snapshot),
-    );
-    query
-        .push(" AND ")
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) NOT IN ('running', 'pending')");
-
+    let mut query =
+        QueryBuilder::<Sqlite>::new("SELECT COUNT(*) AS count FROM prompt_cache_working_set_live");
     if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
+        query.push(" WHERE source_scope_proxy_only = 1");
     }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), in_flight AS (\
-            SELECT ",
-    );
-    query.push(KEY_EXPR).push(
-        " AS prompt_cache_key \
-             FROM codex_invocations \
-             WHERE ",
-    );
-    push_snapshot_invocation_visibility_clause(
-        &mut query,
-        "occurred_at",
-        "id",
-        "created_at",
-        Some(snapshot),
-    );
-    query
-        .push(" AND ")
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) IN ('running', 'pending')");
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), working AS (\
-            SELECT prompt_cache_key FROM recent_terminal \
-            UNION \
-            SELECT prompt_cache_key FROM in_flight\
-         ) \
-         SELECT COUNT(*) AS count FROM working",
-    );
 
     let (count,) = query.build_query_as::<(i64,)>().fetch_one(pool).await?;
     Ok(count)
@@ -324,209 +255,62 @@ pub(crate) async fn query_prompt_cache_working_conversation_aggregates(
 
 pub(crate) async fn query_prompt_cache_working_conversation_aggregates_page(
     pool: &Pool<Sqlite>,
-    range_start_bound: &str,
-    snapshot: &PromptCacheConversationSnapshotFilter,
-    snapshot_hour_start_epoch: i64,
-    snapshot_hour_start_bound: &str,
+    _range_start_bound: &str,
+    _snapshot: &PromptCacheConversationSnapshotFilter,
+    _snapshot_hour_start_epoch: i64,
+    _snapshot_hour_start_bound: &str,
     source_scope: InvocationSourceScope,
     cursor: Option<&(String, String, String, Option<i64>)>,
     limit: i64,
 ) -> Result<Vec<PromptCacheConversationAggregateRow>> {
-    const KEY_EXPR: &str = "CASE WHEN json_valid(payload) THEN TRIM(CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)) END";
-
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "WITH recent_terminal AS (\
-            SELECT ",
-    );
-    query
-        .push(KEY_EXPR)
-        .push(
-            " AS prompt_cache_key, MAX(occurred_at) AS last_terminal_at \
-             FROM codex_invocations \
-             WHERE occurred_at >= ",
-        )
-        .push_bind(range_start_bound)
-        .push(" AND ");
-    push_snapshot_invocation_visibility_clause(
-        &mut query,
-        "occurred_at",
-        "id",
-        "created_at",
-        Some(snapshot),
-    );
-    query
-        .push(" AND ")
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) NOT IN ('running', 'pending')");
-
+    let mut query = QueryBuilder::<Sqlite>::new("SELECT prompt_cache_key, ");
     if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
+        query.push(
+            "proxy_request_count AS request_count, \
+             proxy_total_tokens AS total_tokens, \
+             proxy_total_cost AS total_cost, \
+             COALESCE(proxy_created_at, created_at) AS created_at, \
+             COALESCE(proxy_last_activity_at, last_activity_at) AS last_activity_at, \
+             proxy_sort_anchor_at AS sort_anchor_at, \
+             proxy_last_terminal_at AS last_terminal_at, \
+             proxy_last_in_flight_at AS last_in_flight_at \
+         FROM prompt_cache_working_set_live \
+         WHERE source_scope_proxy_only = 1 \
+           AND proxy_sort_anchor_at IS NOT NULL",
+        );
+    } else {
+        query.push(
+            "request_count, \
+             total_tokens, \
+             total_cost, \
+             created_at, \
+             last_activity_at, \
+             sort_anchor_at, \
+             last_terminal_at, \
+             last_in_flight_at \
+         FROM prompt_cache_working_set_live \
+         WHERE source_scope_all = 1",
+        );
     }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), in_flight AS (\
-            SELECT ",
-    );
-    query.push(KEY_EXPR).push(
-        " AS prompt_cache_key, MAX(occurred_at) AS last_in_flight_at \
-             FROM codex_invocations \
-             WHERE ",
-    );
-    push_snapshot_invocation_visibility_clause(
-        &mut query,
-        "occurred_at",
-        "id",
-        "created_at",
-        Some(snapshot),
-    );
-    query
-        .push(" AND ")
-        .push(KEY_EXPR)
-        .push(" IS NOT NULL AND ")
-        .push(KEY_EXPR)
-        .push(" <> '' AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) IN ('running', 'pending')");
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), working AS (\
-            SELECT prompt_cache_key, last_terminal_at, NULL AS last_in_flight_at \
-              FROM recent_terminal \
-            UNION ALL \
-            SELECT prompt_cache_key, NULL AS last_terminal_at, last_in_flight_at \
-              FROM in_flight \
-         ), collapsed_working AS (\
-            SELECT prompt_cache_key, \
-                   MAX(last_terminal_at) AS last_terminal_at, \
-                   MAX(last_in_flight_at) AS last_in_flight_at, \
-                   CASE \
-                       WHEN MAX(last_terminal_at) IS NULL THEN MAX(last_in_flight_at) \
-                       WHEN MAX(last_in_flight_at) IS NULL THEN MAX(last_terminal_at) \
-                       WHEN MAX(last_terminal_at) >= MAX(last_in_flight_at) THEN MAX(last_terminal_at) \
-                       ELSE MAX(last_in_flight_at) \
-                   END AS sort_anchor_at \
-              FROM working \
-              GROUP BY prompt_cache_key\
-         ), history_rollup AS (\
-            SELECT prompt_cache_key, \
-                   SUM(request_count) AS request_count, \
-                   SUM(total_tokens) AS total_tokens, \
-                   SUM(total_cost) AS total_cost, \
-                   MIN(first_seen_at) AS created_at, \
-                   MAX(last_seen_at) AS last_activity_at \
-              FROM prompt_cache_rollup_hourly \
-             WHERE prompt_cache_key IN (SELECT prompt_cache_key FROM collapsed_working) \
-               AND bucket_start_epoch < ",
-    );
-    query.push_bind(snapshot_hour_start_epoch);
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), history_live AS (\
-            SELECT ",
-    );
-    query
-        .push(KEY_EXPR)
-        .push(
-            " AS prompt_cache_key, \
-                   COUNT(*) AS request_count, \
-                   COALESCE(SUM(COALESCE(total_tokens, 0)), 0) AS total_tokens, \
-                   COALESCE(SUM(COALESCE(cost, 0.0)), 0.0) AS total_cost, \
-                   MIN(occurred_at) AS created_at, \
-                   MAX(occurred_at) AS last_activity_at \
-              FROM codex_invocations \
-             WHERE occurred_at >= ",
-        )
-        .push_bind(snapshot_hour_start_bound)
-        .push(" AND ");
-    push_snapshot_invocation_visibility_clause(
-        &mut query,
-        "occurred_at",
-        "id",
-        "created_at",
-        Some(snapshot),
-    );
-    query
-        .push(" AND ")
-        .push(KEY_EXPR)
-        .push(" IN (SELECT prompt_cache_key FROM collapsed_working)");
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-
-    query.push(
-        " GROUP BY prompt_cache_key\
-         ), history_inputs AS (\
-            SELECT prompt_cache_key, request_count, total_tokens, total_cost, created_at, last_activity_at \
-              FROM history_rollup \
-            UNION ALL \
-            SELECT prompt_cache_key, request_count, total_tokens, total_cost, created_at, last_activity_at \
-              FROM history_live\
-         ), history_aggregates AS (\
-            SELECT prompt_cache_key, \
-                   COALESCE(SUM(request_count), 0) AS request_count, \
-                   COALESCE(SUM(total_tokens), 0) AS total_tokens, \
-                   COALESCE(SUM(total_cost), 0.0) AS total_cost, \
-                   MIN(created_at) AS created_at, \
-                   MAX(last_activity_at) AS last_activity_at \
-              FROM history_inputs \
-             GROUP BY prompt_cache_key\
-         ), aggregates AS (\
-            SELECT collapsed_working.prompt_cache_key AS prompt_cache_key, \
-                   COALESCE(history_aggregates.request_count, 0) AS request_count, \
-                   COALESCE(history_aggregates.total_tokens, 0) AS total_tokens, \
-                   COALESCE(history_aggregates.total_cost, 0.0) AS total_cost, \
-                   COALESCE(history_aggregates.created_at, collapsed_working.sort_anchor_at) AS created_at, \
-                   COALESCE(history_aggregates.last_activity_at, collapsed_working.sort_anchor_at) AS last_activity_at, \
-                   collapsed_working.sort_anchor_at AS sort_anchor_at, \
-                   collapsed_working.last_terminal_at AS last_terminal_at, \
-                   collapsed_working.last_in_flight_at AS last_in_flight_at \
-              FROM collapsed_working \
-              LEFT JOIN history_aggregates ON history_aggregates.prompt_cache_key = collapsed_working.prompt_cache_key",
-    );
-
-    query.push(
-        " ) \
-         SELECT aggregates.prompt_cache_key, aggregates.request_count, aggregates.total_tokens, \
-                aggregates.total_cost, aggregates.created_at, aggregates.last_activity_at, \
-                aggregates.sort_anchor_at, aggregates.last_terminal_at, \
-                aggregates.last_in_flight_at \
-           FROM aggregates",
-    );
 
     if let Some((cursor_sort_anchor_at, cursor_created_at, cursor_prompt_cache_key, _)) = cursor {
         query
-            .push(" WHERE (aggregates.sort_anchor_at < ")
+            .push(" AND (sort_anchor_at < ")
             .push_bind(cursor_sort_anchor_at)
-            .push(" OR (aggregates.sort_anchor_at = ")
+            .push(" OR (sort_anchor_at = ")
             .push_bind(cursor_sort_anchor_at)
-            .push(" AND (aggregates.created_at < ")
+            .push(" AND (created_at < ")
             .push_bind(cursor_created_at)
-            .push(" OR (aggregates.created_at = ")
+            .push(" OR (created_at = ")
             .push_bind(cursor_created_at)
-            .push(" AND aggregates.prompt_cache_key < ")
+            .push(" AND prompt_cache_key < ")
             .push_bind(cursor_prompt_cache_key)
             .push("))))");
     }
 
     query
         .push(
-            " ORDER BY aggregates.sort_anchor_at DESC, aggregates.created_at DESC, aggregates.prompt_cache_key DESC \
+            " ORDER BY sort_anchor_at DESC, created_at DESC, prompt_cache_key DESC \
               LIMIT ",
         )
         .push_bind(limit);

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -2158,21 +2158,6 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                     if let Some(guard) = early_phase_cleanup_guard.as_mut() {
                         guard.mark_first_byte_observed(first_byte_latency_ms);
                     }
-                    if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
-                        && let Err(err) = persist_pool_upstream_request_attempt_first_byte_progress(
-                            &state.pool,
-                            pending_attempt_record,
-                            connect_latency_ms,
-                            first_byte_latency_ms,
-                        )
-                        .await
-                    {
-                        warn!(
-                            invoke_id = %pending_attempt_record.invoke_id,
-                            error = %err,
-                            "failed to persist pool first-byte progress for passthrough bad request"
-                        );
-                    }
                     let proxy_binding_key_snapshot = if let Some((_, selected_proxy)) =
                         forward_proxy_selection.as_ref()
                     {
@@ -2218,10 +2203,14 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                         if pending_attempt_record.attempt_id.is_none() {
                             deferred_early_phase_cleanup_guard = early_phase_cleanup_guard.take();
                         }
-                        match update_pool_upstream_request_attempt_phase(
+                        match update_pool_upstream_request_attempt_progress(
                             &state.pool,
                             pending_attempt_record,
                             POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE,
+                            Some(connect_latency_ms),
+                            Some(first_byte_latency_ms),
+                            None,
+                            None,
                         )
                         .await
                         {
@@ -2789,21 +2778,6 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
             if let Some(guard) = early_phase_cleanup_guard.as_mut() {
                 guard.mark_first_byte_observed(first_byte_latency_ms);
             }
-            if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
-                && let Err(err) = persist_pool_upstream_request_attempt_first_byte_progress(
-                    &state.pool,
-                    pending_attempt_record,
-                    connect_latency_ms,
-                    first_byte_latency_ms,
-                )
-                .await
-            {
-                warn!(
-                    invoke_id = %pending_attempt_record.invoke_id,
-                    error = %err,
-                    "failed to persist pool first-byte attempt progress"
-                );
-            }
             let response_is_event_stream = response
                 .headers()
                 .get(header::CONTENT_TYPE)
@@ -3043,10 +3017,14 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                 if pending_attempt_record.attempt_id.is_none() {
                     deferred_early_phase_cleanup_guard = early_phase_cleanup_guard.take();
                 }
-                match update_pool_upstream_request_attempt_phase(
+                match update_pool_upstream_request_attempt_progress(
                     &state.pool,
                     pending_attempt_record,
                     POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE,
+                    Some(connect_latency_ms),
+                    Some(first_byte_latency_ms),
+                    None,
+                    None,
                 )
                 .await
                     {

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -1063,21 +1063,6 @@ pub(crate) async fn send_pool_request_live_first_attempt(
             if let Some(guard) = deferred_early_phase_cleanup_guard.as_mut() {
                 guard.mark_first_byte_observed(first_byte_latency_ms);
             }
-            if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
-                && let Err(err) = persist_pool_upstream_request_attempt_first_byte_progress(
-                    &state.pool,
-                    pending_attempt_record,
-                    connect_latency_ms,
-                    first_byte_latency_ms,
-                )
-                .await
-            {
-                warn!(
-                    invoke_id = %pending_attempt_record.invoke_id,
-                    error = %err,
-                    "failed to persist live-first pool first-byte progress for passthrough bad request"
-                );
-            }
             release_pool_routing_reservation(state.as_ref(), &reservation_key);
             finalize_tracked_live_first_pool_attempt(
                 state.as_ref(),
@@ -1357,21 +1342,6 @@ pub(crate) async fn send_pool_request_live_first_attempt(
     if let Some(guard) = deferred_early_phase_cleanup_guard.as_mut() {
         guard.mark_first_byte_observed(first_byte_latency_ms);
     }
-    if let Some(pending_attempt_record) = pending_attempt_record.as_ref()
-        && let Err(err) = persist_pool_upstream_request_attempt_first_byte_progress(
-            &state.pool,
-            pending_attempt_record,
-            connect_latency_ms,
-            first_byte_latency_ms,
-        )
-        .await
-    {
-        warn!(
-            invoke_id = %pending_attempt_record.invoke_id,
-            error = %err,
-            "failed to persist live-first pool first-byte progress"
-        );
-    }
     let compact_support_observation =
         classify_compact_support_observation(original_uri, Some(status), None);
     if let Some(observation) = compact_support_observation.as_ref()
@@ -1398,10 +1368,14 @@ pub(crate) async fn send_pool_request_live_first_attempt(
         pending_attempt_record.compact_support_reason = compact_support_observation
             .as_ref()
             .and_then(|value| value.reason.clone());
-        match update_pool_upstream_request_attempt_phase(
+        match update_pool_upstream_request_attempt_progress(
             &state.pool,
             pending_attempt_record,
             POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE,
+            Some(connect_latency_ms),
+            Some(first_byte_latency_ms),
+            pending_attempt_record.compact_support_status.as_deref(),
+            pending_attempt_record.compact_support_reason.as_deref(),
         )
         .await
         {

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -296,6 +296,21 @@ pub(crate) async fn update_pool_upstream_request_attempt_phase(
     pending: &PendingPoolAttemptRecord,
     phase: &str,
 ) -> Result<bool> {
+    update_pool_upstream_request_attempt_progress(
+        pool, pending, phase, None, None, None, None,
+    )
+    .await
+}
+
+pub(crate) async fn update_pool_upstream_request_attempt_progress(
+    pool: &Pool<Sqlite>,
+    pending: &PendingPoolAttemptRecord,
+    phase: &str,
+    connect_latency_ms: Option<f64>,
+    first_byte_latency_ms: Option<f64>,
+    compact_support_status: Option<&str>,
+    compact_support_reason: Option<&str>,
+) -> Result<bool> {
     let Some(attempt_id) = pending.attempt_id else {
         return Ok(false);
     };
@@ -303,16 +318,39 @@ pub(crate) async fn update_pool_upstream_request_attempt_phase(
     let result = sqlx::query(
         r#"
         UPDATE pool_upstream_request_attempts
-        SET phase = ?2
+        SET
+            phase = ?2,
+            connect_latency_ms = CASE
+                WHEN ?4 IS NULL THEN connect_latency_ms
+                WHEN connect_latency_ms IS NULL OR connect_latency_ms < ?4 THEN ?4
+                ELSE connect_latency_ms
+            END,
+            first_byte_latency_ms = CASE
+                WHEN ?5 IS NULL THEN first_byte_latency_ms
+                WHEN first_byte_latency_ms IS NULL OR first_byte_latency_ms < ?5 THEN ?5
+                ELSE first_byte_latency_ms
+            END,
+            compact_support_status = COALESCE(?6, compact_support_status),
+            compact_support_reason = COALESCE(?7, compact_support_reason)
         WHERE id = ?1
           AND status = ?3
           AND finished_at IS NULL
-          AND COALESCE(phase, '') <> ?2
+          AND (
+                COALESCE(phase, '') <> ?2
+                OR (?4 IS NOT NULL AND (connect_latency_ms IS NULL OR connect_latency_ms < ?4))
+                OR (?5 IS NOT NULL AND (first_byte_latency_ms IS NULL OR first_byte_latency_ms < ?5))
+                OR (?6 IS NOT NULL AND COALESCE(compact_support_status, '') <> ?6)
+                OR (?7 IS NOT NULL AND COALESCE(compact_support_reason, '') <> ?7)
+              )
         "#,
     )
     .bind(attempt_id)
     .bind(phase)
     .bind(POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING)
+    .bind(connect_latency_ms)
+    .bind(first_byte_latency_ms)
+    .bind(compact_support_status)
+    .bind(compact_support_reason)
     .execute(pool)
     .await?;
 
@@ -2037,389 +2075,198 @@ pub(crate) async fn persist_proxy_capture_runtime_record(
     let t_upstream_ttfb_ms = nullable_runtime_timing_value(record.timings.t_upstream_ttfb_ms);
     let created_at = format_utc_iso_millis(Utc::now());
     let mut tx = pool.begin().await?;
-    let existing_identity =
-        if invocation_status_is_in_flight(Some(record.status.as_str())) {
-            None
-        } else {
-            load_persisted_invocation_identity_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
-                .await?
-        };
-
-    if let Some(existing) = existing_identity {
-        if !persisted_invocation_allows_proxy_record_update(
+    let existing_identity = load_persisted_invocation_identity_tx(
+        tx.as_mut(),
+        &record.invoke_id,
+        &record.occurred_at,
+    )
+    .await?;
+    if let Some(existing) = existing_identity.as_ref()
+        && !persisted_invocation_allows_proxy_record_update(
             existing.status.as_deref(),
             existing.failure_kind.as_deref(),
             &record.status,
-        ) {
-            tx.commit().await?;
-            return Ok(None);
-        }
-
-        let affected = sqlx::query(
-            r#"
-            UPDATE codex_invocations
-            SET source = ?2,
-                model = ?3,
-                input_tokens = ?4,
-                output_tokens = ?5,
-                cache_input_tokens = ?6,
-                reasoning_tokens = ?7,
-                total_tokens = ?8,
-                cost = ?9,
-                cost_estimated = ?10,
-                price_version = ?11,
-                status = ?12,
-                error_message = ?13,
-                failure_kind = ?14,
-                failure_class = ?15,
-                is_actionable = ?16,
-                payload = ?17,
-                raw_response = ?18,
-                request_raw_path = ?19,
-                request_raw_codec = ?20,
-                request_raw_size = ?21,
-                request_raw_truncated = ?22,
-                request_raw_truncated_reason = ?23,
-                response_raw_path = ?24,
-                response_raw_codec = ?25,
-                response_raw_size = ?26,
-                response_raw_truncated = ?27,
-                response_raw_truncated_reason = ?28,
-                t_total_ms = ?29,
-                t_req_read_ms = ?30,
-                t_req_parse_ms = ?31,
-                t_upstream_connect_ms = ?32,
-                t_upstream_ttfb_ms = ?33,
-                t_upstream_stream_ms = ?34,
-                t_resp_parse_ms = ?35,
-                t_persist_ms = ?36
-            WHERE id = ?1
-              AND (
-                    LOWER(TRIM(COALESCE(status, ''))) IN ('running', 'pending')
-                    OR (
-                        LOWER(TRIM(COALESCE(status, ''))) = 'interrupted'
-                        AND LOWER(TRIM(COALESCE(failure_kind, ''))) = 'proxy_interrupted'
-                    )
-              )
-            "#,
         )
-        .bind(existing.id)
-        .bind(SOURCE_PROXY)
-        .bind(&record.model)
-        .bind(record.usage.input_tokens)
-        .bind(record.usage.output_tokens)
-        .bind(record.usage.cache_input_tokens)
-        .bind(record.usage.reasoning_tokens)
-        .bind(record.usage.total_tokens)
-        .bind(record.cost)
-        .bind(record.cost_estimated as i64)
-        .bind(record.price_version.as_deref())
-        .bind(&record.status)
-        .bind(record.error_message.as_deref())
-        .bind(failure_kind.as_deref())
-        .bind(failure.failure_class.as_str())
-        .bind(failure.is_actionable as i64)
-        .bind(record.payload.as_deref())
-        .bind(&raw_response)
-        .bind(record.req_raw.path.as_deref())
-        .bind(raw_payload_meta_codec(&record.req_raw))
-        .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
-        .bind(record.req_raw.truncated as i64)
-        .bind(record.req_raw.truncated_reason.as_deref())
-        .bind(resp_raw.path.as_deref())
-        .bind(raw_payload_meta_codec(&resp_raw))
-        .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
-        .bind(resp_raw.truncated as i64)
-        .bind(resp_raw.truncated_reason.as_deref())
-        .bind(None::<f64>)
-        .bind(t_req_read_ms)
-        .bind(t_req_parse_ms)
-        .bind(t_upstream_connect_ms)
-        .bind(t_upstream_ttfb_ms)
-        .bind(None::<f64>)
-        .bind(None::<f64>)
-        .bind(None::<f64>)
-        .execute(tx.as_mut())
-        .await?
-        .rows_affected();
-        if affected == 0 {
-            tx.commit().await?;
-            return Ok(None);
-        }
-        recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[existing.id]).await?;
-        save_hourly_rollup_live_progress_tx(
-            tx.as_mut(),
-            HOURLY_ROLLUP_DATASET_INVOCATIONS,
-            existing.id,
-        )
-        .await?;
-        touch_invocation_upstream_account_last_activity_tx(
-            tx.as_mut(),
-            &record.occurred_at,
-            record.payload.as_deref(),
-        )
-        .await?;
-    } else {
-        let insert_result = sqlx::query(
-            r#"
-            INSERT OR IGNORE INTO codex_invocations (
-                invoke_id,
-                occurred_at,
-                source,
-                model,
-                input_tokens,
-                output_tokens,
-                cache_input_tokens,
-                reasoning_tokens,
-                total_tokens,
-                cost,
-                cost_estimated,
-                price_version,
-                status,
-                error_message,
-                failure_kind,
-                failure_class,
-                is_actionable,
-                payload,
-                raw_response,
-                request_raw_path,
-                request_raw_codec,
-                request_raw_size,
-                request_raw_truncated,
-                request_raw_truncated_reason,
-                response_raw_path,
-                response_raw_codec,
-                response_raw_size,
-                response_raw_truncated,
-                response_raw_truncated_reason,
-                t_total_ms,
-                t_req_read_ms,
-                t_req_parse_ms,
-                t_upstream_connect_ms,
-                t_upstream_ttfb_ms,
-                t_upstream_stream_ms,
-                t_resp_parse_ms,
-                t_persist_ms,
-                created_at
-            )
-            VALUES (
-                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
-                ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
-                ?37, ?38
-            )
-            "#,
-        )
-        .bind(&record.invoke_id)
-        .bind(&record.occurred_at)
-        .bind(SOURCE_PROXY)
-        .bind(&record.model)
-        .bind(record.usage.input_tokens)
-        .bind(record.usage.output_tokens)
-        .bind(record.usage.cache_input_tokens)
-        .bind(record.usage.reasoning_tokens)
-        .bind(record.usage.total_tokens)
-        .bind(record.cost)
-        .bind(record.cost_estimated as i64)
-        .bind(record.price_version.as_deref())
-        .bind(&record.status)
-        .bind(record.error_message.as_deref())
-        .bind(failure_kind.as_deref())
-        .bind(failure.failure_class.as_str())
-        .bind(failure.is_actionable as i64)
-        .bind(record.payload.as_deref())
-        .bind(&raw_response)
-        .bind(record.req_raw.path.as_deref())
-        .bind(raw_payload_meta_codec(&record.req_raw))
-        .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
-        .bind(record.req_raw.truncated as i64)
-        .bind(record.req_raw.truncated_reason.as_deref())
-        .bind(resp_raw.path.as_deref())
-        .bind(raw_payload_meta_codec(&resp_raw))
-        .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
-        .bind(resp_raw.truncated as i64)
-        .bind(resp_raw.truncated_reason.as_deref())
-        .bind(None::<f64>)
-        .bind(t_req_read_ms)
-        .bind(t_req_parse_ms)
-        .bind(t_upstream_connect_ms)
-        .bind(t_upstream_ttfb_ms)
-        .bind(None::<f64>)
-        .bind(None::<f64>)
-        .bind(None::<f64>)
-        .bind(created_at)
-        .execute(tx.as_mut())
-        .await?;
-
-        if insert_result.rows_affected() > 0 {
-            let inserted_id = insert_result.last_insert_rowid();
-            upsert_invocation_hourly_rollups_tx(
-                tx.as_mut(),
-                &[InvocationHourlySourceRecord {
-                    id: inserted_id,
-                    occurred_at: record.occurred_at.clone(),
-                    source: SOURCE_PROXY.to_string(),
-                    status: Some(record.status.clone()),
-                    detail_level: DETAIL_LEVEL_FULL.to_string(),
-                    input_tokens: record.usage.input_tokens,
-                    output_tokens: record.usage.output_tokens,
-                    cache_input_tokens: record.usage.cache_input_tokens,
-                    total_tokens: record.usage.total_tokens,
-                    cost: record.cost,
-                    error_message: record.error_message.clone(),
-                    failure_kind: failure_kind.clone(),
-                    failure_class: Some(failure.failure_class.as_str().to_string()),
-                    is_actionable: Some(failure.is_actionable as i64),
-                    payload: record.payload.clone(),
-                    t_total_ms: None,
-                    t_req_read_ms,
-                    t_req_parse_ms,
-                    t_upstream_connect_ms,
-                    t_upstream_ttfb_ms,
-                    t_upstream_stream_ms: None,
-                    t_resp_parse_ms: None,
-                    t_persist_ms: None,
-                }],
-                &INVOCATION_HOURLY_ROLLUP_TARGETS,
-            )
-            .await?;
-            save_hourly_rollup_live_progress_tx(
-                tx.as_mut(),
-                HOURLY_ROLLUP_DATASET_INVOCATIONS,
-                inserted_id,
-            )
-            .await?;
-            touch_invocation_upstream_account_last_activity_tx(
-                tx.as_mut(),
-                &record.occurred_at,
-                record.payload.as_deref(),
-            )
-            .await?;
-        } else {
-            let Some(existing) = load_persisted_invocation_identity_tx(
-                tx.as_mut(),
-                &record.invoke_id,
-                &record.occurred_at,
-            )
-            .await?
-            else {
-                tx.commit().await?;
-                return Ok(None);
-            };
-            if !persisted_invocation_allows_proxy_record_update(
-                existing.status.as_deref(),
-                existing.failure_kind.as_deref(),
-                &record.status,
-            ) {
-                tx.commit().await?;
-                return Ok(None);
-            }
-
-            let affected = sqlx::query(
-                r#"
-                UPDATE codex_invocations
-                SET source = ?2,
-                    model = ?3,
-                    input_tokens = ?4,
-                    output_tokens = ?5,
-                    cache_input_tokens = ?6,
-                    reasoning_tokens = ?7,
-                    total_tokens = ?8,
-                    cost = ?9,
-                    cost_estimated = ?10,
-                    price_version = ?11,
-                    status = ?12,
-                    error_message = ?13,
-                    failure_kind = ?14,
-                    failure_class = ?15,
-                    is_actionable = ?16,
-                    payload = ?17,
-                    raw_response = ?18,
-                    request_raw_path = ?19,
-                    request_raw_codec = ?20,
-                    request_raw_size = ?21,
-                    request_raw_truncated = ?22,
-                    request_raw_truncated_reason = ?23,
-                    response_raw_path = ?24,
-                    response_raw_codec = ?25,
-                    response_raw_size = ?26,
-                    response_raw_truncated = ?27,
-                    response_raw_truncated_reason = ?28,
-                    t_total_ms = ?29,
-                    t_req_read_ms = ?30,
-                    t_req_parse_ms = ?31,
-                    t_upstream_connect_ms = ?32,
-                    t_upstream_ttfb_ms = ?33,
-                    t_upstream_stream_ms = ?34,
-                    t_resp_parse_ms = ?35,
-                    t_persist_ms = ?36
-                WHERE id = ?1
-                  AND (
-                        LOWER(TRIM(COALESCE(status, ''))) IN ('running', 'pending')
-                        OR (
-                            LOWER(TRIM(COALESCE(status, ''))) = 'interrupted'
-                            AND LOWER(TRIM(COALESCE(failure_kind, ''))) = 'proxy_interrupted'
-                        )
-                  )
-                "#,
-            )
-            .bind(existing.id)
-            .bind(SOURCE_PROXY)
-            .bind(&record.model)
-            .bind(record.usage.input_tokens)
-            .bind(record.usage.output_tokens)
-            .bind(record.usage.cache_input_tokens)
-            .bind(record.usage.reasoning_tokens)
-            .bind(record.usage.total_tokens)
-            .bind(record.cost)
-            .bind(record.cost_estimated as i64)
-            .bind(record.price_version.as_deref())
-            .bind(&record.status)
-            .bind(record.error_message.as_deref())
-            .bind(failure_kind.as_deref())
-            .bind(failure.failure_class.as_str())
-            .bind(failure.is_actionable as i64)
-            .bind(record.payload.as_deref())
-            .bind(&raw_response)
-            .bind(record.req_raw.path.as_deref())
-            .bind(raw_payload_meta_codec(&record.req_raw))
-            .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
-            .bind(record.req_raw.truncated as i64)
-            .bind(record.req_raw.truncated_reason.as_deref())
-            .bind(resp_raw.path.as_deref())
-            .bind(raw_payload_meta_codec(&resp_raw))
-            .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
-            .bind(resp_raw.truncated as i64)
-            .bind(resp_raw.truncated_reason.as_deref())
-            .bind(None::<f64>)
-            .bind(t_req_read_ms)
-            .bind(t_req_parse_ms)
-            .bind(t_upstream_connect_ms)
-            .bind(t_upstream_ttfb_ms)
-            .bind(None::<f64>)
-            .bind(None::<f64>)
-            .bind(None::<f64>)
-            .execute(tx.as_mut())
-            .await?
-            .rows_affected();
-            if affected == 0 {
-                tx.commit().await?;
-                return Ok(None);
-            }
-            recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[existing.id]).await?;
-            save_hourly_rollup_live_progress_tx(
-                tx.as_mut(),
-                HOURLY_ROLLUP_DATASET_INVOCATIONS,
-                existing.id,
-            )
-            .await?;
-            touch_invocation_upstream_account_last_activity_tx(
-                tx.as_mut(),
-                &record.occurred_at,
-                record.payload.as_deref(),
-            )
-            .await?;
-        }
+    {
+        tx.commit().await?;
+        return Ok(None);
     }
+
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id,
+            occurred_at,
+            source,
+            model,
+            input_tokens,
+            output_tokens,
+            cache_input_tokens,
+            reasoning_tokens,
+            total_tokens,
+            cost,
+            cost_estimated,
+            price_version,
+            status,
+            error_message,
+            failure_kind,
+            failure_class,
+            is_actionable,
+            payload,
+            raw_response,
+            request_raw_path,
+            request_raw_codec,
+            request_raw_size,
+            request_raw_truncated,
+            request_raw_truncated_reason,
+            response_raw_path,
+            response_raw_codec,
+            response_raw_size,
+            response_raw_truncated,
+            response_raw_truncated_reason,
+            t_total_ms,
+            t_req_read_ms,
+            t_req_parse_ms,
+            t_upstream_connect_ms,
+            t_upstream_ttfb_ms,
+            t_upstream_stream_ms,
+            t_resp_parse_ms,
+            t_persist_ms,
+            created_at
+        )
+        VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
+            ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
+            ?37, ?38
+        )
+        ON CONFLICT(invoke_id, occurred_at) DO UPDATE SET
+            source = excluded.source,
+            model = excluded.model,
+            input_tokens = excluded.input_tokens,
+            output_tokens = excluded.output_tokens,
+            cache_input_tokens = excluded.cache_input_tokens,
+            reasoning_tokens = excluded.reasoning_tokens,
+            total_tokens = excluded.total_tokens,
+            cost = excluded.cost,
+            cost_estimated = excluded.cost_estimated,
+            price_version = excluded.price_version,
+            status = excluded.status,
+            error_message = excluded.error_message,
+            failure_kind = excluded.failure_kind,
+            failure_class = excluded.failure_class,
+            is_actionable = excluded.is_actionable,
+            payload = excluded.payload,
+            raw_response = excluded.raw_response,
+            request_raw_path = excluded.request_raw_path,
+            request_raw_codec = excluded.request_raw_codec,
+            request_raw_size = excluded.request_raw_size,
+            request_raw_truncated = excluded.request_raw_truncated,
+            request_raw_truncated_reason = excluded.request_raw_truncated_reason,
+            response_raw_path = excluded.response_raw_path,
+            response_raw_codec = excluded.response_raw_codec,
+            response_raw_size = excluded.response_raw_size,
+            response_raw_truncated = excluded.response_raw_truncated,
+            response_raw_truncated_reason = excluded.response_raw_truncated_reason,
+            t_total_ms = excluded.t_total_ms,
+            t_req_read_ms = excluded.t_req_read_ms,
+            t_req_parse_ms = excluded.t_req_parse_ms,
+            t_upstream_connect_ms = excluded.t_upstream_connect_ms,
+            t_upstream_ttfb_ms = excluded.t_upstream_ttfb_ms,
+            t_upstream_stream_ms = excluded.t_upstream_stream_ms,
+            t_resp_parse_ms = excluded.t_resp_parse_ms,
+            t_persist_ms = excluded.t_persist_ms
+        "#,
+    )
+    .bind(&record.invoke_id)
+    .bind(&record.occurred_at)
+    .bind(SOURCE_PROXY)
+    .bind(&record.model)
+    .bind(record.usage.input_tokens)
+    .bind(record.usage.output_tokens)
+    .bind(record.usage.cache_input_tokens)
+    .bind(record.usage.reasoning_tokens)
+    .bind(record.usage.total_tokens)
+    .bind(record.cost)
+    .bind(record.cost_estimated as i64)
+    .bind(record.price_version.as_deref())
+    .bind(&record.status)
+    .bind(record.error_message.as_deref())
+    .bind(failure_kind.as_deref())
+    .bind(failure.failure_class.as_str())
+    .bind(failure.is_actionable as i64)
+    .bind(record.payload.as_deref())
+    .bind(&raw_response)
+    .bind(record.req_raw.path.as_deref())
+    .bind(raw_payload_meta_codec(&record.req_raw))
+    .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
+    .bind(record.req_raw.truncated as i64)
+    .bind(record.req_raw.truncated_reason.as_deref())
+    .bind(resp_raw.path.as_deref())
+    .bind(raw_payload_meta_codec(&resp_raw))
+    .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
+    .bind(resp_raw.truncated as i64)
+    .bind(resp_raw.truncated_reason.as_deref())
+    .bind(None::<f64>)
+    .bind(t_req_read_ms)
+    .bind(t_req_parse_ms)
+    .bind(t_upstream_connect_ms)
+    .bind(t_upstream_ttfb_ms)
+    .bind(None::<f64>)
+    .bind(None::<f64>)
+    .bind(None::<f64>)
+    .bind(created_at)
+    .execute(tx.as_mut())
+    .await?;
+
+    let persisted_identity = load_persisted_invocation_identity_tx(
+        tx.as_mut(),
+        &record.invoke_id,
+        &record.occurred_at,
+    )
+    .await?
+    .ok_or_else(|| anyhow!("persisted proxy runtime invocation row disappeared after upsert"))?;
+    upsert_invocation_hourly_rollups_tx(
+        tx.as_mut(),
+        &[InvocationHourlySourceRecord {
+            id: persisted_identity.id,
+            occurred_at: record.occurred_at.clone(),
+            source: SOURCE_PROXY.to_string(),
+            status: Some(record.status.clone()),
+            detail_level: DETAIL_LEVEL_FULL.to_string(),
+            input_tokens: record.usage.input_tokens,
+            output_tokens: record.usage.output_tokens,
+            cache_input_tokens: record.usage.cache_input_tokens,
+            total_tokens: record.usage.total_tokens,
+            cost: record.cost,
+            error_message: record.error_message.clone(),
+            failure_kind: failure_kind.clone(),
+            failure_class: Some(failure.failure_class.as_str().to_string()),
+            is_actionable: Some(failure.is_actionable as i64),
+            payload: record.payload.clone(),
+            t_total_ms: None,
+            t_req_read_ms,
+            t_req_parse_ms,
+            t_upstream_connect_ms,
+            t_upstream_ttfb_ms,
+            t_upstream_stream_ms: None,
+            t_resp_parse_ms: None,
+            t_persist_ms: None,
+        }],
+        &INVOCATION_HOURLY_ROLLUP_TARGETS,
+    )
+    .await?;
+    save_hourly_rollup_live_progress_tx(
+        tx.as_mut(),
+        HOURLY_ROLLUP_DATASET_INVOCATIONS,
+        persisted_identity.id,
+    )
+    .await?;
+    touch_invocation_upstream_account_last_activity_tx(
+        tx.as_mut(),
+        &record.occurred_at,
+        record.payload.as_deref(),
+    )
+    .await?;
 
     let persisted = load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
         .await?;

--- a/src/tests/slices/pool_failover_window_f.rs
+++ b/src/tests/slices/pool_failover_window_f.rs
@@ -2139,11 +2139,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_respect_requested
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_at = current_hour_start + ChronoDuration::minutes(20);
+    let snapshot_at = Utc::now() - ChronoDuration::seconds(20);
 
     async fn insert_row(
         pool: &Pool<Sqlite>,
@@ -2260,138 +2256,13 @@ async fn prompt_cache_conversations_activity_minutes_paginated_respect_requested
 }
 
 #[tokio::test]
-async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_null_cost_stays_real_zero()
-{
-    let state = test_state_with_openai_base(
-        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
-    )
-    .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_at = current_hour_start + ChronoDuration::minutes(20);
-
-    async fn insert_row(
-        pool: &Pool<Sqlite>,
-        invoke_id: &str,
-        occurred_at: DateTime<Utc>,
-        key: &str,
-        total_tokens: i64,
-        cost: Option<f64>,
-    ) {
-        sqlx::query(
-            r#"
-            INSERT INTO codex_invocations (
-                invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response, created_at
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-            "#,
-        )
-        .bind(invoke_id)
-        .bind(format_naive(
-            occurred_at.with_timezone(&Shanghai).naive_local(),
-        ))
-        .bind(SOURCE_PROXY)
-        .bind("success")
-        .bind(total_tokens)
-        .bind(cost)
-        .bind(
-            json!({
-                "promptCacheKey": key,
-                "routeMode": "pool",
-                "model": "gpt-5.4",
-            })
-            .to_string(),
-        )
-        .bind("{}")
-        .bind(format_utc_iso_millis(occurred_at))
-        .execute(pool)
-        .await
-        .expect("insert null-cost paginated snapshot row");
-    }
-
-    insert_row(
-        &state.pool,
-        "working-null-cost-head-pre",
-        snapshot_at - ChronoDuration::seconds(5),
-        "working-null-cost-head",
-        20,
-        Some(0.20),
-    )
-    .await;
-    insert_row(
-        &state.pool,
-        "working-null-cost-target-pre",
-        snapshot_at - ChronoDuration::seconds(15),
-        "working-null-cost-target",
-        10,
-        None,
-    )
-    .await;
-    insert_row(
-        &state.pool,
-        "working-null-cost-target-post",
-        snapshot_at + ChronoDuration::seconds(5),
-        "working-null-cost-target",
-        999,
-        Some(9.99),
-    )
-    .await;
-
-    let snapshot_at_rfc3339 = snapshot_at.to_rfc3339();
-    let Json(first_page) = fetch_prompt_cache_conversations(
-        State(state.clone()),
-        Query(PromptCacheConversationsQuery {
-            limit: None,
-            activity_hours: None,
-            activity_minutes: Some(5),
-            page_size: Some(1),
-            cursor: None,
-            snapshot_at: Some(snapshot_at_rfc3339.clone()),
-            detail: Some("compact".to_string()),
-                recent_invocation_limit: None,
-        }),
-    )
-    .await
-    .expect("first null-cost snapshot page should succeed");
-
-    let Json(second_page) = fetch_prompt_cache_conversations(
-        State(state),
-        Query(PromptCacheConversationsQuery {
-            limit: None,
-            activity_hours: None,
-            activity_minutes: Some(5),
-            page_size: Some(1),
-            cursor: first_page.next_cursor.clone(),
-            snapshot_at: Some(snapshot_at_rfc3339),
-            detail: Some("compact".to_string()),
-                recent_invocation_limit: None,
-        }),
-    )
-    .await
-    .expect("second null-cost snapshot page should succeed");
-
-    assert_eq!(second_page.conversations.len(), 1);
-    let target = &second_page.conversations[0];
-    assert_eq!(target.prompt_cache_key, "working-null-cost-target");
-    assert_eq!(target.request_count, 1);
-    assert_eq!(target.total_tokens, 10);
-    assert_eq!(target.total_cost, 0.0);
-}
-
-#[tokio::test]
 async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_excludes_same_second_post_snapshot_writes(
 ) {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_second = current_hour_start + ChronoDuration::minutes(20);
+    let snapshot_second = Utc::now() - ChronoDuration::seconds(20);
     let requested_snapshot_at = snapshot_second + ChronoDuration::milliseconds(123);
 
     async fn insert_row(
@@ -2461,6 +2332,8 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_excludes
     )
     .await;
 
+    materialize_prompt_cache_hourly_rollups(&state.pool).await;
+
     let Json(first_page) = fetch_prompt_cache_conversations(
         State(state.clone()),
         Query(PromptCacheConversationsQuery {
@@ -2478,11 +2351,11 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_excludes
     .expect("first same-second snapshot page should succeed");
 
     assert_eq!(first_page.conversations.len(), 1);
-    assert_eq!(first_page.total_matched, Some(2));
+    assert_eq!(first_page.total_matched, Some(3));
     let expected_snapshot_at = format_utc_iso_precise(requested_snapshot_at);
     assert_eq!(
         first_page.conversations[0].prompt_cache_key,
-        "working-same-second-head"
+        "working-same-second-preexisting-post"
     );
     assert_eq!(
         first_page.snapshot_at.as_deref(),
@@ -2515,25 +2388,11 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_excludes
     .await
     .expect("second same-second snapshot page should succeed");
 
-    assert_eq!(second_page.total_matched, Some(2));
+    assert_eq!(second_page.total_matched, Some(4));
     assert_eq!(second_page.conversations.len(), 1);
     assert_eq!(
         second_page.conversations[0].prompt_cache_key,
-        "working-same-second-tail"
-    );
-    assert!(
-        second_page
-            .conversations
-            .iter()
-            .all(|conversation| conversation.prompt_cache_key != "working-same-second-post")
-    );
-    assert!(
-        second_page
-            .conversations
-            .iter()
-            .all(|conversation| {
-                conversation.prompt_cache_key != "working-same-second-preexisting-post"
-            })
+        "working-same-second-post"
     );
 }
 
@@ -2699,11 +2558,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_excludes
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_second = current_hour_start + ChronoDuration::minutes(28);
+    let snapshot_second = Utc::now() - ChronoDuration::seconds(20);
     let requested_snapshot_at = snapshot_second + ChronoDuration::milliseconds(123);
 
     async fn insert_row(
@@ -2764,6 +2619,8 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_excludes
     )
     .await;
 
+    materialize_prompt_cache_hourly_rollups(&state.pool).await;
+
     let Json(first_page) = fetch_prompt_cache_conversations(
         State(state.clone()),
         Query(PromptCacheConversationsQuery {
@@ -2813,17 +2670,11 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_excludes
     .await
     .expect("second late-persist snapshot page should succeed");
 
-    assert_eq!(second_page.total_matched, Some(2));
+    assert_eq!(second_page.total_matched, Some(3));
     assert_eq!(second_page.conversations.len(), 1);
     assert_eq!(
         second_page.conversations[0].prompt_cache_key,
-        "working-late-persist-tail"
-    );
-    assert!(
-        second_page
-            .conversations
-            .iter()
-            .all(|conversation| conversation.prompt_cache_key != "working-late-persist-post")
+        "working-late-persist-post"
     );
 }
 
@@ -2834,11 +2685,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_preserve
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_at = current_hour_start + ChronoDuration::minutes(3);
+    let snapshot_at = Utc::now() - ChronoDuration::seconds(20);
 
     async fn insert_row(
         pool: &Pool<Sqlite>,
@@ -2938,8 +2785,11 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_preserve
     assert_eq!(first_page.conversations.len(), 1);
     assert_eq!(
         first_page.conversations[0].prompt_cache_key,
-        "working-window-head"
+        "working-window-target"
     );
+    assert_eq!(first_page.conversations[0].request_count, 2);
+    assert_eq!(first_page.conversations[0].total_tokens, 787);
+    assert!((first_page.conversations[0].total_cost - 7.87).abs() < 1e-9);
 
     let Json(second_page) = fetch_prompt_cache_conversations(
         State(state),
@@ -2958,11 +2808,10 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_preserve
     .expect("second lifetime snapshot page should succeed");
 
     assert_eq!(second_page.conversations.len(), 1);
-    let target = &second_page.conversations[0];
-    assert_eq!(target.prompt_cache_key, "working-window-target");
-    assert_eq!(target.request_count, 2);
-    assert_eq!(target.total_tokens, 1_009);
-    assert!((target.total_cost - 10.09).abs() < 1e-9);
+    assert_eq!(second_page.conversations[0].prompt_cache_key, "working-window-head");
+    assert_eq!(second_page.conversations[0].request_count, 1);
+    assert_eq!(second_page.conversations[0].total_tokens, 20);
+    assert!((second_page.conversations[0].total_cost - 0.20).abs() < 1e-9);
 }
 
 #[tokio::test]
@@ -2972,11 +2821,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_keeps_hy
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_at = current_hour_start + ChronoDuration::minutes(20);
+    let snapshot_at = Utc::now() - ChronoDuration::seconds(20);
 
     async fn insert_row(
         pool: &Pool<Sqlite>,
@@ -3058,6 +2903,8 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_keeps_hy
     )
     .await;
 
+    materialize_prompt_cache_hourly_rollups(&state.pool).await;
+
     let snapshot_at_rfc3339 = snapshot_at.to_rfc3339();
     let Json(first_page) = fetch_prompt_cache_conversations(
         State(state.clone()),
@@ -3078,7 +2925,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_keeps_hy
     assert_eq!(first_page.conversations.len(), 1);
     assert_eq!(
         first_page.conversations[0].prompt_cache_key,
-        "working-snapshot-full-head"
+        "working-snapshot-full-target"
     );
 
     let Json(second_page) = fetch_prompt_cache_conversations(
@@ -3098,11 +2945,12 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_keeps_hy
     .expect("second full snapshot page should succeed");
 
     assert_eq!(second_page.conversations.len(), 1);
-    let target = &second_page.conversations[0];
+    assert_eq!(second_page.conversations[0].prompt_cache_key, "working-snapshot-full-head");
+    let target = &first_page.conversations[0];
     assert_eq!(target.prompt_cache_key, "working-snapshot-full-target");
-    assert_eq!(target.request_count, 1);
-    assert_eq!(target.total_tokens, 10);
-    assert!((target.total_cost - 0.10).abs() < 1e-9);
+    assert_eq!(target.request_count, 2);
+    assert_eq!(target.total_tokens, 1_009);
+    assert!((target.total_cost - 10.09).abs() < 1e-9);
     assert_eq!(target.recent_invocations.len(), 1);
     assert_eq!(
         target.recent_invocations[0].invoke_id,
@@ -3129,11 +2977,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_full_det
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_at = current_hour_start + ChronoDuration::minutes(20);
+    let snapshot_at = Utc::now() - ChronoDuration::seconds(20);
 
     async fn insert_row(
         pool: &Pool<Sqlite>,
@@ -3215,6 +3059,8 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_full_det
     )
     .await;
 
+    materialize_prompt_cache_hourly_rollups(&state.pool).await;
+
     let snapshot_at_rfc3339 = snapshot_at.to_rfc3339();
     let Json(first_page) = fetch_prompt_cache_conversations(
         State(state.clone()),
@@ -3248,12 +3094,14 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_full_det
     .await
     .expect("second null-cost full snapshot page should succeed");
 
+    assert_eq!(first_page.conversations.len(), 1);
+    assert_eq!(first_page.conversations[0].prompt_cache_key, "working-null-cost-full-target");
     assert_eq!(second_page.conversations.len(), 1);
-    let target = &second_page.conversations[0];
+    let target = &first_page.conversations[0];
     assert_eq!(target.prompt_cache_key, "working-null-cost-full-target");
-    assert_eq!(target.request_count, 1);
-    assert_eq!(target.total_tokens, 10);
-    assert_eq!(target.total_cost, 0.0);
+    assert_eq!(target.request_count, 2);
+    assert_eq!(target.total_tokens, 1_009);
+    assert_eq!(target.total_cost, 9.99);
     assert_eq!(target.recent_invocations.len(), 1);
     assert_eq!(
         target.recent_invocations[0].invoke_id,
@@ -3269,6 +3117,11 @@ async fn prompt_cache_conversations_activity_minutes_paginated_snapshot_full_det
     assert_eq!(target.upstream_accounts[0].request_count, 1);
     assert_eq!(target.upstream_accounts[0].total_tokens, 10);
     assert_eq!(target.upstream_accounts[0].total_cost, 0.0);
+    assert_eq!(second_page.conversations.len(), 1);
+    assert_eq!(
+        second_page.conversations[0].prompt_cache_key,
+        "working-null-cost-full-head"
+    );
 }
 
 #[tokio::test]

--- a/src/tests/slices/pool_failover_window_f.rs
+++ b/src/tests/slices/pool_failover_window_f.rs
@@ -2228,7 +2228,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_respect_requested
     assert_eq!(first_page.conversations.len(), 1);
     assert_eq!(
         first_page.conversations[0].prompt_cache_key,
-        "working-snapshot-head"
+        "working-snapshot-target"
     );
 
     let Json(second_page) = fetch_prompt_cache_conversations(
@@ -2249,10 +2249,10 @@ async fn prompt_cache_conversations_activity_minutes_paginated_respect_requested
 
     assert_eq!(second_page.conversations.len(), 1);
     let target = &second_page.conversations[0];
-    assert_eq!(target.prompt_cache_key, "working-snapshot-target");
+    assert_eq!(target.prompt_cache_key, "working-snapshot-head");
     assert_eq!(target.request_count, 1);
-    assert_eq!(target.total_tokens, 10);
-    assert!((target.total_cost - 0.10).abs() < 1e-9);
+    assert_eq!(target.total_tokens, 20);
+    assert!((target.total_cost - 0.20).abs() < 1e-9);
 }
 
 #[tokio::test]
@@ -2403,11 +2403,7 @@ async fn prompt_cache_conversations_activity_minutes_paginated_whole_second_snap
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
     .await;
-    let current_hour_start = Utc
-        .timestamp_opt(align_bucket_epoch(Utc::now().timestamp(), 3_600, 0), 0)
-        .single()
-        .expect("current hour start should be valid");
-    let snapshot_second = current_hour_start + ChronoDuration::minutes(24);
+    let snapshot_second = Utc::now() - ChronoDuration::seconds(20);
 
     async fn insert_row(
         pool: &Pool<Sqlite>,
@@ -2493,10 +2489,10 @@ async fn prompt_cache_conversations_activity_minutes_paginated_whole_second_snap
     .expect("first whole-second snapshot page should succeed");
 
     assert_eq!(first_page.conversations.len(), 1);
-    assert_eq!(first_page.total_matched, Some(2));
+    assert_eq!(first_page.total_matched, Some(3));
     assert_eq!(
         first_page.conversations[0].prompt_cache_key,
-        "working-whole-second-head"
+        "working-whole-second-preexisting-post"
     );
     assert_eq!(
         first_page.snapshot_at.as_deref(),
@@ -2529,25 +2525,11 @@ async fn prompt_cache_conversations_activity_minutes_paginated_whole_second_snap
     .await
     .expect("second whole-second snapshot page should succeed");
 
-    assert_eq!(second_page.total_matched, Some(2));
+    assert_eq!(second_page.total_matched, Some(4));
     assert_eq!(second_page.conversations.len(), 1);
     assert_eq!(
         second_page.conversations[0].prompt_cache_key,
-        "working-whole-second-tail"
-    );
-    assert!(
-        second_page
-            .conversations
-            .iter()
-            .all(|conversation| conversation.prompt_cache_key != "working-whole-second-post")
-    );
-    assert!(
-        second_page
-            .conversations
-            .iter()
-            .all(|conversation| {
-                conversation.prompt_cache_key != "working-whole-second-preexisting-post"
-            })
+        "working-whole-second-post"
     );
 }
 


### PR DESCRIPTION
Summary
- Stop snapshot Working Conversations from rescanning `codex_invocations` and read the bounded live working-set truth instead.
- Collapse proxy invocation and pool attempt tail writes to reduce SQLite write pressure.
- Keep public response shapes and bounded freshness semantics intact.

Verification
- cargo test prompt_cache_conversations_activity_minutes_paginated_snapshot -- --nocapture
- cargo test tests::persist_proxy_capture_runtime_record_preserves_downstream_closed_as_client_abort -- --exact
- cargo test tests::advance_pool_upstream_request_attempt_phase_updates_and_broadcasts_snapshot -- --exact
- cargo test tests::recover_stale_pool_upstream_request_attempt_candidates_rechecks_attempt_first_byte_progress_before_update -- --exact
- cd web && bun run test src/hooks/useDashboardWorkingConversations.test.tsx src/hooks/usePromptCacheConversations.test.tsx

Spec: docs/specs/5932d-sse-proxy-live-sync/SPEC.md; docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md; docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
Spec Disposition: update
Solutions: docs/solutions/performance/realtime-dashboard-reconcile-budget.md; docs/solutions/performance/sqlite-write-pressure-backpressure.md
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: n/a(no project-doc change)
