### PR TITLE
fix(web): expand inherited timeout overrides

### DIFF
--- a/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
@@ -139,7 +139,7 @@ jobs:
           fi
 
           if [ -n "${base_branch}" ]; then
-            git fetch --no-tags --depth=1 origin "${base_branch}"
+            git fetch --no-tags origin "${base_branch}"
             source_ref="origin/${base_branch}"
             source_kind="base-branch"
             if [ "${{ github.event_name }}" = "merge_group" ]; then

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -139,7 +139,7 @@ jobs:
           fi
 
           if [ -n "${base_branch}" ]; then
-            git fetch --no-tags --depth=1 origin "${base_branch}"
+            git fetch --no-tags origin "${base_branch}"
             source_ref="origin/${base_branch}"
             source_kind="base-branch"
             if [ "${{ github.event_name }}" = "merge_group" ]; then

--- a/web/src/components/EffectiveRoutingRuleCard.stories.tsx
+++ b/web/src/components/EffectiveRoutingRuleCard.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect } from 'storybook/test'
+import { expect, userEvent } from 'storybook/test'
 import type { UpdateGroupAccountRoutingRulePayload } from '../lib/api'
 import type { EffectiveRoutingRule } from '../lib/api'
 import { EffectiveRoutingRuleCard } from './EffectiveRoutingRuleCard'
@@ -409,6 +409,22 @@ function EditableRoutingRuleDemo({
 
 export const EditableInherited: Story = {
   render: () => <EditableRoutingRuleDemo initialRule={relaxedRule} />,
+  play: async ({ canvasElement }) => {
+    const timeoutButton = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Edit account override: Standard response first byte timeout"]',
+    )
+    if (!timeoutButton) {
+      throw new Error('missing inherited timeout edit button')
+    }
+
+    await userEvent.click(timeoutButton)
+
+    expect(
+      canvasElement.querySelector<HTMLInputElement>(
+        'input[name="responsesFirstByteTimeoutSecs"]',
+      ),
+    ).not.toBeNull()
+  },
 }
 
 export const EditableAccountOverrides: Story = {

--- a/web/src/components/EffectiveRoutingRuleCard.test.tsx
+++ b/web/src/components/EffectiveRoutingRuleCard.test.tsx
@@ -264,6 +264,70 @@ describe('EffectiveRoutingRuleCard', () => {
     expect(timeoutButton?.disabled).toBe(false)
   })
 
+  it('expands an inherited timeout row instead of clearing it', () => {
+    const onChange = vi.fn()
+    render(
+      <EffectiveRoutingRuleCard
+        rule={buildRule()}
+        labels={labels}
+        editablePolicy={{ onChange }}
+      />,
+    )
+
+    const timeoutButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Edit account override: Standard response first byte timeout"]',
+    )
+
+    act(() => {
+      timeoutButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(
+      document.querySelector<HTMLInputElement>(
+        'input[name="responsesFirstByteTimeoutSecs"]',
+      ),
+    ).not.toBeNull()
+  })
+
+  it('clears an account timeout override when its active override button is clicked', () => {
+    const onChange = vi.fn()
+    render(
+      <EffectiveRoutingRuleCard
+        rule={buildRule({
+          timeouts: {
+            responsesFirstByteTimeoutSecs: 180,
+            compactFirstByteTimeoutSecs: 300,
+            responsesStreamTimeoutSecs: 300,
+            compactStreamTimeoutSecs: 300,
+          },
+          timeoutFieldSources: {
+            responsesFirstByteTimeoutSecs: 'account',
+            compactFirstByteTimeoutSecs: 'root',
+            responsesStreamTimeoutSecs: 'root',
+            compactStreamTimeoutSecs: 'root',
+          },
+        })}
+        labels={labels}
+        editablePolicy={{ onChange }}
+      />,
+    )
+
+    const timeoutButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Clear account override: Standard response first byte timeout"]',
+    )
+
+    act(() => {
+      timeoutButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onChange).toHaveBeenCalledWith('timeoutResponsesFirstByte', {
+      timeouts: {
+        responsesFirstByteTimeoutSecs: null,
+      },
+    })
+  })
+
   it('expands the first account override by default', () => {
     render(
       <EffectiveRoutingRuleCard

--- a/web/src/components/EffectiveRoutingRuleCard.tsx
+++ b/web/src/components/EffectiveRoutingRuleCard.tsx
@@ -379,7 +379,7 @@ export function EffectiveRoutingRuleCard({ rule, identityKey, labels, editablePo
     ]
     setExpandedFields((current) => {
       if (userTouchedExpansionRef.current) return current
-      if (current.some((field) => fieldToSource(field, fieldSources) === 'account')) return current
+      if (current.some((field) => fieldToSource(field, fieldSources, timeoutSources) === 'account')) return current
       return nextDefaultExpandedFields
     })
   }, [
@@ -424,7 +424,7 @@ export function EffectiveRoutingRuleCard({ rule, identityKey, labels, editablePo
     clearPayload: UpdateGroupAccountRoutingRulePayload,
   ) => {
     userTouchedExpansionRef.current = true
-    const active = fieldToSource(field, fieldSources) === 'account'
+    const active = fieldToSource(field, fieldSources, timeoutSources) === 'account'
     if (active) {
       clearField(field, clearPayload)
       return
@@ -862,7 +862,11 @@ export function EffectiveRoutingRuleCard({ rule, identityKey, labels, editablePo
   )
 }
 
-function fieldToSource(field: EditablePolicyField, sources: FieldSourceMap): string {
+function fieldToSource(
+  field: EditablePolicyField,
+  sources: FieldSourceMap,
+  timeoutSources: EffectiveRoutingTimeoutFieldSources,
+): string {
   switch (field) {
     case 'allowNewConversations':
       return sources.blockNewConversations
@@ -883,13 +887,13 @@ function fieldToSource(field: EditablePolicyField, sources: FieldSourceMap): str
     case 'availableModels':
       return sources.availableModels ?? 'root'
     case 'timeoutResponsesFirstByte':
-      return 'account'
+      return timeoutSources.responsesFirstByteTimeoutSecs
     case 'timeoutCompactFirstByte':
-      return 'account'
+      return timeoutSources.compactFirstByteTimeoutSecs
     case 'timeoutResponsesStream':
-      return 'account'
+      return timeoutSources.responsesStreamTimeoutSecs
     case 'timeoutCompactStream':
-      return 'account'
+      return timeoutSources.compactStreamTimeoutSecs
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix inherited/root timeout edit clicks so they expand an override editor instead of trying to clear an account override.
- Add focused component coverage for inherited timeout expansion and account timeout clearing.
- Preserve the PR merge-base in quality-gates trusted source resolution by avoiding shallow refetch of the base branch.

## Verification
- cd web && bun run test -- EffectiveRoutingRuleCard.test.tsx
- cd web && bun run test-storybook -- EffectiveRoutingRuleCard.stories.tsx (no tests matched in current config)
- cd web && bun run build-storybook
- python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --declaration .github/quality-gates.json --metadata-script .github/scripts/metadata_gate.py --profile final
- bash .github/scripts/test-quality-gates-contract.sh
- git diff --check

## References
- Specs: -
- Solutions: docs/solutions/workflow/release-arm64-build-retry-hardening.md
- Project Docs: -

## Sync
- Spec Sync: n/a (spec-free)
- Spec Drift: none
- Solutions Sync: n/a (referenced, no doc change)
- Project Docs Sync: n/a (no project-doc change)

## Notes
- Visual evidence is intentionally omitted for this PR per owner instruction.
