### PR TITLE
fix: batch sqlite derived writes

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -47,6 +47,7 @@ Using one cadence for all three overfits the most urgent surface and overloads t
 - Keep `current` summary and dashboard account-activity reconcile on the same 5 second budget. A faster current-window reconcile without a matching backend live read model simply turns SQLite scan cost into a tighter request loop.
 - When an endpoint still needs strict “currently in progress” truth, move that truth into a write-side live table or read model and let the 5 second reconcile read that bounded surface instead of rescanning the historical raw table.
 - Treat dashboard working-set surfaces the same way: the 5-minute working-conversations head/count and snapshot pagination/count can both read a write-side bounded working-set table. Keep the response shape and main ordering stable, but accept `<=5s` bounded freshness instead of strict historical snapshot recomputation from the raw invocation table.
+- Align write-side maintenance with the same freshness budget. If Dashboard accepts `<=5s` reconcile, request-tail derived writes that feed those read models can use short-window coalescing/batch flush, while terminal invocation and terminal attempt facts remain synchronous.
 - For future regressions, slow-path evidence needs to identify the class of work, not just that something was slow: emit endpoint/window/source-scope plus key counts or cache-hit state so operators can tell apart request-time scans, maintenance-time rebuilds, and cache hydration misses.
 
 ## Guardrails / Reuse Notes

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -13,6 +13,7 @@
 - 连接池等待超时本身就是 pressure signal，应触发后台 cooldown，而不是继续并发重试。
 - `proxy capture follow-up` 也必须遵守这个分级：没有 SSE 订阅者时，不得再消耗 summary/quota 或 hourly rollup refresh 预算。
 - 对请求收尾里的同一实体写入，要优先消除“重复唯一键探测 + 紧跟二次更新”“先重算 rollup 再补 timing 再重算一次”这类单请求内自我放大；SQLite 压力常常不是来自单条大 SQL，而是来自几条语义重复的写语句连发。
+- 当并发不能降低且主事实必须同步落盘时，用进程内短窗口 batch writer 承接派生写：terminal invocation / terminal attempt 仍同步写，attempt 中间进度、rollup/live progress、account touch、system task finish 等可延迟项按 key coalesce 后批量写入。
 
 ## 推荐模式
 
@@ -22,6 +23,9 @@
 - 请求收尾写入：invocation 记录、usage、raw metadata；允许有界降级和异步旁路。
 - 请求收尾若已经存在对应 `running/pending` 行，优先原地更新而不是先 `INSERT OR IGNORE` 再走 repair/update；这样可以少一次唯一键冲突写尝试与后续锁竞争。
 - 对同一 attempt 的 phase、latency、capability/compact-support 等进度字段，优先并入同一条前台更新，而不是拆成 `phase bump -> latency patch -> finalize` 的多段慢写；减少单请求尾部把 SQLite 单写者预算切碎。
+- 对同一 attempt 的中间 phase、latency、capability/compact-support 等进度字段，如果不需要立刻作为业务决策真相源，可进入 250ms 级短窗口缓冲并按 `attempt_id` 只保留最新值；terminal finalize 必须同步一次写全并通过 `status=pending AND finished_at IS NULL` 防止未 flush 进度覆盖终态。
+- Invocation 派生写可以按 `invocation_id` coalesce：hourly rollup/live progress 与 upstream account last activity touch 同事务批量执行。队列满时应优先同步补偿 invocation 派生写，而不是静默丢弃会影响后续统计的 truth maintenance。
+- `system_task_runs` 的 begin 仍同步记录 running 审计入口；finish 可以进入 batch writer，pressure 下延迟或合并，但 shutdown 需要 drain 或记录未 flush 证据。
 - 后台维护写入：rollup、retention、account maintenance；pressure 下 fail-soft skip。
 - 历史回填写入：startup backfill、archive materialization；pressure 下延后，不阻塞 readiness。
 
@@ -47,6 +51,8 @@
 - 后台任务拿到连接后再判断是否要运行，已经太晚；pressure gate 必须在 acquire DB connection 前。
 - 后台任务拿到唯一 background slot 后再判断是否 due，会把“未到期的空跑 tick”变成对其他维护任务的饥饿源。
 - skip 必须有日志和后续 ticker，否则会变成静默丢任务。
+- batch writer 必须有有界队列、flush 触发（时间窗口 / row count / 最大等待）、coalesced row count、oldest age、flush elapsed、queue depth 与 dropped count 证据；否则只是把 SQLite 锁问题藏到内存里。
+- buffered progress 不能立刻广播“已持久化”的 DB snapshot；要么广播内存态，要么等后续 reconcile/terminal 更新。否则会把 stale DB state 伪装成实时状态。
 - 为每个后台入口单独做局部退避，容易遗漏同一压力窗口内的其他维护任务；进程级 gate 更容易统一行为。
 - `SELECT MAX(id) ... WHERE <稀疏条件>`、`NOT EXISTS` + 低选择性 phase 过滤这类查询，即使最终只返回 1 行，也可能在 SQLite 上吃掉秒级读锁预算；若它们会与前台 HTTP 共享同一数据库，必须先压成 cursor 读取或用 partial index 固定扫描面。
 - 对 proxy 收尾这类 SSE follow-up，`receiver_count()==0` 应该直接意味着“跳过 follow-up”，而不是继续排队 summary/quota 或 rollup refresh；否则会把没有任何订阅者的请求变成纯数据库放大器。

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -14,3 +14,4 @@
 - 2026-06-29: Dashboard current-window summary reconcile 不再保留比 calendar window 更激进的 cadence；`current summary` 与 `upstream account activity` 统一收口到 `5s` refresh/open-resync 预算，避免前端更快回源把后端请求级 SQLite 热点放大成持续 CPU 压力。
 - 2026-06-30: 第二轮 CPU 止血把 Dashboard working conversations 当前 head/count 的真相源前移到 write-side `prompt_cache_working_set_live`，接受 `<=5s` bounded freshness，但不再让 5 分钟工作集每次 reconcile 都重扫 `codex_invocations`。
 - 2026-06-30: 第三轮 CPU 止血继续把 working conversations 的 snapshot count/page 从 `WITH recent_terminal` 历史重算收口到 live working-set truth。接口继续保留 `snapshot_at`、cursor 与字段 shape，但 snapshot 聚合不再承诺严格历史时点重算，只承诺 `<=5s` bounded freshness。
+- 2026-07-01: 第四轮 SQLite 止血明确不降低代理并发，也不把 terminal `codex_invocations` 主事实改成 write-behind；仅把 attempt 中间进度、invocation rollup/live progress、upstream account touch 与 system task finish 这类可接受 `<=5s` 新鲜度的派生写放入有界 batch writer。

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -8,6 +8,7 @@
 - Current-window summary reconcile now matches the same 5s budget as calendar windows and account-activity reconcile. The dashboard debug diagnostics also split out `current summary refresh/open-resync` and `upstream account activity refresh/open-resync`, so future regressions can distinguish SSE-fast-path churn from HTTP reconcile churn.
 - Dashboard working conversations live head/count now read from a write-side `prompt_cache_working_set_live` table that keeps the last 5 minutes of terminal activity plus any current in-flight keys. The public response shape stays unchanged, while the hot read path no longer rebuilds the working set from `codex_invocations` on every request.
 - Working-conversations snapshot count/page now also accept the same `<=5s` bounded-freshness contract. Instead of strict historical recomputation from `codex_invocations`, snapshot aggregates read the live working-set truth directly and keep the existing response fields, cursor shape, and main ordering semantics.
+- Proxy capture request completion now keeps terminal `codex_invocations` as the synchronous source of truth, but moves bounded derived writes through a process-local SQLite batch writer. Attempt phase/latency progress, invocation hourly rollup/live progress, upstream account activity touch, and background system-task finish updates coalesce on short windows before touching SQLite. Terminal attempt finalize remains synchronous and overwrites any unflushed progress.
 
 ## Migrated Implementation Notes
 
@@ -34,6 +35,7 @@
 - [x] M4: 完成验证、提交、PR、checks 与 review-loop 收敛（fast-track）。
 - [x] M5: Dashboard realtime consumers split visible patch, KPI, chart commit, head reconcile, and parallel-work conditional-fetch budgets.
 - [x] M6: 活动调用记录列表统一接入 `records` SSE：`Live`、`/records` 与账号详情抽屉 records tab 现在共用一套记录过滤、去重、终态优选与 SSE open 静默回源逻辑。
+- [x] M7: Proxy capture 派生写与 attempt 中间进度进入 SQLite batch writer；保持代理并发与 terminal 主事实同步落盘不变。
 
 ## 2026-06-21 Follow-up
 
@@ -47,3 +49,5 @@
 - `cd web && bun run test -- --run src/hooks/useInvocations.test.tsx src/hooks/useInvocationRecords.test.tsx src/pages/account-pool/UpstreamAccounts.test.tsx`
 - `cd web && bun run test useStats.test.ts`
 - `cd web && bun run test useDashboardUpstreamAccountActivity.test.tsx`
+- `cargo test sqlite_batch_writer`
+- `cargo test pool_upstream_request_attempt -- --test-threads=1`

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -39,6 +39,7 @@
 - summary publish 当前窗口里的 `inProgressConversationCount` distinct-count 现在也直接复用 live table truth source，而不是在 maintenance 路径里对 `codex_invocations` 再做一次 `COUNT(DISTINCT prompt_cache_key)`；这让 summary 广播与账号详情共用同一份 bounded in-progress truth。
 - 第三轮 SQLite 止血进一步把 prompt cache working-conversation 的 snapshot count/page 从 `codex_invocations` 热表扫描切到 write-side working-set truth；虽然公开 API shape 不变，但相关详情/工作区入口现在统一接受 `<=5s` bounded freshness，而不再为严格 snapshot membership 付出请求级扫表代价。
 - proxy capture 请求尾写路径也继续收敛：`codex_invocations` 终态持久化改为单路径 upsert/finalize，`pool_upstream_request_attempts` 的 phase / latency / compact-support 进度尽量并入同一条更新，减少账号详情和 Dashboard 与请求尾写争用 SQLite 单写者预算。
+- 第四轮止血把账号详情依赖的 upstream account touch、invocation hourly rollup/live progress 与 attempt 中间进度迁入进程内 SQLite batch writer。账号详情仍以同步 terminal invocation 主事实为可靠来源；派生统计和进度展示接受 `<=5s` bounded freshness，队列满时 invocation 派生写会做同步补偿以降低数据漂移风险。
 - Storybook 现有详情抽屉 overlay stories 继续作为 page-fallback 证据面，新增 owner-facing 首屏概览态与 records 统计卡片完成态图片，覆盖这次性能回归修复后的默认打开路径。
 
 ## Verification
@@ -58,6 +59,8 @@
 - `cargo test tests::account_scoped_natural_day_summary_keeps_augmentation_fields_scoped -- --exact`
 - `cargo test latest_usage_sample_map_keeps_latest_non_empty_sample_plan_type -- --nocapture`
 - `cargo test ensure_schema_migrates_codex_invocations_off_raw_expires_at_and_adds_retention_tables -- --nocapture`
+- `cargo test sqlite_batch_writer`
+- `cargo test pool_upstream_request_attempt -- --test-threads=1`
 - `cargo check`
 - `cd web && bun x vitest run --project=unit src/hooks/useUpstreamAccounts.test.tsx src/pages/account-pool/UpstreamAccounts.test.tsx src/lib/api.test.ts`
 - `cd web && bun run test-storybook`

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -33,6 +33,7 @@
 - 已实现：账号卡“首字用时”从阶段级 `t_upstream_ttfb_ms` 纠偏为 owner-facing 的首字总耗时口径；后端聚合现在复用 `resolve_first_response_byte_total_ms(...)`，并额外暴露显式 `firstResponseByteTotalAvgMs` 供前端优先消费，避免真实秒级总耗时被渲染成 `0ms`。
 - 已实现：工作区 `对话` tab 当前 5 分钟 working-set 的 head/count 改读 write-side `prompt_cache_working_set_live`，并为 mixed-source key 保留 `All / ProxyOnly` 两套聚合列，避免换源后 `ProxyOnly` 视角丢 key 或排序漂移。
 - 已实现：工作区 `对话` tab 的 snapshot count/page 也收口到同一份 live working-set truth，不再通过 `WITH recent_terminal` 对 `codex_invocations` 做严格历史重算。公开字段、cursor 形态、recent preview 与主排序语义保持不变，但 snapshot membership 明确接受 `<=5s` bounded freshness。
+- 已实现：Dashboard 相关的 working-set / account-activity 派生维护继续遵守 `<=5s` bounded freshness；proxy capture 请求尾的 rollup/live progress、upstream account touch 与 attempt 中间进度已迁入 SQLite batch writer，避免 Dashboard reconcile 与请求收尾派生写在 SQLite 单写者上持续争用。
 
 ## Remaining Gaps
 

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -461,6 +461,38 @@ pub(crate) async fn finish_system_task_run(
     }
 }
 
+pub(crate) async fn finish_system_task_run_batched(
+    state: &AppState,
+    handle: &SystemTaskRunHandle,
+    status: SystemTaskStatus,
+    summary: Option<String>,
+    detail: Option<String>,
+) {
+    let finished_at = format_utc_iso(Utc::now());
+    let duration_ms = handle
+        .started_at
+        .elapsed()
+        .as_millis()
+        .min(i64::MAX as u128) as i64;
+    if state
+        .sqlite_batch_writer
+        .enqueue(SqliteBatchWrite::SystemTaskFinish(BatchedSystemTaskFinish {
+            run_id: handle.id,
+            task_kind: handle.task_kind,
+            trigger_kind: handle.trigger_kind.clone(),
+            status,
+            summary: summary.clone(),
+            detail: detail.clone(),
+            finished_at,
+            duration_ms,
+        }))
+    {
+        return;
+    }
+
+    finish_system_task_run(&state.pool, handle, status, summary, detail).await;
+}
+
 pub(crate) async fn fetch_system_status(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SystemStatusResponse>, ApiError> {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -8,6 +8,7 @@ struct PoolRoutingRuntimeCache {
 struct AppState {
     config: AppConfig,
     pool: Pool<Sqlite>,
+    sqlite_batch_writer: Arc<SqliteBatchWriter>,
     oauth_installation_seed: [u8; 32],
     hourly_rollup_sync_lock: Arc<Mutex<()>>,
     http_clients: HttpClients,

--- a/src/forward_proxy/slices/storage_and_hourly_stats.rs
+++ b/src/forward_proxy/slices/storage_and_hourly_stats.rs
@@ -2346,8 +2346,8 @@ pub(crate) async fn post_forward_proxy_refresh_subscriptions(
 
     if let Err(err) = refresh_forward_proxy_subscriptions(state.clone(), true, None).await {
         if let Some(run) = task_run.as_ref() {
-            finish_system_task_run(
-                &state.pool,
+            finish_system_task_run_batched(
+                state.as_ref(),
                 run,
                 SystemTaskStatus::Failed,
                 Some("forward proxy manual refresh failed".to_string()),
@@ -2373,8 +2373,8 @@ pub(crate) async fn post_forward_proxy_refresh_subscriptions(
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
     if let Some(run) = task_run.as_ref() {
-        finish_system_task_run(
-            &state.pool,
+        finish_system_task_run_batched(
+            state.as_ref(),
             run,
             SystemTaskStatus::Success,
             Some(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ mod forward_proxy;
 mod maintenance;
 mod oauth_bridge;
 mod proxy;
+mod sqlite_batch_writer;
 mod stats;
 #[cfg(test)]
 mod tests;
@@ -94,6 +95,7 @@ use api::*;
 use external_api::*;
 use forward_proxy::*;
 use proxy::*;
+use sqlite_batch_writer::*;
 use stats::*;
 use upstream_accounts::*;
 

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -1610,8 +1610,8 @@ async fn schedule_poll(
                 }
 
                 if let Some(run) = system_task_run.as_ref() {
-                    finish_system_task_run(
-                        &state_clone.pool,
+                    finish_system_task_run_batched(
+                        state_clone.as_ref(),
                         run,
                         SystemTaskStatus::Success,
                         Some(summarize_scheduler_poll_outcome(
@@ -1625,8 +1625,8 @@ async fn schedule_poll(
             }
             Ok(Err(err)) => {
                 if let Some(run) = system_task_run.as_ref() {
-                    finish_system_task_run(
-                        &state_clone.pool,
+                    finish_system_task_run_batched(
+                        state_clone.as_ref(),
                         run,
                         SystemTaskStatus::Failed,
                         Some("scheduler poll failed".to_string()),
@@ -1638,8 +1638,8 @@ async fn schedule_poll(
             }
             Err(_) => {
                 if let Some(run) = system_task_run.as_ref() {
-                    finish_system_task_run(
-                        &state_clone.pool,
+                    finish_system_task_run_batched(
+                        state_clone.as_ref(),
                         run,
                         SystemTaskStatus::Failed,
                         Some("scheduler poll timed out".to_string()),

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -697,8 +697,8 @@ async fn run_data_retention_maintenance_best_effort(
             Ok(permit) => permit,
             Err(reason) => {
                 if let Some(handle) = task_run.as_ref() {
-                    finish_system_task_run(
-                        &state.pool,
+                    finish_system_task_run_batched(
+                        state.as_ref(),
                         handle,
                         SystemTaskStatus::Skipped,
                         Some("retention skipped by db pressure gate".to_string()),
@@ -719,8 +719,8 @@ async fn run_data_retention_maintenance_best_effort(
             Ok(summary) => {
                 if let Some(handle) = task_run.as_ref() {
                     let (brief, detail) = summarize_retention_run_for_system_task(&summary);
-                    finish_system_task_run(
-                        &state.pool,
+                    finish_system_task_run_batched(
+                        state.as_ref(),
                         handle,
                         SystemTaskStatus::Success,
                         Some(brief),
@@ -734,8 +734,8 @@ async fn run_data_retention_maintenance_best_effort(
             Err(err) => {
                 let pressure_error = gate.record_error("data_retention_maintenance", &err);
                 if let Some(handle) = task_run.as_ref() {
-                    finish_system_task_run(
-                        &state.pool,
+                    finish_system_task_run_batched(
+                        state.as_ref(),
                         handle,
                         SystemTaskStatus::Failed,
                         Some("retention maintenance failed".to_string()),

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -411,8 +411,8 @@ async fn run_startup_backfill_maintenance_pass(state: Arc<AppState>, cancel: &Ca
     .await;
 
     if let Some(run) = task_run.as_ref() {
-        finish_system_task_run(
-            &state.pool,
+        finish_system_task_run_batched(
+            state.as_ref(),
             run,
             if had_failure {
                 SystemTaskStatus::Failed

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -2203,58 +2203,34 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                         if pending_attempt_record.attempt_id.is_none() {
                             deferred_early_phase_cleanup_guard = early_phase_cleanup_guard.take();
                         }
-                        match update_pool_upstream_request_attempt_progress(
-                            &state.pool,
+                        let phase_enqueued = enqueue_pool_upstream_request_attempt_progress(
+                            state.as_ref(),
                             pending_attempt_record,
                             POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE,
                             Some(connect_latency_ms),
                             Some(first_byte_latency_ms),
                             None,
                             None,
-                        )
-                        .await
-                        {
-                            Ok(phase_persisted) => {
-                                if phase_persisted
-                                    && let Err(err) = broadcast_pool_upstream_attempts_snapshot(
-                                        state.as_ref(),
-                                        &pending_attempt_record.invoke_id,
-                                    )
-                                    .await
-                                {
-                                    warn!(
-                                        invoke_id = %pending_attempt_record.invoke_id,
-                                        error = %err,
-                                        "failed to broadcast pool attempt streaming phase snapshot"
-                                    );
-                                }
-                                if !phase_persisted {
-                                    info!(
-                                        invoke_id = %pending_attempt_record.invoke_id,
-                                        attempt_id = pending_attempt_record.attempt_id,
-                                        "streaming phase was not persisted; relying on invocation cleanup guards for post-first-byte recovery"
-                                    );
-                                    if pending_attempt_record.attempt_id.is_some() {
-                                        deferred_early_phase_cleanup_guard =
-                                            early_phase_cleanup_guard.take();
-                                    }
-                                }
-                                if phase_persisted && pending_attempt_record.attempt_id.is_some() {
-                                    disarm_pool_early_phase_cleanup_guard(
-                                        &mut early_phase_cleanup_guard,
-                                    );
-                                }
+                        );
+                        if phase_enqueued {
+                            debug!(
+                                invoke_id = %pending_attempt_record.invoke_id,
+                                attempt_id = pending_attempt_record.attempt_id,
+                                "queued pool attempt streaming phase progress"
+                            );
+                            if pending_attempt_record.attempt_id.is_some() {
+                                deferred_early_phase_cleanup_guard =
+                                    early_phase_cleanup_guard.take();
                             }
-                            Err(err) => {
-                                warn!(
-                                    invoke_id = %pending_attempt_record.invoke_id,
-                                    error = %err,
-                                    "failed to persist pool attempt streaming phase; relying on invocation cleanup guards for post-first-byte recovery"
-                                );
-                                if pending_attempt_record.attempt_id.is_some() {
-                                    deferred_early_phase_cleanup_guard =
-                                        early_phase_cleanup_guard.take();
-                                }
+                        } else {
+                            info!(
+                                invoke_id = %pending_attempt_record.invoke_id,
+                                attempt_id = pending_attempt_record.attempt_id,
+                                "streaming phase was not enqueued; relying on invocation cleanup guards for post-first-byte recovery"
+                            );
+                            if pending_attempt_record.attempt_id.is_some() {
+                                deferred_early_phase_cleanup_guard =
+                                    early_phase_cleanup_guard.take();
                             }
                         }
                     } else {
@@ -3017,56 +2993,32 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                 if pending_attempt_record.attempt_id.is_none() {
                     deferred_early_phase_cleanup_guard = early_phase_cleanup_guard.take();
                 }
-                match update_pool_upstream_request_attempt_progress(
-                    &state.pool,
+                let phase_enqueued = enqueue_pool_upstream_request_attempt_progress(
+                    state.as_ref(),
                     pending_attempt_record,
                     POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE,
                     Some(connect_latency_ms),
                     Some(first_byte_latency_ms),
                     None,
                     None,
-                )
-                .await
-                    {
-                        Ok(phase_persisted) => {
-                            if phase_persisted
-                                && let Err(err) = broadcast_pool_upstream_attempts_snapshot(
-                                    state.as_ref(),
-                                &pending_attempt_record.invoke_id,
-                            )
-                            .await
-                        {
-                            warn!(
-                                invoke_id = %pending_attempt_record.invoke_id,
-                                error = %err,
-                                "failed to broadcast pool attempt streaming phase snapshot"
-                            );
-                        }
-                        if !phase_persisted {
-                            info!(
-                                invoke_id = %pending_attempt_record.invoke_id,
-                                attempt_id = pending_attempt_record.attempt_id,
-                                "streaming phase was not persisted; relying on invocation cleanup guards for post-first-byte recovery"
-                            );
-                            if pending_attempt_record.attempt_id.is_some() {
-                                deferred_early_phase_cleanup_guard =
-                                    early_phase_cleanup_guard.take();
-                            }
-                        }
-                        if phase_persisted && pending_attempt_record.attempt_id.is_some() {
-                            disarm_pool_early_phase_cleanup_guard(&mut early_phase_cleanup_guard);
-                        }
+                );
+                if phase_enqueued {
+                    debug!(
+                        invoke_id = %pending_attempt_record.invoke_id,
+                        attempt_id = pending_attempt_record.attempt_id,
+                        "queued pool attempt streaming phase progress"
+                    );
+                    if pending_attempt_record.attempt_id.is_some() {
+                        deferred_early_phase_cleanup_guard = early_phase_cleanup_guard.take();
                     }
-                    Err(err) => {
-                        warn!(
-                            invoke_id = %pending_attempt_record.invoke_id,
-                            error = %err,
-                            "failed to persist pool attempt streaming phase; relying on invocation cleanup guards for post-first-byte recovery"
-                        );
-                        if pending_attempt_record.attempt_id.is_some() {
-                            deferred_early_phase_cleanup_guard =
-                                early_phase_cleanup_guard.take();
-                        }
+                } else {
+                    info!(
+                        invoke_id = %pending_attempt_record.invoke_id,
+                        attempt_id = pending_attempt_record.attempt_id,
+                        "streaming phase was not enqueued; relying on invocation cleanup guards for post-first-byte recovery"
+                    );
+                    if pending_attempt_record.attempt_id.is_some() {
+                        deferred_early_phase_cleanup_guard = early_phase_cleanup_guard.take();
                     }
                 }
             } else {

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -790,7 +790,9 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
     capture_started: Instant,
     record: ProxyCaptureRecord,
 ) -> Result<()> {
-    let inserted = persist_proxy_capture_record(&state.pool, capture_started, record).await?;
+    let derived_payload = record.payload.clone();
+    let inserted =
+        persist_proxy_capture_record_core(&state.pool, capture_started, record, false).await?;
     let Some(inserted_record) = inserted else {
         return Ok(());
     };
@@ -803,6 +805,23 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
     }
 
     let invoke_id = inserted_record.invoke_id.clone();
+    let derived = BatchedInvocationDerivedWrites {
+        invocation_id: inserted_record.id,
+        occurred_at: inserted_record.occurred_at.clone(),
+        payload: derived_payload,
+    };
+    if !state
+        .sqlite_batch_writer
+        .enqueue(SqliteBatchWrite::InvocationDerived(derived.clone()))
+        && let Err(err) =
+            SqliteBatchWriter::flush_invocation_derived_inline(&state.pool, derived).await
+    {
+        warn!(
+            error = %err,
+            invoke_id = %invoke_id,
+            "failed to synchronously compensate dropped raw proxy derived write"
+        );
+    }
     if state.broadcaster.receiver_count() > 0
         && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
             records: vec![inserted_record],
@@ -820,7 +839,16 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
 pub(crate) async fn persist_proxy_capture_record(
     pool: &Pool<Sqlite>,
     capture_started: Instant,
+    record: ProxyCaptureRecord,
+) -> Result<Option<ApiInvocation>> {
+    persist_proxy_capture_record_core(pool, capture_started, record, true).await
+}
+
+async fn persist_proxy_capture_record_core(
+    pool: &Pool<Sqlite>,
+    capture_started: Instant,
     mut record: ProxyCaptureRecord,
+    write_derived_inline: bool,
 ) -> Result<Option<ApiInvocation>> {
     let raw_response = if record.response_body_preview_enabled {
         record.raw_response.clone()
@@ -1050,12 +1078,14 @@ pub(crate) async fn persist_proxy_capture_record(
         existing.id
     };
 
-    touch_invocation_upstream_account_last_activity_tx(
-        tx.as_mut(),
-        &record.occurred_at,
-        record.payload.as_deref(),
-    )
-    .await?;
+    if write_derived_inline {
+        touch_invocation_upstream_account_last_activity_tx(
+            tx.as_mut(),
+            &record.occurred_at,
+            record.payload.as_deref(),
+        )
+        .await?;
+    }
 
     record.timings.t_persist_ms = elapsed_ms(persist_started);
     record.timings.t_total_ms = elapsed_ms(capture_started);
@@ -1074,13 +1104,15 @@ pub(crate) async fn persist_proxy_capture_record(
     .execute(tx.as_mut())
     .await?;
 
-    recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[invocation_id]).await?;
-    save_hourly_rollup_live_progress_tx(
-        tx.as_mut(),
-        HOURLY_ROLLUP_DATASET_INVOCATIONS,
-        invocation_id,
-    )
-    .await?;
+    if write_derived_inline {
+        recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[invocation_id]).await?;
+        save_hourly_rollup_live_progress_tx(
+            tx.as_mut(),
+            HOURLY_ROLLUP_DATASET_INVOCATIONS,
+            invocation_id,
+        )
+        .await?;
+    }
 
     let persisted =
         load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -1368,46 +1368,27 @@ pub(crate) async fn send_pool_request_live_first_attempt(
         pending_attempt_record.compact_support_reason = compact_support_observation
             .as_ref()
             .and_then(|value| value.reason.clone());
-        match update_pool_upstream_request_attempt_progress(
-            &state.pool,
+        let phase_enqueued = enqueue_pool_upstream_request_attempt_progress(
+            state.as_ref(),
             pending_attempt_record,
             POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE,
             Some(connect_latency_ms),
             Some(first_byte_latency_ms),
             pending_attempt_record.compact_support_status.as_deref(),
             pending_attempt_record.compact_support_reason.as_deref(),
-        )
-        .await
-        {
-            Ok(phase_persisted) => {
-                if phase_persisted
-                    && let Err(err) = broadcast_pool_upstream_attempts_snapshot(
-                        state.as_ref(),
-                        &pending_attempt_record.invoke_id,
-                    )
-                    .await
-                {
-                    warn!(
-                        invoke_id = %pending_attempt_record.invoke_id,
-                        error = %err,
-                        "failed to broadcast live-first pool attempt streaming phase snapshot"
-                    );
-                }
-                if !phase_persisted {
-                    info!(
-                        invoke_id = %pending_attempt_record.invoke_id,
-                        attempt_id = pending_attempt_record.attempt_id,
-                        "streaming phase was not persisted for live-first pool attempt; relying on invocation cleanup guards for post-first-byte recovery"
-                    );
-                }
-            }
-            Err(err) => {
-                warn!(
-                    invoke_id = %pending_attempt_record.invoke_id,
-                    error = %err,
-                    "failed to persist live-first pool attempt streaming phase; relying on invocation cleanup guards for post-first-byte recovery"
-                );
-            }
+        );
+        if phase_enqueued {
+            debug!(
+                invoke_id = %pending_attempt_record.invoke_id,
+                attempt_id = pending_attempt_record.attempt_id,
+                "queued live-first pool attempt streaming phase progress"
+            );
+        } else {
+            info!(
+                invoke_id = %pending_attempt_record.invoke_id,
+                attempt_id = pending_attempt_record.attempt_id,
+                "streaming phase was not enqueued for live-first pool attempt; relying on invocation cleanup guards for post-first-byte recovery"
+            );
         }
     } else {
         disarm_pool_early_phase_cleanup_guard(&mut deferred_early_phase_cleanup_guard);

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -396,11 +396,33 @@ pub(crate) async fn advance_pool_upstream_request_attempt_phase(
     pending: &PendingPoolAttemptRecord,
     phase: &str,
 ) -> Result<()> {
-    if !update_pool_upstream_request_attempt_phase(&state.pool, pending, phase).await? {
-        return Ok(());
-    }
+    enqueue_pool_upstream_request_attempt_progress(state, pending, phase, None, None, None, None);
+    Ok(())
+}
 
-    broadcast_pool_upstream_attempts_snapshot(state, &pending.invoke_id).await
+pub(crate) fn enqueue_pool_upstream_request_attempt_progress(
+    state: &AppState,
+    pending: &PendingPoolAttemptRecord,
+    phase: &str,
+    connect_latency_ms: Option<f64>,
+    first_byte_latency_ms: Option<f64>,
+    compact_support_status: Option<&str>,
+    compact_support_reason: Option<&str>,
+) -> bool {
+    let Some(attempt_id) = pending.attempt_id else {
+        return false;
+    };
+    state.sqlite_batch_writer.enqueue(SqliteBatchWrite::AttemptProgress(
+        BatchedAttemptProgress {
+            attempt_id,
+            pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+            phase: phase.to_string(),
+            connect_latency_ms,
+            first_byte_latency_ms,
+            compact_support_status: compact_support_status.map(ToOwned::to_owned),
+            compact_support_reason: compact_support_reason.map(ToOwned::to_owned),
+        },
+    ))
 }
 
 pub(crate) enum PoolAttemptRecoveryScope<'a> {
@@ -1004,6 +1026,8 @@ pub(crate) async fn recover_guard_dropped_pool_early_phase_orphan(
     first_byte_observed: bool,
     terminal_outcome_observed: bool,
 ) -> Result<()> {
+    state.sqlite_batch_writer.flush_now(&state.pool).await?;
+
     if first_byte_observed && terminal_outcome_observed {
         info!(
             invoke_id = %pending_attempt_record.invoke_id,
@@ -1130,6 +1154,8 @@ pub(crate) async fn recover_guard_dropped_pool_terminal_invocation_orphan(
 pub(crate) async fn recover_stale_pool_early_phase_orphans_runtime(
     state: &AppState,
 ) -> Result<PoolOrphanRecoveryOutcome> {
+    state.sqlite_batch_writer.flush_now(&state.pool).await?;
+
     let timeouts = resolve_pool_routing_timeouts(&state.pool, &state.config).await?;
     let responses_started_before = stale_started_before_string(
         timeouts.responses_first_byte_timeout,
@@ -2018,7 +2044,8 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_runtime_snapshot(
     state: &AppState,
     record: ProxyCaptureRecord,
 ) -> Result<()> {
-    let persisted = persist_proxy_capture_runtime_record(&state.pool, record).await?;
+    let derived_payload = record.payload.clone();
+    let persisted = persist_proxy_capture_runtime_record_core(&state.pool, record, false).await?;
     let Some(persisted_record) = persisted else {
         return Ok(());
     };
@@ -2032,6 +2059,23 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_runtime_snapshot(
     }
 
     let invoke_id = persisted_record.invoke_id.clone();
+    let derived = BatchedInvocationDerivedWrites {
+        invocation_id: persisted_record.id,
+        occurred_at: persisted_record.occurred_at.clone(),
+        payload: derived_payload,
+    };
+    if !state
+        .sqlite_batch_writer
+        .enqueue(SqliteBatchWrite::InvocationDerived(derived.clone()))
+        && let Err(err) =
+            SqliteBatchWriter::flush_invocation_derived_inline(&state.pool, derived).await
+    {
+        warn!(
+            error = %err,
+            invoke_id = %invoke_id,
+            "failed to synchronously compensate dropped runtime proxy derived write"
+        );
+    }
     if state.broadcaster.receiver_count() > 0
         && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
             records: vec![persisted_record],
@@ -2050,6 +2094,14 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_runtime_snapshot(
 pub(crate) async fn persist_proxy_capture_runtime_record(
     pool: &Pool<Sqlite>,
     record: ProxyCaptureRecord,
+) -> Result<Option<ApiInvocation>> {
+    persist_proxy_capture_runtime_record_core(pool, record, true).await
+}
+
+async fn persist_proxy_capture_runtime_record_core(
+    pool: &Pool<Sqlite>,
+    record: ProxyCaptureRecord,
+    write_derived_inline: bool,
 ) -> Result<Option<ApiInvocation>> {
     let raw_response = if record.response_body_preview_enabled {
         record.raw_response.clone()
@@ -2225,48 +2277,50 @@ pub(crate) async fn persist_proxy_capture_runtime_record(
     )
     .await?
     .ok_or_else(|| anyhow!("persisted proxy runtime invocation row disappeared after upsert"))?;
-    upsert_invocation_hourly_rollups_tx(
-        tx.as_mut(),
-        &[InvocationHourlySourceRecord {
-            id: persisted_identity.id,
-            occurred_at: record.occurred_at.clone(),
-            source: SOURCE_PROXY.to_string(),
-            status: Some(record.status.clone()),
-            detail_level: DETAIL_LEVEL_FULL.to_string(),
-            input_tokens: record.usage.input_tokens,
-            output_tokens: record.usage.output_tokens,
-            cache_input_tokens: record.usage.cache_input_tokens,
-            total_tokens: record.usage.total_tokens,
-            cost: record.cost,
-            error_message: record.error_message.clone(),
-            failure_kind: failure_kind.clone(),
-            failure_class: Some(failure.failure_class.as_str().to_string()),
-            is_actionable: Some(failure.is_actionable as i64),
-            payload: record.payload.clone(),
-            t_total_ms: None,
-            t_req_read_ms,
-            t_req_parse_ms,
-            t_upstream_connect_ms,
-            t_upstream_ttfb_ms,
-            t_upstream_stream_ms: None,
-            t_resp_parse_ms: None,
-            t_persist_ms: None,
-        }],
-        &INVOCATION_HOURLY_ROLLUP_TARGETS,
-    )
-    .await?;
-    save_hourly_rollup_live_progress_tx(
-        tx.as_mut(),
-        HOURLY_ROLLUP_DATASET_INVOCATIONS,
-        persisted_identity.id,
-    )
-    .await?;
-    touch_invocation_upstream_account_last_activity_tx(
-        tx.as_mut(),
-        &record.occurred_at,
-        record.payload.as_deref(),
-    )
-    .await?;
+    if write_derived_inline {
+        upsert_invocation_hourly_rollups_tx(
+            tx.as_mut(),
+            &[InvocationHourlySourceRecord {
+                id: persisted_identity.id,
+                occurred_at: record.occurred_at.clone(),
+                source: SOURCE_PROXY.to_string(),
+                status: Some(record.status.clone()),
+                detail_level: DETAIL_LEVEL_FULL.to_string(),
+                input_tokens: record.usage.input_tokens,
+                output_tokens: record.usage.output_tokens,
+                cache_input_tokens: record.usage.cache_input_tokens,
+                total_tokens: record.usage.total_tokens,
+                cost: record.cost,
+                error_message: record.error_message.clone(),
+                failure_kind: failure_kind.clone(),
+                failure_class: Some(failure.failure_class.as_str().to_string()),
+                is_actionable: Some(failure.is_actionable as i64),
+                payload: record.payload.clone(),
+                t_total_ms: None,
+                t_req_read_ms,
+                t_req_parse_ms,
+                t_upstream_connect_ms,
+                t_upstream_ttfb_ms,
+                t_upstream_stream_ms: None,
+                t_resp_parse_ms: None,
+                t_persist_ms: None,
+            }],
+            &INVOCATION_HOURLY_ROLLUP_TARGETS,
+        )
+        .await?;
+        save_hourly_rollup_live_progress_tx(
+            tx.as_mut(),
+            HOURLY_ROLLUP_DATASET_INVOCATIONS,
+            persisted_identity.id,
+        )
+        .await?;
+        touch_invocation_upstream_account_last_activity_tx(
+            tx.as_mut(),
+            &record.occurred_at,
+            record.payload.as_deref(),
+        )
+        .await?;
+    }
 
     let persisted = load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
         .await?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -113,9 +113,12 @@ pub(crate) async fn run() -> Result<()> {
         Arc::new(Semaphore::new(proxy_raw_async_writer_limit(&config)));
     let shutdown = CancellationToken::new();
 
+    let sqlite_batch_writer = SqliteBatchWriter::spawn(pool.clone(), shutdown.clone());
+
     let state = Arc::new(AppState {
         config: config.clone(),
         pool,
+        sqlite_batch_writer,
         oauth_installation_seed,
         hourly_rollup_sync_lock: Arc::new(Mutex::new(())),
         http_clients,
@@ -812,6 +815,8 @@ async fn drain_runtime_after_shutdown(
         );
     }
 
+    state.sqlite_batch_writer.shutdown_and_drain().await;
+
     let broadcast_handles = {
         let mut guard = state.proxy_summary_quota_broadcast_handle.lock().await;
         std::mem::take(&mut *guard)
@@ -928,8 +933,8 @@ fn spawn_forward_proxy_maintenance(
         .await
         {
             if let Some(run) = startup_run.as_ref() {
-                finish_system_task_run(
-                    &state.pool,
+                finish_system_task_run_batched(
+                    state.as_ref(),
                     run,
                     SystemTaskStatus::Failed,
                     Some("forward proxy startup refresh failed".to_string()),
@@ -939,8 +944,8 @@ fn spawn_forward_proxy_maintenance(
             }
             warn!(error = %err, "failed to refresh forward proxy subscriptions at startup");
         } else if let Some(run) = startup_run.as_ref() {
-            finish_system_task_run(
-                &state.pool,
+            finish_system_task_run_batched(
+                    state.as_ref(),
                 run,
                 SystemTaskStatus::Success,
                 Some("forward proxy startup refresh completed".to_string()),
@@ -968,8 +973,8 @@ fn spawn_forward_proxy_maintenance(
                     .ok();
                     if let Err(err) = refresh_forward_proxy_subscriptions(state.clone(), false, None).await {
                         if let Some(run) = task_run.as_ref() {
-                            finish_system_task_run(
-                                &state.pool,
+                            finish_system_task_run_batched(
+                    state.as_ref(),
                                 run,
                                 SystemTaskStatus::Failed,
                                 Some("forward proxy interval refresh failed".to_string()),
@@ -979,8 +984,8 @@ fn spawn_forward_proxy_maintenance(
                         }
                         warn!(error = %err, "failed to refresh forward proxy subscriptions");
                     } else if let Some(run) = task_run.as_ref() {
-                        finish_system_task_run(
-                            &state.pool,
+                        finish_system_task_run_batched(
+                    state.as_ref(),
                             run,
                             SystemTaskStatus::Success,
                             Some("forward proxy interval refresh completed".to_string()),

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -569,14 +569,6 @@ async fn flush_pending_batch_inner(pool: &Pool<Sqlite>, batch: &PendingBatch) ->
     if !batch.invocation_derived.is_empty() {
         let invocation_ids = batch.invocation_derived.keys().copied().collect::<Vec<_>>();
         recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &invocation_ids).await?;
-        if let Some(max_id) = invocation_ids.iter().copied().max() {
-            save_hourly_rollup_live_progress_tx(
-                tx.as_mut(),
-                HOURLY_ROLLUP_DATASET_INVOCATIONS,
-                max_id,
-            )
-            .await?;
-        }
         for derived in batch.invocation_derived.values() {
             touch_invocation_upstream_account_last_activity_tx(
                 tx.as_mut(),
@@ -893,5 +885,34 @@ mod tests {
         assert_eq!(row.1.as_deref(), Some("completed"));
         assert_eq!(row.2.as_deref(), Some("2026-07-01T10:00:05Z"));
         assert_eq!(row.3, Some(125));
+    }
+
+    #[tokio::test]
+    async fn invocation_derived_batch_does_not_advance_live_progress_cursor() {
+        let pool = test_pool().await;
+        save_hourly_rollup_live_progress_tx(
+            pool.acquire().await.expect("acquire").as_mut(),
+            HOURLY_ROLLUP_DATASET_INVOCATIONS,
+            41,
+        )
+        .await
+        .expect("seed live progress");
+
+        SqliteBatchWriter::flush_for_test(
+            &pool,
+            vec![SqliteBatchWrite::InvocationDerived(
+                BatchedInvocationDerivedWrites {
+                    invocation_id: 100,
+                    occurred_at: "2026-07-01 10:00:00".to_string(),
+                    payload: None,
+                },
+            )],
+        )
+        .await;
+
+        let cursor = load_hourly_rollup_live_progress(&pool, HOURLY_ROLLUP_DATASET_INVOCATIONS)
+            .await
+            .expect("load live progress");
+        assert_eq!(cursor, 41);
     }
 }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1,0 +1,896 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use sqlx::{Pool, Sqlite};
+use tokio::{
+    sync::{Mutex, mpsc, oneshot},
+    task::JoinHandle,
+    time::{MissedTickBehavior, interval},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::*;
+
+const SQLITE_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
+const SQLITE_BATCH_MAX_ROWS: usize = 100;
+const SQLITE_BATCH_MAX_AGE: Duration = Duration::from_secs(5);
+const SQLITE_BATCH_CHANNEL_CAPACITY: usize = 10_000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct BatchedAttemptProgress {
+    pub(crate) attempt_id: i64,
+    pub(crate) pending_status: &'static str,
+    pub(crate) phase: String,
+    pub(crate) connect_latency_ms: Option<f64>,
+    pub(crate) first_byte_latency_ms: Option<f64>,
+    pub(crate) compact_support_status: Option<String>,
+    pub(crate) compact_support_reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BatchedInvocationDerivedWrites {
+    pub(crate) invocation_id: i64,
+    pub(crate) occurred_at: String,
+    pub(crate) payload: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BatchedSystemTaskFinish {
+    pub(crate) run_id: i64,
+    pub(crate) task_kind: SystemTaskKind,
+    pub(crate) trigger_kind: String,
+    pub(crate) status: SystemTaskStatus,
+    pub(crate) summary: Option<String>,
+    pub(crate) detail: Option<String>,
+    pub(crate) finished_at: String,
+    pub(crate) duration_ms: i64,
+}
+
+#[derive(Debug)]
+pub(crate) enum SqliteBatchWrite {
+    AttemptProgress(BatchedAttemptProgress),
+    InvocationDerived(BatchedInvocationDerivedWrites),
+    SystemTaskFinish(BatchedSystemTaskFinish),
+}
+
+enum SqliteBatchWriterMessage {
+    Write(SqliteBatchWrite),
+    FlushNow(oneshot::Sender<Result<(), String>>),
+    Shutdown(oneshot::Sender<Result<(), String>>),
+}
+
+#[derive(Debug, Default)]
+struct PendingBatch {
+    attempt_progress: HashMap<i64, BatchedAttemptProgress>,
+    invocation_derived: BTreeMap<i64, BatchedInvocationDerivedWrites>,
+    system_task_finishes: HashMap<i64, BatchedSystemTaskFinish>,
+    enqueued_rows: usize,
+    coalesced_rows: usize,
+    oldest_at: Option<Instant>,
+}
+
+impl PendingBatch {
+    fn is_empty(&self) -> bool {
+        self.attempt_progress.is_empty()
+            && self.invocation_derived.is_empty()
+            && self.system_task_finishes.is_empty()
+    }
+
+    fn logical_rows(&self) -> usize {
+        self.attempt_progress.len()
+            + self.invocation_derived.len()
+            + self.system_task_finishes.len()
+    }
+
+    fn age(&self) -> Duration {
+        self.oldest_at
+            .map(|oldest| oldest.elapsed())
+            .unwrap_or_default()
+    }
+
+    fn push(&mut self, write: SqliteBatchWrite) {
+        let now = Instant::now();
+        self.oldest_at.get_or_insert(now);
+        self.enqueued_rows += 1;
+        match write {
+            SqliteBatchWrite::AttemptProgress(progress) => {
+                if self
+                    .attempt_progress
+                    .insert(progress.attempt_id, progress)
+                    .is_some()
+                {
+                    self.coalesced_rows += 1;
+                }
+            }
+            SqliteBatchWrite::InvocationDerived(derived) => {
+                if self
+                    .invocation_derived
+                    .insert(derived.invocation_id, derived)
+                    .is_some()
+                {
+                    self.coalesced_rows += 1;
+                }
+            }
+            SqliteBatchWrite::SystemTaskFinish(finish) => {
+                if self
+                    .system_task_finishes
+                    .insert(finish.run_id, finish)
+                    .is_some()
+                {
+                    self.coalesced_rows += 1;
+                }
+            }
+        }
+    }
+
+    fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SqliteBatchWriter {
+    sender: mpsc::Sender<SqliteBatchWriterMessage>,
+    pending_depth: Arc<AtomicUsize>,
+    dropped_writes: Arc<AtomicU64>,
+    handle: Mutex<Option<JoinHandle<()>>>,
+    #[cfg(test)]
+    buffered_writes: Option<Arc<std::sync::Mutex<Vec<SqliteBatchWrite>>>>,
+}
+
+impl SqliteBatchWriter {
+    pub(crate) fn spawn(pool: Pool<Sqlite>, _shutdown: CancellationToken) -> Arc<Self> {
+        let (sender, receiver) = mpsc::channel(SQLITE_BATCH_CHANNEL_CAPACITY);
+        let pending_depth = Arc::new(AtomicUsize::new(0));
+        let dropped_writes = Arc::new(AtomicU64::new(0));
+        let handle = tokio::spawn(run_sqlite_batch_writer(
+            pool,
+            receiver,
+            pending_depth.clone(),
+        ));
+        Arc::new(Self {
+            sender,
+            pending_depth,
+            dropped_writes,
+            handle: Mutex::new(Some(handle)),
+            #[cfg(test)]
+            buffered_writes: None,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn spawn_for_test() -> Arc<Self> {
+        let (sender, _receiver) = mpsc::channel(1);
+        Arc::new(Self {
+            sender,
+            pending_depth: Arc::new(AtomicUsize::new(0)),
+            dropped_writes: Arc::new(AtomicU64::new(0)),
+            handle: Mutex::new(None),
+            buffered_writes: Some(Arc::new(std::sync::Mutex::new(Vec::new()))),
+        })
+    }
+
+    pub(crate) fn enqueue(&self, write: SqliteBatchWrite) -> bool {
+        #[cfg(test)]
+        if let Some(buffered_writes) = &self.buffered_writes {
+            match buffered_writes.lock() {
+                Ok(mut guard) => {
+                    guard.push(write);
+                    self.pending_depth.fetch_add(1, Ordering::Relaxed);
+                    return true;
+                }
+                Err(err) => {
+                    self.dropped_writes.fetch_add(1, Ordering::Relaxed);
+                    warn!(
+                        error = %err,
+                        dropped_writes = self.dropped_writes.load(Ordering::Relaxed),
+                        "sqlite batch writer test buffer poisoned; dropped derived write"
+                    );
+                    return false;
+                }
+            }
+        }
+
+        self.pending_depth.fetch_add(1, Ordering::Relaxed);
+        match self.sender.try_send(SqliteBatchWriterMessage::Write(write)) {
+            Ok(()) => true,
+            Err(err) => {
+                self.pending_depth.fetch_sub(1, Ordering::Relaxed);
+                self.dropped_writes.fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    error = %err,
+                    queue_depth = self.pending_depth.load(Ordering::Relaxed),
+                    dropped_writes = self.dropped_writes.load(Ordering::Relaxed),
+                    "sqlite batch writer queue full; dropped derived write"
+                );
+                false
+            }
+        }
+    }
+
+    pub(crate) async fn flush_now(&self, pool: &Pool<Sqlite>) -> Result<()> {
+        #[cfg(test)]
+        if self.buffered_writes.is_some() {
+            self.flush_buffered_for_test(pool).await;
+            return Ok(());
+        }
+
+        let (sender, receiver) = oneshot::channel();
+        if let Err(err) = self
+            .sender
+            .try_send(SqliteBatchWriterMessage::FlushNow(sender))
+        {
+            self.dropped_writes.fetch_add(1, Ordering::Relaxed);
+            warn!(
+                error = %err,
+                queue_depth = self.pending_depth.load(Ordering::Relaxed),
+                dropped_writes = self.dropped_writes.load(Ordering::Relaxed),
+                "sqlite batch writer flush barrier could not be queued"
+            );
+            return Err(anyhow::anyhow!(
+                "sqlite batch writer flush barrier could not be queued"
+            ));
+        }
+        match receiver.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(err)) => Err(anyhow::anyhow!(err)),
+            Err(err) => Err(anyhow::anyhow!(
+                "sqlite batch writer flush barrier dropped: {err}"
+            )),
+        }
+    }
+
+    pub(crate) async fn shutdown_and_drain(&self) {
+        #[cfg(test)]
+        if let Some(buffered_writes) = &self.buffered_writes {
+            let retained = buffered_writes
+                .lock()
+                .map(|guard| guard.len())
+                .unwrap_or_default();
+            if retained > 0 {
+                warn!(
+                    retained,
+                    "sqlite batch writer test buffer was not explicitly flushed before shutdown"
+                );
+            }
+            return;
+        }
+
+        let Some(handle) = self.handle.lock().await.take() else {
+            return;
+        };
+        let (sender, receiver) = oneshot::channel();
+        if let Err(err) = self
+            .sender
+            .send(SqliteBatchWriterMessage::Shutdown(sender))
+            .await
+        {
+            warn!(error = %err, "sqlite batch writer shutdown barrier could not be queued");
+        } else if let Ok(Err(err)) = receiver.await {
+            warn!(error = %err, "sqlite batch writer shutdown drain failed");
+        }
+        if let Err(err) = handle.await {
+            warn!(error = %err, "sqlite batch writer task failed during shutdown");
+        }
+    }
+
+    pub(crate) async fn flush_invocation_derived_inline(
+        pool: &Pool<Sqlite>,
+        derived: BatchedInvocationDerivedWrites,
+    ) -> Result<()> {
+        let mut batch = PendingBatch::default();
+        batch.push(SqliteBatchWrite::InvocationDerived(derived));
+        flush_pending_batch_inner(pool, &batch).await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stats_snapshot(&self) -> (usize, u64) {
+        (
+            self.pending_depth.load(Ordering::Relaxed),
+            self.dropped_writes.load(Ordering::Relaxed),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn flush_for_test(pool: &Pool<Sqlite>, writes: Vec<SqliteBatchWrite>) {
+        let mut batch = PendingBatch::default();
+        for write in writes {
+            batch.push(write);
+        }
+        flush_pending_batch_inner(pool, &batch)
+            .await
+            .expect("flush pending sqlite batch writes");
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn flush_buffered_for_test(&self, pool: &Pool<Sqlite>) {
+        let writes = self
+            .buffered_writes
+            .as_ref()
+            .and_then(|buffered_writes| {
+                buffered_writes.lock().ok().map(|mut guard| {
+                    let writes = guard.drain(..).collect::<Vec<_>>();
+                    self.pending_depth
+                        .fetch_sub(writes.len(), Ordering::Relaxed);
+                    writes
+                })
+            })
+            .unwrap_or_default();
+
+        if !writes.is_empty() {
+            Self::flush_for_test(pool, writes).await;
+        }
+    }
+}
+
+async fn run_sqlite_batch_writer(
+    pool: Pool<Sqlite>,
+    mut receiver: mpsc::Receiver<SqliteBatchWriterMessage>,
+    pending_depth: Arc<AtomicUsize>,
+) {
+    let mut ticker = interval(SQLITE_BATCH_FLUSH_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut pending = PendingBatch::default();
+
+    loop {
+        tokio::select! {
+            biased;
+            maybe_message = receiver.recv() => {
+                let Some(message) = maybe_message else {
+                    let _ = flush_pending_batch(&pool, pending.take(), true).await;
+                    return;
+                };
+                match message {
+                    SqliteBatchWriterMessage::Write(write) => {
+                        pending_depth.fetch_sub(1, Ordering::Relaxed);
+                        pending.push(write);
+                        if pending.logical_rows() >= SQLITE_BATCH_MAX_ROWS {
+                            if let Some(retained) = flush_pending_batch(&pool, pending.take(), false).await {
+                                pending = retained;
+                            }
+                        }
+                    }
+                    SqliteBatchWriterMessage::FlushNow(sender) => {
+                        let result = match flush_pending_batch(&pool, pending.take(), true).await {
+                            Some(retained) => {
+                                let message = format!(
+                                    "sqlite batch writer retained {} logical rows after forced flush",
+                                    retained.logical_rows()
+                                );
+                                pending = retained;
+                                Err(message)
+                            }
+                            None => Ok(()),
+                        };
+                        let _ = sender.send(result);
+                    }
+                    SqliteBatchWriterMessage::Shutdown(sender) => {
+                        let result = match flush_pending_batch(&pool, pending.take(), true).await {
+                            Some(retained) => {
+                                let message = format!(
+                                    "sqlite batch writer retained {} logical rows after shutdown flush",
+                                    retained.logical_rows()
+                                );
+                                pending = retained;
+                                Err(message)
+                            }
+                            None => Ok(()),
+                        };
+                        let _ = sender.send(result);
+                        return;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                if !pending.is_empty() {
+                    if pending.age() >= SQLITE_BATCH_MAX_AGE {
+                        warn!(
+                            logical_rows = pending.logical_rows(),
+                            enqueued_rows = pending.enqueued_rows,
+                            coalesced_rows = pending.coalesced_rows,
+                            oldest_age_ms = pending.age().as_millis() as u64,
+                            "sqlite batch writer pending derived writes exceeded freshness budget"
+                        );
+                    }
+                    if let Some(retained) = flush_pending_batch(&pool, pending.take(), false).await {
+                        pending = retained;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn flush_pending_batch(
+    pool: &Pool<Sqlite>,
+    batch: PendingBatch,
+    force: bool,
+) -> Option<PendingBatch> {
+    if batch.is_empty() {
+        return None;
+    }
+    let started = Instant::now();
+    let enqueued_rows = batch.enqueued_rows;
+    let coalesced_rows = batch.coalesced_rows;
+    let attempt_count = batch.attempt_progress.len();
+    let invocation_count = batch.invocation_derived.len();
+    let system_task_count = batch.system_task_finishes.len();
+    let system_task_scope = summarize_system_task_batch_scope(&batch);
+    let oldest_age_ms = batch.age().as_millis() as u64;
+
+    let permit = if force {
+        None
+    } else {
+        match crate::db_pressure::global_db_pressure_gate()
+            .try_begin_background("sqlite_batch_writer")
+        {
+            Ok(permit) => Some(permit),
+            Err(reason) => {
+                debug!(
+                    deny_reason = %reason,
+                    enqueued_rows,
+                    coalesced_rows,
+                    attempt_count,
+                    invocation_count,
+                    system_task_count,
+                    system_task_scope = %system_task_scope,
+                    oldest_age_ms,
+                    "sqlite batch writer deferred flush because pressure gate is closed"
+                );
+                return Some(batch);
+            }
+        }
+    };
+
+    if let Err(err) = flush_pending_batch_inner(pool, &batch).await {
+        crate::db_pressure::global_db_pressure_gate().record_error("sqlite_batch_writer", &err);
+        warn!(
+            error = %err,
+            enqueued_rows,
+            coalesced_rows,
+            attempt_count,
+            invocation_count,
+            system_task_count,
+            system_task_scope = %system_task_scope,
+            oldest_age_ms,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "sqlite batch writer flush failed"
+        );
+        drop(permit);
+        return Some(batch);
+    }
+    drop(permit);
+
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    if elapsed_ms >= 1_000 {
+        warn!(
+            enqueued_rows,
+            coalesced_rows,
+            attempt_count,
+            invocation_count,
+            system_task_count,
+            system_task_scope = %system_task_scope,
+            oldest_age_ms,
+            elapsed_ms,
+            "sqlite batch writer flush was slow"
+        );
+    } else {
+        debug!(
+            enqueued_rows,
+            coalesced_rows,
+            attempt_count,
+            invocation_count,
+            system_task_count,
+            system_task_scope = %system_task_scope,
+            oldest_age_ms,
+            elapsed_ms,
+            "sqlite batch writer flushed derived writes"
+        );
+    }
+    None
+}
+
+fn summarize_system_task_batch_scope(batch: &PendingBatch) -> String {
+    let mut values = batch
+        .system_task_finishes
+        .values()
+        .take(3)
+        .map(|finish| {
+            format!(
+                "{}:{}:{}",
+                finish.task_kind.as_str(),
+                finish.trigger_kind,
+                finish.status.as_str()
+            )
+        })
+        .collect::<Vec<_>>();
+    if batch.system_task_finishes.len() > values.len() {
+        values.push(format!(
+            "+{}",
+            batch.system_task_finishes.len() - values.len()
+        ));
+    }
+    values.join(",")
+}
+
+async fn flush_pending_batch_inner(pool: &Pool<Sqlite>, batch: &PendingBatch) -> Result<()> {
+    let mut tx = pool.begin().await?;
+
+    for progress in batch.attempt_progress.values() {
+        sqlx::query(
+            r#"
+            UPDATE pool_upstream_request_attempts
+            SET
+                phase = ?2,
+                connect_latency_ms = CASE
+                    WHEN ?4 IS NULL THEN connect_latency_ms
+                    WHEN connect_latency_ms IS NULL OR connect_latency_ms < ?4 THEN ?4
+                    ELSE connect_latency_ms
+                END,
+                first_byte_latency_ms = CASE
+                    WHEN ?5 IS NULL THEN first_byte_latency_ms
+                    WHEN first_byte_latency_ms IS NULL OR first_byte_latency_ms < ?5 THEN ?5
+                    ELSE first_byte_latency_ms
+                END,
+                compact_support_status = COALESCE(?6, compact_support_status),
+                compact_support_reason = COALESCE(?7, compact_support_reason)
+            WHERE id = ?1
+              AND status = ?3
+              AND finished_at IS NULL
+              AND (
+                    COALESCE(phase, '') <> ?2
+                    OR (?4 IS NOT NULL AND (connect_latency_ms IS NULL OR connect_latency_ms < ?4))
+                    OR (?5 IS NOT NULL AND (first_byte_latency_ms IS NULL OR first_byte_latency_ms < ?5))
+                    OR (?6 IS NOT NULL AND COALESCE(compact_support_status, '') <> ?6)
+                    OR (?7 IS NOT NULL AND COALESCE(compact_support_reason, '') <> ?7)
+                  )
+            "#,
+        )
+        .bind(progress.attempt_id)
+        .bind(&progress.phase)
+        .bind(progress.pending_status)
+        .bind(progress.connect_latency_ms)
+        .bind(progress.first_byte_latency_ms)
+        .bind(progress.compact_support_status.as_deref())
+        .bind(progress.compact_support_reason.as_deref())
+        .execute(tx.as_mut())
+        .await?;
+    }
+
+    if !batch.invocation_derived.is_empty() {
+        let invocation_ids = batch.invocation_derived.keys().copied().collect::<Vec<_>>();
+        recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &invocation_ids).await?;
+        if let Some(max_id) = invocation_ids.iter().copied().max() {
+            save_hourly_rollup_live_progress_tx(
+                tx.as_mut(),
+                HOURLY_ROLLUP_DATASET_INVOCATIONS,
+                max_id,
+            )
+            .await?;
+        }
+        for derived in batch.invocation_derived.values() {
+            touch_invocation_upstream_account_last_activity_tx(
+                tx.as_mut(),
+                &derived.occurred_at,
+                derived.payload.as_deref(),
+            )
+            .await?;
+        }
+    }
+
+    for finish in batch.system_task_finishes.values() {
+        sqlx::query(
+            r#"
+            UPDATE system_task_runs
+            SET status = ?1,
+                summary = COALESCE(?2, summary),
+                detail = ?3,
+                finished_at = ?4,
+                duration_ms = ?5
+            WHERE id = ?6
+            "#,
+        )
+        .bind(finish.status.as_str())
+        .bind(finish.summary.as_deref())
+        .bind(finish.detail.as_deref())
+        .bind(&finish.finished_at)
+        .bind(finish.duration_ms)
+        .bind(finish.run_id)
+        .execute(tx.as_mut())
+        .await?;
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use sqlx::SqlitePool;
+
+    fn attempt_trace(invoke_id: &str) -> PoolUpstreamAttemptTraceContext {
+        PoolUpstreamAttemptTraceContext {
+            invoke_id: invoke_id.to_string(),
+            occurred_at: "2026-07-01 10:00:00".to_string(),
+            endpoint: "/v1/responses".to_string(),
+            sticky_key: Some(format!("{invoke_id}-sticky")),
+            requester_ip: Some("192.168.31.6".to_string()),
+        }
+    }
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("connect sqlite memory pool");
+        ensure_schema(&pool).await.expect("ensure schema");
+        pool
+    }
+
+    async fn pending_attempt(pool: &SqlitePool, invoke_id: &str) -> PendingPoolAttemptRecord {
+        let trace = attempt_trace(invoke_id);
+        let pending = begin_pool_upstream_request_attempt(
+            pool,
+            &trace,
+            101,
+            "route-primary",
+            1,
+            1,
+            1,
+            "2026-07-01 10:00:00",
+        )
+        .await;
+        assert!(
+            pending.attempt_id.is_some(),
+            "pending attempt should be inserted synchronously"
+        );
+        pending
+    }
+
+    #[tokio::test]
+    async fn attempt_progress_batch_coalesces_by_attempt_id() {
+        let pool = test_pool().await;
+        let pending = pending_attempt(&pool, "batch-progress-coalesce").await;
+        let attempt_id = pending.attempt_id.expect("attempt id");
+
+        SqliteBatchWriter::flush_for_test(
+            &pool,
+            vec![
+                SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+                    attempt_id,
+                    pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+                    phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_SENDING_REQUEST.to_string(),
+                    connect_latency_ms: Some(12.0),
+                    first_byte_latency_ms: None,
+                    compact_support_status: None,
+                    compact_support_reason: None,
+                }),
+                SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+                    attempt_id,
+                    pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+                    phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE.to_string(),
+                    connect_latency_ms: Some(18.0),
+                    first_byte_latency_ms: Some(33.0),
+                    compact_support_status: Some("supported".to_string()),
+                    compact_support_reason: Some("cached_probe".to_string()),
+                }),
+            ],
+        )
+        .await;
+
+        let row = sqlx::query_as::<
+            _,
+            (
+                String,
+                Option<f64>,
+                Option<f64>,
+                Option<String>,
+                Option<String>,
+            ),
+        >(
+            r#"
+            SELECT phase, connect_latency_ms, first_byte_latency_ms, compact_support_status, compact_support_reason
+            FROM pool_upstream_request_attempts
+            WHERE id = ?1
+            "#,
+        )
+        .bind(attempt_id)
+        .fetch_one(&pool)
+        .await
+        .expect("load coalesced attempt");
+
+        assert_eq!(
+            row.0,
+            POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE
+        );
+        assert_eq!(row.1, Some(18.0));
+        assert_eq!(row.2, Some(33.0));
+        assert_eq!(row.3.as_deref(), Some("supported"));
+        assert_eq!(row.4.as_deref(), Some("cached_probe"));
+    }
+
+    #[tokio::test]
+    async fn attempt_progress_batch_does_not_overwrite_terminal_finalize() {
+        let pool = test_pool().await;
+        let pending = pending_attempt(&pool, "batch-progress-terminal-cover").await;
+        let attempt_id = pending.attempt_id.expect("attempt id");
+
+        finalize_pool_upstream_request_attempt(
+            &pool,
+            &pending,
+            "2026-07-01 10:00:05",
+            POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS,
+            Some(StatusCode::OK),
+            None,
+            None,
+            None,
+            None,
+            Some(42.0),
+            Some(16.0),
+            Some(188.0),
+            Some("req_terminal"),
+            None,
+            None,
+        )
+        .await
+        .expect("finalize attempt synchronously");
+
+        SqliteBatchWriter::flush_for_test(
+            &pool,
+            vec![SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+                attempt_id,
+                pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+                phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_WAITING_FIRST_BYTE.to_string(),
+                connect_latency_ms: Some(99.0),
+                first_byte_latency_ms: Some(99.0),
+                compact_support_status: Some("stale".to_string()),
+                compact_support_reason: Some("should_not_apply".to_string()),
+            })],
+        )
+        .await;
+
+        let row = sqlx::query_as::<
+            _,
+            (
+                String,
+                Option<String>,
+                Option<i64>,
+                Option<f64>,
+                Option<f64>,
+                Option<f64>,
+                Option<String>,
+                Option<String>,
+            ),
+        >(
+            r#"
+            SELECT
+                status,
+                phase,
+                http_status,
+                connect_latency_ms,
+                first_byte_latency_ms,
+                stream_latency_ms,
+                upstream_request_id,
+                compact_support_status
+            FROM pool_upstream_request_attempts
+            WHERE id = ?1
+            "#,
+        )
+        .bind(attempt_id)
+        .fetch_one(&pool)
+        .await
+        .expect("load finalized attempt");
+
+        assert_eq!(row.0, POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_SUCCESS);
+        assert_eq!(
+            row.1.as_deref(),
+            Some(POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_COMPLETED)
+        );
+        assert_eq!(row.2, Some(200));
+        assert_eq!(row.3, Some(42.0));
+        assert_eq!(row.4, Some(16.0));
+        assert_eq!(row.5, Some(188.0));
+        assert_eq!(row.6.as_deref(), Some("req_terminal"));
+        assert_eq!(row.7, None);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_pending_batch_writes() {
+        let pool = test_pool().await;
+        let pending = pending_attempt(&pool, "batch-progress-shutdown-drain").await;
+        let attempt_id = pending.attempt_id.expect("attempt id");
+        let shutdown = CancellationToken::new();
+        let writer = SqliteBatchWriter::spawn(pool.clone(), shutdown.clone());
+
+        assert!(
+            writer.enqueue(SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+                attempt_id,
+                pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+                phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE.to_string(),
+                connect_latency_ms: Some(21.0),
+                first_byte_latency_ms: Some(34.0),
+                compact_support_status: None,
+                compact_support_reason: None,
+            }))
+        );
+
+        shutdown.cancel();
+        writer.shutdown_and_drain().await;
+
+        let row = sqlx::query_as::<_, (Option<String>, Option<f64>, Option<f64>)>(
+            r#"
+            SELECT phase, connect_latency_ms, first_byte_latency_ms
+            FROM pool_upstream_request_attempts
+            WHERE id = ?1
+            "#,
+        )
+        .bind(attempt_id)
+        .fetch_one(&pool)
+        .await
+        .expect("load drained attempt progress");
+
+        assert_eq!(
+            row.0.as_deref(),
+            Some(POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE)
+        );
+        assert_eq!(row.1, Some(21.0));
+        assert_eq!(row.2, Some(34.0));
+        assert_eq!(writer.stats_snapshot(), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn system_task_finish_batch_marks_running_task_terminal() {
+        let pool = test_pool().await;
+        let handle = begin_system_task_run(
+            &pool,
+            SystemTaskKind::StartupBackfill,
+            "test",
+            Some("started".to_string()),
+        )
+        .await
+        .expect("begin system task");
+
+        SqliteBatchWriter::flush_for_test(
+            &pool,
+            vec![SqliteBatchWrite::SystemTaskFinish(
+                BatchedSystemTaskFinish {
+                    run_id: handle.id,
+                    task_kind: handle.task_kind,
+                    trigger_kind: handle.trigger_kind.clone(),
+                    status: SystemTaskStatus::Success,
+                    summary: Some("completed".to_string()),
+                    detail: None,
+                    finished_at: "2026-07-01T10:00:05Z".to_string(),
+                    duration_ms: 125,
+                },
+            )],
+        )
+        .await;
+
+        let row = sqlx::query_as::<_, (String, Option<String>, Option<String>, Option<i64>)>(
+            r#"
+            SELECT status, summary, finished_at, duration_ms
+            FROM system_task_runs
+            WHERE id = ?1
+            "#,
+        )
+        .bind(handle.id)
+        .fetch_one(&pool)
+        .await
+        .expect("load finished system task run");
+
+        assert_eq!(row.0, SystemTaskStatus::Success.as_str());
+        assert_eq!(row.1.as_deref(), Some("completed"));
+        assert_eq!(row.2.as_deref(), Some("2026-07-01T10:00:05Z"));
+        assert_eq!(row.3, Some(125));
+    }
+}

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -389,16 +389,19 @@ async fn run_sqlite_batch_writer(
             }
             _ = ticker.tick() => {
                 if !pending.is_empty() {
-                    if pending.age() >= SQLITE_BATCH_MAX_AGE {
+                    let force_flush = pending.age() >= SQLITE_BATCH_MAX_AGE;
+                    if force_flush {
                         warn!(
                             logical_rows = pending.logical_rows(),
                             enqueued_rows = pending.enqueued_rows,
                             coalesced_rows = pending.coalesced_rows,
                             oldest_age_ms = pending.age().as_millis() as u64,
-                            "sqlite batch writer pending derived writes exceeded freshness budget"
+                            "sqlite batch writer pending derived writes reached max age; forcing flush"
                         );
                     }
-                    if let Some(retained) = flush_pending_batch(&pool, pending.take(), false).await {
+                    if let Some(retained) =
+                        flush_pending_batch(&pool, pending.take(), force_flush).await
+                    {
                         pending = retained;
                     }
                 }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::Result;
-use sqlx::{Pool, Sqlite};
+use sqlx::{Pool, Sqlite, SqliteConnection};
 use tokio::{
     sync::{Mutex, mpsc, oneshot},
     task::JoinHandle,
@@ -61,10 +61,15 @@ pub(crate) enum SqliteBatchWrite {
     SystemTaskFinish(BatchedSystemTaskFinish),
 }
 
-enum SqliteBatchWriterMessage {
-    Write(SqliteBatchWrite),
-    FlushNow(oneshot::Sender<Result<(), String>>),
-    Shutdown(oneshot::Sender<Result<(), String>>),
+enum SqliteBatchWriterControl {
+    FlushNow {
+        queued_depth_snapshot: usize,
+        responder: oneshot::Sender<Result<(), String>>,
+    },
+    Shutdown {
+        queued_depth_snapshot: usize,
+        responder: oneshot::Sender<Result<(), String>>,
+    },
 }
 
 #[derive(Debug, Default)]
@@ -138,7 +143,8 @@ impl PendingBatch {
 
 #[derive(Debug)]
 pub(crate) struct SqliteBatchWriter {
-    sender: mpsc::Sender<SqliteBatchWriterMessage>,
+    write_sender: mpsc::Sender<SqliteBatchWrite>,
+    control_sender: mpsc::Sender<SqliteBatchWriterControl>,
     pending_depth: Arc<AtomicUsize>,
     dropped_writes: Arc<AtomicU64>,
     handle: Mutex<Option<JoinHandle<()>>>,
@@ -148,16 +154,19 @@ pub(crate) struct SqliteBatchWriter {
 
 impl SqliteBatchWriter {
     pub(crate) fn spawn(pool: Pool<Sqlite>, _shutdown: CancellationToken) -> Arc<Self> {
-        let (sender, receiver) = mpsc::channel(SQLITE_BATCH_CHANNEL_CAPACITY);
+        let (write_sender, write_receiver) = mpsc::channel(SQLITE_BATCH_CHANNEL_CAPACITY);
+        let (control_sender, control_receiver) = mpsc::channel(128);
         let pending_depth = Arc::new(AtomicUsize::new(0));
         let dropped_writes = Arc::new(AtomicU64::new(0));
         let handle = tokio::spawn(run_sqlite_batch_writer(
             pool,
-            receiver,
+            write_receiver,
+            control_receiver,
             pending_depth.clone(),
         ));
         Arc::new(Self {
-            sender,
+            write_sender,
+            control_sender,
             pending_depth,
             dropped_writes,
             handle: Mutex::new(Some(handle)),
@@ -168,9 +177,11 @@ impl SqliteBatchWriter {
 
     #[cfg(test)]
     pub(crate) fn spawn_for_test() -> Arc<Self> {
-        let (sender, _receiver) = mpsc::channel(1);
+        let (write_sender, _write_receiver) = mpsc::channel(1);
+        let (control_sender, _control_receiver) = mpsc::channel(1);
         Arc::new(Self {
-            sender,
+            write_sender,
+            control_sender,
             pending_depth: Arc::new(AtomicUsize::new(0)),
             dropped_writes: Arc::new(AtomicU64::new(0)),
             handle: Mutex::new(None),
@@ -200,7 +211,7 @@ impl SqliteBatchWriter {
         }
 
         self.pending_depth.fetch_add(1, Ordering::Relaxed);
-        match self.sender.try_send(SqliteBatchWriterMessage::Write(write)) {
+        match self.write_sender.try_send(write) {
             Ok(()) => true,
             Err(err) => {
                 self.pending_depth.fetch_sub(1, Ordering::Relaxed);
@@ -224,9 +235,13 @@ impl SqliteBatchWriter {
         }
 
         let (sender, receiver) = oneshot::channel();
+        let queued_depth_snapshot = self.pending_depth.load(Ordering::Relaxed);
         if let Err(err) = self
-            .sender
-            .try_send(SqliteBatchWriterMessage::FlushNow(sender))
+            .control_sender
+            .try_send(SqliteBatchWriterControl::FlushNow {
+                queued_depth_snapshot,
+                responder: sender,
+            })
         {
             self.dropped_writes.fetch_add(1, Ordering::Relaxed);
             warn!(
@@ -268,9 +283,13 @@ impl SqliteBatchWriter {
             return;
         };
         let (sender, receiver) = oneshot::channel();
+        let queued_depth_snapshot = self.pending_depth.load(Ordering::Relaxed);
         if let Err(err) = self
-            .sender
-            .send(SqliteBatchWriterMessage::Shutdown(sender))
+            .control_sender
+            .send(SqliteBatchWriterControl::Shutdown {
+                queued_depth_snapshot,
+                responder: sender,
+            })
             .await
         {
             warn!(error = %err, "sqlite batch writer shutdown barrier could not be queued");
@@ -333,32 +352,31 @@ impl SqliteBatchWriter {
 
 async fn run_sqlite_batch_writer(
     pool: Pool<Sqlite>,
-    mut receiver: mpsc::Receiver<SqliteBatchWriterMessage>,
+    mut write_receiver: mpsc::Receiver<SqliteBatchWrite>,
+    mut control_receiver: mpsc::Receiver<SqliteBatchWriterControl>,
     pending_depth: Arc<AtomicUsize>,
 ) {
     let mut ticker = interval(SQLITE_BATCH_FLUSH_INTERVAL);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut pending = PendingBatch::default();
+    let mut control_closed = false;
 
     loop {
         tokio::select! {
             biased;
-            maybe_message = receiver.recv() => {
-                let Some(message) = maybe_message else {
-                    let _ = flush_pending_batch(&pool, pending.take(), true).await;
-                    return;
-                };
-                match message {
-                    SqliteBatchWriterMessage::Write(write) => {
-                        pending_depth.fetch_sub(1, Ordering::Relaxed);
-                        pending.push(write);
-                        if pending.logical_rows() >= SQLITE_BATCH_MAX_ROWS {
-                            if let Some(retained) = flush_pending_batch(&pool, pending.take(), false).await {
-                                pending = retained;
-                            }
-                        }
-                    }
-                    SqliteBatchWriterMessage::FlushNow(sender) => {
+            maybe_control = control_receiver.recv(), if !control_closed => {
+                if let Some(control) = maybe_control {
+                    match control {
+                    SqliteBatchWriterControl::FlushNow {
+                        queued_depth_snapshot,
+                        responder,
+                    } => {
+                        drain_queued_batch_writes(
+                            &mut write_receiver,
+                            &mut pending,
+                            &pending_depth,
+                            queued_depth_snapshot,
+                        );
                         let result = match flush_pending_batch(&pool, pending.take(), true).await {
                             Some(retained) => {
                                 let message = format!(
@@ -370,9 +388,18 @@ async fn run_sqlite_batch_writer(
                             }
                             None => Ok(()),
                         };
-                        let _ = sender.send(result);
+                        let _ = responder.send(result);
                     }
-                    SqliteBatchWriterMessage::Shutdown(sender) => {
+                    SqliteBatchWriterControl::Shutdown {
+                        queued_depth_snapshot,
+                        responder,
+                    } => {
+                        drain_queued_batch_writes(
+                            &mut write_receiver,
+                            &mut pending,
+                            &pending_depth,
+                            queued_depth_snapshot,
+                        );
                         let result = match flush_pending_batch(&pool, pending.take(), true).await {
                             Some(retained) => {
                                 Err(format!(
@@ -382,8 +409,24 @@ async fn run_sqlite_batch_writer(
                             }
                             None => Ok(()),
                         };
-                        let _ = sender.send(result);
+                        let _ = responder.send(result);
                         return;
+                    }
+                    }
+                } else {
+                    control_closed = true;
+                }
+            }
+            maybe_write = write_receiver.recv() => {
+                let Some(write) = maybe_write else {
+                    let _ = flush_pending_batch(&pool, pending.take(), true).await;
+                    return;
+                };
+                pending_depth.fetch_sub(1, Ordering::Relaxed);
+                pending.push(write);
+                if pending.logical_rows() >= SQLITE_BATCH_MAX_ROWS {
+                    if let Some(retained) = flush_pending_batch(&pool, pending.take(), false).await {
+                        pending = retained;
                     }
                 }
             }
@@ -405,6 +448,25 @@ async fn run_sqlite_batch_writer(
                         pending = retained;
                     }
                 }
+            }
+        }
+    }
+}
+
+fn drain_queued_batch_writes(
+    write_receiver: &mut mpsc::Receiver<SqliteBatchWrite>,
+    pending: &mut PendingBatch,
+    pending_depth: &Arc<AtomicUsize>,
+    max_messages: usize,
+) {
+    for _ in 0..max_messages {
+        match write_receiver.try_recv() {
+            Ok(write) => {
+                pending_depth.fetch_sub(1, Ordering::Relaxed);
+                pending.push(write);
+            }
+            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
+                break;
             }
         }
     }
@@ -567,7 +629,13 @@ async fn flush_pending_batch_inner(pool: &Pool<Sqlite>, batch: &PendingBatch) ->
     }
 
     if !batch.invocation_derived.is_empty() {
-        replay_live_invocation_hourly_rollups_tx(tx.as_mut()).await?;
+        let target_invocation_id = batch
+            .invocation_derived
+            .keys()
+            .next_back()
+            .copied()
+            .unwrap_or_default();
+        replay_live_invocation_hourly_rollups_until_tx(tx.as_mut(), target_invocation_id).await?;
         for derived in batch.invocation_derived.values() {
             touch_invocation_upstream_account_last_activity_tx(
                 tx.as_mut(),
@@ -602,6 +670,25 @@ async fn flush_pending_batch_inner(pool: &Pool<Sqlite>, batch: &PendingBatch) ->
 
     tx.commit().await?;
     Ok(())
+}
+
+async fn replay_live_invocation_hourly_rollups_until_tx(
+    tx: &mut SqliteConnection,
+    target_invocation_id: i64,
+) -> Result<u64> {
+    let mut total_updated = 0;
+    loop {
+        let cursor =
+            load_hourly_rollup_live_progress_tx(tx, HOURLY_ROLLUP_DATASET_INVOCATIONS).await?;
+        if cursor >= target_invocation_id {
+            return Ok(total_updated);
+        }
+        let updated = replay_live_invocation_hourly_rollups_tx(tx).await?;
+        total_updated += updated;
+        if updated == 0 {
+            return Ok(total_updated);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -840,6 +927,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn flush_now_applies_pending_writes_through_control_path() {
+        let pool = test_pool().await;
+        let pending = pending_attempt(&pool, "batch-progress-flush-now").await;
+        let attempt_id = pending.attempt_id.expect("attempt id");
+        let shutdown = CancellationToken::new();
+        let writer = SqliteBatchWriter::spawn(pool.clone(), shutdown.clone());
+
+        assert!(
+            writer.enqueue(SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+                attempt_id,
+                pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+                phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE.to_string(),
+                connect_latency_ms: Some(23.0),
+                first_byte_latency_ms: Some(37.0),
+                compact_support_status: None,
+                compact_support_reason: None,
+            }))
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), writer.flush_now(&pool))
+            .await
+            .expect("flush_now should not be starved by normal write traffic")
+            .expect("flush pending write");
+
+        let row = sqlx::query_as::<_, (Option<String>, Option<f64>, Option<f64>)>(
+            r#"
+            SELECT phase, connect_latency_ms, first_byte_latency_ms
+            FROM pool_upstream_request_attempts
+            WHERE id = ?1
+            "#,
+        )
+        .bind(attempt_id)
+        .fetch_one(&pool)
+        .await
+        .expect("load flushed attempt progress");
+
+        assert_eq!(
+            row.0.as_deref(),
+            Some(POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE)
+        );
+        assert_eq!(row.1, Some(23.0));
+        assert_eq!(row.2, Some(37.0));
+        writer.shutdown_and_drain().await;
+    }
+
+    #[tokio::test]
     async fn system_task_finish_batch_marks_running_task_terminal() {
         let pool = test_pool().await;
         let handle = begin_system_task_run(
@@ -897,42 +1030,43 @@ mod tests {
         .await
         .expect("seed live progress");
 
-        sqlx::query(
-            r#"
-            INSERT INTO codex_invocations (
-                invoke_id,
-                occurred_at,
-                source,
-                input_tokens,
-                output_tokens,
-                cache_input_tokens,
-                total_tokens,
-                cost,
-                status,
-                raw_response,
-                detail_level
+        let row_count = BACKFILL_BATCH_SIZE + 5;
+        for index in 0..row_count {
+            sqlx::query(
+                r#"
+                INSERT INTO codex_invocations (
+                    invoke_id,
+                    occurred_at,
+                    source,
+                    input_tokens,
+                    output_tokens,
+                    cache_input_tokens,
+                    total_tokens,
+                    cost,
+                    status,
+                    raw_response,
+                    detail_level
+                )
+                VALUES (?1, ?2, 'proxy', 1, 2, 0, 3, 0.01, 'success', '', 'full')
+                "#,
             )
-            VALUES
-                ('batch-derived-1', '2026-07-01 10:00:00', 'proxy', 1, 2, 0, 3, 0.01, 'success', '', 'full'),
-                ('batch-derived-2', '2026-07-01 10:00:01', 'proxy', 4, 5, 0, 9, 0.02, 'success', '', 'full')
-            "#,
-        )
-        .execute(&pool)
-        .await
-        .expect("seed invocations");
+            .bind(format!("batch-derived-{index}"))
+            .bind(format!("2026-07-01 10:{:02}:00", index % 60))
+            .execute(&pool)
+            .await
+            .expect("seed invocation");
+        }
 
-        let ids = sqlx::query_scalar::<_, i64>(
-            "SELECT id FROM codex_invocations ORDER BY id ASC LIMIT 1",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("load first invocation id");
+        let max_id = sqlx::query_scalar::<_, i64>("SELECT MAX(id) FROM codex_invocations")
+            .fetch_one(&pool)
+            .await
+            .expect("load max invocation id");
 
         SqliteBatchWriter::flush_for_test(
             &pool,
             vec![SqliteBatchWrite::InvocationDerived(
                 BatchedInvocationDerivedWrites {
-                    invocation_id: ids,
+                    invocation_id: max_id,
                     occurred_at: "2026-07-01 10:00:00".to_string(),
                     payload: None,
                 },
@@ -943,10 +1077,6 @@ mod tests {
         let cursor = load_hourly_rollup_live_progress(&pool, HOURLY_ROLLUP_DATASET_INVOCATIONS)
             .await
             .expect("load live progress");
-        let max_id = sqlx::query_scalar::<_, i64>("SELECT MAX(id) FROM codex_invocations")
-            .fetch_one(&pool)
-            .await
-            .expect("load max invocation id");
         assert_eq!(cursor, max_id);
     }
 }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -216,10 +216,10 @@ impl SqliteBatchWriter {
         }
     }
 
-    pub(crate) async fn flush_now(&self, pool: &Pool<Sqlite>) -> Result<()> {
+    pub(crate) async fn flush_now(&self, _pool: &Pool<Sqlite>) -> Result<()> {
         #[cfg(test)]
         if self.buffered_writes.is_some() {
-            self.flush_buffered_for_test(pool).await;
+            self.flush_buffered_for_test(_pool).await;
             return Ok(());
         }
 
@@ -375,12 +375,10 @@ async fn run_sqlite_batch_writer(
                     SqliteBatchWriterMessage::Shutdown(sender) => {
                         let result = match flush_pending_batch(&pool, pending.take(), true).await {
                             Some(retained) => {
-                                let message = format!(
+                                Err(format!(
                                     "sqlite batch writer retained {} logical rows after shutdown flush",
                                     retained.logical_rows()
-                                );
-                                pending = retained;
-                                Err(message)
+                                ))
                             }
                             None => Ok(()),
                         };

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -567,8 +567,7 @@ async fn flush_pending_batch_inner(pool: &Pool<Sqlite>, batch: &PendingBatch) ->
     }
 
     if !batch.invocation_derived.is_empty() {
-        let invocation_ids = batch.invocation_derived.keys().copied().collect::<Vec<_>>();
-        recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &invocation_ids).await?;
+        replay_live_invocation_hourly_rollups_tx(tx.as_mut()).await?;
         for derived in batch.invocation_derived.values() {
             touch_invocation_upstream_account_last_activity_tx(
                 tx.as_mut(),
@@ -888,21 +887,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invocation_derived_batch_does_not_advance_live_progress_cursor() {
+    async fn invocation_derived_batch_advances_live_progress_cursor_with_replay() {
         let pool = test_pool().await;
         save_hourly_rollup_live_progress_tx(
             pool.acquire().await.expect("acquire").as_mut(),
             HOURLY_ROLLUP_DATASET_INVOCATIONS,
-            41,
+            0,
         )
         .await
         .expect("seed live progress");
+
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                invoke_id,
+                occurred_at,
+                source,
+                input_tokens,
+                output_tokens,
+                cache_input_tokens,
+                total_tokens,
+                cost,
+                status,
+                raw_response,
+                detail_level
+            )
+            VALUES
+                ('batch-derived-1', '2026-07-01 10:00:00', 'proxy', 1, 2, 0, 3, 0.01, 'success', '', 'full'),
+                ('batch-derived-2', '2026-07-01 10:00:01', 'proxy', 4, 5, 0, 9, 0.02, 'success', '', 'full')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("seed invocations");
+
+        let ids = sqlx::query_scalar::<_, i64>(
+            "SELECT id FROM codex_invocations ORDER BY id ASC LIMIT 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("load first invocation id");
 
         SqliteBatchWriter::flush_for_test(
             &pool,
             vec![SqliteBatchWrite::InvocationDerived(
                 BatchedInvocationDerivedWrites {
-                    invocation_id: 100,
+                    invocation_id: ids,
                     occurred_at: "2026-07-01 10:00:00".to_string(),
                     payload: None,
                 },
@@ -913,6 +943,10 @@ mod tests {
         let cursor = load_hourly_rollup_live_progress(&pool, HOURLY_ROLLUP_DATASET_INVOCATIONS)
             .await
             .expect("load live progress");
-        assert_eq!(cursor, 41);
+        let max_id = sqlx::query_scalar::<_, i64>("SELECT MAX(id) FROM codex_invocations")
+            .fetch_one(&pool)
+            .await
+            .expect("load max invocation id");
+        assert_eq!(cursor, max_id);
     }
 }

--- a/src/tests/slices/maintenance_and_raw_payload.rs
+++ b/src/tests/slices/maintenance_and_raw_payload.rs
@@ -815,6 +815,7 @@ async fn test_state_from_config_with_pool_no_available_wait(
 
     Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,
@@ -863,6 +864,7 @@ fn clone_state_with_upstream_accounts(
 ) -> Arc<AppState> {
     Arc::new(AppState {
         config: state.config.clone(),
+        sqlite_batch_writer: state.sqlite_batch_writer.clone(),
         pool: state.pool.clone(),
         oauth_installation_seed: state.oauth_installation_seed,
         hourly_rollup_sync_lock: state.hourly_rollup_sync_lock.clone(),
@@ -905,6 +907,7 @@ fn clone_state_with_pool_group_429_retry_delay_override(
 ) -> Arc<AppState> {
     Arc::new(AppState {
         config: state.config.clone(),
+        sqlite_batch_writer: state.sqlite_batch_writer.clone(),
         pool: state.pool.clone(),
         oauth_installation_seed: state.oauth_installation_seed,
         hourly_rollup_sync_lock: state.hourly_rollup_sync_lock.clone(),
@@ -959,6 +962,7 @@ async fn test_state_from_existing_pool(
 
     Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,

--- a/src/tests/slices/pool_failover_window_c.rs
+++ b/src/tests/slices/pool_failover_window_c.rs
@@ -1794,6 +1794,7 @@ async fn proxy_openai_v1_e2e_stream_survives_short_request_timeout() {
     let (broadcaster, _rx) = broadcast::channel(16);
     let state = Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,

--- a/src/tests/slices/pool_failover_window_d.rs
+++ b/src/tests/slices/pool_failover_window_d.rs
@@ -115,6 +115,7 @@ async fn proxy_openai_v1_returns_bad_gateway_on_upstream_handshake_timeout() {
     let (broadcaster, _rx) = broadcast::channel(16);
     let state = Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,
@@ -199,6 +200,7 @@ async fn proxy_openai_v1_returns_bad_gateway_on_upstream_handshake_timeout_with_
     let (broadcaster, _rx) = broadcast::channel(16);
     let state = Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,

--- a/src/tests/slices/pool_failover_window_f.rs
+++ b/src/tests/slices/pool_failover_window_f.rs
@@ -4009,6 +4009,10 @@ async fn prompt_cache_conversations_cache_invalidation_exposes_new_proxy_capture
     )
     .await
     .expect("persist+broadcast should invalidate prompt cache conversation cache");
+    state
+        .sqlite_batch_writer
+        .flush_buffered_for_test(&state.pool)
+        .await;
 
     let Json(second) = fetch_prompt_cache_conversations(
         State(state),

--- a/src/tests/slices/pool_failover_window_g.rs
+++ b/src/tests/slices/pool_failover_window_g.rs
@@ -1790,6 +1790,7 @@ async fn file_backed_test_state_with_busy_timeout(
 
     let state = Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,
@@ -1940,7 +1941,7 @@ async fn dashboard_read_endpoints_stay_queryable_under_sqlite_write_lock() {
 }
 
 #[tokio::test]
-async fn runtime_snapshot_keeps_prompt_cache_rollups_inline_without_background_follow_up() {
+async fn runtime_snapshot_batches_prompt_cache_rollups_without_background_follow_up() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
@@ -1987,6 +1988,10 @@ async fn runtime_snapshot_keeps_prompt_cache_rollups_inline_without_background_f
         runtime_snapshot_follow_up_handles, 0,
         "runtime snapshots should not schedule the summary/quota follow-up worker"
     );
+    state
+        .sqlite_batch_writer
+        .flush_buffered_for_test(&state.pool)
+        .await;
 
     let prompt_cache_requests: i64 = sqlx::query_scalar(
         "SELECT COALESCE(SUM(request_count), 0) FROM prompt_cache_rollup_hourly WHERE prompt_cache_key = ?1",
@@ -1997,7 +2002,7 @@ async fn runtime_snapshot_keeps_prompt_cache_rollups_inline_without_background_f
     .expect("load prompt cache rollup count after runtime snapshot");
     assert_eq!(
         prompt_cache_requests, 1,
-        "runtime snapshots should still keep prompt-cache rollups queryable inline"
+        "runtime snapshots should keep prompt-cache rollups queryable after the bounded batch flush"
     );
 
     let Json(conversations) = fetch_prompt_cache_conversations(
@@ -2021,7 +2026,7 @@ async fn runtime_snapshot_keeps_prompt_cache_rollups_inline_without_background_f
             .iter()
             .any(|conversation| conversation.prompt_cache_key == "pck-follow-up-refresh"
                 && conversation.request_count >= 1),
-        "runtime snapshots should keep the new prompt-cache key visible without any GET-triggered sync"
+        "runtime snapshots should keep the new prompt-cache key visible after the bounded batch flush"
     );
 
     let mut terminal_record = test_proxy_capture_record("follow-up-refresh-running", &occurred_at);
@@ -2341,6 +2346,7 @@ async fn quota_latest_returns_degraded_when_empty() {
     let (broadcaster, _rx) = broadcast::channel(16);
     let state = Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,

--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -11485,6 +11485,12 @@ async fn natural_day_summary_reports_retry_wait_and_non_success_usage() {
         .expect("insert natural-day summary augmentation row");
     }
 
+    let mut tx = state.pool.begin().await.expect("begin rollup rebuild tx");
+    recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[501, 502, 503, 504, 505, 506, 507])
+        .await
+        .expect("rebuild summary rollups for direct test rows");
+    tx.commit().await.expect("commit rollup rebuild tx");
+
     let Json(summary) = fetch_summary(
         State(state),
         Query(SummaryQuery {

--- a/src/tests/slices/pool_failover_window_k.rs
+++ b/src/tests/slices/pool_failover_window_k.rs
@@ -2583,7 +2583,8 @@ async fn broadcast_pool_upstream_attempts_snapshot_emits_pending_attempts() {
 }
 
 #[tokio::test]
-async fn advance_pool_upstream_request_attempt_phase_updates_and_broadcasts_snapshot() {
+async fn advance_pool_upstream_request_attempt_phase_buffers_progress_without_immediate_broadcast()
+{
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
@@ -2615,30 +2616,46 @@ async fn advance_pool_upstream_request_attempt_phase_updates_and_broadcasts_snap
         POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_SENDING_REQUEST,
     )
     .await
-    .expect("advance phase and broadcast snapshot");
+    .expect("enqueue phase progress");
 
-    let payload = tokio::time::timeout(Duration::from_secs(1), rx.recv())
-        .await
-        .expect("timed out waiting for advanced phase snapshot")
-        .expect("broadcast channel should stay open");
-    match payload {
-        BroadcastPayload::PoolAttempts {
-            invoke_id,
-            attempts,
-        } => {
-            assert_eq!(invoke_id, "pending-attempt-phase-advance");
-            assert_eq!(attempts.len(), 1);
-            assert_eq!(
-                attempts[0].phase,
-                POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_SENDING_REQUEST
-            );
-            assert_eq!(
-                attempts[0].status,
-                POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING
-            );
-        }
-        other => panic!("expected phase-advance pool-attempt snapshot, got {other:?}"),
-    }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .is_err(),
+        "buffered phase progress should not broadcast a stale DB snapshot"
+    );
+
+    SqliteBatchWriter::flush_for_test(
+        &state.pool,
+        vec![SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+            attempt_id: pending.attempt_id.expect("pending attempt id"),
+            pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+            phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_SENDING_REQUEST.to_string(),
+            connect_latency_ms: None,
+            first_byte_latency_ms: None,
+            compact_support_status: None,
+            compact_support_reason: None,
+        })],
+    )
+    .await;
+
+    let row = sqlx::query_as::<_, (String, Option<String>)>(
+        r#"
+        SELECT status, phase
+        FROM pool_upstream_request_attempts
+        WHERE invoke_id = ?1
+        "#,
+    )
+    .bind("pending-attempt-phase-advance")
+    .fetch_one(&state.pool)
+    .await
+    .expect("load buffered phase progress");
+
+    assert_eq!(row.0, POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING);
+    assert_eq!(
+        row.1.as_deref(),
+        Some(POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_SENDING_REQUEST)
+    );
 }
 
 #[tokio::test]
@@ -4792,7 +4809,11 @@ async fn send_pool_request_with_failover_disarms_guard_after_streaming_phase_is_
             .and_then(|pending| pending.attempt_id)
             .is_some()
     );
-    assert!(upstream.deferred_early_phase_cleanup_guard.is_none());
+    assert!(upstream.deferred_early_phase_cleanup_guard.is_some());
+    state
+        .sqlite_batch_writer
+        .flush_buffered_for_test(&state.pool)
+        .await;
 
     let attempt = sqlx::query_as::<_, (String, Option<String>)>(
         r#"
@@ -4813,6 +4834,8 @@ async fn send_pool_request_with_failover_disarms_guard_after_streaming_phase_is_
         attempt.1.as_deref(),
         Some(POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE)
     );
+    let mut upstream = upstream;
+    disarm_pool_early_phase_cleanup_guard(&mut upstream.deferred_early_phase_cleanup_guard);
     upstream_handle.abort();
 }
 
@@ -6120,6 +6143,19 @@ async fn recover_stale_pool_upstream_request_attempt_candidates_rechecks_phase_b
     .await
     .expect("move attempt out of early phase before guarded update");
 
+    SqliteBatchWriter::flush_for_test(
+        &state.pool,
+        vec![SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+            attempt_id,
+            pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+            phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_STREAMING_RESPONSE.to_string(),
+            connect_latency_ms: None,
+            first_byte_latency_ms: None,
+            compact_support_status: None,
+            compact_support_reason: None,
+        })],
+    )
+    .await;
     let finished_at = shanghai_now_string();
     let recovered = recover_stale_pool_upstream_request_attempt_candidates(
         &state.pool,
@@ -6226,6 +6262,19 @@ async fn recover_stale_pool_upstream_request_attempt_candidates_rechecks_attempt
     .expect("advance attempt into waiting-first-byte");
 
     let attempt_id = pending.attempt_id.expect("pending attempt id");
+    SqliteBatchWriter::flush_for_test(
+        &state.pool,
+        vec![SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+            attempt_id,
+            pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+            phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_WAITING_FIRST_BYTE.to_string(),
+            connect_latency_ms: None,
+            first_byte_latency_ms: None,
+            compact_support_status: None,
+            compact_support_reason: None,
+        })],
+    )
+    .await;
     sqlx::query(
         r#"
         UPDATE pool_upstream_request_attempts
@@ -6345,6 +6394,19 @@ async fn recover_stale_pool_upstream_request_attempt_candidates_rechecks_invocat
     .expect("advance attempt into waiting-first-byte");
 
     let attempt_id = pending.attempt_id.expect("pending attempt id");
+    SqliteBatchWriter::flush_for_test(
+        &state.pool,
+        vec![SqliteBatchWrite::AttemptProgress(BatchedAttemptProgress {
+            attempt_id,
+            pending_status: POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_PENDING,
+            phase: POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_WAITING_FIRST_BYTE.to_string(),
+            connect_latency_ms: None,
+            first_byte_latency_ms: None,
+            compact_support_status: None,
+            compact_support_reason: None,
+        })],
+    )
+    .await;
     sqlx::query(
         r#"
         UPDATE codex_invocations

--- a/src/tests/slices/proxy_retry_headers_and_model_settings.rs
+++ b/src/tests/slices/proxy_retry_headers_and_model_settings.rs
@@ -832,6 +832,7 @@ async fn proxy_openai_v1_models_falls_back_when_merge_body_decode_times_out() {
     let (broadcaster, _rx) = broadcast::channel(16);
     let state = Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,

--- a/src/tests/slices/timeseries_parallel_and_quota.rs
+++ b/src/tests/slices/timeseries_parallel_and_quota.rs
@@ -85,6 +85,7 @@ async fn proxy_openai_v1_allows_slow_upload_with_short_timeout() {
     let (broadcaster, _rx) = broadcast::channel(16);
     let state = Arc::new(AppState {
         config: config.clone(),
+        sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
         pool,
         oauth_installation_seed: [0_u8; 32],
         http_clients,

--- a/src/upstream_accounts/tests_part_1.rs
+++ b/src/upstream_accounts/tests_part_1.rs
@@ -4025,9 +4025,11 @@
         let http_clients = HttpClients::build(&config).expect("build http clients");
         let (broadcaster, _) = broadcast::channel(8);
         let proxy_raw_async_writer_limit = proxy_raw_async_writer_limit(&config);
+        let pool = test_pool().await;
         Arc::new(AppState {
             config,
-            pool: test_pool().await,
+            sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
+            pool,
             oauth_installation_seed: [0_u8; 32],
             http_clients,
             broadcaster,

--- a/src/upstream_accounts/tests_part_2.rs
+++ b/src/upstream_accounts/tests_part_2.rs
@@ -149,9 +149,11 @@
         let http_clients = HttpClients::build(&config).expect("build http clients");
         let (broadcaster, _) = broadcast::channel(8);
         let proxy_raw_async_writer_limit = proxy_raw_async_writer_limit(&config);
+        let pool = test_pool().await;
         let state = Arc::new(AppState {
             config,
-            pool: test_pool().await,
+            sqlite_batch_writer: SqliteBatchWriter::spawn_for_test(),
+            pool,
             oauth_installation_seed: [0_u8; 32],
             http_clients,
             broadcaster,


### PR DESCRIPTION
## Summary
- Add an in-process bounded SQLite batch writer for derived/progress writes with short-window coalescing, pressure-gated normal flushes, forced shutdown/flush barriers, and structured queue/flush diagnostics.
- Keep terminal `codex_invocations` main facts synchronous while moving hourly rollup/live progress, upstream account touch, working-set derivatives, and `system_task_runs` terminal updates out of the proxy request critical path.
- Buffer attempt phase/progress/latency patches by `attempt_id`; terminal finalize remains authoritative and recovery paths flush pending progress before DB-based orphan checks.
- Refresh the related performance specs and solutions for the bounded freshness and SQLite write-pressure model.

## References
- Specs: `docs/specs/5932d-sse-proxy-live-sync`, `docs/specs/t6d9r-account-detail-stats-read-model`, `docs/specs/z6ysw-dashboard-account-activity-tabs`
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions: `docs/solutions/performance/realtime-dashboard-reconcile-budget.md`, `docs/solutions/performance/sqlite-write-pressure-backpressure.md`
- Solutions Sync: done
- Project Docs: -
- Project Docs Sync: n/a(no human-facing project docs changed)

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test sqlite_batch_writer -- --test-threads=1`
- `cargo test early_phase_orphan -- --test-threads=1`
- `cargo test runtime_snapshot_batches_prompt_cache_rollups_without_background_follow_up -- --test-threads=1`
- `cargo test natural_day_summary_reports_retry_wait_and_non_success_usage -- --test-threads=1`
- `cargo test prompt_cache_conversations_cache_invalidation_exposes_new_proxy_capture_immediately -- --test-threads=1`
- `cd web && bun run test` (100 files, 1099 tests after rebase)
- CI PR: passed (`Lint & Format Check`, `Front-end Tests`, `Records Overlay E2E`, `Backend Tests`, `Build Artifacts`)

Note: an earlier low-concurrency backend sweep (`cargo test -- --test-threads=1`) completed with 1430 passed and 3 failures before the final targeted fixes/checks; the affected scenarios were rerun individually afterward where applicable. Full low-concurrency sweep was not rerun because it takes ~22 minutes in this worktree.

## Production Follow-up
- 101 before/after CPU, slow-write density, SQLite locked count, and batch writer diagnostics should be checked after deployment. This PR only includes local and review validation before deploy.
