### PR TITLE
feat(web): compact dashboard invocation latency

### DIFF
--- a/web/src/components/AppIcon.tsx
+++ b/web/src/components/AppIcon.tsx
@@ -37,6 +37,7 @@ import earthIcon from '@iconify-icons/mdi/earth'
 import fileDocumentEditOutlineIcon from '@iconify-icons/mdi/file-document-edit-outline'
 import githubIcon from '@iconify-icons/mdi/github'
 import helpCircleOutlineIcon from '@iconify-icons/mdi/help-circle-outline'
+import imageOutlineIcon from '@iconify-icons/mdi/image-outline'
 import informationOutlineIcon from '@iconify-icons/mdi/information-outline'
 import keyChainVariantIcon from '@iconify-icons/mdi/key-chain-variant'
 import keyOutlineIcon from '@iconify-icons/mdi/key-outline'
@@ -103,6 +104,7 @@ const appIconRegistry = {
   'file-document-edit-outline': fileDocumentEditOutlineIcon,
   'github': githubIcon,
   'help-circle-outline': helpCircleOutlineIcon,
+  'image-outline': imageOutlineIcon,
   'information-outline': informationOutlineIcon,
   'key-chain-variant': keyChainVariantIcon,
   'key-outline': keyOutlineIcon,

--- a/web/src/components/DashboardWorkingConversationsSection.stories.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.stories.tsx
@@ -281,21 +281,21 @@ function createUpstreamAccountActivityStoryResponse(
     "pck-story-account-final",
   ];
   const statuses = [
-    "running",
-    "success",
-    "failed",
-    "pending",
-    "running",
     "success",
     "success",
     "failed",
+    "success",
+    "success",
+    "success",
+    "success",
+    "failed",
     "pending",
     "success",
-    "running",
+    "success",
     "success",
     "failed",
     "success",
-    "pending",
+    "success",
     "success",
   ];
   const recentInvocations = Array.from(
@@ -320,6 +320,8 @@ function createUpstreamAccountActivityStoryResponse(
         requestModel: index === 0 ? "gpt-5.5-mini" : undefined,
         responseModel: index === 0 ? "gpt-5.5" : undefined,
         model: index === 0 ? "gpt-5.5" : undefined,
+        imageIntent: index === 0 ? "yes" : undefined,
+        tTotalMs: index === 0 ? 20_000 : undefined,
       }),
   );
   return {
@@ -411,6 +413,8 @@ const currentAndPreviousResponse = createResponse([
       upstreamAccountName: "growth-alpha@example.com",
       upstreamAccountPlanType: "plus",
       reasoningEffort: "medium",
+      imageIntent: "yes",
+      tTotalMs: 20_000,
     }),
     createPreview({
       id: 11,
@@ -1991,6 +1995,66 @@ function DrawerPreviewStory({
         );
       }
 
+      if (url.pathname === "/api/stats/dashboard-activity") {
+        const activity = upstreamAccountActivity ?? {
+          range: "today",
+          rangeStart: "2026-04-04T10:00:00Z",
+          rangeEnd: "2026-04-04T10:05:00Z",
+          accounts: [],
+        };
+        const includeAccounts =
+          url.searchParams.get("includeAccounts") !== "false";
+        return jsonResponse({
+          range: activity.range,
+          rangeStart: activity.rangeStart,
+          rangeEnd: activity.rangeEnd,
+          snapshotId: Date.parse(activity.rangeEnd) || 0,
+          rateWindow: {
+            start: activity.rangeStart,
+            end: activity.rangeEnd,
+            windowMinutes: 5,
+            mode: "story",
+          },
+          summary: {
+            stats: {
+              totalCount: activity.accounts.reduce(
+                (sum, account) => sum + account.requestCount,
+                0,
+              ),
+              successCount: activity.accounts.reduce(
+                (sum, account) => sum + account.successCount,
+                0,
+              ),
+              failureCount: activity.accounts.reduce(
+                (sum, account) => sum + account.failureCount,
+                0,
+              ),
+              totalCost: activity.accounts.reduce(
+                (sum, account) => sum + account.totalCost,
+                0,
+              ),
+              totalTokens: activity.accounts.reduce(
+                (sum, account) => sum + account.totalTokens,
+                0,
+              ),
+              inProgressConversationCount: activity.accounts.reduce(
+                (sum, account) => sum + (account.inProgressInvocationCount ?? 0),
+                0,
+              ),
+            },
+            tokensPerMinute: activity.accounts.reduce(
+              (sum, account) => sum + (account.tokensPerMinute ?? 0),
+              0,
+            ),
+            spendRate: activity.accounts.reduce(
+              (sum, account) => sum + (account.spendRate ?? 0),
+              0,
+            ),
+          },
+          accounts: includeAccounts ? activity.accounts : undefined,
+        });
+      }
+
       const detailMatch = url.pathname.match(
         /^\/api\/invocations\/(\d+)\/detail$/,
       );
@@ -2144,6 +2208,39 @@ export const CurrentAndPrevious: Story = {
     cards: buildCards(currentAndPreviousResponse),
     isLoading: false,
     error: null,
+  },
+  play: async ({ canvasElement }) => {
+    const currentSlot = canvasElement.querySelector(
+      '[data-testid="dashboard-working-conversation-slot"][data-slot-kind="current"]',
+    );
+    if (!(currentSlot instanceof HTMLElement)) {
+      throw new Error("missing current slot");
+    }
+
+    const firstByteLatency = currentSlot.querySelector(
+      '[data-testid="dashboard-compact-latency-first-byte"]',
+    );
+    const responseLatency = currentSlot.querySelector(
+      '[data-testid="dashboard-compact-latency-response-time"]',
+    );
+    if (!(firstByteLatency instanceof HTMLElement) || !(responseLatency instanceof HTMLElement)) {
+      throw new Error("missing compact latency readings");
+    }
+    await expect(firstByteLatency.className).not.toMatch(/rounded|border|bg-/);
+    await expect(responseLatency.className).not.toMatch(/rounded|border|bg-/);
+    const imageBadge = currentSlot.querySelector(
+      '[data-testid="dashboard-image-tool-icon-badge"]',
+    );
+    if (!(imageBadge instanceof HTMLElement)) {
+      throw new Error("missing image tool icon badge");
+    }
+    await expect(imageBadge).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/图片工具|Image tool/),
+    );
+    await expect(imageBadge.className).toMatch(/rounded-full/);
+    await expect(imageBadge.className).toMatch(/border/);
+    await expect(currentSlot).not.toHaveTextContent(/RQ |UP |ED |TT /);
   },
 };
 
@@ -2535,6 +2632,36 @@ export const UpstreamAccountTab: Story = {
     await expect(canvas.getByText("story-account-1")).toBeInTheDocument();
     await expect(canvas.getByText("gpt-5.5-mini")).toBeInTheDocument();
     await expect(canvas.getByText("gpt-5.5")).toBeInTheDocument();
+    const firstRecentRow = canvas.getAllByTestId(
+      "dashboard-upstream-account-recent-row",
+    )[0];
+    if (!(firstRecentRow instanceof HTMLElement)) {
+      throw new Error("missing first upstream recent row");
+    }
+    const firstByteLatency = firstRecentRow.querySelector(
+      '[data-testid="dashboard-compact-latency-first-byte"]',
+    );
+    const responseLatency = firstRecentRow.querySelector(
+      '[data-testid="dashboard-compact-latency-response-time"]',
+    );
+    if (!(firstByteLatency instanceof HTMLElement) || !(responseLatency instanceof HTMLElement)) {
+      throw new Error("missing upstream compact latency readings");
+    }
+    await expect(firstByteLatency.className).not.toMatch(/rounded|border|bg-/);
+    await expect(responseLatency.className).not.toMatch(/rounded|border|bg-/);
+    const imageBadge = firstRecentRow.querySelector(
+      '[data-testid="dashboard-image-tool-icon-badge"]',
+    );
+    if (!(imageBadge instanceof HTMLElement)) {
+      throw new Error("missing upstream image tool icon badge");
+    }
+    await expect(imageBadge).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/图片工具|Image tool/),
+    );
+    await expect(imageBadge.className).toMatch(/rounded-full/);
+    await expect(imageBadge.className).toMatch(/border/);
+    await expect(firstRecentRow).not.toHaveTextContent(/RQ |UP |ED |TT /);
     await expect(
       canvas.getAllByTestId("dashboard-upstream-account-recent-identity-chip"),
     ).toHaveLength(4);

--- a/web/src/components/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.test.tsx
@@ -606,9 +606,22 @@ describe("DashboardWorkingConversationsSection", () => {
     );
     expect(firstRecentRow?.textContent).toContain("Responses");
     expect(firstRecentRow?.textContent).toContain("T 200");
-    expect(firstRecentRow?.textContent).toContain("RQ 10/7");
-    expect(firstRecentRow?.textContent).toContain("UP 90/70/220");
-    expect(firstRecentRow?.textContent).toContain("ED 12/9");
+    expect(firstRecentRow?.textContent).not.toContain("RQ ");
+    expect(firstRecentRow?.textContent).not.toContain("UP ");
+    expect(firstRecentRow?.textContent).not.toContain("ED ");
+    expect(firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-first-byte"]')).not.toBeNull();
+    expect(firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-response-time"]')).not.toBeNull();
+    expect(
+      firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-first-byte"]')?.className,
+    ).not.toMatch(/rounded|border|bg-/);
+    expect(
+      firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-response-time"]')?.className,
+    ).not.toMatch(/rounded|border|bg-/);
+    expect(
+      firstRecentRow
+        ?.querySelector('[data-testid="dashboard-compact-latency-pills"]')
+        ?.getAttribute("aria-label"),
+    ).toMatch(/首字用时|Time to first byte/i);
 
     expect(
       host?.querySelector('[data-testid="dashboard-upstream-account-live-call-breakdown"]'),
@@ -618,6 +631,10 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(accountHeaderText).toContain("3");
     expect(accountHeaderText).not.toContain("并行对话");
     expect(accountHeaderText).not.toContain("重试");
+    const headerPlanBadge = accountHeader?.querySelector(
+      ".upstream-plan-badge[data-plan='enterprise']",
+    );
+    expect(headerPlanBadge?.textContent).toBe("Ent");
     expect(accountHeader?.querySelector('[aria-label="进行中调用 3"]')).not.toBeNull();
     expect(
       accountHeader?.querySelector('[aria-label="TPM 640"]'),
@@ -1654,6 +1671,22 @@ describe("DashboardWorkingConversationsSection", () => {
     ).not.toBe(0);
     expect(compactBadge.textContent).toMatch(/远程压缩|Compact/);
     expect(currentSlot.textContent).toContain("Team");
+    expect(currentSlot.textContent).not.toContain("RQ ");
+    expect(currentSlot.textContent).not.toContain("UP ");
+    expect(currentSlot.textContent).not.toContain("ED ");
+    expect(currentSlot.textContent).not.toContain("TT ");
+    expect(
+      currentSlot.querySelector('[data-testid="dashboard-compact-latency-first-byte"]'),
+    ).not.toBeNull();
+    expect(
+      currentSlot.querySelector('[data-testid="dashboard-compact-latency-response-time"]'),
+    ).not.toBeNull();
+    expect(
+      currentSlot.querySelector('[data-testid="dashboard-compact-latency-first-byte"]')?.className,
+    ).not.toMatch(/rounded|border|bg-/);
+    expect(
+      currentSlot.querySelector('[data-testid="dashboard-compact-latency-response-time"]')?.className,
+    ).not.toMatch(/rounded|border|bg-/);
   });
 
   it("shows the remote compaction v2 badge for running responses previews", () => {
@@ -1709,10 +1742,13 @@ describe("DashboardWorkingConversationsSection", () => {
     );
 
     const badges = host?.querySelectorAll(
-      '[data-testid="invocation-image-tool-badge"]',
+      '[data-testid="dashboard-image-tool-icon-badge"]',
     );
     expect(badges?.length ?? 0).toBe(1);
-    expect(host?.textContent).toMatch(/图片工具|Image tool/);
+    expect(badges?.[0]?.getAttribute("aria-label")).toMatch(/图片工具|Image tool/);
+    expect(badges?.[0]?.textContent).not.toMatch(/图片工具|Image tool/);
+    expect(badges?.[0]?.className).toContain("rounded-full");
+    expect(badges?.[0]?.className).toContain("border");
   });
 
   it("keeps image and remote_v2 badges visible together for mixed-signal previews", () => {
@@ -1736,7 +1772,7 @@ describe("DashboardWorkingConversationsSection", () => {
       '[data-testid="invocation-endpoint-badge"][data-endpoint-kind="remote_v2"]',
     );
     const imageBadge = host?.querySelector(
-      '[data-testid="invocation-image-tool-badge"][data-image-intent-kind="direct_image"]',
+      '[data-testid="dashboard-image-tool-icon-badge"][data-image-intent-kind="direct_image"]',
     );
 
     if (!(remoteBadge instanceof HTMLElement) || !(imageBadge instanceof HTMLElement)) {
@@ -1744,7 +1780,8 @@ describe("DashboardWorkingConversationsSection", () => {
     }
 
     expect(remoteBadge.textContent).toMatch(/远程压缩V2|Remote compaction V2/);
-    expect(imageBadge.textContent).toMatch(/图片工具|Image tool/);
+    expect(imageBadge.getAttribute("aria-label")).toMatch(/图片工具|Image tool/);
+    expect(imageBadge.textContent).not.toMatch(/图片工具|Image tool/);
   });
 
   it("renders compact account plan badges and hides local or missing plans", () => {

--- a/web/src/components/DashboardWorkingConversationsSection.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.tsx
@@ -54,9 +54,9 @@ import {
   buildInvocationDetailViewModel,
   renderEndpointSummary,
   renderFastIndicator,
-  renderImageIntentBadge,
   renderInvocationModelBadge,
 } from "./invocation-details-shared";
+import type { InvocationImageIntentDisplay } from "../lib/invocation";
 import { renderInvocationTransportBadge } from "./invocation-transport-badge";
 import { useDashboardUpstreamAccountActivity } from "../hooks/useDashboardUpstreamAccountActivity";
 import {
@@ -253,6 +253,85 @@ function CompactReasoningEffortBadge({ value }: { value: string }) {
   );
 }
 
+function CompactLatencyPills({
+  firstResponseByteTotalValue,
+  responseTimeValue,
+  t,
+  className,
+}: {
+  firstResponseByteTotalValue: string;
+  responseTimeValue: string;
+  t: ReturnType<typeof useTranslation>["t"];
+  className?: string;
+}) {
+  const firstResponseTimeLabel = t("dashboard.today.firstResponseTime");
+  const responseTimeLabel = t("dashboard.today.responseTime");
+
+  return (
+    <div
+      data-testid="dashboard-compact-latency-pills"
+      className={cn(
+        "inline-flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-2 font-mono text-[11px] font-semibold leading-none text-base-content/86",
+        className,
+      )}
+      aria-label={`${firstResponseTimeLabel} ${firstResponseByteTotalValue}; ${responseTimeLabel} ${responseTimeValue}`}
+      title={`${firstResponseTimeLabel}: ${firstResponseByteTotalValue} · ${responseTimeLabel}: ${responseTimeValue}`}
+    >
+      <span
+        data-testid="dashboard-compact-latency-first-byte"
+        className="inline-flex min-w-0 items-center gap-1 text-secondary"
+      >
+        <AppIcon name="timer-outline" className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <span className="truncate whitespace-nowrap">{firstResponseByteTotalValue}</span>
+      </span>
+      <span
+        data-testid="dashboard-compact-latency-response-time"
+        className="inline-flex min-w-0 items-center gap-1 text-primary"
+      >
+        <AppIcon name="speedometer" className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <span className="truncate whitespace-nowrap">{responseTimeValue}</span>
+      </span>
+    </div>
+  );
+}
+
+function DashboardImageToolIconBadge({
+  imageIntentDisplay,
+  t,
+  className,
+}: {
+  imageIntentDisplay: InvocationImageIntentDisplay;
+  t: ReturnType<typeof useTranslation>["t"];
+  className?: string;
+}) {
+  if (
+    !imageIntentDisplay.showsBadge ||
+    imageIntentDisplay.badgeVariant == null ||
+    imageIntentDisplay.badgeLabelKey == null
+  ) {
+    return null;
+  }
+
+  const label = t(imageIntentDisplay.badgeLabelKey);
+
+  return (
+    <Badge
+      variant={imageIntentDisplay.badgeVariant}
+      className={cn(
+        "h-5 w-5 justify-center overflow-hidden px-0 py-0 text-[11px] leading-none shadow-none",
+        className,
+      )}
+      data-testid="dashboard-image-tool-icon-badge"
+      data-image-intent-kind={imageIntentDisplay.kind}
+      aria-label={label}
+      title={label}
+      role="img"
+    >
+      <AppIcon name="image-outline" className="h-3.5 w-3.5" aria-hidden />
+    </Badge>
+  );
+}
+
 function renderUpstreamAccountRecentModelDisplay(
   hasMismatch: boolean,
   modelValue: string,
@@ -319,13 +398,6 @@ function CompactAccountPlanBadge({ planType }: { planType: string | null }) {
       {label}
     </Badge>
   );
-}
-
-function formatCompactMilliseconds(value: number | null | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value))
-    return FALLBACK_CELL;
-  if (Math.abs(value) >= 100) return `${Math.round(value)}`;
-  return `${Number(value.toFixed(1))}`;
 }
 
 function resolveStatusMeta(
@@ -1080,7 +1152,6 @@ function AccountRecentInvocationRow({
     : null;
   const requestModelValue = viewModel.requestModelValue;
   const responseModelValue = viewModel.responseModelValue;
-  const compactTimingSummary = `RQ ${formatCompactMilliseconds(invocation.record.tReqReadMs)}/${formatCompactMilliseconds(invocation.record.tReqParseMs)} · UP ${formatCompactMilliseconds(invocation.record.tUpstreamConnectMs)}/${formatCompactMilliseconds(invocation.record.tUpstreamTtfbMs)}/${formatCompactMilliseconds(invocation.record.tUpstreamStreamMs)} · ED ${formatCompactMilliseconds(invocation.record.tRespParseMs)}/${formatCompactMilliseconds(invocation.record.tPersistMs)} · TT ${typeof invocation.record.tTotalMs === "number" && Number.isFinite(invocation.record.tTotalMs) ? `${formatCompactMilliseconds(invocation.record.tTotalMs)}ms` : viewModel.totalLatencyValue}`;
   const invocationActionLabel = `${t("dashboard.workingConversations.openInvocation")} · ${invocation.record.invokeId}`;
   const conversationActionLabel = displayPromptCacheKey
     ? `${t("dashboard.workingConversations.openConversation")} · ${displayConversationSequenceId} · ${displayPromptCacheKey}`
@@ -1149,7 +1220,7 @@ function AccountRecentInvocationRow({
       onKeyDown={handleRowKeyDown}
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
             <div
               className="flex min-w-0 items-center gap-1.5"
@@ -1199,11 +1270,25 @@ function AccountRecentInvocationRow({
             )}
             {renderInvocationTransportBadge(
               invocation.record,
-              "min-h-5 border-[rgba(148,163,184,0.24)] bg-primary/8 px-2 py-0.5 text-[9px]",
+              "min-h-5 border-[rgba(148,163,184,0.24)] bg-primary/8 px-2 py-0.5 text-[9.5px]",
             )}
+            {renderEndpointSummary(
+              viewModel.endpointDisplay,
+              t,
+              UPSTREAM_ACCOUNT_RECENT_COMPACT_BADGE_CLASS_NAME,
+            )}
+            <DashboardImageToolIconBadge
+              imageIntentDisplay={viewModel.imageIntentDisplay}
+              t={t}
+            />
             {fastIndicator}
+            <CompactLatencyPills
+              firstResponseByteTotalValue={viewModel.firstResponseByteTotalValue}
+              responseTimeValue={viewModel.totalLatencyValue}
+              t={t}
+            />
           </div>
-          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] leading-[1.45] text-base-content/70">
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px] leading-[1.45] text-base-content/72">
             <span>{occurredAtShortLabel}</span>
             <span className="text-base-content/28">·</span>
             <span className="min-w-0">
@@ -1221,30 +1306,16 @@ function AccountRecentInvocationRow({
                 <CompactReasoningEffortBadge value={viewModel.reasoningEffortValue} />
               </>
             ) : null}
-            {renderEndpointSummary(
-              viewModel.endpointDisplay,
-              t,
-              UPSTREAM_ACCOUNT_RECENT_COMPACT_BADGE_CLASS_NAME,
-            ) ? (
-              <>
-                <span className="text-base-content/28">·</span>
-                {renderEndpointSummary(
-                  viewModel.endpointDisplay,
-                  t,
-                  UPSTREAM_ACCOUNT_RECENT_COMPACT_BADGE_CLASS_NAME,
-                )}
-              </>
-            ) : null}
           </div>
         </div>
         <div className="text-right">
-          <div className="font-mono text-[11px] font-semibold text-base-content/88">
+          <div className="font-mono text-[12px] font-semibold text-base-content/88">
             {viewModel.totalTokensValue}
           </div>
-          <div className="text-[10px] text-base-content/62">{compactCostValue}</div>
+          <div className="text-[10.5px] text-base-content/62">{compactCostValue}</div>
         </div>
       </div>
-      <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 font-mono text-[10px] leading-[1.45] text-base-content/72">
+      <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 font-mono text-[10.5px] leading-[1.45] text-base-content/74">
         <span>IN {viewModel.inputTokensValue}</span>
         <span className="text-base-content/28">·</span>
         <span>C {viewModel.cacheInputTokensValue}</span>
@@ -1252,8 +1323,6 @@ function AccountRecentInvocationRow({
         <span>O {viewModel.outputTokensValue}</span>
         <span className="text-base-content/28">·</span>
         <span>T {viewModel.totalTokensValue}</span>
-        <span className="text-base-content/28">·</span>
-        <span>{compactTimingSummary}</span>
       </div>
       {viewModel.collapsedErrorSummary ? (
         <div
@@ -1333,12 +1402,12 @@ function InvocationMetaLine({
 }) {
   return (
     <div className="grid min-w-0 grid-cols-[2.2rem_minmax(0,1fr)] items-start gap-1.5">
-      <span className="pt-[1px] text-[8px] font-semibold uppercase tracking-[0.12em] text-base-content/42">
+      <span className="pt-[1px] text-[8.5px] font-semibold uppercase tracking-[0.1em] text-base-content/48">
         {label}
       </span>
       <div
         className={cn(
-          "min-w-0 font-mono text-[8.5px] font-semibold leading-[1.35] text-base-content/84",
+          "min-w-0 font-mono text-[9.5px] font-semibold leading-[1.35] text-base-content/86",
           toneClassName,
         )}
         title={title}
@@ -1552,17 +1621,9 @@ function InvocationSlot({
   const fastIndicator = renderFastIndicator(viewModel.fastIndicatorState, t);
   const displayConversationSequenceId =
     formatDashboardWorkingConversationSequenceId(conversationSequenceId);
-  const requestReadValue = viewModel.timingPairs[0]?.value ?? FALLBACK_CELL;
-  const requestParseValue = viewModel.timingPairs[1]?.value ?? FALLBACK_CELL;
-  const upstreamConnectValue = viewModel.timingPairs[2]?.value ?? FALLBACK_CELL;
-  const upstreamTtfbValue = viewModel.timingPairs[3]?.value ?? FALLBACK_CELL;
-  const upstreamStreamValue = viewModel.timingPairs[4]?.value ?? FALLBACK_CELL;
-  const responseParseValue = viewModel.timingPairs[5]?.value ?? FALLBACK_CELL;
-  const persistValue = viewModel.timingPairs[6]?.value ?? FALLBACK_CELL;
   const compactCostValue = viewModel.costValue.startsWith("US$")
     ? `$${viewModel.costValue.slice(3)}`
     : viewModel.costValue;
-  const compactTimingSummary = `RQ ${formatCompactMilliseconds(invocation.record.tReqReadMs)}/${formatCompactMilliseconds(invocation.record.tReqParseMs)} · UP ${formatCompactMilliseconds(invocation.record.tUpstreamConnectMs)}/${formatCompactMilliseconds(invocation.record.tUpstreamTtfbMs)}/${formatCompactMilliseconds(invocation.record.tUpstreamStreamMs)} · ED ${formatCompactMilliseconds(invocation.record.tRespParseMs)}/${formatCompactMilliseconds(invocation.record.tPersistMs)} · TT ${typeof invocation.record.tTotalMs === "number" && Number.isFinite(invocation.record.tTotalMs) ? `${formatCompactMilliseconds(invocation.record.tTotalMs)}ms` : viewModel.totalLatencyValue}`;
   const invocationActionLabel = `${t("dashboard.workingConversations.openInvocation")} · ${label} · ${displayConversationSequenceId} · ${invocation.record.invokeId}`;
 
   const handleOpenInvocation = useCallback(() => {
@@ -1605,25 +1666,25 @@ function InvocationSlot({
       onClick={handleOpenInvocation}
       onKeyDown={handleSlotKeyDown}
     >
-      <div className="flex min-h-5 items-start justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <div className="shrink-0 text-[9px] font-semibold uppercase tracking-[0.12em] text-base-content/55">
+      <div className="space-y-1">
+        <div className="flex min-h-5 min-w-0 items-center gap-1.5">
+          <div className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.08em] text-base-content/62">
             {label}
           </div>
-          <div className="shrink-0 font-mono text-[9px] text-base-content/68">
+          <div className="shrink-0 font-mono text-[10px] text-base-content/72">
             {occurredAtShortLabel}
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-1.5 self-start">
+        <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
           {invocation.livePhase ? (
             <InvocationPhaseBadge
               phase={invocation.livePhase}
-              className="h-4.5 px-1.5 py-0 text-[8.5px] font-semibold leading-none shadow-none"
+              className="h-5 px-1.5 py-0 text-[9.5px] font-semibold leading-none shadow-none"
             />
           ) : (
             <Badge
               variant={statusMeta.badgeVariant}
-              className="h-4.5 gap-1 border-transparent bg-base-100/12 px-1.5 py-0 text-[8.5px] font-semibold leading-none shadow-none"
+              className="h-5 gap-1 border-transparent bg-base-100/12 px-1.5 py-0 text-[9.5px] font-semibold leading-none shadow-none"
             >
               <AppIcon
                 name={statusMeta.icon}
@@ -1635,25 +1696,30 @@ function InvocationSlot({
           )}
           {renderInvocationTransportBadge(
             invocation.record,
-            "h-4.5 border-primary/45 bg-primary/10 px-1.5 text-[8.5px]",
+            "h-5 border-primary/45 bg-primary/10 px-1.5 text-[9.5px]",
           )}
           <div className="flex h-5 shrink-0 items-center">
             <div className="flex items-center gap-1">
               {renderEndpointSummary(
                 viewModel.endpointDisplay,
                 t,
-                "h-4.5 rounded-full border-transparent bg-base-100/10 px-1.5 py-0 text-[8.5px] font-semibold leading-none text-base-content/72 shadow-none",
+                "h-5 rounded-full border-transparent bg-base-100/10 px-1.5 py-0 text-[9.5px] font-semibold leading-none text-base-content/76 shadow-none",
               )}
-              {renderImageIntentBadge(
-                viewModel.imageIntentDisplay,
-                t,
-                "h-4.5 border-transparent bg-base-100/10 px-1.5 py-0 text-[8.5px] font-semibold leading-none text-base-content/72 shadow-none",
-              )}
+              <DashboardImageToolIconBadge
+                imageIntentDisplay={viewModel.imageIntentDisplay}
+                t={t}
+              />
             </div>
           </div>
+          <CompactLatencyPills
+            firstResponseByteTotalValue={viewModel.firstResponseByteTotalValue}
+            responseTimeValue={viewModel.totalLatencyValue}
+            t={t}
+            className="text-[11.5px]"
+          />
           {viewModel.collapsedErrorSummary ? (
             <span
-              className="inline-flex h-4.5 w-4.5 items-center justify-center rounded-full bg-base-100/12 text-error/90"
+              className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-base-100/12 text-error/90"
               title={viewModel.collapsedErrorSummary}
               aria-label={viewModel.collapsedErrorSummary}
             >
@@ -1673,14 +1739,14 @@ function InvocationSlot({
           value={
             <div
               data-testid="dashboard-working-conversation-account-line"
-              className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 text-[8.5px] leading-[1.3] text-base-content sm:flex-nowrap"
+              className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 text-[9.5px] leading-[1.3] text-base-content sm:flex-nowrap"
             >
               <div className="flex min-w-[7rem] max-w-full flex-1 items-baseline gap-1.5 font-mono font-semibold">
                 {viewModel.accountClickable && viewModel.accountId != null ? (
                   <button
                     type="button"
                     data-testid="dashboard-working-conversation-account-chip"
-                    className="inline-flex min-w-0 max-w-full cursor-pointer appearance-none items-baseline border-0 bg-transparent p-0 text-left font-mono text-[8.5px] font-semibold text-base-content no-underline transition-colors duration-200 hover:text-primary focus-visible:rounded-[0.2rem] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                    className="inline-flex min-w-0 max-w-full cursor-pointer appearance-none items-baseline border-0 bg-transparent p-0 text-left font-mono text-[9.5px] font-semibold text-base-content no-underline transition-colors duration-200 hover:text-primary focus-visible:rounded-[0.2rem] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                     onClick={(event) => {
                       event.stopPropagation();
                       onOpenUpstreamAccount?.(
@@ -1764,16 +1830,6 @@ function InvocationSlot({
               <span>T {viewModel.totalTokensValue}</span>
               <span className="text-base-content/28">·</span>
               <span>{compactCostValue}</span>
-            </div>
-          }
-        />
-
-        <InvocationMetaLine
-          label={lineLabels.timing}
-          title={`${t("table.details.timingsTitle")}: REQ ${requestReadValue}/${requestParseValue} · UP ${upstreamConnectValue}/${upstreamTtfbValue}/${upstreamStreamValue} · END ${responseParseValue}/${persistValue} · TOT ${viewModel.totalLatencyValue}`}
-          value={
-            <div className="min-w-0 text-base-content/70">
-              {compactTimingSummary}
             </div>
           }
         />
@@ -2286,6 +2342,7 @@ function DashboardUpstreamAccountActivityCard({
             {shouldShowUpstreamPlanBadge(account.planType) ? (
               <Badge
                 variant={upstreamPlanBadgeRecipe(account.planType)?.variant ?? "secondary"}
+                data-plan={upstreamPlanBadgeRecipe(account.planType)?.dataPlan}
                 className={cn(
                   "h-5 px-2 py-0 text-[10px] font-semibold",
                   upstreamPlanBadgeRecipe(account.planType)?.className,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -283,10 +283,13 @@ body {
   }
 
   [data-theme='vibe-dark'] .upstream-plan-badge[data-plan='enterprise'] {
-    border-color: rgba(250, 204, 21, 0.34);
-    background-color: rgba(61, 45, 8, 0.8);
-    color: #fde68a;
-    box-shadow: inset 0 0 0 1px rgba(234, 179, 8, 0.2);
+    border-color: rgba(250, 204, 21, 0.62);
+    background-color: rgba(92, 63, 8, 0.86);
+    color: #fef3c7;
+    font-weight: 700;
+    box-shadow:
+      inset 0 0 0 1px rgba(253, 230, 138, 0.24),
+      0 0 0 1px rgba(250, 204, 21, 0.08);
   }
 
   [data-theme='vibe-dark'] .upstream-plan-badge[data-plan='free'] {


### PR DESCRIPTION
## Summary
- Reworked Dashboard compact invocation rows to scan as status, endpoint, image capability, time to first byte, and response time.
- Replaced the Dashboard image-tool text badge with an icon badge that keeps title, aria-label, and stable test selectors.
- Removed the compact `RQ / UP / ED / TT` phase timing string from current/previous invocation slots and upstream account recent rows.

## Validation
- `cd web && bun run test -- DashboardWorkingConversationsSection.test.tsx`
- `cd web && bun x tsc -b --pretty false`
- `cd web && bun run build-storybook`
- `cd web && bun run test-storybook -- DashboardWorkingConversationsSection` (storybook project reports this file as skipped/no tests in the current repo config)
- Playwright Storybook DOM sampling confirmed both compact surfaces have first-byte, response-time, and image icon badges, with no visible `RQ`, `UP`, `ED`, or `TT` strings.
- Codex review: no findings.

## Visual Evidence
- Storybook dark-mode screenshots generated for `CurrentAndPrevious` and `UpstreamAccountTab` in the Codex thread.

## References
- Specs: `spec_disposition=not_needed` (no current spec required for this display-only refinement)
- Solutions: `solution_disposition=none`
- Project Docs: `project_doc_disposition=none`