### PR TITLE
test: stabilize early phase guard cleanup wait

### DIFF
--- a/src/tests/slices/pool_failover_window_k.rs
+++ b/src/tests/slices/pool_failover_window_k.rs
@@ -4993,40 +4993,60 @@ async fn send_pool_request_with_failover_keeps_early_phase_guard_armed_when_stre
     assert!(upstream.deferred_early_phase_cleanup_guard.is_some());
 
     drop(upstream);
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let attempt = sqlx::query_as::<_, (String, Option<String>, Option<String>)>(
-        r#"
-        SELECT status, phase, failure_kind
-        FROM pool_upstream_request_attempts
-        WHERE invoke_id = ?1 AND occurred_at = ?2
-        ORDER BY id DESC
-        LIMIT 1
-        "#,
-    )
-    .bind(invoke_id)
-    .bind(occurred_at)
-    .fetch_one(&state.pool)
-    .await
-    .expect("load attempt after suppressed streaming-phase update");
+    let attempt = {
+        let mut poll_count = 0;
+        loop {
+            let attempt = sqlx::query_as::<_, (String, Option<String>, Option<String>)>(
+                r#"
+                SELECT status, phase, failure_kind
+                FROM pool_upstream_request_attempts
+                WHERE invoke_id = ?1 AND occurred_at = ?2
+                ORDER BY id DESC
+                LIMIT 1
+                "#,
+            )
+            .bind(invoke_id)
+            .bind(occurred_at)
+            .fetch_one(&state.pool)
+            .await
+            .expect("load attempt after suppressed streaming-phase update");
+            if attempt.0 == POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE
+                || poll_count >= 100
+            {
+                break attempt;
+            }
+            poll_count += 1;
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    };
     assert_eq!(attempt.0, POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE);
     assert_eq!(attempt.1.as_deref(), Some(POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_FAILED));
     assert_eq!(attempt.2.as_deref(), Some(PROXY_FAILURE_POOL_ATTEMPT_INTERRUPTED));
 
-    let invocation = sqlx::query_as::<_, (String, Option<String>)>(
-        r#"
-        SELECT status, failure_kind
-        FROM codex_invocations
-        WHERE invoke_id = ?1 AND occurred_at = ?2
-        ORDER BY id DESC
-        LIMIT 1
-        "#,
-    )
-    .bind(invoke_id)
-    .bind(occurred_at)
-    .fetch_one(&state.pool)
-    .await
-    .expect("load invocation after suppressed streaming-phase update");
+    let invocation = {
+        let mut poll_count = 0;
+        loop {
+            let invocation = sqlx::query_as::<_, (String, Option<String>)>(
+                r#"
+                SELECT status, failure_kind
+                FROM codex_invocations
+                WHERE invoke_id = ?1 AND occurred_at = ?2
+                ORDER BY id DESC
+                LIMIT 1
+                "#,
+            )
+            .bind(invoke_id)
+            .bind(occurred_at)
+            .fetch_one(&state.pool)
+            .await
+            .expect("load invocation after suppressed streaming-phase update");
+            if invocation.0 == INVOCATION_STATUS_INTERRUPTED || poll_count >= 100 {
+                break invocation;
+            }
+            poll_count += 1;
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    };
     assert_eq!(invocation.0, INVOCATION_STATUS_INTERRUPTED);
     assert_eq!(
         invocation.1.as_deref(),


### PR DESCRIPTION
## Summary
- Replace the fixed 50ms cleanup wait in the early-phase guard test with bounded polling for the terminal attempt and invocation states.
- Preserve the existing assertions so timeout diagnostics still show the last observed database state.

## Verification
- cargo fmt --all -- --check
- cargo test --locked --all-features send_pool_request_with_failover_keeps_early_phase_guard_armed_when_streaming_phase_was_not_persisted -- --nocapture
- 20x targeted stress loop for send_pool_request_with_failover_keeps_early_phase_guard_armed_when_streaming_phase_was_not_persisted

## References
- Specs: -
- Solutions: -
- Project Docs: -