### PR TITLE
fix(proxy): spill large replay snapshots to files

### DIFF
--- a/docs/solutions/performance/proxy-capture-body-replay-safety.md
+++ b/docs/solutions/performance/proxy-capture-body-replay-safety.md
@@ -32,10 +32,14 @@ The capture path historically used one full in-memory request body as both routi
 ## Resolution
 
 - Put capture request reads on the same replay snapshot control plane as pool routing: memory for small bodies, file-backed replay for large bodies.
+- Centralize every `Bytes` / `Vec<u8>` to `PoolReplayBodySnapshot` conversion in one threshold helper. Use memory only at or below `POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES`; above the threshold, write a `cvm-pool-replay-*` temp file and return a file-backed snapshot.
+- Replace direct large-body `PoolReplayBodySnapshot::Memory(...)` construction in capture outbound, route-selection prebuffer fallback, and rewritten-body paths. A direct memory snapshot is only acceptable for small bodies, empty bodies, or fail-soft temp-file failure.
 - Preserve bounded partial body evidence on read timeout, client stream errors, and body-limit failures; do not retain the whole body in memory after switching to file-backed replay.
 - Consume file-backed snapshots with a single materialization step only when the existing capture semantics require full JSON parse/rewrite; do not add an extra `Bytes -> Vec` full-body copy.
+- If rewrite is required but produces no body changes, return the original snapshot instead of serializing the body back into memory. If rewrite changes the body, pass the rewritten bytes through the same threshold helper.
 - Log `body_read_done`, `body_size_bucket`, `request_body_snapshot_kind`, and `live_first_reason` before materializing the snapshot for full parse/rewrite.
 - Keep response streaming ordered as “forward chunk downstream first, finish raw writer later”; log `downstream_first_byte_elapsed` and `raw_response_write_elapsed` separately.
+- Make production evidence thresholded: large or slow request body reads, slow downstream first byte, and slow or large raw response writes should be visible at `info`; ordinary small requests can remain `debug`.
 - Enable live-first for capture only when tests prove encrypted owner binding, prompt-cache binding, body rewrite, failover replay, raw completeness, and terminal record fields remain identical to fallback behavior.
 
 ## Guardrails / Reuse notes
@@ -45,6 +49,7 @@ The capture path historically used one full in-memory request body as both routi
 - Do not infer “no encrypted content” from a prefix scan; absence is only safe after full parse or an equivalent explicit contract.
 - Do not drop or truncate raw payload as a performance optimization. If raw writer fails, log and classify it, but keep business response semantics separate.
 - Keep fallback reason values stable enough for production log comparison.
+- Treat `snapshot_kind="memory"` on multi-MiB requests as a regression unless the same log window shows a temp-file create/write/flush warning explaining the fail-soft fallback.
 
 ## References
 

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
@@ -11,3 +11,5 @@
 - 号池路由使用组合级短期降权，以 `pool_upstream_request_attempts.upstream_route_key + proxy_binding_key_snapshot` 作为传输组合键；仅 timeout/transport/stream failure 触发，后续成功清除惩罚，避免把账号硬失败误当作代理组合问题。
 - 2026-07-05: `/v1/*` 本地并发语义收口为纯观测：`PROXY_REQUEST_CONCURRENCY_*` 继续兼容读取但不参与 admission、raw writer sizing 或新失败分类。tracked 请求在 route 前创建内存 running shell，并用 terminal overlay 收敛失败路径。
 - 2026-07-05: capture 转发提速先按“不劣化功能”收口：大 body 读取切到 replay snapshot/file-backed 控制面，并补齐 live-first fallback 与响应首字节/raw writer 耗时证据；未在本轮强开可能破坏 encrypted owner、prompt-cache binding、rewrite 或 failover replay 的 capture live-first。
+- 2026-07-05: 101 线上证据显示 11MB/21MB/62MB 请求在 timeout 日志中仍有 `snapshot_kind="memory"`，说明直接从完整 body 构造 memory replay 的残留路径未收口。本轮把 `Bytes` / `Vec<u8>` 到 replay snapshot 的转换统一到阈值 helper，capture outbound、route-selection prebuffer fallback、rewrite changed 都复用该 helper；rewrite no-op 保留原 snapshot，避免 file-backed snapshot 被无意义重新物化为 memory。
+- 2026-07-05: 生产排障证据从 debug-only 调整为阈值化 info：普通小请求不刷屏，但大 body、慢 body read、慢 downstream first byte、慢/大 raw response write 在默认 info 日志下可见，避免把“没有 debug 日志”误判成没有埋点。

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
@@ -19,6 +19,9 @@
 - Note: capture 入口的 request body 读取改为 replay snapshot 控制面；大 body 先落 file-backed replay snapshot，再进入现有完整 parse/rewrite/owner-binding 路径。超限错误只保留有界 partial body，避免 raw failure 证据回退且不重新制造整包内存副本。
 - Note: file-backed capture snapshot 在进入现有 parse/rewrite 语义时只做一次 consume materialization；本轮没有把 capture pipeline 改成零拷贝 shared snapshot，因为这会牵涉 raw、failover、rewrite 与 terminal record 的共同数据模型。
 - Note: 本轮没有强开 capture live-first；对仍需完整 request 语义的 capture 请求输出 `live_first_reason=capture_requires_full_request_semantics`，并新增 `body_size_bucket`、`request_body_snapshot_kind`、`downstream_first_byte_elapsed`、`raw_response_write_elapsed` 证据，供 101 判断剩余慢点。
+- Note: pool failover replay snapshot 构造已收口到统一 helper：`Bytes` / `Vec<u8>` 小于等于 `POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES` 时保留 memory，大于阈值时写入 `cvm-pool-replay-*` 临时文件并返回 file snapshot；临时文件失败只 fail-soft 回退 memory 并输出 warning。
+- Note: capture pool outbound 与 route-selection prebuffer fallback 不再直接为大 body 构造 `PoolReplayBodySnapshot::Memory(...)`；rewrite required 但 no-op 的分支保留原 file snapshot，真实 rewrite 后按同一阈值重新选择 memory/file。
+- Note: `body_read_done/live_first_reason/request_body_snapshot_kind`、`downstream_first_byte_elapsed`、`raw_response_write_elapsed` 改为阈值化生产可见：大 body 或慢 body read、慢下游首字节、慢/大 raw response 在 `info` 输出，普通小请求继续保留 `debug`。
 
 ## 验证
 
@@ -37,6 +40,9 @@
 - `cargo test acquire_proxy_request_concurrency_permit_tracks_100_in_flight_without_local_rejection -- --nocapture`
 - `cargo test proxy_openai_v1_invalid_pool_key_bypasses_admission_backpressure -- --nocapture`
 - `cargo test capture_snapshot_reader_ -- --nocapture`
+- `cargo test pool_replay_snapshot_from_ -- --nocapture`
+- `cargo test prepare_pool_request_body_for_account_ -- --nocapture`
+- `cargo test capture_snapshot_reader_spills -- --nocapture`
 
 ## Migrated Task-Ticket Sections
 

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
@@ -55,6 +55,9 @@
 - 号池路由只能把近期 `transport_failure` 且 failure kind 属于 `upstream_handshake_timeout`、`failed_contact_upstream` 或 `upstream_stream_error` 的 `upstream_route_key + proxy_binding_key_snapshot` 组合纳入短期降权；同组合后续成功应清除该短期惩罚，认证、配额、402 等账号级硬失败不得混入组合降权。
 - capture 入口不得为了提速跳过完整 raw、usage、failure、prompt-cache/encrypted owner 与 body rewrite 语义。可证明安全前，capture 请求必须先使用 replay snapshot 控制面读取：小体积保留内存，大体积落 file-backed replay；日志必须给出 `body_read_done`、`body_size_bucket`、`request_body_snapshot_kind` 与 `live_first_reason`，说明为何未启用 live-first。
 - capture response streaming 必须先向下游转发 chunk，再异步收敛 raw/record；日志应能区分 `downstream_first_byte_elapsed` 与 `raw_response_write_elapsed`，避免把原始响应落盘耗时误判为上游首字节慢。
+- 任何从完整 `Bytes` / `Vec<u8>` 构造 pool failover replay snapshot 的路径都必须经过统一阈值 helper：`<=1MiB` 才允许 `memory`，超过阈值必须优先写 `cvm-pool-replay-*` 临时文件并返回 `file` snapshot。只有临时文件创建、写入或 flush 失败时才允许 fail-soft 回退 `memory`，且必须产生日志证据。
+- `prepare_pool_request_body_for_account` 在 rewrite required 但实际 no-op 时必须保留原 snapshot kind；不得因为读取 JSON 判断而把原 file-backed snapshot 重新包装成 memory。真实 rewrite 后的新 body 也必须重新经过同一阈值 helper。
+- 生产默认 `RUST_LOG=info` 下必须能看到关键慢段阈值事件：body `>=1MiB` 或 read `>=1000ms` 的 `body_read_done/live_first_reason/request_body_snapshot_kind`，downstream first byte `>=2000ms`，raw response write `>=500ms` 或 raw bytes `>=1MiB`。普通小请求可继续只输出 debug，避免刷屏。
 
 ## 验收标准（Acceptance Criteria）
 
@@ -62,8 +65,10 @@
 - response raw append 不再位于 chunk 转发之前；request raw 写盘不再阻塞上游发送。
 - 大于小体积阈值的 pool request body 不再默认整包内存物化；sticky 探测仅依赖前缀窗口或 replay snapshot 前缀。
 - capture 大 body 读取会产生 file-backed replay snapshot；超限/超时/客户端断开时仅保留有界 partial body 证据，不得因为切换 snapshot 控制面而丢 raw failure context，也不得把成功读取的大 body 同时整包留在内存。
+- capture pool outbound 与 route-selection prebuffer fallback 的大 body failover snapshot kind 必须为 `file`；11MB/21MB/62MB 等请求不得在正常临时文件可用时继续以 `snapshot_kind="memory"` 进入上游 timeout / failover 日志。
 - capture 在现有完整语义仍要求 JSON parse/rewrite 时，只允许对 file-backed snapshot 做一次最终物化；不得再额外制造 `Bytes -> Vec` 级别的整包副本，也不得把该保守路径宣称为零拷贝 live-first。
 - capture 日志能解释 live-first eligibility：不能证明安全的请求必须显式记录 fallback reason；后续若启用 live-first，必须覆盖 encrypted owner、prompt-cache binding、body rewrite、failover replay 与 raw 完整性测试。
+- rewrite no-op 与 rewrite changed 场景都必须保持 raw request/response、terminal record metadata、usage、failure kind、prompt-cache/encrypted owner 语义不变；本 spec 不允许用截断 raw 或跳过 failover replay 换取速度。
 - `/api/invocations` 的分页主查询只先选出当前页 id，再对当前页记录执行完整投影。
 - summary/quota follow-up 在 burst 写入时能够合并，不再对每条记录立即触发一次完整汇总。
 - 无 SSE 订阅者时，`persist_and_broadcast_proxy_capture` 与 `broadcast_recovered_proxy_invocations` 不会再启动 follow-up worker，也不会触发后台 hourly rollup refresh。

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -534,17 +534,31 @@ pub(crate) async fn proxy_openai_v1_capture_target(
     let t_req_read_ms = elapsed_ms(req_read_started);
     let request_body_snapshot_kind = pool_request_snapshot_kind(&request_body_snapshot);
     let request_body_bytes_len = pool_request_snapshot_body_bytes(&request_body_snapshot);
-    debug!(
-        proxy_request_id,
-        body_read_done = true,
-        body_read_elapsed_ms = t_req_read_ms,
-        request_body_bytes = request_body_bytes_len,
-        body_size_bucket = request_body_size_bucket(request_body_bytes_len),
-        request_body_snapshot_kind,
-        live_first_eligible = false,
-        live_first_reason = "capture_requires_full_request_semantics",
-        "openai proxy capture request body read completed"
-    );
+    if capture_request_body_read_log_at_info(request_body_bytes_len, t_req_read_ms) {
+        info!(
+            proxy_request_id,
+            body_read_done = true,
+            body_read_elapsed_ms = t_req_read_ms,
+            request_body_bytes = request_body_bytes_len,
+            body_size_bucket = request_body_size_bucket(request_body_bytes_len),
+            request_body_snapshot_kind,
+            live_first_eligible = false,
+            live_first_reason = "capture_requires_full_request_semantics",
+            "openai proxy capture request body read completed"
+        );
+    } else {
+        debug!(
+            proxy_request_id,
+            body_read_done = true,
+            body_read_elapsed_ms = t_req_read_ms,
+            request_body_bytes = request_body_bytes_len,
+            body_size_bucket = request_body_size_bucket(request_body_bytes_len),
+            request_body_snapshot_kind,
+            live_first_eligible = false,
+            live_first_reason = "capture_requires_full_request_semantics",
+            "openai proxy capture request body read completed"
+        );
+    }
     let request_body_bytes = match request_body_snapshot.into_vec().await {
         Ok(bytes) => bytes,
         Err(err) => {
@@ -793,6 +807,8 @@ pub(crate) async fn proxy_openai_v1_capture_target(
     let t_req_parse_ms = elapsed_ms(req_parse_started);
     let upstream_body_bytes = Bytes::from(upstream_body);
     let base_request_bytes_for_capture = upstream_body_bytes.clone();
+    let upstream_body_snapshot =
+        pool_replay_snapshot_from_bytes(proxy_request_id, upstream_body_bytes.clone()).await;
 
     let initial_running_record = build_running_proxy_capture_record(
         &invoke_id,
@@ -874,7 +890,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             Method::POST,
             &original_uri,
             &upstream_headers,
-            Some(PoolReplayBodySnapshot::Memory(upstream_body_bytes.clone())),
+            Some(upstream_body_snapshot),
             handshake_timeout,
             pool_attempt_trace_context.clone(),
             pool_attempt_runtime_snapshot.clone(),
@@ -1613,13 +1629,25 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     let _ = proxy_request_permit_for_task.take();
                 } else if !downstream_first_byte_logged {
                     downstream_first_byte_logged = true;
-                    debug!(
-                        invoke_id = %invoke_id_for_task,
-                        downstream_first_byte_elapsed = stream_started.elapsed().as_millis() as u64,
-                        upstream_ttfb_ms = t_upstream_ttfb_ms,
-                        forwarded_bytes,
-                        "openai proxy capture streamed first byte downstream"
-                    );
+                    let downstream_first_byte_elapsed =
+                        stream_started.elapsed().as_millis() as u64;
+                    if downstream_first_byte_log_at_info(downstream_first_byte_elapsed) {
+                        info!(
+                            invoke_id = %invoke_id_for_task,
+                            downstream_first_byte_elapsed,
+                            upstream_ttfb_ms = t_upstream_ttfb_ms,
+                            forwarded_bytes,
+                            "openai proxy capture streamed first byte downstream"
+                        );
+                    } else {
+                        debug!(
+                            invoke_id = %invoke_id_for_task,
+                            downstream_first_byte_elapsed,
+                            upstream_ttfb_ms = t_upstream_ttfb_ms,
+                            forwarded_bytes,
+                            "openai proxy capture streamed first byte downstream"
+                        );
+                    }
                 }
             }
         }
@@ -1770,13 +1798,25 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                             let _ = proxy_request_permit_for_task.take();
                         } else if !downstream_first_byte_logged {
                             downstream_first_byte_logged = true;
-                            debug!(
-                                invoke_id = %invoke_id_for_task,
-                                downstream_first_byte_elapsed = stream_started.elapsed().as_millis() as u64,
-                                upstream_ttfb_ms = t_upstream_ttfb_ms,
-                                forwarded_bytes,
-                                "openai proxy capture streamed first byte downstream"
-                            );
+                            let downstream_first_byte_elapsed =
+                                stream_started.elapsed().as_millis() as u64;
+                            if downstream_first_byte_log_at_info(downstream_first_byte_elapsed) {
+                                info!(
+                                    invoke_id = %invoke_id_for_task,
+                                    downstream_first_byte_elapsed,
+                                    upstream_ttfb_ms = t_upstream_ttfb_ms,
+                                    forwarded_bytes,
+                                    "openai proxy capture streamed first byte downstream"
+                                );
+                            } else {
+                                debug!(
+                                    invoke_id = %invoke_id_for_task,
+                                    downstream_first_byte_elapsed,
+                                    upstream_ttfb_ms = t_upstream_ttfb_ms,
+                                    forwarded_bytes,
+                                    "openai proxy capture streamed first byte downstream"
+                                );
+                            }
                         }
                     }
                 }
@@ -1825,14 +1865,26 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         let req_raw_for_task = req_raw_pending_for_task.finish().await;
         let raw_response_finish_started = Instant::now();
         let resp_raw = response_raw_writer.finish().await;
-        debug!(
-            invoke_id = %invoke_id_for_task,
-            raw_response_write_elapsed = raw_response_finish_started.elapsed().as_millis() as u64,
-            raw_response_bytes = resp_raw.size_bytes,
-            raw_response_codec = raw_payload_meta_codec(&resp_raw),
-            raw_response_truncated = resp_raw.truncated,
-            "openai proxy capture response raw writer finished"
-        );
+        let raw_response_write_elapsed = raw_response_finish_started.elapsed().as_millis() as u64;
+        if raw_response_write_log_at_info(raw_response_write_elapsed, resp_raw.size_bytes) {
+            info!(
+                invoke_id = %invoke_id_for_task,
+                raw_response_write_elapsed,
+                raw_response_bytes = resp_raw.size_bytes,
+                raw_response_codec = raw_payload_meta_codec(&resp_raw),
+                raw_response_truncated = resp_raw.truncated,
+                "openai proxy capture response raw writer finished"
+            );
+        } else {
+            debug!(
+                invoke_id = %invoke_id_for_task,
+                raw_response_write_elapsed,
+                raw_response_bytes = resp_raw.size_bytes,
+                raw_response_codec = raw_payload_meta_codec(&resp_raw),
+                raw_response_truncated = resp_raw.truncated,
+                "openai proxy capture response raw writer finished"
+            );
+        }
         let preview_bytes = response_preview.as_slice().to_vec();
         let raw_response_preview = response_preview.into_preview();
         let streamed_response_outcome = stream_response_parser.finish();
@@ -2685,6 +2737,18 @@ fn request_body_size_bucket(bytes: usize) -> &'static str {
         1048577..=8388608 => "le_8m",
         _ => "gt_8m",
     }
+}
+
+fn capture_request_body_read_log_at_info(bytes: usize, elapsed_ms: f64) -> bool {
+    bytes >= POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES || elapsed_ms >= 1_000.0
+}
+
+fn downstream_first_byte_log_at_info(elapsed_ms: u64) -> bool {
+    elapsed_ms >= 2_000
+}
+
+fn raw_response_write_log_at_info(elapsed_ms: u64, bytes: i64) -> bool {
+    elapsed_ms >= 500 || bytes >= POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES as i64
 }
 
 pub(crate) fn resolve_compaction_response_kind_for_payload(

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -1395,9 +1395,6 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                             .clone()
                             .expect("api key pool route should always have an upstream url"),
                     );
-                    let preserve_content_length = pool_request_snapshot_preserves_content_length(
-                        &prepared_request_body.snapshot,
-                    );
                     let forwarded_content_length = headers
                         .get(header::CONTENT_LENGTH)
                         .and_then(|value| value.to_str().ok())
@@ -1406,6 +1403,12 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                         pool_request_snapshot_kind(&prepared_request_body.snapshot);
                     let outbound_body_bytes =
                         pool_request_snapshot_body_bytes(&prepared_request_body.snapshot);
+                    let preserve_content_length = pool_request_snapshot_preserves_content_length(
+                        &prepared_request_body.snapshot,
+                    ) && forwarded_content_length
+                        .as_deref()
+                        .and_then(|value| value.parse::<usize>().ok())
+                        == Some(outbound_body_bytes);
                     for (name, value) in headers {
                         if *name == header::AUTHORIZATION {
                             continue;
@@ -1418,6 +1421,9 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
                         }
                     }
                     request = request.header(header::AUTHORIZATION, authorization.clone());
+                    if !preserve_content_length {
+                        request = request.header(header::CONTENT_LENGTH, outbound_body_bytes);
+                    }
                     request = request.body(prepared_request_body.snapshot.to_reqwest_body());
                     record_account_selected(state.as_ref(), account.account_id).await;
                     let group_name_snapshot =

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -1297,6 +1297,7 @@ pub(crate) async fn send_pool_request_with_failover_and_binding_constraint(
             let mut early_phase_cleanup_guard: Option<PoolEarlyPhaseOrphanCleanupGuard>;
             let live_attempt_activity_lease: Option<PoolLiveAttemptActivityLease>;
             let prepared_request_body = match prepare_pool_request_body_for_account(
+                proxy_request_id,
                 body.as_ref(),
                 original_uri,
                 &method,

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1792,6 +1792,7 @@ pub(crate) enum PoolAccountResolutionWithWait {
 
 pub(crate) const POOL_UPSTREAM_SAME_ACCOUNT_MAX_ATTEMPTS: u8 = 3;
 pub(crate) const OAUTH_RESPONSES_MAX_REWRITE_BODY_BYTES: usize = 8 * 1024 * 1024;
+static NEXT_POOL_REPLAY_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(1);
 
 impl PoolReplayBodyBuffer {
     pub(crate) fn new(proxy_request_id: u64) -> Self {
@@ -1852,6 +1853,64 @@ impl PoolReplayBodyBuffer {
             Ok(PoolReplayBodySnapshot::Memory(Bytes::from(self.memory)))
         }
     }
+}
+
+pub(crate) async fn pool_replay_snapshot_from_bytes(
+    proxy_request_id: u64,
+    bytes: Bytes,
+) -> PoolReplayBodySnapshot {
+    if bytes.is_empty() {
+        return PoolReplayBodySnapshot::Empty;
+    }
+    if bytes.len() <= POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES {
+        return PoolReplayBodySnapshot::Memory(bytes);
+    }
+
+    let temp_file = Arc::new(PoolReplayTempFile {
+        path: build_pool_replay_temp_path(proxy_request_id),
+    });
+    match tokio::fs::File::create(&temp_file.path).await {
+        Ok(mut file) => {
+            if let Err(err) = file.write_all(&bytes).await {
+                warn!(
+                    proxy_request_id,
+                    bytes = bytes.len(),
+                    error = %err,
+                    "failed to write large replay snapshot; falling back to memory"
+                );
+                return PoolReplayBodySnapshot::Memory(bytes);
+            }
+            if let Err(err) = file.flush().await {
+                warn!(
+                    proxy_request_id,
+                    bytes = bytes.len(),
+                    error = %err,
+                    "failed to flush large replay snapshot; falling back to memory"
+                );
+                return PoolReplayBodySnapshot::Memory(bytes);
+            }
+            PoolReplayBodySnapshot::File {
+                temp_file,
+                size: bytes.len(),
+            }
+        }
+        Err(err) => {
+            warn!(
+                proxy_request_id,
+                bytes = bytes.len(),
+                error = %err,
+                "failed to create large replay snapshot; falling back to memory"
+            );
+            PoolReplayBodySnapshot::Memory(bytes)
+        }
+    }
+}
+
+pub(crate) async fn pool_replay_snapshot_from_vec(
+    proxy_request_id: u64,
+    bytes: Vec<u8>,
+) -> PoolReplayBodySnapshot {
+    pool_replay_snapshot_from_bytes(proxy_request_id, Bytes::from(bytes)).await
 }
 
 impl PoolReplayBodySnapshot {
@@ -2112,6 +2171,7 @@ fn rewrite_openai_responses_image_tools(
 }
 
 pub(crate) async fn prepare_pool_request_body_for_account(
+    proxy_request_id: u64,
     body: Option<&PoolReplayBodySnapshot>,
     original_uri: &Uri,
     method: &Method,
@@ -2174,7 +2234,7 @@ pub(crate) async fn prepare_pool_request_body_for_account(
         .map_err(|err| format!("failed to materialize pool request body for rewrite: {err}"))?;
     let Some(target) = capture_target else {
         return Ok(PreparedPoolRequestBody {
-            snapshot: PoolReplayBodySnapshot::Memory(original_bytes.clone()),
+            snapshot,
             request_body_for_capture: Some(original_bytes),
             requested_service_tier: None,
             requested_image_intent: ImageIntent::Unknown,
@@ -2184,7 +2244,7 @@ pub(crate) async fn prepare_pool_request_body_for_account(
         Ok(value) => value,
         Err(_) => {
             return Ok(PreparedPoolRequestBody {
-                snapshot: PoolReplayBodySnapshot::Memory(original_bytes.clone()),
+                snapshot,
                 request_body_for_capture: Some(original_bytes),
                 requested_service_tier: None,
                 requested_image_intent: ImageIntent::Unknown,
@@ -2214,7 +2274,7 @@ pub(crate) async fn prepare_pool_request_body_for_account(
     let upstream_image_intent = infer_image_intent_from_request_body(target, &value);
     if !rewritten && !image_rewritten {
         return Ok(PreparedPoolRequestBody {
-            snapshot: PoolReplayBodySnapshot::Memory(original_bytes.clone()),
+            snapshot,
             request_body_for_capture: Some(original_bytes),
             requested_service_tier,
             requested_image_intent: upstream_image_intent,
@@ -2224,8 +2284,10 @@ pub(crate) async fn prepare_pool_request_body_for_account(
     let rewritten_bytes = serde_json::to_vec(&value)
         .map(Bytes::from)
         .map_err(|err| format!("failed to serialize rewritten pool request body: {err}"))?;
+    let rewritten_snapshot =
+        pool_replay_snapshot_from_bytes(proxy_request_id, rewritten_bytes.clone()).await;
     Ok(PreparedPoolRequestBody {
-        snapshot: PoolReplayBodySnapshot::Memory(rewritten_bytes.clone()),
+        snapshot: rewritten_snapshot,
         request_body_for_capture: Some(rewritten_bytes.clone()),
         requested_service_tier,
         requested_image_intent: upstream_image_intent,
@@ -2234,9 +2296,10 @@ pub(crate) async fn prepare_pool_request_body_for_account(
 
 pub(crate) fn build_pool_replay_temp_path(proxy_request_id: u64) -> PathBuf {
     let mut path = env::temp_dir();
+    let unique_id = NEXT_POOL_REPLAY_TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed);
     path.push(format!(
-        "cvm-pool-replay-{proxy_request_id}-{}.bin",
-        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        "cvm-pool-replay-{proxy_request_id}-{}-{unique_id}.bin",
+        Utc::now().timestamp_nanos_opt().unwrap_or_default(),
     ));
     path
 }

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1919,12 +1919,12 @@ impl PoolReplayBodySnapshot {
             Self::Empty => reqwest::Body::from(Bytes::new()),
             Self::Memory(bytes) => reqwest::Body::from(bytes.clone()),
             Self::File { temp_file, size } => {
-                let path = temp_file.path.clone();
+                let temp_file = temp_file.clone();
                 let expected_size = *size;
                 let stream = stream::unfold(
-                    Some((path, expected_size, None::<tokio::fs::File>)),
+                    Some((temp_file, expected_size, None::<tokio::fs::File>)),
                     |state| async move {
-                        let Some((path, remaining, file)) = state else {
+                        let Some((temp_file, remaining, file)) = state else {
                             return None;
                         };
                         if remaining == 0 {
@@ -1932,7 +1932,7 @@ impl PoolReplayBodySnapshot {
                         }
                         let mut file = match file {
                             Some(file) => file,
-                            None => match tokio::fs::File::open(&path).await {
+                            None => match tokio::fs::File::open(&temp_file.path).await {
                                 Ok(file) => file,
                                 Err(err) => {
                                     return Some((Err(io::Error::other(err.to_string())), None));
@@ -1946,7 +1946,7 @@ impl PoolReplayBodySnapshot {
                                 buf.truncate(read_len);
                                 Some((
                                     Ok(Bytes::from(buf)),
-                                    Some((path, remaining - read_len, Some(file))),
+                                    Some((temp_file, remaining - read_len, Some(file))),
                                 ))
                             }
                             Err(err) => Some((Err(io::Error::other(err.to_string())), None)),

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -2032,6 +2032,9 @@ pub(crate) async fn proxy_openai_v1_via_pool(
                 original_uri.path(),
                 body_sticky_key.clone(),
             );
+            let request_body_snapshot =
+                pool_replay_snapshot_from_bytes(proxy_request_id, request_body_bytes.clone())
+                    .await;
             (
                 send_pool_request_with_failover_and_binding_constraint(
                     state.clone(),
@@ -2039,7 +2042,7 @@ pub(crate) async fn proxy_openai_v1_via_pool(
                     method,
                     original_uri,
                     &headers,
-                    Some(PoolReplayBodySnapshot::Memory(request_body_bytes)),
+                    Some(request_body_snapshot),
                     handshake_timeout,
                     Some(pool_attempt_trace_context),
                     Some(PoolAttemptRuntimeSnapshotContext {

--- a/src/tests/slices/forward_proxy_algo_and_config.rs
+++ b/src/tests/slices/forward_proxy_algo_and_config.rs
@@ -1007,6 +1007,49 @@ async fn capture_snapshot_reader_spills_large_body_to_file_and_preserves_bytes()
 }
 
 #[tokio::test]
+async fn pool_replay_snapshot_from_bytes_uses_file_for_large_body() {
+    let small = Bytes::from(vec![b'a'; POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES]);
+    let large = Bytes::from(vec![b'b'; POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES + 1]);
+
+    let small_snapshot = pool_replay_snapshot_from_bytes(45, small.clone()).await;
+    assert_eq!(pool_request_snapshot_kind(&small_snapshot), "memory");
+    assert_eq!(
+        small_snapshot.to_bytes().await.expect("read small snapshot"),
+        small
+    );
+
+    let large_snapshot = pool_replay_snapshot_from_bytes(46, large.clone()).await;
+    assert_eq!(pool_request_snapshot_kind(&large_snapshot), "file");
+    assert_eq!(pool_request_snapshot_body_bytes(&large_snapshot), large.len());
+    assert_eq!(
+        large_snapshot.to_bytes().await.expect("read large snapshot"),
+        large
+    );
+}
+
+#[tokio::test]
+async fn pool_replay_snapshot_from_vec_uses_file_for_large_body() {
+    let large = vec![b'c'; POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES + 8];
+
+    let snapshot = pool_replay_snapshot_from_vec(47, large.clone()).await;
+
+    assert_eq!(pool_request_snapshot_kind(&snapshot), "file");
+    assert_eq!(pool_request_snapshot_body_bytes(&snapshot), large.len());
+    assert_eq!(
+        snapshot.to_bytes().await.expect("read large vec snapshot"),
+        Bytes::from(large)
+    );
+}
+
+#[test]
+fn build_pool_replay_temp_path_is_unique_for_same_proxy_request() {
+    let first = build_pool_replay_temp_path(48);
+    let second = build_pool_replay_temp_path(48);
+
+    assert_ne!(first, second);
+}
+
+#[tokio::test]
 async fn capture_snapshot_reader_keeps_partial_body_on_limit_error() {
     let err = read_request_body_snapshot_with_partial_limit(
         Body::from(Bytes::from_static(b"abcdef")),

--- a/src/tests/slices/pool_failover_window_d.rs
+++ b/src/tests/slices/pool_failover_window_d.rs
@@ -448,6 +448,7 @@ async fn prepare_pool_request_body_for_account_skips_fast_mode_rewrite_for_compa
     let body = Bytes::from(serde_json::to_vec(&expected).expect("serialize compact request body"));
 
     let prepared = prepare_pool_request_body_for_account(
+        450450,
         Some(&PoolReplayBodySnapshot::Memory(body)),
         &"/v1/responses/compact".parse().expect("valid compact uri"),
         &Method::POST,
@@ -464,6 +465,39 @@ async fn prepare_pool_request_body_for_account_skips_fast_mode_rewrite_for_compa
     let payload: Value = serde_json::from_slice(&request_body).expect("decode body");
     assert_eq!(payload, expected);
     assert!(payload.get("service_tier").is_none());
+}
+
+#[tokio::test]
+async fn prepare_pool_request_body_for_account_preserves_file_snapshot_when_rewrite_is_noop() {
+    let expected = json!({
+        "model": "gpt-5.1-codex-max",
+        "serviceTier": "flex",
+        "input": "summarize this thread",
+        "padding": "x".repeat(POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES + 64),
+    });
+    let body = Bytes::from(serde_json::to_vec(&expected).expect("serialize compact request body"));
+    let snapshot = pool_replay_snapshot_from_bytes(450451, body.clone()).await;
+    assert_eq!(pool_request_snapshot_kind(&snapshot), "file");
+
+    let prepared = prepare_pool_request_body_for_account(
+        450451,
+        Some(&snapshot),
+        &"/v1/responses".parse().expect("valid responses uri"),
+        &Method::POST,
+        TagFastModeRewriteMode::KeepOriginal,
+        crate::ImageToolRewriteMode::ForceRemove,
+    )
+    .await
+    .expect("prepare compact pool request body");
+
+    assert_eq!(pool_request_snapshot_kind(&prepared.snapshot), "file");
+    assert_eq!(prepared.requested_service_tier.as_deref(), Some("flex"));
+    assert_eq!(
+        prepared
+            .request_body_for_capture
+            .expect("capture request body should be materialized"),
+        body
+    );
 }
 
 #[tokio::test]
@@ -486,6 +520,7 @@ async fn prepare_pool_request_body_for_account_reports_rewritten_image_intent_af
     );
 
     let prepared = prepare_pool_request_body_for_account(
+        488488,
         Some(&PoolReplayBodySnapshot::Memory(body)),
         &"/v1/responses".parse().expect("valid responses uri"),
         &Method::POST,
@@ -495,6 +530,52 @@ async fn prepare_pool_request_body_for_account_reports_rewritten_image_intent_af
     .await
     .expect("prepare responses pool request body");
 
+    assert_eq!(prepared.requested_image_intent, crate::ImageIntent::No);
+    let request_body = prepared
+        .request_body_for_capture
+        .expect("capture request body should be materialized");
+    let payload: Value = serde_json::from_slice(&request_body).expect("decode body");
+    assert!(
+        !payload["tools"]
+            .as_array()
+            .expect("tools should remain an array")
+            .iter()
+            .any(|tool| tool["type"].as_str() == Some("image_generation"))
+    );
+    assert!(payload.get("tool_choice").is_none());
+}
+
+#[tokio::test]
+async fn prepare_pool_request_body_for_account_keeps_large_rewrite_file_backed() {
+    let body = Bytes::from(
+        serde_json::to_vec(&json!({
+            "model": "gpt-5.3-codex",
+            "input": "x".repeat(POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES + 64),
+            "tools": [
+                {
+                    "type": "image_generation",
+                    "output_format": "png"
+                }
+            ],
+            "tool_choice": {
+                "type": "image_generation"
+            }
+        }))
+        .expect("serialize large responses request body"),
+    );
+
+    let prepared = prepare_pool_request_body_for_account(
+        488489,
+        Some(&PoolReplayBodySnapshot::Memory(body)),
+        &"/v1/responses".parse().expect("valid responses uri"),
+        &Method::POST,
+        TagFastModeRewriteMode::KeepOriginal,
+        crate::ImageToolRewriteMode::ForceRemove,
+    )
+    .await
+    .expect("prepare responses pool request body");
+
+    assert_eq!(pool_request_snapshot_kind(&prepared.snapshot), "file");
     assert_eq!(prepared.requested_image_intent, crate::ImageIntent::No);
     let request_body = prepared
         .request_body_for_capture


### PR DESCRIPTION
## Summary
- Route all large Bytes/Vec replay snapshots through a threshold helper so >1MiB requests use file-backed replay instead of memory.
- Preserve file-backed snapshots for rewrite-required/no-op bodies and reapply the same threshold after real rewrites.
- Promote large/slow proxy body, downstream first byte, and raw response writer evidence to thresholded info logs while keeping small requests at debug.

## Verification
- cargo fmt --check
- cargo check --tests
- cargo test pool_replay_snapshot_from_ -- --nocapture
- cargo test build_pool_replay_temp_path_is_unique_for_same_proxy_request -- --nocapture
- cargo test prepare_pool_request_body_for_account_ -- --nocapture
- cargo test capture_snapshot_reader_spills -- --nocapture
- cargo test pool_openai_v1_responses_fast_fill_missing_large_body_recomputes_content_length -- --nocapture
- GitHub CI: Backend Tests, Build Artifacts, Front-end Tests, Lint & Format Check, Records Overlay E2E, Review Policy Gate, Validate PR labels

## References
- Specs: docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
- Spec Disposition: update
- Solutions: docs/solutions/performance/proxy-capture-body-replay-safety.md
- Project Docs: -

## Sync
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: done
- Project Docs Sync: n/a(no human-facing project docs changed)

## Notes
- UI unchanged; no visual evidence required.
- Frontend behavior unchanged; web tests are covered by GitHub CI.
