### PR TITLE
test(web): stabilize invocation virtualization assertion

### DIFF
--- a/web/src/components/InvocationTable.test.tsx
+++ b/web/src/components/InvocationTable.test.tsx
@@ -533,8 +533,14 @@ describe("InvocationTable", () => {
       Array.from({ length: 1_000 }, (_, index) => createInvocationRecord(index)),
     );
 
-    expect(document.querySelectorAll("tbody tr").length).toBeLessThan(80);
-    expect(document.body.textContent).toContain("virtual-proxy-1");
+    const mountedRows = Array.from(document.querySelectorAll("tbody tr"));
+    const mountedText = mountedRows
+      .map((row) => row.textContent ?? "")
+      .join(" ");
+
+    expect(mountedRows.length).toBeGreaterThan(0);
+    expect(mountedRows.length).toBeLessThan(80);
+    expect(mountedText).toMatch(/virtual-proxy-\d+/);
     expect(document.body.textContent).not.toContain("virtual-proxy-1000");
     expect(document.querySelector('[data-testid="invocation-table-scroll"]')).toBeTruthy();
     expect(document.querySelector('[data-testid="invocation-list"]')).toBeNull();

--- a/web/src/components/PromptCacheConversationTable.test.tsx
+++ b/web/src/components/PromptCacheConversationTable.test.tsx
@@ -332,6 +332,12 @@ describe("PromptCacheConversationTable", () => {
     );
   }
 
+  function findInputByAriaLabel(label: string) {
+    return document.querySelector(
+      `input[aria-label="${label}"]`,
+    ) as HTMLInputElement | null;
+  }
+
   async function clickDrawerTab(label: string) {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     const tab = Array.from(document.querySelectorAll('[role="tab"]')).find(
@@ -1553,11 +1559,11 @@ describe("PromptCacheConversationTable", () => {
       expect(apiMocks.updatePromptCacheConversationBinding).toHaveBeenCalledTimes(4),
     );
     await user.click(findButtonByAriaLabel("编辑对话覆盖: 可用模型")!);
-    await user.clear(
-      document.querySelector('input[aria-label="可用模型"]') as HTMLInputElement,
-    );
+    await vi.waitFor(() => expect(findInputByAriaLabel("可用模型")).toBeTruthy());
+    const availableModelsInput = findInputByAriaLabel("可用模型")!;
+    await user.clear(availableModelsInput);
     await user.type(
-      document.querySelector('input[aria-label="可用模型"]') as HTMLInputElement,
+      availableModelsInput,
       "gpt-5.1-codex-max, gpt-5.1-codex-mini",
     );
     await user.click(findButtonByAriaLabel("应用覆盖")!);


### PR DESCRIPTION
## Summary
- Stabilize the InvocationTable virtualization test by asserting that a bounded virtualized window is mounted, instead of assuming the jsdom virtualizer always starts at the first row.
- Keep the regression check that the far-off row (`virtual-proxy-1000`) is not mounted.

## Verification
- `cd web && bun run test -- InvocationTable.test.tsx`
- `cd web && bun run test`
- Git hooks: pre-commit `check-web`, `typecheck-web`; commit-msg `commitlint`

## References
- Specs: -
- Solutions: -
- Project Docs: -

## Disposition
- `spec_disposition=not_needed`; spec sync n/a(spec-free); spec drift none.
- `solution_disposition=none`.
- `project_doc_disposition=none`; Project Docs Sync: n/a(no project-doc change).
- Visual evidence: n/a, test-only stabilization.
