### PR TITLE
fix: align working conversation totals with live window

### DIFF
--- a/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/aggregate_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/aggregate_queries.rs
@@ -1,5 +1,30 @@
 use super::*;
 
+fn append_working_set_freshness_filter<'a>(
+    query: &mut QueryBuilder<'a, Sqlite>,
+    range_start_bound: &'a str,
+    last_activity_column: &str,
+    last_terminal_column: &str,
+    last_in_flight_column: &str,
+) {
+    query
+        .push(" AND (")
+        .push(last_in_flight_column)
+        .push(" IS NOT NULL OR ")
+        .push(last_terminal_column)
+        .push(" >= ")
+        .push_bind(range_start_bound)
+        .push(" OR (")
+        .push(last_in_flight_column)
+        .push(" IS NULL AND ")
+        .push(last_terminal_column)
+        .push(" IS NULL AND ")
+        .push(last_activity_column)
+        .push(" >= ")
+        .push_bind(range_start_bound)
+        .push("))");
+}
+
 pub(crate) async fn query_prompt_cache_conversation_aggregates(
     pool: &Pool<Sqlite>,
     range_start_bound: &str,
@@ -74,16 +99,36 @@ pub(crate) async fn query_active_prompt_cache_conversation_count(
 
 pub(crate) async fn query_working_prompt_cache_conversation_count(
     pool: &Pool<Sqlite>,
-    _range_start_bound: &str,
+    range_start_bound: &str,
     source_scope: InvocationSourceScope,
 ) -> Result<i64> {
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT COUNT(*) AS count \
-         FROM prompt_cache_working_set_live \
-         WHERE source_scope_all = 1",
-    );
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source_scope_proxy_only = 1");
+    let mut query = QueryBuilder::<Sqlite>::new(match source_scope {
+        InvocationSourceScope::All => {
+            "SELECT COUNT(*) AS count \
+             FROM prompt_cache_working_set_live \
+             WHERE source_scope_all = 1"
+        }
+        InvocationSourceScope::ProxyOnly => {
+            "SELECT COUNT(*) AS count \
+             FROM prompt_cache_working_set_live \
+             WHERE source_scope_proxy_only = 1"
+        }
+    });
+    match source_scope {
+        InvocationSourceScope::All => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "last_activity_at",
+            "last_terminal_at",
+            "last_in_flight_at",
+        ),
+        InvocationSourceScope::ProxyOnly => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "proxy_last_activity_at",
+            "proxy_last_terminal_at",
+            "proxy_last_in_flight_at",
+        ),
     }
 
     let (count,) = query.build_query_as::<(i64,)>().fetch_one(pool).await?;
@@ -116,14 +161,37 @@ pub(crate) async fn query_in_progress_prompt_cache_conversation_count(
 
 pub(crate) async fn query_working_prompt_cache_conversation_count_at_snapshot(
     pool: &Pool<Sqlite>,
-    _range_start_bound: &str,
+    range_start_bound: &str,
     _snapshot: &PromptCacheConversationSnapshotFilter,
     source_scope: InvocationSourceScope,
 ) -> Result<i64> {
-    let mut query =
-        QueryBuilder::<Sqlite>::new("SELECT COUNT(*) AS count FROM prompt_cache_working_set_live");
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" WHERE source_scope_proxy_only = 1");
+    let mut query = QueryBuilder::<Sqlite>::new(match source_scope {
+        InvocationSourceScope::All => {
+            "SELECT COUNT(*) AS count \
+             FROM prompt_cache_working_set_live \
+             WHERE source_scope_all = 1"
+        }
+        InvocationSourceScope::ProxyOnly => {
+            "SELECT COUNT(*) AS count \
+             FROM prompt_cache_working_set_live \
+             WHERE source_scope_proxy_only = 1"
+        }
+    });
+    match source_scope {
+        InvocationSourceScope::All => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "last_activity_at",
+            "last_terminal_at",
+            "last_in_flight_at",
+        ),
+        InvocationSourceScope::ProxyOnly => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "proxy_last_activity_at",
+            "proxy_last_terminal_at",
+            "proxy_last_in_flight_at",
+        ),
     }
 
     let (count,) = query.build_query_as::<(i64,)>().fetch_one(pool).await?;
@@ -202,7 +270,7 @@ pub(crate) async fn query_prompt_cache_conversation_hidden_count(
 
 pub(crate) async fn query_prompt_cache_working_conversation_aggregates(
     pool: &Pool<Sqlite>,
-    _range_start_bound: &str,
+    range_start_bound: &str,
     source_scope: InvocationSourceScope,
     limit: i64,
 ) -> Result<Vec<PromptCacheConversationAggregateRow>> {
@@ -239,6 +307,22 @@ pub(crate) async fn query_prompt_cache_working_conversation_aggregates(
          WHERE source_scope_all = 1",
         );
     }
+    match source_scope {
+        InvocationSourceScope::All => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "last_activity_at",
+            "last_terminal_at",
+            "last_in_flight_at",
+        ),
+        InvocationSourceScope::ProxyOnly => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "proxy_last_activity_at",
+            "proxy_last_terminal_at",
+            "proxy_last_in_flight_at",
+        ),
+    }
     query
         .push(
             " ORDER BY sort_anchor_at DESC, created_at DESC, prompt_cache_key DESC \
@@ -255,7 +339,7 @@ pub(crate) async fn query_prompt_cache_working_conversation_aggregates(
 
 pub(crate) async fn query_prompt_cache_working_conversation_aggregates_page(
     pool: &Pool<Sqlite>,
-    _range_start_bound: &str,
+    range_start_bound: &str,
     _snapshot: &PromptCacheConversationSnapshotFilter,
     _snapshot_hour_start_epoch: i64,
     _snapshot_hour_start_bound: &str,
@@ -291,6 +375,22 @@ pub(crate) async fn query_prompt_cache_working_conversation_aggregates_page(
          FROM prompt_cache_working_set_live \
          WHERE source_scope_all = 1",
         );
+    }
+    match source_scope {
+        InvocationSourceScope::All => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "last_activity_at",
+            "last_terminal_at",
+            "last_in_flight_at",
+        ),
+        InvocationSourceScope::ProxyOnly => append_working_set_freshness_filter(
+            &mut query,
+            range_start_bound,
+            "proxy_last_activity_at",
+            "proxy_last_terminal_at",
+            "proxy_last_in_flight_at",
+        ),
     }
 
     if let Some((cursor_sort_anchor_at, cursor_created_at, cursor_prompt_cache_key, _)) = cursor {

--- a/src/tests/slices/pool_failover_window_f.rs
+++ b/src/tests/slices/pool_failover_window_f.rs
@@ -1914,6 +1914,128 @@ async fn prompt_cache_conversations_activity_minutes_paginated_preserves_sort_an
 }
 
 #[tokio::test]
+async fn prompt_cache_conversations_activity_minutes_exclude_stale_terminal_rows_from_totals() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let now = Utc::now();
+
+    async fn insert_row(
+        pool: &Pool<Sqlite>,
+        invoke_id: &str,
+        occurred_at: DateTime<Utc>,
+        key: &str,
+        status: &str,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            "#,
+        )
+        .bind(invoke_id)
+        .bind(format_naive(
+            occurred_at.with_timezone(&Shanghai).naive_local(),
+        ))
+        .bind(SOURCE_PROXY)
+        .bind(status)
+        .bind(42_i64)
+        .bind(0.01_f64)
+        .bind(
+            json!({
+                "promptCacheKey": key,
+                "routeMode": "pool",
+                "model": "gpt-5.4",
+            })
+            .to_string(),
+        )
+        .bind("{}")
+        .execute(pool)
+        .await
+        .expect("insert working row");
+    }
+
+    insert_row(
+        &state.pool,
+        "working-in-flight",
+        now - ChronoDuration::minutes(20),
+        "working-in-flight",
+        "running",
+    )
+    .await;
+    insert_row(
+        &state.pool,
+        "working-recent-terminal",
+        now - ChronoDuration::seconds(45),
+        "working-recent-terminal",
+        "success",
+    )
+    .await;
+    insert_row(
+        &state.pool,
+        "working-stale-terminal",
+        now - ChronoDuration::minutes(11),
+        "working-stale-terminal",
+        "success",
+    )
+    .await;
+
+    let Json(non_paginated) = fetch_prompt_cache_conversations(
+        State(state.clone()),
+        Query(PromptCacheConversationsQuery {
+            limit: None,
+            activity_hours: None,
+            activity_minutes: Some(5),
+            page_size: None,
+            cursor: None,
+            snapshot_at: None,
+            detail: None,
+            recent_invocation_limit: None,
+        }),
+    )
+    .await
+    .expect("non-paginated working conversations should succeed");
+
+    assert_eq!(non_paginated.conversations.len(), 2);
+    assert_eq!(
+        non_paginated
+            .conversations
+            .iter()
+            .map(|conversation| conversation.prompt_cache_key.as_str())
+            .collect::<Vec<_>>(),
+        vec!["working-recent-terminal", "working-in-flight"]
+    );
+
+    let Json(first_page) = fetch_prompt_cache_conversations(
+        State(state),
+        Query(PromptCacheConversationsQuery {
+            limit: None,
+            activity_hours: None,
+            activity_minutes: Some(5),
+            page_size: Some(20),
+            cursor: None,
+            snapshot_at: None,
+            detail: Some("compact".to_string()),
+            recent_invocation_limit: None,
+        }),
+    )
+    .await
+    .expect("paginated working conversations should succeed");
+
+    assert_eq!(
+        first_page.total_matched,
+        Some(2),
+        "snapshot totals must exclude stale terminal rows",
+    );
+    assert_eq!(first_page.conversations.len(), 2);
+    assert!(!first_page.has_more);
+    assert!(first_page.next_cursor.is_none());
+}
+
+#[tokio::test]
 async fn prompt_cache_conversations_paginated_cursors_support_prompt_cache_keys_with_pipes() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),


### PR DESCRIPTION
## Summary
- exclude stale terminal working-conversation rows from backend working-set counts
- apply the same live-window freshness filter to working-conversation pagination and aggregate queries
- add a regression test covering stale terminal rows inflating `totalMatched`

## Validation
- `cargo test stale_terminal_rows -- --nocapture`
- `cargo test prompt_cache_conversations_activity_minutes_paginated_preserves_sort_anchor_order -- --nocapture`
- `git diff --check`

## References
- Specs: -
- Solutions: `docs/solutions/performance/realtime-dashboard-reconcile-budget.md`
- Project Docs: -
