### PR TITLE
fix(api): exclude terminal runtime rows from summary overlay

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -62,6 +62,7 @@ Using one cadence for all three overfits the most urgent surface and overloads t
 - Large retained-history drawers need a separate history budget: load the first visible page only, fetch additional pages from the drawer scroll threshold, and let SSE refresh merge the already loaded range rather than replaying from page 1 to `total`.
 - Virtualize dense invocation surfaces at the shared table component, and render only the active responsive layout. Hidden desktop/mobile duplicates still contribute DOM and event-handler pressure.
 - Do not let HTTP open-resync depend on DB persistence of transient runtime rows. If DB writes are intentionally skipped for `running` snapshots, open-resync must overlay the same runtime store used by SSE; otherwise the UI will flicker or lose visible in-flight rows until terminal.
+- Apply terminal-DB exclusion to every runtime overlay path, including stats summary live augmentation. A runtime memory row may outlive terminal persistence after a missed cleanup, so overlay code must query terminal DB keys and skip matching memory rows before counting in-progress totals, retry totals, or wait averages.
 
 ## References
 

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -49,7 +49,7 @@
 - Storybook 现有详情抽屉 overlay stories 继续作为 page-fallback 证据面，覆盖 owner-facing 概览页活动总览、records 表格本体与 records 无限滚动场景。
 - 第七轮止血把账号详情 records/current summary/account-activity 的 running 视图统一改为 DB 结果 + 进程内 runtime store overlay。`running/pending` 过程态不再依赖 `codex_invocations` 的常规刷新写；terminal 主事实落库后仍会覆盖并移除对应内存行，账号详情公开字段不变。
 - summary live augmentation 在叠加进程内 runtime store 前会先查询同 key 的 terminal DB rows；即使某条内存 `running` 快照未被 terminal cleanup 清掉，也不会继续贡献 in-progress 总数、retry 总数或 wait 平均值。
-- 自然日 summary 测试夹具会把 `earlier_today` 限定在当前时刻之前，避免在 Asia/Shanghai 自然日开始后的前半小时造出未来行并误排除非成功用量。
+- 自然日 summary 测试夹具会把 `earlier_today` 限定在当前 Asia/Shanghai 自然日内且不落到未来，避免自然日开始后的前半小时造出未来行并误排除非成功用量。
 
 ## Verification
 

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -48,6 +48,7 @@
 - 第六轮止血继续收窄账号相关写锁：路由账号选择的 `last_selected_at` 不再在前台同步更新账号表，而是先记录到进程内公平性锚点并叠加到候选排序，再通过 batch writer 按账号 coalesce 落库。账号 status、cooldown 与 failure 仍保持同步写，因为它们是路由正确性的主事实。
 - Storybook 现有详情抽屉 overlay stories 继续作为 page-fallback 证据面，覆盖 owner-facing 概览页活动总览、records 表格本体与 records 无限滚动场景。
 - 第七轮止血把账号详情 records/current summary/account-activity 的 running 视图统一改为 DB 结果 + 进程内 runtime store overlay。`running/pending` 过程态不再依赖 `codex_invocations` 的常规刷新写；terminal 主事实落库后仍会覆盖并移除对应内存行，账号详情公开字段不变。
+- summary live augmentation 在叠加进程内 runtime store 前会先查询同 key 的 terminal DB rows；即使某条内存 `running` 快照未被 terminal cleanup 清掉，也不会继续贡献 in-progress 总数、retry 总数或 wait 平均值。
 
 ## Verification
 

--- a/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
+++ b/docs/specs/t6d9r-account-detail-stats-read-model/IMPLEMENTATION.md
@@ -49,6 +49,7 @@
 - Storybook 现有详情抽屉 overlay stories 继续作为 page-fallback 证据面，覆盖 owner-facing 概览页活动总览、records 表格本体与 records 无限滚动场景。
 - 第七轮止血把账号详情 records/current summary/account-activity 的 running 视图统一改为 DB 结果 + 进程内 runtime store overlay。`running/pending` 过程态不再依赖 `codex_invocations` 的常规刷新写；terminal 主事实落库后仍会覆盖并移除对应内存行，账号详情公开字段不变。
 - summary live augmentation 在叠加进程内 runtime store 前会先查询同 key 的 terminal DB rows；即使某条内存 `running` 快照未被 terminal cleanup 清掉，也不会继续贡献 in-progress 总数、retry 总数或 wait 平均值。
+- 自然日 summary 测试夹具会把 `earlier_today` 限定在当前时刻之前，避免在 Asia/Shanghai 自然日开始后的前半小时造出未来行并误排除非成功用量。
 
 ## Verification
 

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -2536,6 +2536,8 @@ async fn load_in_progress_summary_snapshot(
         .fetch_all(&state.pool)
         .await?;
     let runtime_snapshot = state.proxy_runtime_invocations.snapshot();
+    let db_terminal_keys =
+        query_terminal_db_keys_for_runtime_records(&state.pool, &runtime_snapshot, None).await?;
     let runtime_by_key = runtime_snapshot
         .iter()
         .map(|record| {
@@ -2576,6 +2578,9 @@ async fn load_in_progress_summary_snapshot(
         .collect::<HashMap<_, _>>();
     let runtime_records = runtime_snapshot
         .into_iter()
+        .filter(|record| {
+            !db_terminal_keys.contains(&(record.invoke_id.clone(), record.occurred_at.clone()))
+        })
         .filter(|record| runtime_record_matches_filters(record, &filter, source_scope))
         .collect::<Vec<_>>();
     let runtime_in_progress_count = runtime_records

--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -11475,11 +11475,13 @@ async fn natural_day_summary_reports_retry_wait_and_non_success_usage() {
     let previous_complete_hour_utc =
         (current_hour_utc - ChronoDuration::hours(1)).max(today_start_utc);
     let occurred_at = format_naive(now_utc.with_timezone(&Shanghai).naive_local());
-    let earlier_today = format_naive(
-        (previous_complete_hour_utc + ChronoDuration::minutes(30))
-            .with_timezone(&Shanghai)
-            .naive_local(),
-    );
+    let earlier_today_utc = previous_complete_hour_utc + ChronoDuration::minutes(30);
+    let earlier_today_utc = if earlier_today_utc < now_utc {
+        earlier_today_utc
+    } else {
+        now_utc - ChronoDuration::seconds(1)
+    };
+    let earlier_today = format_naive(earlier_today_utc.with_timezone(&Shanghai).naive_local());
 
     for (
         id,

--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -11479,7 +11479,7 @@ async fn natural_day_summary_reports_retry_wait_and_non_success_usage() {
     let earlier_today_utc = if earlier_today_utc < now_utc {
         earlier_today_utc
     } else {
-        now_utc - ChronoDuration::seconds(1)
+        (now_utc - ChronoDuration::seconds(1)).max(today_start_utc)
     };
     let earlier_today = format_naive(earlier_today_utc.with_timezone(&Shanghai).naive_local());
 

--- a/src/tests/slices/pool_failover_window_h.rs
+++ b/src/tests/slices/pool_failover_window_h.rs
@@ -11340,6 +11340,127 @@ async fn empty_summary_response_keeps_live_in_progress_conversation_count() {
 }
 
 #[tokio::test]
+async fn summary_ignores_runtime_overlay_records_with_terminal_db_rows() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let occurred_at = format_naive(Utc::now().with_timezone(&Shanghai).naive_local());
+    let request_info = RequestCaptureInfo {
+        model: Some("gpt-5.5".to_string()),
+        prompt_cache_key: Some("pck-summary-runtime-terminal".to_string()),
+        is_stream: true,
+        ..RequestCaptureInfo::default()
+    };
+
+    let stale_runtime_record = build_running_proxy_capture_record(
+        "summary-runtime-terminal",
+        &occurred_at,
+        ProxyCaptureTarget::Responses,
+        &request_info,
+        Some("203.0.113.42"),
+        Some("summary-runtime-terminal"),
+        Some("pck-summary-runtime-terminal"),
+        true,
+        Some(42),
+        Some("Runtime Summary"),
+        Some("api_key_codex"),
+        Some("api.openai.com"),
+        Some("runtime-summary-proxy"),
+        Some(2),
+        Some(1),
+        None,
+        None,
+        10.0,
+        2.0,
+        33.0,
+        910.0,
+    );
+    persist_and_broadcast_proxy_capture_runtime_snapshot(&state, stale_runtime_record)
+        .await
+        .expect("store stale runtime summary snapshot");
+
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            id,
+            invoke_id,
+            occurred_at,
+            source,
+            status,
+            total_tokens,
+            cost,
+            t_upstream_ttfb_ms,
+            payload,
+            raw_response
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        "#,
+    )
+    .bind(481_i64)
+    .bind("summary-runtime-terminal")
+    .bind(&occurred_at)
+    .bind(SOURCE_PROXY)
+    .bind("success")
+    .bind(100_i64)
+    .bind(0.1_f64)
+    .bind(910.0_f64)
+    .bind(json!({ "promptCacheKey": "pck-summary-runtime-terminal" }).to_string())
+    .bind("{}")
+    .execute(&state.pool)
+    .await
+    .expect("insert terminal DB row for stale runtime snapshot");
+
+    let active_runtime_record = build_running_proxy_capture_record(
+        "summary-runtime-active",
+        &occurred_at,
+        ProxyCaptureTarget::Responses,
+        &request_info,
+        Some("203.0.113.43"),
+        Some("summary-runtime-active"),
+        Some("pck-summary-runtime-active"),
+        true,
+        Some(43),
+        Some("Runtime Summary Active"),
+        Some("api_key_codex"),
+        Some("api.openai.com"),
+        Some("runtime-summary-proxy"),
+        Some(1),
+        Some(1),
+        None,
+        None,
+        11.0,
+        3.0,
+        34.0,
+        333.0,
+    );
+    persist_and_broadcast_proxy_capture_runtime_snapshot(&state, active_runtime_record)
+        .await
+        .expect("store active runtime summary snapshot");
+
+    let Json(summary) = fetch_summary(
+        State(state),
+        Query(SummaryQuery {
+            window: Some("today".to_string()),
+            limit: None,
+            time_zone: Some("Asia/Shanghai".to_string()),
+            upstream_account_id: None,
+        }),
+    )
+    .await
+    .expect("fetch today summary with runtime terminal exclusion");
+
+    assert_eq!(summary.in_progress_conversation_count, Some(1));
+    assert_eq!(summary.in_progress_retry_conversation_count, Some(0));
+    assert_f64_close(
+        summary
+            .in_progress_avg_wait_ms
+            .expect("active runtime wait should be reported"),
+        333.0,
+    );
+}
+
+#[tokio::test]
 async fn natural_day_summary_reports_retry_wait_and_non_success_usage() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),


### PR DESCRIPTION
## Summary
- Exclude memory runtime rows from stats summary live augmentation when a terminal DB row already exists for the same `(invoke_id, occurred_at)`.
- Add a regression test for stale runtime snapshots that would otherwise inflate in-progress counts, retry counts, and wait averages.
- Record the terminal-DB-wins guardrail in the related spec implementation notes and solution doc.

## Verification
- `cargo test tests::summary_ignores_runtime_overlay_records_with_terminal_db_rows -- --exact`
- `cargo test summary -- --nocapture`
- `cargo check`
- `/Users/ivan/.codex/skills/spec-sync/scripts/spec_drift_check.sh --base-ref origin/main --spec-path docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md`
- pre-commit hook: `fmt`, `check`, `format-markdown`, `typecheck-web`
- pre-PR review proof: `codex -m gpt-5.5 -c model_reasoning_effort="low" --sandbox read-only -a never review --base origin/main` reported no actionable correctness issues

## References
Spec: docs/specs/t6d9r-account-detail-stats-read-model/SPEC.md
Spec Disposition: link
Solutions:
- docs/solutions/performance/realtime-dashboard-reconcile-budget.md
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: n/a(no project-doc change)

## Notes
Visual evidence is not applicable because this is backend summary aggregation logic with no UI surface change.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
