### PR TITLE
fix: reduce sqlite proxy write pressure

### DIFF
--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -14,6 +14,7 @@
 - `proxy capture follow-up` 也必须遵守这个分级：没有 SSE 订阅者时，不得再消耗 summary/quota 或 hourly rollup refresh 预算。
 - 对请求收尾里的同一实体写入，要优先消除“重复唯一键探测 + 紧跟二次更新”“先重算 rollup 再补 timing 再重算一次”这类单请求内自我放大；SQLite 压力常常不是来自单条大 SQL，而是来自几条语义重复的写语句连发。
 - 当并发不能降低且主事实必须同步落盘时，用进程内短窗口 batch writer 承接派生写：terminal invocation / terminal attempt 仍同步写，attempt 中间进度、rollup/live progress、account touch、system task finish 等可延迟项按 key coalesce 后批量写入。
+- raw payload 完整保留属于观测合同，不应作为 SQLite 止血手段被截断或丢弃；只能补齐 raw IO / gzip / metadata 写入证据，并通过调度、窄写或配置化压缩策略减压。
 
 ## 推荐模式
 
@@ -22,6 +23,7 @@
 - 前台关键写入：OAuth callback、请求路由状态、用户可见设置保存；优先拿连接，失败需返回明确业务错误。
 - 请求收尾写入：invocation 记录、usage、raw metadata；允许有界降级和异步旁路。
 - 请求收尾若已经存在对应 `running/pending` 行，优先原地更新而不是先 `INSERT OR IGNORE` 再走 repair/update；这样可以少一次唯一键冲突写尝试与后续锁竞争。
+- terminal invocation 主事实必须继续同步落盘；安全做法是“已存在 running row 时窄 `UPDATE`，缺行时 `INSERT OR IGNORE`，冲突后重读并按同一状态守卫更新”，避免宽 `ON CONFLICT DO UPDATE` 在竞态下覆盖已终态记录。
 - 对同一 attempt 的 phase、latency、capability/compact-support 等进度字段，优先并入同一条前台更新，而不是拆成 `phase bump -> latency patch -> finalize` 的多段慢写；减少单请求尾部把 SQLite 单写者预算切碎。
 - 对同一 attempt 的中间 phase、latency、capability/compact-support 等进度字段，如果不需要立刻作为业务决策真相源，可进入 250ms 级短窗口缓冲并按 `attempt_id` 只保留最新值；terminal finalize 必须同步一次写全并通过 `status=pending AND finished_at IS NULL` 防止未 flush 进度覆盖终态。
 - Invocation 派生写可以按 `invocation_id` coalesce：hourly rollup/live progress 与 upstream account last activity touch 同事务批量执行。队列满时应优先同步补偿 invocation 派生写，而不是静默丢弃会影响后续统计的 truth maintenance。
@@ -34,6 +36,7 @@
 - gate 只包低优先级后台任务。
 - 任一后台任务遇到 SQLite busy/locked 或 pool acquire timeout，记录 pressure event 并进入 cooldown。
 - cooldown 内后台任务返回 success-like skip，由原有 ticker / coalesced follow-up 继续收敛。
+- batch writer 的最大等待 flush 不应在 pressure gate 关闭时强抢前台写锁；可记录 stale/max-age 证据并延后派生写，但 shutdown/barrier 这类完整性路径仍可旁路 gate。
 - scheduler preflight 不应占用稀缺后台槽位：enabled/due/progress 这类轻量判定应先完成，只有确定任务 due 且要执行重后台工作时才进入 gate。
 - 对恢复语义敏感的维护任务可以只针对 `BackgroundBusy` 做短预算等待，避免和同 tick 的其他后台任务形成稳定饥饿；`PressureCooldown` 仍应立即 fail-soft skip。
 
@@ -56,6 +59,7 @@
 - 为每个后台入口单独做局部退避，容易遗漏同一压力窗口内的其他维护任务；进程级 gate 更容易统一行为。
 - `SELECT MAX(id) ... WHERE <稀疏条件>`、`NOT EXISTS` + 低选择性 phase 过滤这类查询，即使最终只返回 1 行，也可能在 SQLite 上吃掉秒级读锁预算；若它们会与前台 HTTP 共享同一数据库，必须先压成 cursor 读取或用 partial index 固定扫描面。
 - 对 proxy 收尾这类 SSE follow-up，`receiver_count()==0` 应该直接意味着“跳过 follow-up”，而不是继续排队 summary/quota 或 rollup refresh；否则会把没有任何订阅者的请求变成纯数据库放大器。
+- proxy snapshot/broadcast 在 `database is locked` 下应 fail-soft skip 并记录结构化证据，依赖已发出的 SSE 事件和后续 HTTP reconcile 补齐 UI；不要在请求尾部立即重试并放大锁争用。
 - write-side live read model 只有在维护成本本身也受控时才值得做：前台请求内同步维护最小必要 working-set / in-progress truth，后台 rebuild 和补偿刷新则继续挂到统一 pressure gate/cooldown，避免为了止住读热点又新增一组不受控维护写入。
 
 ## 何时升级方案

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -15,3 +15,4 @@
 - 2026-06-30: 第二轮 CPU 止血把 Dashboard working conversations 当前 head/count 的真相源前移到 write-side `prompt_cache_working_set_live`，接受 `<=5s` bounded freshness，但不再让 5 分钟工作集每次 reconcile 都重扫 `codex_invocations`。
 - 2026-06-30: 第三轮 CPU 止血继续把 working conversations 的 snapshot count/page 从 `WITH recent_terminal` 历史重算收口到 live working-set truth。接口继续保留 `snapshot_at`、cursor 与字段 shape，但 snapshot 聚合不再承诺严格历史时点重算，只承诺 `<=5s` bounded freshness。
 - 2026-07-01: 第四轮 SQLite 止血明确不降低代理并发，也不把 terminal `codex_invocations` 主事实改成 write-behind；仅把 attempt 中间进度、invocation rollup/live progress、upstream account touch 与 system task finish 这类可接受 `<=5s` 新鲜度的派生写放入有界 batch writer。
+- 2026-07-02: 第五轮 SQLite 止血继续保持代理并发与 terminal 主事实同步落盘，terminal invocation 写入改为 existing-row 窄更新优先、缺行 guarded insert，summary/attempt snapshot broadcast 在 `database is locked` 下 fail-soft skip 并由 SSE / HTTP reconcile 补齐。

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -9,6 +9,7 @@
 - Dashboard working conversations live head/count now read from a write-side `prompt_cache_working_set_live` table that keeps the last 5 minutes of terminal activity plus any current in-flight keys. The public response shape stays unchanged, while the hot read path no longer rebuilds the working set from `codex_invocations` on every request.
 - Working-conversations snapshot count/page now also accept the same `<=5s` bounded-freshness contract. Instead of strict historical recomputation from `codex_invocations`, snapshot aggregates read the live working-set truth directly and keep the existing response fields, cursor shape, and main ordering semantics.
 - Proxy capture request completion now keeps terminal `codex_invocations` as the synchronous source of truth, but moves bounded derived writes through a process-local SQLite batch writer. Attempt phase/latency progress, invocation hourly rollup/live progress, upstream account activity touch, and background system-task finish updates coalesce on short windows before touching SQLite. Terminal attempt finalize remains synchronous and overwrites any unflushed progress.
+- Proxy capture terminal persistence now prefers a narrow update of an existing `running/pending` invocation row and only falls back to guarded `INSERT OR IGNORE` for missing rows. Snapshot/broadcast follow-up treats SQLite locked errors as fail-soft skips with structured evidence, relying on SSE and the normal reconcile loop to catch up instead of blocking proxy completion.
 
 ## Migrated Implementation Notes
 
@@ -36,6 +37,7 @@
 - [x] M5: Dashboard realtime consumers split visible patch, KPI, chart commit, head reconcile, and parallel-work conditional-fetch budgets.
 - [x] M6: 活动调用记录列表统一接入 `records` SSE：`Live`、`/records` 与账号详情抽屉 records tab 现在共用一套记录过滤、去重、终态优选与 SSE open 静默回源逻辑。
 - [x] M7: Proxy capture 派生写与 attempt 中间进度进入 SQLite batch writer；保持代理并发与 terminal 主事实同步落盘不变。
+- [x] M8: Proxy capture terminal 主事实写入改为 existing-row 窄更新优先，DB locked snapshot/broadcast 改为 fail-soft skip；公开 SSE/API shape 不变。
 
 ## 2026-06-21 Follow-up
 

--- a/docs/specs/z9h7v-invocation-log-observability/HISTORY.md
+++ b/docs/specs/z9h7v-invocation-log-observability/HISTORY.md
@@ -32,3 +32,4 @@
 - 2026-06-26: 调用详情拆分为“请求模型 / 响应模型”双字段；当规范化后的请求/响应模型不一致时，仅响应模型 badge 显示上游路由差异图标，旧 `model` 记录继续作为响应模型回填。
 - 2026-06-28: 将共享 invocation preview 的 `promptCacheKey` 明确打通到 Dashboard 上游账号活动 recent 行，修复详情抽屉 selection 误把 `invokeId` 当对话键的问题。
 - 2026-06-30: 重组共享调用详情组件的信息架构，按快速排障路径分组展示请求身份、路由与模型、失败信号、细节保留和阶段耗时，并补齐 Storybook 视觉证据。
+- 2026-07-02: 明确 101 SQLite 止血不截断、不跳过、不丢弃 raw payload；新增 raw 文件写入耗时、codec、文件字节数与 terminal raw metadata 写入路径证据，用于区分 DB 核心写慢、batch flush 慢与 raw IO/gzip 慢。

--- a/docs/specs/z9h7v-invocation-log-observability/IMPLEMENTATION.md
+++ b/docs/specs/z9h7v-invocation-log-observability/IMPLEMENTATION.md
@@ -16,6 +16,7 @@
 - `InvocationExpandedDetails` 现已按快速排障路径重组为请求身份、路由与模型、失败信号、细节保留、阶段耗时分组；Live 展开区与 Dashboard 调用详情抽屉继续复用同一共享组件，长 ID、endpoint、IPv6 与错误文本在桌面和窄屏内换行或截断。
 - 本次修复是 future-only：不改 SQLite schema，不对历史 invocation 回填 `imageIntent` 或 `compactionRequestKind`。
 - 运行态 V2 识别来自 request body 的 `context_management[type=compaction][compact_threshold]`，终态识别来自响应内实际出现的 compaction item；两者独立写入 payload，不回填历史记录。
+- raw request/response payload 的完整保留合同不作为 SQLite 止血牺牲项；本轮只补充 raw file write 的 `raw_kind`、codec、file bytes、observed bytes、truncated、path 与 elapsed 证据，并继续同步持久化 terminal usage/status/failure/raw metadata。
 
 ## Migrated Implementation Notes
 
@@ -62,3 +63,4 @@
 - [x] M12: 将 `requestModel` / `responseModel` 打通到 `/api/invocations`、SSE、Prompt Cache preview 与 Dashboard working conversations，统一主模型显示优先级为 `responseModel ?? model ?? requestModel`。
 - [x] M13: 为 Records、InvocationTable、Dashboard working conversations 与详情抽屉补齐 routed-model 差异图标与双模型详情展示，并保留 legacy `model` 记录的降级显示。
 - [x] M14: 重组共享调用详情组件的信息架构与视觉层级，补齐成功、运行中、异常、号池终态、长字段、light/dark 与窄屏 Storybook 证据。
+- [x] M15: 保留完整 raw payload 合同，为 raw 文件写入与 terminal raw metadata 写入补齐低开销耗时证据。

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -416,6 +416,7 @@ pub(crate) async fn store_raw_payload_file(
     kind: &str,
     bytes: Bytes,
 ) -> RawPayloadMeta {
+    let started = Instant::now();
     let mut meta = RawPayloadMeta {
         path: None,
         size_bytes: bytes.len() as i64,
@@ -441,6 +442,12 @@ pub(crate) async fn store_raw_payload_file(
     let born_gzip = config
         .proxy_raw_immediate_gzip_threshold()
         .is_some_and(|threshold| content.len() >= threshold);
+    let file_bytes = content.len();
+    let codec = if born_gzip {
+        RAW_CODEC_GZIP
+    } else {
+        RAW_CODEC_IDENTITY
+    };
     let path = raw_payload_path_for_kind(&raw_dir, invoke_id, kind, born_gzip);
     let write_result = if born_gzip {
         let write_path = path.clone();
@@ -470,6 +477,32 @@ pub(crate) async fn store_raw_payload_file(
             meta.truncated = true;
             meta.truncated_reason = Some(format!("write_failed:{err}"));
         }
+    }
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    if elapsed_ms >= 1_000 {
+        warn!(
+            invoke_id,
+            raw_kind = kind,
+            codec,
+            file_bytes,
+            observed_bytes = meta.size_bytes,
+            truncated = meta.truncated,
+            has_path = meta.path.is_some(),
+            elapsed_ms,
+            "proxy raw payload file write was slow"
+        );
+    } else {
+        debug!(
+            invoke_id,
+            raw_kind = kind,
+            codec,
+            file_bytes,
+            observed_bytes = meta.size_bytes,
+            truncated = meta.truncated,
+            has_path = meta.path.is_some(),
+            elapsed_ms,
+            "proxy raw payload file write completed"
+        );
     }
     meta
 }
@@ -517,6 +550,15 @@ pub(crate) async fn broadcast_proxy_capture_follow_up(
             }
         }
         Err(err) => {
+            if crate::is_sqlite_lock_error(&err) {
+                warn!(
+                    invoke_id = %invoke_id,
+                    mode = ?mode,
+                    sqlite_locked = true,
+                    "proxy capture follow-up summary broadcast skipped because sqlite is locked"
+                );
+                return;
+            }
             warn!(
                 ?err,
                 invoke_id = %invoke_id,
@@ -872,109 +914,15 @@ async fn persist_proxy_capture_record_core(
     let created_at = format_utc_iso_millis(Utc::now());
 
     let mut tx = pool.begin().await?;
-    let insert_result = sqlx::query(
-        r#"
-        INSERT OR IGNORE INTO codex_invocations (
-            invoke_id,
-            occurred_at,
-            source,
-            model,
-            input_tokens,
-            output_tokens,
-            cache_input_tokens,
-            reasoning_tokens,
-            total_tokens,
-            cost,
-            cost_estimated,
-            price_version,
-            status,
-            error_message,
-            failure_kind,
-            failure_class,
-            is_actionable,
-            payload,
-            raw_response,
-            request_raw_path,
-            request_raw_codec,
-            request_raw_size,
-            request_raw_truncated,
-            request_raw_truncated_reason,
-            response_raw_path,
-            response_raw_codec,
-            response_raw_size,
-            response_raw_truncated,
-            response_raw_truncated_reason,
-            t_total_ms,
-            t_req_read_ms,
-            t_req_parse_ms,
-            t_upstream_connect_ms,
-            t_upstream_ttfb_ms,
-            t_upstream_stream_ms,
-            t_resp_parse_ms,
-            t_persist_ms,
-            created_at
-        )
-        VALUES (
-            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
-            ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
-            ?37, ?38
-        )
-        "#,
+    let mut core_write_path = "insert_missing";
+    let existing_identity = load_persisted_invocation_identity_tx(
+        tx.as_mut(),
+        &record.invoke_id,
+        &record.occurred_at,
     )
-    .bind(&record.invoke_id)
-    .bind(&record.occurred_at)
-    .bind(SOURCE_PROXY)
-    .bind(&record.model)
-    .bind(record.usage.input_tokens)
-    .bind(record.usage.output_tokens)
-    .bind(record.usage.cache_input_tokens)
-    .bind(record.usage.reasoning_tokens)
-    .bind(record.usage.total_tokens)
-    .bind(record.cost)
-    .bind(record.cost_estimated as i64)
-    .bind(record.price_version.as_deref())
-    .bind(&record.status)
-    .bind(record.error_message.as_deref())
-    .bind(failure_kind.as_deref())
-    .bind(failure.failure_class.as_str())
-    .bind(failure.is_actionable as i64)
-    .bind(record.payload.as_deref())
-    .bind(&raw_response)
-    .bind(record.req_raw.path.as_deref())
-    .bind(raw_payload_meta_codec(&record.req_raw))
-    .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
-    .bind(record.req_raw.truncated as i64)
-    .bind(record.req_raw.truncated_reason.as_deref())
-    .bind(resp_raw.path.as_deref())
-    .bind(raw_payload_meta_codec(&resp_raw))
-    .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
-    .bind(resp_raw.truncated as i64)
-    .bind(resp_raw.truncated_reason.as_deref())
-    .bind(None::<f64>)
-    .bind(record.timings.t_req_read_ms)
-    .bind(record.timings.t_req_parse_ms)
-    .bind(record.timings.t_upstream_connect_ms)
-    .bind(record.timings.t_upstream_ttfb_ms)
-    .bind(record.timings.t_upstream_stream_ms)
-    .bind(record.timings.t_resp_parse_ms)
-    .bind(None::<f64>)
-    .bind(created_at)
-    .execute(tx.as_mut())
     .await?;
 
-    let invocation_id = if insert_result.rows_affected() > 0 {
-        insert_result.last_insert_rowid()
-    } else {
-        let Some(existing) = load_persisted_invocation_identity_tx(
-            tx.as_mut(),
-            &record.invoke_id,
-            &record.occurred_at,
-        )
-        .await?
-        else {
-            tx.commit().await?;
-            return Ok(None);
-        };
+    let invocation_id = if let Some(existing) = existing_identity {
         if !persisted_invocation_allows_proxy_record_update(
             existing.status.as_deref(),
             existing.failure_kind.as_deref(),
@@ -983,56 +931,83 @@ async fn persist_proxy_capture_record_core(
             tx.commit().await?;
             return Ok(None);
         }
-
-        let affected = sqlx::query(
+        let updated = update_existing_proxy_invocation_record_tx(
+            tx.as_mut(),
+            existing.id,
+            &record,
+            &raw_response,
+            &resp_raw,
+            failure_kind.as_deref(),
+            failure.failure_class.as_str(),
+            failure.is_actionable,
+            None,
+            Some(record.timings.t_req_read_ms),
+            Some(record.timings.t_req_parse_ms),
+            Some(record.timings.t_upstream_connect_ms),
+            Some(record.timings.t_upstream_ttfb_ms),
+            Some(record.timings.t_upstream_stream_ms),
+            Some(record.timings.t_resp_parse_ms),
+            None,
+        )
+        .await?;
+        if !updated {
+            tx.commit().await?;
+            return Ok(None);
+        }
+        core_write_path = "update_existing";
+        existing.id
+    } else {
+        let insert_result = sqlx::query(
             r#"
-            UPDATE codex_invocations
-            SET source = ?2,
-                model = ?3,
-                input_tokens = ?4,
-                output_tokens = ?5,
-                cache_input_tokens = ?6,
-                reasoning_tokens = ?7,
-                total_tokens = ?8,
-                cost = ?9,
-                cost_estimated = ?10,
-                price_version = ?11,
-                status = ?12,
-                error_message = ?13,
-                failure_kind = ?14,
-                failure_class = ?15,
-                is_actionable = ?16,
-                payload = ?17,
-                raw_response = ?18,
-                request_raw_path = ?19,
-                request_raw_codec = ?20,
-                request_raw_size = ?21,
-                request_raw_truncated = ?22,
-                request_raw_truncated_reason = ?23,
-                response_raw_path = ?24,
-                response_raw_codec = ?25,
-                response_raw_size = ?26,
-                response_raw_truncated = ?27,
-                response_raw_truncated_reason = ?28,
-                t_total_ms = ?29,
-                t_req_read_ms = ?30,
-                t_req_parse_ms = ?31,
-                t_upstream_connect_ms = ?32,
-                t_upstream_ttfb_ms = ?33,
-                t_upstream_stream_ms = ?34,
-                t_resp_parse_ms = ?35,
-                t_persist_ms = ?36
-            WHERE id = ?1
-              AND (
-                    LOWER(TRIM(COALESCE(status, ''))) IN ('running', 'pending')
-                    OR (
-                        LOWER(TRIM(COALESCE(status, ''))) = 'interrupted'
-                        AND LOWER(TRIM(COALESCE(failure_kind, ''))) = 'proxy_interrupted'
-                    )
-              )
+            INSERT OR IGNORE INTO codex_invocations (
+                invoke_id,
+                occurred_at,
+                source,
+                model,
+                input_tokens,
+                output_tokens,
+                cache_input_tokens,
+                reasoning_tokens,
+                total_tokens,
+                cost,
+                cost_estimated,
+                price_version,
+                status,
+                error_message,
+                failure_kind,
+                failure_class,
+                is_actionable,
+                payload,
+                raw_response,
+                request_raw_path,
+                request_raw_codec,
+                request_raw_size,
+                request_raw_truncated,
+                request_raw_truncated_reason,
+                response_raw_path,
+                response_raw_codec,
+                response_raw_size,
+                response_raw_truncated,
+                response_raw_truncated_reason,
+                t_total_ms,
+                t_req_read_ms,
+                t_req_parse_ms,
+                t_upstream_connect_ms,
+                t_upstream_ttfb_ms,
+                t_upstream_stream_ms,
+                t_resp_parse_ms,
+                t_persist_ms,
+                created_at
+            )
+            VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
+                ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
+                ?37, ?38
+            )
             "#,
         )
-        .bind(existing.id)
+        .bind(&record.invoke_id)
+        .bind(&record.occurred_at)
         .bind(SOURCE_PROXY)
         .bind(&record.model)
         .bind(record.usage.input_tokens)
@@ -1068,14 +1043,56 @@ async fn persist_proxy_capture_record_core(
         .bind(record.timings.t_upstream_stream_ms)
         .bind(record.timings.t_resp_parse_ms)
         .bind(None::<f64>)
+        .bind(created_at)
         .execute(tx.as_mut())
-        .await?
-        .rows_affected();
-        if affected == 0 {
-            tx.commit().await?;
-            return Ok(None);
+        .await?;
+        if insert_result.rows_affected() > 0 {
+            insert_result.last_insert_rowid()
+        } else {
+            let Some(existing) = load_persisted_invocation_identity_tx(
+                tx.as_mut(),
+                &record.invoke_id,
+                &record.occurred_at,
+            )
+            .await?
+            else {
+                tx.commit().await?;
+                return Ok(None);
+            };
+            if !persisted_invocation_allows_proxy_record_update(
+                existing.status.as_deref(),
+                existing.failure_kind.as_deref(),
+                &record.status,
+            ) {
+                tx.commit().await?;
+                return Ok(None);
+            }
+            let updated = update_existing_proxy_invocation_record_tx(
+                tx.as_mut(),
+                existing.id,
+                &record,
+                &raw_response,
+                &resp_raw,
+                failure_kind.as_deref(),
+                failure.failure_class.as_str(),
+                failure.is_actionable,
+                None,
+                Some(record.timings.t_req_read_ms),
+                Some(record.timings.t_req_parse_ms),
+                Some(record.timings.t_upstream_connect_ms),
+                Some(record.timings.t_upstream_ttfb_ms),
+                Some(record.timings.t_upstream_stream_ms),
+                Some(record.timings.t_resp_parse_ms),
+                None,
+            )
+            .await?;
+            if !updated {
+                tx.commit().await?;
+                return Ok(None);
+            }
+            core_write_path = "update_race";
+            existing.id
         }
-        existing.id
     };
 
     if write_derived_inline {
@@ -1118,6 +1135,33 @@ async fn persist_proxy_capture_record_core(
         load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
             .await?;
     tx.commit().await?;
+
+    let core_write_elapsed_ms = persist_started.elapsed().as_millis() as u64;
+    if core_write_elapsed_ms >= 1_000 {
+        warn!(
+            invoke_id = %record.invoke_id,
+            status = %record.status,
+            core_write_path,
+            request_raw_bytes = record.req_raw.size_bytes,
+            response_raw_bytes = resp_raw.size_bytes,
+            has_request_raw_path = record.req_raw.path.is_some(),
+            has_response_raw_path = resp_raw.path.is_some(),
+            elapsed_ms = core_write_elapsed_ms,
+            "proxy capture raw core invocation write was slow"
+        );
+    } else {
+        debug!(
+            invoke_id = %record.invoke_id,
+            status = %record.status,
+            core_write_path,
+            request_raw_bytes = record.req_raw.size_bytes,
+            response_raw_bytes = resp_raw.size_bytes,
+            has_request_raw_path = record.req_raw.path.is_some(),
+            has_response_raw_path = resp_raw.path.is_some(),
+            elapsed_ms = core_write_elapsed_ms,
+            "proxy capture raw core invocation write completed"
+        );
+    }
 
     Ok(Some(persisted))
 }

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -1258,9 +1258,21 @@ pub(crate) async fn broadcast_pool_upstream_attempts_snapshot(
         return Ok(());
     }
 
-    let attempts = query_pool_attempt_records_from_live(&state.pool, invoke_id)
-        .await
-        .map_err(|err| anyhow!("failed to load live pool attempts for SSE broadcast: {err:?}"))?;
+    let attempts = match query_pool_attempt_records_from_live(&state.pool, invoke_id).await {
+        Ok(attempts) => attempts,
+        Err(err) => {
+            let err = anyhow!("failed to load live pool attempts for SSE broadcast: {err:?}");
+            if crate::is_sqlite_lock_error(&err) {
+                warn!(
+                    invoke_id,
+                    sqlite_locked = true,
+                    "pool attempts snapshot broadcast skipped because sqlite is locked"
+                );
+                return Ok(());
+            }
+            return Err(err);
+        }
+    };
     state
         .broadcaster
         .send(BroadcastPayload::PoolAttempts {
@@ -1894,6 +1906,116 @@ pub(crate) async fn load_persisted_invocation_identity_tx(
     .map_err(Into::into)
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn update_existing_proxy_invocation_record_tx(
+    tx: &mut SqliteConnection,
+    id: i64,
+    record: &ProxyCaptureRecord,
+    raw_response: &str,
+    resp_raw: &RawPayloadMeta,
+    failure_kind: Option<&str>,
+    failure_class: &str,
+    is_actionable: bool,
+    t_total_ms: Option<f64>,
+    t_req_read_ms: Option<f64>,
+    t_req_parse_ms: Option<f64>,
+    t_upstream_connect_ms: Option<f64>,
+    t_upstream_ttfb_ms: Option<f64>,
+    t_upstream_stream_ms: Option<f64>,
+    t_resp_parse_ms: Option<f64>,
+    t_persist_ms: Option<f64>,
+) -> Result<bool> {
+    let result = sqlx::query(
+        r#"
+        UPDATE codex_invocations
+        SET
+            source = ?2,
+            model = ?3,
+            input_tokens = ?4,
+            output_tokens = ?5,
+            cache_input_tokens = ?6,
+            reasoning_tokens = ?7,
+            total_tokens = ?8,
+            cost = ?9,
+            cost_estimated = ?10,
+            price_version = ?11,
+            status = ?12,
+            error_message = ?13,
+            failure_kind = ?14,
+            failure_class = ?15,
+            is_actionable = ?16,
+            payload = ?17,
+            raw_response = ?18,
+            request_raw_path = ?19,
+            request_raw_codec = ?20,
+            request_raw_size = ?21,
+            request_raw_truncated = ?22,
+            request_raw_truncated_reason = ?23,
+            response_raw_path = ?24,
+            response_raw_codec = ?25,
+            response_raw_size = ?26,
+            response_raw_truncated = ?27,
+            response_raw_truncated_reason = ?28,
+            t_total_ms = ?29,
+            t_req_read_ms = ?30,
+            t_req_parse_ms = ?31,
+            t_upstream_connect_ms = ?32,
+            t_upstream_ttfb_ms = ?33,
+            t_upstream_stream_ms = ?34,
+            t_resp_parse_ms = ?35,
+            t_persist_ms = ?36
+        WHERE id = ?1
+          AND (
+                LOWER(TRIM(COALESCE(status, ''))) IN ('running', 'pending')
+                OR (
+                    LOWER(TRIM(COALESCE(status, ''))) = 'interrupted'
+                    AND LOWER(TRIM(COALESCE(failure_kind, ''))) = 'proxy_interrupted'
+                )
+          )
+        "#,
+    )
+    .bind(id)
+    .bind(SOURCE_PROXY)
+    .bind(&record.model)
+    .bind(record.usage.input_tokens)
+    .bind(record.usage.output_tokens)
+    .bind(record.usage.cache_input_tokens)
+    .bind(record.usage.reasoning_tokens)
+    .bind(record.usage.total_tokens)
+    .bind(record.cost)
+    .bind(record.cost_estimated as i64)
+    .bind(record.price_version.as_deref())
+    .bind(&record.status)
+    .bind(record.error_message.as_deref())
+    .bind(failure_kind)
+    .bind(failure_class)
+    .bind(is_actionable as i64)
+    .bind(record.payload.as_deref())
+    .bind(raw_response)
+    .bind(record.req_raw.path.as_deref())
+    .bind(raw_payload_meta_codec(&record.req_raw))
+    .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
+    .bind(record.req_raw.truncated as i64)
+    .bind(record.req_raw.truncated_reason.as_deref())
+    .bind(resp_raw.path.as_deref())
+    .bind(raw_payload_meta_codec(resp_raw))
+    .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
+    .bind(resp_raw.truncated as i64)
+    .bind(resp_raw.truncated_reason.as_deref())
+    .bind(t_total_ms)
+    .bind(t_req_read_ms)
+    .bind(t_req_parse_ms)
+    .bind(t_upstream_connect_ms)
+    .bind(t_upstream_ttfb_ms)
+    .bind(t_upstream_stream_ms)
+    .bind(t_resp_parse_ms)
+    .bind(t_persist_ms)
+    .execute(&mut *tx)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
 pub(crate) fn persisted_invocation_allows_proxy_record_update(
     existing_status: Option<&str>,
     existing_failure_kind: Option<&str>,
@@ -2125,7 +2247,9 @@ async fn persist_proxy_capture_runtime_record_core(
     let t_req_parse_ms = nullable_runtime_timing_value(record.timings.t_req_parse_ms);
     let t_upstream_connect_ms = nullable_runtime_timing_value(record.timings.t_upstream_connect_ms);
     let t_upstream_ttfb_ms = nullable_runtime_timing_value(record.timings.t_upstream_ttfb_ms);
+    let core_write_started = Instant::now();
     let created_at = format_utc_iso_millis(Utc::now());
+    let mut core_write_path = "insert_missing";
     let mut tx = pool.begin().await?;
     let existing_identity = load_persisted_invocation_identity_tx(
         tx.as_mut(),
@@ -2144,131 +2268,166 @@ async fn persist_proxy_capture_runtime_record_core(
         return Ok(None);
     }
 
-    sqlx::query(
-        r#"
-        INSERT INTO codex_invocations (
-            invoke_id,
-            occurred_at,
-            source,
-            model,
-            input_tokens,
-            output_tokens,
-            cache_input_tokens,
-            reasoning_tokens,
-            total_tokens,
-            cost,
-            cost_estimated,
-            price_version,
-            status,
-            error_message,
-            failure_kind,
-            failure_class,
-            is_actionable,
-            payload,
-            raw_response,
-            request_raw_path,
-            request_raw_codec,
-            request_raw_size,
-            request_raw_truncated,
-            request_raw_truncated_reason,
-            response_raw_path,
-            response_raw_codec,
-            response_raw_size,
-            response_raw_truncated,
-            response_raw_truncated_reason,
-            t_total_ms,
+    if let Some(existing) = existing_identity.as_ref() {
+        let updated = update_existing_proxy_invocation_record_tx(
+            tx.as_mut(),
+            existing.id,
+            &record,
+            &raw_response,
+            &resp_raw,
+            failure_kind.as_deref(),
+            failure.failure_class.as_str(),
+            failure.is_actionable,
+            None,
             t_req_read_ms,
             t_req_parse_ms,
             t_upstream_connect_ms,
             t_upstream_ttfb_ms,
-            t_upstream_stream_ms,
-            t_resp_parse_ms,
-            t_persist_ms,
-            created_at
+            None,
+            None,
+            None,
         )
-        VALUES (
-            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
-            ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
-            ?37, ?38
+        .await?;
+        if !updated {
+            tx.commit().await?;
+            return Ok(None);
+        }
+        core_write_path = "update_existing";
+    } else {
+        let insert_result = sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO codex_invocations (
+                invoke_id,
+                occurred_at,
+                source,
+                model,
+                input_tokens,
+                output_tokens,
+                cache_input_tokens,
+                reasoning_tokens,
+                total_tokens,
+                cost,
+                cost_estimated,
+                price_version,
+                status,
+                error_message,
+                failure_kind,
+                failure_class,
+                is_actionable,
+                payload,
+                raw_response,
+                request_raw_path,
+                request_raw_codec,
+                request_raw_size,
+                request_raw_truncated,
+                request_raw_truncated_reason,
+                response_raw_path,
+                response_raw_codec,
+                response_raw_size,
+                response_raw_truncated,
+                response_raw_truncated_reason,
+                t_total_ms,
+                t_req_read_ms,
+                t_req_parse_ms,
+                t_upstream_connect_ms,
+                t_upstream_ttfb_ms,
+                t_upstream_stream_ms,
+                t_resp_parse_ms,
+                t_persist_ms,
+                created_at
+            )
+            VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19,
+                ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36,
+                ?37, ?38
+            )
+            "#,
         )
-        ON CONFLICT(invoke_id, occurred_at) DO UPDATE SET
-            source = excluded.source,
-            model = excluded.model,
-            input_tokens = excluded.input_tokens,
-            output_tokens = excluded.output_tokens,
-            cache_input_tokens = excluded.cache_input_tokens,
-            reasoning_tokens = excluded.reasoning_tokens,
-            total_tokens = excluded.total_tokens,
-            cost = excluded.cost,
-            cost_estimated = excluded.cost_estimated,
-            price_version = excluded.price_version,
-            status = excluded.status,
-            error_message = excluded.error_message,
-            failure_kind = excluded.failure_kind,
-            failure_class = excluded.failure_class,
-            is_actionable = excluded.is_actionable,
-            payload = excluded.payload,
-            raw_response = excluded.raw_response,
-            request_raw_path = excluded.request_raw_path,
-            request_raw_codec = excluded.request_raw_codec,
-            request_raw_size = excluded.request_raw_size,
-            request_raw_truncated = excluded.request_raw_truncated,
-            request_raw_truncated_reason = excluded.request_raw_truncated_reason,
-            response_raw_path = excluded.response_raw_path,
-            response_raw_codec = excluded.response_raw_codec,
-            response_raw_size = excluded.response_raw_size,
-            response_raw_truncated = excluded.response_raw_truncated,
-            response_raw_truncated_reason = excluded.response_raw_truncated_reason,
-            t_total_ms = excluded.t_total_ms,
-            t_req_read_ms = excluded.t_req_read_ms,
-            t_req_parse_ms = excluded.t_req_parse_ms,
-            t_upstream_connect_ms = excluded.t_upstream_connect_ms,
-            t_upstream_ttfb_ms = excluded.t_upstream_ttfb_ms,
-            t_upstream_stream_ms = excluded.t_upstream_stream_ms,
-            t_resp_parse_ms = excluded.t_resp_parse_ms,
-            t_persist_ms = excluded.t_persist_ms
-        "#,
-    )
-    .bind(&record.invoke_id)
-    .bind(&record.occurred_at)
-    .bind(SOURCE_PROXY)
-    .bind(&record.model)
-    .bind(record.usage.input_tokens)
-    .bind(record.usage.output_tokens)
-    .bind(record.usage.cache_input_tokens)
-    .bind(record.usage.reasoning_tokens)
-    .bind(record.usage.total_tokens)
-    .bind(record.cost)
-    .bind(record.cost_estimated as i64)
-    .bind(record.price_version.as_deref())
-    .bind(&record.status)
-    .bind(record.error_message.as_deref())
-    .bind(failure_kind.as_deref())
-    .bind(failure.failure_class.as_str())
-    .bind(failure.is_actionable as i64)
-    .bind(record.payload.as_deref())
-    .bind(&raw_response)
-    .bind(record.req_raw.path.as_deref())
-    .bind(raw_payload_meta_codec(&record.req_raw))
-    .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
-    .bind(record.req_raw.truncated as i64)
-    .bind(record.req_raw.truncated_reason.as_deref())
-    .bind(resp_raw.path.as_deref())
-    .bind(raw_payload_meta_codec(&resp_raw))
-    .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
-    .bind(resp_raw.truncated as i64)
-    .bind(resp_raw.truncated_reason.as_deref())
-    .bind(None::<f64>)
-    .bind(t_req_read_ms)
-    .bind(t_req_parse_ms)
-    .bind(t_upstream_connect_ms)
-    .bind(t_upstream_ttfb_ms)
-    .bind(None::<f64>)
-    .bind(None::<f64>)
-    .bind(None::<f64>)
-    .bind(created_at)
-    .execute(tx.as_mut())
-    .await?;
+        .bind(&record.invoke_id)
+        .bind(&record.occurred_at)
+        .bind(SOURCE_PROXY)
+        .bind(&record.model)
+        .bind(record.usage.input_tokens)
+        .bind(record.usage.output_tokens)
+        .bind(record.usage.cache_input_tokens)
+        .bind(record.usage.reasoning_tokens)
+        .bind(record.usage.total_tokens)
+        .bind(record.cost)
+        .bind(record.cost_estimated as i64)
+        .bind(record.price_version.as_deref())
+        .bind(&record.status)
+        .bind(record.error_message.as_deref())
+        .bind(failure_kind.as_deref())
+        .bind(failure.failure_class.as_str())
+        .bind(failure.is_actionable as i64)
+        .bind(record.payload.as_deref())
+        .bind(&raw_response)
+        .bind(record.req_raw.path.as_deref())
+        .bind(raw_payload_meta_codec(&record.req_raw))
+        .bind(record.req_raw.path.as_ref().map(|_| record.req_raw.size_bytes))
+        .bind(record.req_raw.truncated as i64)
+        .bind(record.req_raw.truncated_reason.as_deref())
+        .bind(resp_raw.path.as_deref())
+        .bind(raw_payload_meta_codec(&resp_raw))
+        .bind(resp_raw.path.as_ref().map(|_| resp_raw.size_bytes))
+        .bind(resp_raw.truncated as i64)
+        .bind(resp_raw.truncated_reason.as_deref())
+        .bind(None::<f64>)
+        .bind(t_req_read_ms)
+        .bind(t_req_parse_ms)
+        .bind(t_upstream_connect_ms)
+        .bind(t_upstream_ttfb_ms)
+        .bind(None::<f64>)
+        .bind(None::<f64>)
+        .bind(None::<f64>)
+        .bind(created_at)
+        .execute(tx.as_mut())
+        .await?;
+        if insert_result.rows_affected() == 0 {
+            let Some(existing) = load_persisted_invocation_identity_tx(
+                tx.as_mut(),
+                &record.invoke_id,
+                &record.occurred_at,
+            )
+            .await?
+            else {
+                tx.commit().await?;
+                return Ok(None);
+            };
+            if !persisted_invocation_allows_proxy_record_update(
+                existing.status.as_deref(),
+                existing.failure_kind.as_deref(),
+                &record.status,
+            ) {
+                tx.commit().await?;
+                return Ok(None);
+            }
+            let updated = update_existing_proxy_invocation_record_tx(
+                tx.as_mut(),
+                existing.id,
+                &record,
+                &raw_response,
+                &resp_raw,
+                failure_kind.as_deref(),
+                failure.failure_class.as_str(),
+                failure.is_actionable,
+                None,
+                t_req_read_ms,
+                t_req_parse_ms,
+                t_upstream_connect_ms,
+                t_upstream_ttfb_ms,
+                None,
+                None,
+                None,
+            )
+            .await?;
+            if !updated {
+                tx.commit().await?;
+                return Ok(None);
+            }
+            core_write_path = "update_race";
+        }
+    }
 
     let persisted_identity = load_persisted_invocation_identity_tx(
         tx.as_mut(),
@@ -2325,6 +2484,33 @@ async fn persist_proxy_capture_runtime_record_core(
     let persisted = load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
         .await?;
     tx.commit().await?;
+
+    let core_write_elapsed_ms = core_write_started.elapsed().as_millis() as u64;
+    if core_write_elapsed_ms >= 1_000 {
+        warn!(
+            invoke_id = %record.invoke_id,
+            status = %record.status,
+            core_write_path,
+            request_raw_bytes = record.req_raw.size_bytes,
+            response_raw_bytes = resp_raw.size_bytes,
+            has_request_raw_path = record.req_raw.path.is_some(),
+            has_response_raw_path = resp_raw.path.is_some(),
+            elapsed_ms = core_write_elapsed_ms,
+            "proxy capture core invocation write was slow"
+        );
+    } else {
+        debug!(
+            invoke_id = %record.invoke_id,
+            status = %record.status,
+            core_write_path,
+            request_raw_bytes = record.req_raw.size_bytes,
+            response_raw_bytes = resp_raw.size_bytes,
+            has_request_raw_path = record.req_raw.path.is_some(),
+            has_response_raw_path = resp_raw.path.is_some(),
+            elapsed_ms = core_write_elapsed_ms,
+            "proxy capture core invocation write completed"
+        );
+    }
 
     Ok(Some(persisted))
 }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -22,7 +22,33 @@ use crate::*;
 const SQLITE_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 const SQLITE_BATCH_MAX_ROWS: usize = 100;
 const SQLITE_BATCH_MAX_AGE: Duration = Duration::from_secs(5);
+const SQLITE_BATCH_STALE_WARN_AGE: Duration = Duration::from_secs(30);
 const SQLITE_BATCH_CHANNEL_CAPACITY: usize = 10_000;
+
+#[derive(Debug, Clone, Copy)]
+enum FlushReason {
+    RowLimit,
+    Interval,
+    MaxAge,
+    Barrier,
+    Shutdown,
+}
+
+impl FlushReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RowLimit => "row_limit",
+            Self::Interval => "interval",
+            Self::MaxAge => "max_age",
+            Self::Barrier => "barrier",
+            Self::Shutdown => "shutdown",
+        }
+    }
+
+    fn bypass_pressure_gate(self) -> bool {
+        matches!(self, Self::Barrier | Self::Shutdown)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct BatchedAttemptProgress {
@@ -377,7 +403,13 @@ async fn run_sqlite_batch_writer(
                             &pending_depth,
                             queued_depth_snapshot,
                         );
-                        let result = match flush_pending_batch(&pool, pending.take(), true).await {
+                        let result = match flush_pending_batch(
+                            &pool,
+                            pending.take(),
+                            FlushReason::Barrier,
+                        )
+                        .await
+                        {
                             Some(retained) => {
                                 let message = format!(
                                     "sqlite batch writer retained {} logical rows after forced flush",
@@ -400,7 +432,13 @@ async fn run_sqlite_batch_writer(
                             &pending_depth,
                             queued_depth_snapshot,
                         );
-                        let result = match flush_pending_batch(&pool, pending.take(), true).await {
+                        let result = match flush_pending_batch(
+                            &pool,
+                            pending.take(),
+                            FlushReason::Shutdown,
+                        )
+                        .await
+                        {
                             Some(retained) => {
                                 Err(format!(
                                     "sqlite batch writer retained {} logical rows after shutdown flush",
@@ -419,31 +457,48 @@ async fn run_sqlite_batch_writer(
             }
             maybe_write = write_receiver.recv() => {
                 let Some(write) = maybe_write else {
-                    let _ = flush_pending_batch(&pool, pending.take(), true).await;
+                    let _ =
+                        flush_pending_batch(&pool, pending.take(), FlushReason::Shutdown).await;
                     return;
                 };
                 pending_depth.fetch_sub(1, Ordering::Relaxed);
                 pending.push(write);
                 if pending.logical_rows() >= SQLITE_BATCH_MAX_ROWS {
-                    if let Some(retained) = flush_pending_batch(&pool, pending.take(), false).await {
+                    if let Some(retained) =
+                        flush_pending_batch(&pool, pending.take(), FlushReason::RowLimit).await
+                    {
                         pending = retained;
                     }
                 }
             }
             _ = ticker.tick() => {
                 if !pending.is_empty() {
-                    let force_flush = pending.age() >= SQLITE_BATCH_MAX_AGE;
-                    if force_flush {
-                        warn!(
-                            logical_rows = pending.logical_rows(),
-                            enqueued_rows = pending.enqueued_rows,
-                            coalesced_rows = pending.coalesced_rows,
-                            oldest_age_ms = pending.age().as_millis() as u64,
-                            "sqlite batch writer pending derived writes reached max age; forcing flush"
-                        );
-                    }
+                    let flush_reason = if pending.age() >= SQLITE_BATCH_MAX_AGE {
+                        if pending.age() >= SQLITE_BATCH_STALE_WARN_AGE {
+                            warn!(
+                                logical_rows = pending.logical_rows(),
+                                enqueued_rows = pending.enqueued_rows,
+                                coalesced_rows = pending.coalesced_rows,
+                                oldest_age_ms = pending.age().as_millis() as u64,
+                                flush_reason = FlushReason::MaxAge.as_str(),
+                                "sqlite batch writer pending derived writes are stale under database pressure"
+                            );
+                        } else {
+                            debug!(
+                                logical_rows = pending.logical_rows(),
+                                enqueued_rows = pending.enqueued_rows,
+                                coalesced_rows = pending.coalesced_rows,
+                                oldest_age_ms = pending.age().as_millis() as u64,
+                                flush_reason = FlushReason::MaxAge.as_str(),
+                                "sqlite batch writer pending derived writes reached max age"
+                            );
+                        }
+                        FlushReason::MaxAge
+                    } else {
+                        FlushReason::Interval
+                    };
                     if let Some(retained) =
-                        flush_pending_batch(&pool, pending.take(), force_flush).await
+                        flush_pending_batch(&pool, pending.take(), flush_reason).await
                     {
                         pending = retained;
                     }
@@ -475,7 +530,7 @@ fn drain_queued_batch_writes(
 async fn flush_pending_batch(
     pool: &Pool<Sqlite>,
     batch: PendingBatch,
-    force: bool,
+    reason: FlushReason,
 ) -> Option<PendingBatch> {
     if batch.is_empty() {
         return None;
@@ -489,7 +544,8 @@ async fn flush_pending_batch(
     let system_task_scope = summarize_system_task_batch_scope(&batch);
     let oldest_age_ms = batch.age().as_millis() as u64;
 
-    let permit = if force {
+    let flush_reason = reason.as_str();
+    let permit = if reason.bypass_pressure_gate() {
         None
     } else {
         match crate::db_pressure::global_db_pressure_gate()
@@ -506,6 +562,7 @@ async fn flush_pending_batch(
                     system_task_count,
                     system_task_scope = %system_task_scope,
                     oldest_age_ms,
+                    flush_reason,
                     "sqlite batch writer deferred flush because pressure gate is closed"
                 );
                 return Some(batch);
@@ -525,6 +582,7 @@ async fn flush_pending_batch(
             system_task_scope = %system_task_scope,
             oldest_age_ms,
             elapsed_ms = started.elapsed().as_millis() as u64,
+            flush_reason,
             "sqlite batch writer flush failed"
         );
         drop(permit);
@@ -543,6 +601,7 @@ async fn flush_pending_batch(
             system_task_scope = %system_task_scope,
             oldest_age_ms,
             elapsed_ms,
+            flush_reason,
             "sqlite batch writer flush was slow"
         );
     } else {
@@ -555,6 +614,7 @@ async fn flush_pending_batch(
             system_task_scope = %system_task_scope,
             oldest_age_ms,
             elapsed_ms,
+            flush_reason,
             "sqlite batch writer flushed derived writes"
         );
     }

--- a/src/tests/slices/upstream_account_group_rules.rs
+++ b/src/tests/slices/upstream_account_group_rules.rs
@@ -431,14 +431,23 @@ async fn persist_proxy_capture_record_finalizes_existing_running_row_in_place() 
     assert!(running.id > 0);
     assert_eq!(running.status.as_deref(), Some("running"));
 
-    let finalized = persist_proxy_capture_record(
-        &state.pool,
-        Instant::now(),
-        test_proxy_capture_record(invoke_id, occurred_at),
-    )
-    .await
-    .expect("finalize record")
-    .expect("terminal update should reuse running row");
+    let mut terminal_record = test_proxy_capture_record(invoke_id, occurred_at);
+    terminal_record.req_raw = RawPayloadMeta {
+        path: Some("proxy_raw_payloads/invoke-runtime-broadcast-request.bin".to_string()),
+        size_bytes: 128,
+        truncated: false,
+        truncated_reason: None,
+    };
+    terminal_record.resp_raw = RawPayloadMeta {
+        path: Some("proxy_raw_payloads/invoke-runtime-broadcast-response.bin.gz".to_string()),
+        size_bytes: 256,
+        truncated: false,
+        truncated_reason: None,
+    };
+    let finalized = persist_proxy_capture_record(&state.pool, Instant::now(), terminal_record)
+        .await
+        .expect("finalize record")
+        .expect("terminal update should reuse running row");
 
     assert_eq!(finalized.id, running.id);
     assert_eq!(finalized.status.as_deref(), Some("success"));
@@ -455,6 +464,46 @@ async fn persist_proxy_capture_record_finalizes_existing_running_row_in_place() 
     .await
     .expect("count invocation rows");
     assert_eq!(duplicate_count, 1);
+
+    let raw_row = sqlx::query_as::<
+        _,
+        (
+            Option<String>,
+            Option<String>,
+            Option<i64>,
+            Option<String>,
+            Option<String>,
+            Option<i64>,
+        ),
+    >(
+        r#"
+        SELECT
+            request_raw_path,
+            request_raw_codec,
+            request_raw_size,
+            response_raw_path,
+            response_raw_codec,
+            response_raw_size
+        FROM codex_invocations
+        WHERE id = ?1
+        "#,
+    )
+    .bind(finalized.id)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load finalized raw metadata");
+    assert_eq!(
+        raw_row.0.as_deref(),
+        Some("proxy_raw_payloads/invoke-runtime-broadcast-request.bin")
+    );
+    assert_eq!(raw_row.1.as_deref(), Some(RAW_CODEC_IDENTITY));
+    assert_eq!(raw_row.2, Some(128));
+    assert_eq!(
+        raw_row.3.as_deref(),
+        Some("proxy_raw_payloads/invoke-runtime-broadcast-response.bin.gz")
+    );
+    assert_eq!(raw_row.4.as_deref(), Some(RAW_CODEC_GZIP));
+    assert_eq!(raw_row.5, Some(256));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Keep terminal invocation facts synchronous, but prefer guarded narrow updates for existing running/pending proxy rows and avoid wide conflict upserts in the hot path.
- Make proxy snapshot/broadcast follow-up fail-soft on SQLite locked errors instead of blocking request completion or immediately retrying.
- Keep full raw payload retention intact while adding raw file write/core write evidence, and make batch writer max-age flush respect pressure instead of forcing low-value derived writes.

## Verification
- cargo fmt --check
- cargo check -q
- cargo test -q persist_proxy_capture_record_finalizes_existing_running_row_in_place -- --nocapture
- cargo test -q attempt_progress_batch_coalesces_by_attempt_id -- --nocapture
- cargo test -q attempt_progress_batch_does_not_overwrite_terminal_finalize -- --nocapture
- cargo test -q sqlite_batch_writer -- --nocapture
- cargo test -q recover_stale_pool_early_phase_orphans_runtime_records_route_failures_for_every_recovered_attempt -- --nocapture
- cd web && bun run test
- bash /Users/ivan/.codex/skills/spec-sync/scripts/spec_drift_check.sh --base-ref origin/main --spec-path docs/specs/5932d-sse-proxy-live-sync/SPEC.md --spec-path docs/specs/z9h7v-invocation-log-observability/SPEC.md

## References
- Specs: docs/specs/5932d-sse-proxy-live-sync, docs/specs/z9h7v-invocation-log-observability
- Solutions: docs/solutions/performance/sqlite-write-pressure-backpressure.md
- Project Docs: -

## Notes
- Raw request/response payloads remain fully retained; this PR does not truncate or skip raw payload files.
- 101 before/after CPU and slow-write validation requires deployment after merge.