### PR TITLE
test: reduce backend SQLite fixture runtime

### DIFF
--- a/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
+++ b/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
@@ -1,0 +1,31 @@
+# Rust 后端测试运行时反馈环
+
+## 适用场景
+
+- Rust 后端测试数量很大，`cargo test` 输出被编译和 warning 噪音淹没，难以判断真实测试运行时。
+- 测试大量创建 SQLite 临时库、archive gzip 文件或完整应用状态，默认并发下出现 60s runner warning。
+- 慢点主要来自 fixture 搭建，而不是生产逻辑本身。
+
+## 核心结论
+
+- 先用 `cargo test --no-run` 生成热缓存 test binary，再直接运行 `target/debug/deps/<bin> <filter> --format=terse`，用 `/usr/bin/time -p` 测单测和全套运行时。
+- 对只验证 DB 行为、不验证主库文件路径的测试，优先使用唯一命名的 in-memory SQLite，保留 `AppConfig.database_path`、archive/raw 目录形状即可。
+- 文件 SQLite fixture 要限制测试连接池大小；默认 pool 在全套并发下会把每个测试放大成多连接竞争。
+- 如果测试只需要“已 materialized archive metadata”或“缺失 replay marker”状态，直接构造窄表状态，不要为了 setup 跑完整 retention/archive pipeline。
+- 对确实验证 archive 文件内容或文件主库行为的测试，保留文件 SQLite，并把它们作为剩余 top offenders 明确列出。
+
+## 推荐反馈环
+
+```sh
+cargo test --no-run
+bin=$(find target/debug/deps -maxdepth 1 -type f -perm -111 -name 'codex_vibe_monitor-*' | head -1)
+/usr/bin/time -p "$bin" archive_backfill_respects_scan_limit_budget --format=terse
+/usr/bin/time -p "$bin" --test-threads=4 --format=terse
+```
+
+## 常见坑
+
+- 不要把首轮编译时间当成慢测试时间；先分离 compile 和 hot test execution。
+- 不要为了速度把所有文件 SQLite 测试切成 in-memory；archive writer/reader、relative path、真实 write-lock 行为需要文件 DB。
+- 单跑很快但全套出现 60s warning，通常是并发资源放大；先看 `sys` time 和 SQLite pool 数量，再决定是否下沉 fixture。
+- 直接构造窄状态时要保留被测语义，例如 materialized archive 需要 `historical_rollups_materialized_at` 和必要 replay marker 状态，否则测试会误触发 archive 文件读取。

--- a/src/tests/slices/forward_proxy_algo_and_config.rs
+++ b/src/tests/slices/forward_proxy_algo_and_config.rs
@@ -2266,10 +2266,37 @@ async fn retention_test_pool_and_config(prefix: &str) -> (SqlitePool, AppConfig,
     let db_path = temp_dir.join("codex-vibe-monitor.db");
     fs::File::create(&db_path).expect("create retention sqlite file");
     let db_url = sqlite_url_for_path(&db_path);
-    let pool = SqlitePool::connect(&db_url)
+    let pool = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&db_url)
         .await
         .expect("connect retention sqlite");
     ensure_schema(&pool).await.expect("ensure retention schema");
+
+    let mut config = test_config();
+    config.database_path = db_path;
+    config.proxy_raw_dir = temp_dir.join("proxy_raw_payloads");
+    config.archive_dir = temp_dir.join("archives");
+    config.retention_batch_rows = 2;
+    config.invocation_archive_ttl_days = 365;
+    fs::create_dir_all(&config.proxy_raw_dir).expect("create retention raw dir");
+    fs::create_dir_all(&config.archive_dir).expect("create retention archive dir");
+    (pool, config, temp_dir)
+}
+
+async fn retention_memory_test_pool_and_config(prefix: &str) -> (SqlitePool, AppConfig, PathBuf) {
+    let temp_dir = make_temp_test_dir(prefix);
+    let db_path = temp_dir.join("codex-vibe-monitor.db");
+    let db_id = NEXT_PROXY_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    let db_url = format!("sqlite:file:{prefix}-{db_id}?mode=memory&cache=shared");
+    let pool = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&db_url)
+        .await
+        .expect("connect retention in-memory sqlite");
+    ensure_schema(&pool)
+        .await
+        .expect("ensure retention in-memory schema");
 
     let mut config = test_config();
     config.database_path = db_path;
@@ -2531,10 +2558,11 @@ async fn insert_stats_source_snapshot_row(pool: &SqlitePool, captured_at: &str, 
 
 #[tokio::test]
 async fn ensure_schema_backfills_raw_codecs_and_manifest_tables() {
-    let temp_dir = make_temp_test_dir("ensure-schema-raw-codecs");
-    let db_path = temp_dir.join("codex-vibe-monitor.db");
-    fs::File::create(&db_path).expect("create schema sqlite file");
-    let pool = SqlitePool::connect(&sqlite_url_for_path(&db_path))
+    let db_id = NEXT_PROXY_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    let db_url = format!("sqlite:file:ensure-schema-raw-codecs-{db_id}?mode=memory&cache=shared");
+    let pool = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&db_url)
         .await
         .expect("connect schema sqlite");
 
@@ -2601,8 +2629,6 @@ async fn ensure_schema_backfills_raw_codecs_and_manifest_tables() {
     assert!(manifest_columns.contains("archive_batch_id"));
     assert!(manifest_columns.contains("account_id"));
     assert!(manifest_columns.contains("last_activity_at"));
-
-    cleanup_temp_test_dir(&temp_dir);
 }
 
 #[tokio::test]

--- a/src/tests/slices/maintenance_and_raw_payload.rs
+++ b/src/tests/slices/maintenance_and_raw_payload.rs
@@ -799,7 +799,9 @@ async fn test_state_from_config_with_pool_no_available_wait(
     let db_id = NEXT_PROXY_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
     let config = isolate_stateful_test_config_runtime_paths(config, db_id);
     let db_url = format!("sqlite:file:codex-vibe-monitor-test-{db_id}?mode=memory&cache=shared");
-    let pool = SqlitePool::connect(&db_url)
+    let pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect(&db_url)
         .await
         .expect("connect in-memory sqlite");
     ensure_schema(&pool)

--- a/src/tests/slices/pool_failover_window_i.rs
+++ b/src/tests/slices/pool_failover_window_i.rs
@@ -2637,7 +2637,8 @@ async fn upstream_last_activity_archive_backfill_refreshes_existing_activity_whe
 
 #[tokio::test]
 async fn archive_backfill_waits_for_manifest_until_rebuilt() {
-    let (pool, config, temp_dir) = retention_test_pool_and_config("archive-manifest-rebuild").await;
+    let (pool, config, temp_dir) =
+        retention_memory_test_pool_and_config("archive-manifest-rebuild").await;
     let account_id = 991_i64;
     let created_at = format_utc_iso(Utc::now());
     sqlx::query(
@@ -2771,7 +2772,7 @@ async fn archive_backfill_waits_for_manifest_until_rebuilt() {
 #[tokio::test]
 async fn archive_manifest_refresh_leaves_missing_batches_pending_for_retry() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("manifest-missing-terminal").await;
+        retention_memory_test_pool_and_config("manifest-missing-terminal").await;
     let account_id = 993_i64;
     let created_at = format_utc_iso(Utc::now());
     sqlx::query(

--- a/src/tests/slices/pool_failover_window_j.rs
+++ b/src/tests/slices/pool_failover_window_j.rs
@@ -1,7 +1,7 @@
 #[tokio::test]
 async fn archive_manifest_refresh_dedupes_duplicate_account_rows_from_archive_file() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("archive-manifest-refresh-dedupe").await;
+        retention_memory_test_pool_and_config("archive-manifest-refresh-dedupe").await;
     let primary_account_id = 996_i64;
     let secondary_account_id = 997_i64;
     let created_at = format_utc_iso(Utc::now());
@@ -380,7 +380,8 @@ async fn startup_persistent_prep_rebuilds_manifest_before_archive_backfill() {
 
 #[tokio::test]
 async fn archive_backfill_respects_scan_limit_budget() {
-    let (pool, _config, temp_dir) = retention_test_pool_and_config("archive-backfill-budget").await;
+    let (pool, _config, temp_dir) =
+        retention_memory_test_pool_and_config("archive-backfill-budget").await;
     let created_at = format_utc_iso(Utc::now());
     for account_id in [993_i64, 994_i64] {
         sqlx::query(
@@ -492,7 +493,8 @@ async fn archive_backfill_respects_scan_limit_budget() {
 
 #[tokio::test]
 async fn cleanup_expired_invocation_archive_batches_removes_manifest_rows() {
-    let (pool, mut config, temp_dir) = retention_test_pool_and_config("archive-ttl-cleanup").await;
+    let (pool, mut config, temp_dir) =
+        retention_memory_test_pool_and_config("archive-ttl-cleanup").await;
     config.invocation_archive_ttl_days = 0;
 
     let archive_path = temp_dir.join("expired-archive.sqlite.gz");
@@ -564,7 +566,8 @@ async fn cleanup_expired_invocation_archive_batches_removes_manifest_rows() {
 
 #[tokio::test]
 async fn backfill_invocation_archive_expiries_uses_coverage_end_at() {
-    let (pool, config, temp_dir) = retention_test_pool_and_config("archive-expiry-backfill").await;
+    let (pool, config, temp_dir) =
+        retention_memory_test_pool_and_config("archive-expiry-backfill").await;
     let coverage_end_at = shanghai_local_days_ago(45, 18, 30, 0);
     let created_at = format_utc_iso(Utc::now());
 
@@ -1987,7 +1990,7 @@ async fn materialize_historical_rollups_marks_account_replay_targets_when_only_a
 #[tokio::test]
 async fn bootstrap_hourly_rollups_repairs_missing_materialized_account_replay_markers() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("bootstrap-repairs-account-markers").await;
+        retention_memory_test_pool_and_config("bootstrap-repairs-account-markers").await;
     let old_invocation = shanghai_local_days_ago((config.invocation_max_days + 2) as i64, 9, 0, 0);
 
     insert_retention_invocation(
@@ -2064,7 +2067,7 @@ async fn bootstrap_hourly_rollups_repairs_missing_materialized_account_replay_ma
 #[tokio::test]
 async fn historical_rollup_backfill_stays_critical_until_legacy_invocations_materialized() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("historical-rollup-backfill-critical").await;
+        retention_memory_test_pool_and_config("historical-rollup-backfill-critical").await;
     let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
         - ChronoDuration::days((config.invocation_max_days + 2) as i64))
     .and_hms_opt(8, 0, 0)
@@ -3158,7 +3161,7 @@ async fn missing_pool_node_health_archives_clear_stale_cached_rows_before_markin
 #[tokio::test]
 async fn cleanup_expired_pool_upstream_archives_waits_for_cache_replay_completion() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("pool-node-health-cleanup-cache-replay-gate").await;
+        retention_memory_test_pool_and_config("pool-node-health-cleanup-cache-replay-gate").await;
     let coverage_end_at = shanghai_local_days_ago(14, 9, 0, 0);
     let archive_file_path = archive_batch_file_path(&config, "pool_upstream_request_attempts", &coverage_end_at[..7])
         .expect("resolve expired pool upstream archive path");
@@ -3233,7 +3236,7 @@ async fn cleanup_expired_pool_upstream_archives_waits_for_cache_replay_completio
 #[tokio::test]
 async fn cleanup_expired_pool_upstream_archives_preserves_recent_exact_window_history() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("pool-node-health-cleanup-window-gate").await;
+        retention_memory_test_pool_and_config("pool-node-health-cleanup-window-gate").await;
     let coverage_end_at = shanghai_local_days_ago(2, 9, 0, 0);
     let archive_file_path = archive_batch_file_path(&config, "pool_upstream_request_attempts", &coverage_end_at[..7])
         .expect("resolve recent pool upstream archive path");
@@ -3837,29 +3840,74 @@ async fn prune_archive_batches_removes_expired_segments_and_legacy_batches() {
 #[tokio::test]
 async fn bootstrap_hourly_rollups_keeps_retention_materialized_totals_unchanged() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("hourly-rollup-retention-accounted").await;
+        retention_memory_test_pool_and_config("hourly-rollup-retention-accounted").await;
     let old_invocation = shanghai_local_days_ago((config.invocation_max_days + 2) as i64, 9, 0, 0);
-    insert_retention_invocation(
+    let bucket_start = local_naive_to_utc(
+        parse_shanghai_local_naive(&old_invocation).expect("valid old invocation time"),
+        Shanghai,
+    );
+    insert_invocation_hourly_rollup_bucket(
         &pool,
-        "hourly-rollup-retention-accounted",
-        &old_invocation,
+        bucket_start,
         SOURCE_PROXY,
-        "success",
-        Some("{\"endpoint\":\"/v1/responses\"}"),
-        "{\"ok\":true}",
-        None,
-        None,
-        Some(42),
-        Some(0.42),
+        1,
+        1,
+        0,
+        42,
+        0.42,
     )
     .await;
-    let old_attempt = Utc::now()
-        - ChronoDuration::days((config.forward_proxy_attempts_retention_days + 2) as i64);
-    seed_forward_proxy_attempt_at(&pool, "proxy-retention-accounted", old_attempt, true).await;
+    sqlx::query(
+        r#"
+        INSERT INTO forward_proxy_attempt_hourly (
+            proxy_key,
+            bucket_start_epoch,
+            attempts,
+            success_count,
+            failure_count,
+            updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))
+        "#,
+    )
+    .bind("proxy-retention-accounted")
+    .bind(bucket_start.timestamp())
+    .bind(1_i64)
+    .bind(1_i64)
+    .bind(0_i64)
+    .execute(&pool)
+    .await
+    .expect("seed materialized forward proxy hourly rollup");
+    for table in [
+        "upstream_account_stats_hourly",
+        "upstream_account_stats_minute",
+    ] {
+        let statement = format!(
+            r#"
+            INSERT INTO {table} (
+                bucket_start_epoch,
+                source,
+                upstream_account_id,
+                total_count,
+                success_count,
+                failure_count,
+                updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))
+            "#
+        );
+        sqlx::query(&statement)
+            .bind(bucket_start.timestamp())
+            .bind(SOURCE_PROXY)
+            .bind(17_i64)
+            .bind(1_i64)
+            .bind(1_i64)
+            .bind(0_i64)
+            .execute(&pool)
+            .await
+            .expect("seed account stats rollup guard");
+    }
 
-    sync_hourly_rollups_from_live_tables(&pool)
-        .await
-        .expect("seed live hourly rollups before retention");
     let invocation_total_before: i64 = sqlx::query_scalar(
         "SELECT COALESCE(SUM(total_count), 0) FROM invocation_rollup_hourly WHERE source = ?1",
     )
@@ -3875,11 +3923,42 @@ async fn bootstrap_hourly_rollups_keeps_retention_materialized_totals_unchanged(
     .await
     .expect("load forward proxy hourly totals before retention");
 
-    let summary = run_data_retention_maintenance(&pool, &config, Some(false), None)
+    for (dataset, file_name) in [
+        ("codex_invocations", "materialized-invocation.sqlite.gz"),
+        (
+            "forward_proxy_attempts",
+            "materialized-forward-proxy.sqlite.gz",
+        ),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO archive_batches (
+                dataset,
+                month_key,
+                file_path,
+                sha256,
+                row_count,
+                status,
+                coverage_start_at,
+                coverage_end_at,
+                historical_rollups_materialized_at,
+                created_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'), datetime('now'))
+            "#,
+        )
+        .bind(dataset)
+        .bind(&old_invocation[..7])
+        .bind(temp_dir.join(file_name).to_string_lossy().to_string())
+        .bind(format!("{dataset}-sha"))
+        .bind(1_i64)
+        .bind(ARCHIVE_STATUS_COMPLETED)
+        .bind(&old_invocation)
+        .bind(&old_invocation)
+        .execute(&pool)
         .await
-        .expect("run retention before bootstrap replay");
-    assert_eq!(summary.invocation_rows_archived, 1);
-    assert_eq!(summary.forward_proxy_attempt_rows_archived, 1);
+        .expect("seed materialized archive batch");
+    }
 
     bootstrap_hourly_rollups(&pool)
         .await
@@ -3933,7 +4012,7 @@ async fn bootstrap_hourly_rollups_keeps_retention_materialized_totals_unchanged(
 #[tokio::test]
 async fn bootstrap_hourly_rollups_ignores_missing_replay_markers() {
     let (pool, config, temp_dir) =
-        retention_test_pool_and_config("hourly-rollup-missing-invocation-target").await;
+        retention_memory_test_pool_and_config("hourly-rollup-missing-invocation-target").await;
     let old_invocation = shanghai_local_days_ago((config.invocation_max_days + 2) as i64, 9, 0, 0);
     let payload = r#"{"endpoint":"/v1/responses","promptCacheKey":"cache-replay","upstreamAccountId":17,"upstreamAccountName":"Replay Account","stickyKey":"sticky-replay"}"#;
     insert_retention_invocation(

--- a/src/tests/slices/pool_failover_window_k.rs
+++ b/src/tests/slices/pool_failover_window_k.rs
@@ -1,7 +1,7 @@
 #[tokio::test]
 async fn bootstrap_hourly_rollups_ignores_missing_invocation_archive_batch() {
     let (pool, _config, temp_dir) =
-        retention_test_pool_and_config("hourly-rollup-missing-invocation-archive").await;
+        retention_memory_test_pool_and_config("hourly-rollup-missing-invocation-archive").await;
     let missing_archive = temp_dir.join("missing-codex-invocations.sqlite.gz");
     let missing_archive_path = missing_archive.to_string_lossy().to_string();
 
@@ -31,7 +31,7 @@ async fn bootstrap_hourly_rollups_ignores_missing_invocation_archive_batch() {
 #[tokio::test]
 async fn bootstrap_hourly_rollups_ignores_missing_forward_proxy_archive_batch() {
     let (pool, _config, temp_dir) =
-        retention_test_pool_and_config("hourly-rollup-missing-forward-proxy-archive").await;
+        retention_memory_test_pool_and_config("hourly-rollup-missing-forward-proxy-archive").await;
     let missing_archive = temp_dir.join("missing-forward-proxy-attempts.sqlite.gz");
     let missing_archive_path = missing_archive.to_string_lossy().to_string();
 


### PR DESCRIPTION
## Summary
- Add a lightweight in-memory retention SQLite fixture for tests that do not verify the primary DB file path.
- Switch archive/backfill, manifest, cleanup, and materialized-rollup tests away from unnecessary file-backed primary SQLite setup.
- Limit high-volume test SQLite pools and add a performance solution note for the direct test-binary feedback loop.

## Validation
- cargo fmt --check
- cargo test --no-run
- Direct targeted test-binary matrix for archive/backfill, bootstrap, cleanup, schema, proxy timeout, and sqlite_batch_writer representative tests: passed.
- Direct full test binary, default concurrency: passed, 1469 passed / 45 ignored, 1109.30s. Remaining 60s warnings are mostly retention/materialize/cold-compression families, so the full backend suite is still slow overall.
- Direct full test binary, --test-threads=4: passed, 1469 passed / 45 ignored, 894.15s.
- Spec drift check: passed, spec-free.
- Pre-commit hook: passed after installing repo/web/docs-site dependencies with bun run worktree:setup.

## References
- Specs: -
- Solutions: docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
- Project Docs: -

## Notes
- solution_disposition=create
- spec_disposition=not_needed
- project_doc_disposition=none
- Non-UI change; visual evidence not applicable.