### PR TITLE
fix(proxy): allow realtime websocket passthrough

### DIFF
--- a/docs/specs/w5s2x-openai-websocket-proxy/HISTORY.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/HISTORY.md
@@ -1,5 +1,11 @@
 # OpenAI 兼容 WebSocket 代理演进记录（#w5s2x）
 
+## 2026-07-06
+
+- 修正协议分流：`/v1/responses` 保持首帧驱动的 turn-aware relay；`/v1/realtime` 等非 Responses WS 改为即时上游 passthrough，避免 Realtime 连接因等待 downstream `response.create` 而超时。
+- 补齐首帧前失败观测：`/v1/responses` 在上游建连前因首帧超时、读取错误或协议拒绝失败时写入 pool attempt failure，避免线上只看到请求日志而看不到失败 attempt。
+- 线上只读诊断确认：101 当前部署的 WebSocket 开关已启用，历史失败集中在第三方 `api_key_codex` 兼容上游的 `/v1/responses`，表现为 `426 Upgrade Required` 或握手后在 terminal 前 close；这类上游能力问题不应掩盖代理对 `/v1/realtime` 的 server-first passthrough 分流缺陷。
+
 ## 2026-07-05
 
 - 将历史透明隧道式 WS 契约提升为 Responses WS 协议感知 passthrough relay。

--- a/docs/specs/w5s2x-openai-websocket-proxy/IMPLEMENTATION.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/IMPLEMENTATION.md
@@ -3,7 +3,9 @@
 ## Coverage
 
 - 已实现：`/v1/*` WebSocket upgrade 检测、pool 鉴权、downstream/upstream 双开关和 proxy request concurrency gate。
-- 已实现：所有 downstream WS session 统一在 upgrade 后读取首个 text JSON `response.create`，再执行 prompt-cache routing、encrypted owner guard、账号池选择和上游 WS 握手。
+- 已实现：`/v1/responses` downstream WS session 在 upgrade 后读取首个 text JSON `response.create`，再执行 prompt-cache routing、encrypted owner guard、账号池选择和上游 WS 握手。
+- 已实现：非 Responses 的 `/v1/*` WebSocket（例如 `/v1/realtime`）在 upgrade 后立即执行账号池选择和上游 WS 握手，不等待 downstream `response.create`，支持上游先发事件 passthrough。
+- 已实现：`/v1/responses` 首帧读取超时、读取错误和首帧协议拒绝会写入 `pool_upstream_request_attempts` transport failure，并广播 attempt snapshot；客户端未开始 turn 的正常主动关闭不记失败。
 - 已实现：payload `prompt_cache_key` 优先于 header prompt cache key；sticky-only header 不会进入 prompt-cache owner guard。
 - 已实现：首帧 payload `model` 优先于 query `model` 进入账号池选择；`previous_response_id` 作为 turn metadata 解析与日志观测输入保留。
 - 已实现：上游握手成功后发送保留首帧；握手失败、timeout、unsupported HTTP 状态和 transport error 仍复用账号池 failover，在同一个 downstream session 内尝试下一个候选。
@@ -29,3 +31,5 @@
 - upstream terminal 前 close 转换为 downstream `1013` retryable close，并记录 attempt failure。
 - 上游 handshake failure 在同一 downstream session 内 failover 到下一候选，并发送保留首帧。
 - downstream subprotocol 与 upstream subprotocol 不匹配时不发送保留首帧，记录 attempt failure 并返回 retryable close。
+- `/v1/realtime` passthrough 建连后不等待 downstream 首帧即可 relay 上游 `session.created`。
+- `/v1/responses` 首帧协议拒绝会关闭 downstream，并留下 `pool-ws-*` pre-upstream attempt failure。

--- a/docs/specs/w5s2x-openai-websocket-proxy/SPEC.md
+++ b/docs/specs/w5s2x-openai-websocket-proxy/SPEC.md
@@ -4,7 +4,7 @@
 
 - Status: active
 - Created: 2026-05-04
-- Last: 2026-07-05
+- Last: 2026-07-06
 
 ## 背景 / 问题陈述
 
@@ -14,7 +14,8 @@
 
 ## Goals
 
-- `/v1/*` downstream WebSocket 在通过 HTTP 层鉴权、开关和并发门禁后，先读取首个 text JSON `response.create` payload，再执行账号池路由和上游 WS 握手。
+- `/v1/responses` downstream WebSocket 在通过 HTTP 层鉴权、开关和并发门禁后，先读取首个 text JSON `response.create` payload，再执行账号池路由和上游 WS 握手。
+- 非 Responses 的 `/v1/*` WebSocket（例如 `/v1/realtime`）在通过 HTTP 层鉴权、开关和并发门禁后立即执行账号池路由和上游 WS 握手，不等待 downstream 首帧。
 - 首帧 payload 的 `model`、`prompt_cache_key`、`previous_response_id` 和 encrypted content 参与路由、owner guard 和观测；header `prompt_cache_key` 只作为 fallback，sticky-only header 不得被当作 prompt cache key。
 - 上游握手成功后才发送被保留的首帧；握手、429、unsupported 或网络失败仍在同一个 downstream WS session 内按账号池 failover 尝试后续候选。
 - relay 以 `response.create` 到 terminal event 为 active turn 边界，继续透传 text、binary、ping、pong、close。
@@ -36,7 +37,9 @@
 - Downstream: `GET /v1/*` 携带标准 WebSocket upgrade headers，且必须携带现有 pool route key。
 - Downstream gate: `websocketEnabled=false` 时返回 HTTP `503` JSON error，不进入 WS upgrade。
 - Upstream gate: `upstreamWebsocketDefaultEnabled=false` 时，已 upgrade 的 downstream WS 收到 retryable close，不建立不可靠上游隧道。
-- Initial frame: upgrade 成功后，第一个 downstream frame 必须是 text JSON，`type` 必须为 `response.create`。非 text、非 JSON 或非 `response.create` 首帧以 close `1011` 结束。
+- Responses initial frame: `/v1/responses` upgrade 成功后，第一个 downstream frame 必须是 text JSON，`type` 必须为 `response.create`。非 text、非 JSON 或非 `response.create` 首帧以 close `1011` 结束。
+- Pre-upstream observability: `/v1/responses` 在上游建连前发生首帧读取超时、读取错误或首帧协议拒绝时，必须写入 `pool_upstream_request_attempts` 的 `transport_failure` / `failed` 记录，保留 `pool-ws-*` invoke id、failure kind 和 downstream error message；downstream 正常主动关闭且未开始 turn 时不制造失败记录。
+- Realtime passthrough: `/v1/realtime` upgrade 成功后必须立即连接上游并 relay 上游先发事件；不得等待 downstream `response.create`。
 - Subprotocol: 若 downstream 请求 `Sec-WebSocket-Protocol`，代理可为客户端兼容性选择第一个请求值，但上游握手必须返回同一 subprotocol 后才允许发送保留首帧；不匹配视为 retryable upstream transport failure 并进入 failover。
 - Routing keys: payload `prompt_cache_key` / `promptCacheKey` 优先；无 payload key 时才使用 header `x-prompt-cache-key` / `prompt-cache-key` / `x-openai-prompt-cache-key`；`x-sticky-key` 只影响 sticky routing，不参与 prompt-cache owner guard。
 - Model: payload `model` 优先于 query `model` 参与账号池模型约束选择。
@@ -51,6 +54,8 @@
 - 无 header `prompt_cache_key` 时，首帧 payload 的 `prompt_cache_key` 能决定 owner/binding 路由。
 - sticky-only header 不会被当作 prompt cache key，也不会触发 encrypted owner guard。
 - 首个候选上游 handshake 失败时，同一 downstream WS session 内切到下一候选，并把保留首帧发送给成功候选。
+- `/v1/realtime` downstream 建连后，即使 downstream 尚未发送业务帧，也能收到上游先发的 `session.created` 等事件。
+- `/v1/responses` 首帧协议拒绝或首帧读取超时后，失败在 pool attempt 视图中可查询，不再只剩请求日志。
 - downstream 请求 subprotocol 且上游未选择同一值时，代理不得 relay 首帧，应记录 retryable attempt failure 并向客户端返回 `1013 upstream_unavailable; retry` 或继续 failover 到匹配候选。
 - 多个 `response.create` turn 能逐 turn relay，terminal usage 分别落入 invocation/cost 统计。
 - 缺字段 usage 不产生半字段 usage/cost 记录。

--- a/src/proxy/websocket.rs
+++ b/src/proxy/websocket.rs
@@ -184,27 +184,51 @@ pub(crate) async fn proxy_openai_v1_ws_common(
     };
 
     let downstream_subprotocol = requested_websocket_subprotocol(&headers);
+    let requires_response_create_first_frame =
+        websocket_requires_response_create_first_frame(original_uri.path());
     let ws = match downstream_subprotocol.clone() {
         Some(protocol) => ws.protocols([protocol]),
         None => ws,
     };
     ws.on_upgrade(move |downstream| async move {
-        proxy_websocket_tunnel_deferred_prepare(
-            state,
-            downstream,
-            proxy_request_id,
-            original_uri,
-            headers,
-            runtime_timeouts,
-            sticky_key,
-            requested_model,
-            header_prompt_cache_key,
-            downstream_subprotocol,
-            trace,
-            proxy_request_permit,
-        )
-        .await;
+        if requires_response_create_first_frame {
+            proxy_websocket_tunnel_deferred_prepare(
+                state,
+                downstream,
+                proxy_request_id,
+                original_uri,
+                headers,
+                runtime_timeouts,
+                sticky_key,
+                requested_model,
+                header_prompt_cache_key,
+                downstream_subprotocol,
+                trace,
+                proxy_request_permit,
+            )
+            .await;
+        } else {
+            proxy_websocket_tunnel_immediate_prepare(
+                state,
+                downstream,
+                proxy_request_id,
+                original_uri,
+                headers,
+                runtime_timeouts,
+                sticky_key,
+                requested_model,
+                header_prompt_cache_key,
+                downstream_subprotocol,
+                trace,
+                proxy_request_permit,
+            )
+            .await;
+        }
     })
+}
+
+fn websocket_requires_response_create_first_frame(path: &str) -> bool {
+    path == "/v1/responses" || path.starts_with("/v1/responses/")
 }
 
 pub(crate) struct PreparedUpstreamWebSocket {
@@ -671,7 +695,12 @@ async fn prepare_single_upstream_websocket_attempt(
         .as_ref()
         .map(|pending| PoolEarlyPhaseOrphanCleanupGuard::new(state.clone(), pending.clone()));
 
-    let request = match build_upstream_ws_request(&upstream_url, headers, &account) {
+    let request = match build_upstream_ws_request(
+        &upstream_url,
+        headers,
+        &account,
+        websocket_requires_response_create_first_frame(original_uri.path()),
+    ) {
         Ok(request) => request,
         Err(err) => {
             let message = format!("failed to build upstream websocket request: {err}");
@@ -1287,19 +1316,48 @@ async fn proxy_websocket_tunnel_deferred_prepare(
         match timeout(runtime_timeouts.request_read_timeout, downstream.next()).await {
             Ok(Some(Ok(message))) => message,
             Ok(Some(Err(err))) => {
+                let message = format!(
+                    "failed to read websocket first response.create frame: {err}"
+                );
                 warn!(
                     proxy_request_id,
-                    error = %err,
+                    error = %message,
                     "downstream websocket closed before deferred upstream prepare"
+                );
+                record_ws_pre_upstream_failure(
+                    state.as_ref(),
+                    &trace,
+                    PROXY_FAILURE_REQUEST_BODY_READ_TIMEOUT,
+                    message.as_str(),
+                )
+                .await;
+                return;
+            }
+            Ok(None) => {
+                debug!(
+                    proxy_request_id,
+                    "downstream websocket closed before first response.create frame"
                 );
                 return;
             }
-            Ok(None) => return,
             Err(_) => {
+                let message = "websocket first response.create timed out";
+                warn!(
+                    proxy_request_id,
+                    timeout_secs = runtime_timeouts.request_read_timeout.as_secs_f64(),
+                    "websocket first response.create timed out"
+                );
+                record_ws_pre_upstream_failure(
+                    state.as_ref(),
+                    &trace,
+                    PROXY_FAILURE_REQUEST_BODY_READ_TIMEOUT,
+                    message,
+                )
+                .await;
                 let _ = downstream
                     .send(AxumWsMessage::Close(Some(axum::extract::ws::CloseFrame {
                         code: axum::extract::ws::close_code::ERROR,
-                        reason: "websocket first response.create timed out".into(),
+                        reason: message.into(),
                     })))
                     .await;
                 return;
@@ -1319,6 +1377,13 @@ async fn proxy_websocket_tunnel_deferred_prepare(
                 reason,
                 "websocket first downstream frame rejected"
             );
+            record_ws_pre_upstream_failure(
+                state.as_ref(),
+                &trace,
+                PROXY_FAILURE_REQUEST_BODY_READ_TIMEOUT,
+                reason,
+            )
+            .await;
             let _ = downstream
                 .send(AxumWsMessage::Close(Some(axum::extract::ws::CloseFrame {
                     code: axum::extract::ws::close_code::ERROR,
@@ -1405,6 +1470,141 @@ async fn proxy_websocket_tunnel_deferred_prepare(
         prepared,
         proxy_request_permit,
         Some(first_downstream_message),
+    )
+    .await;
+}
+
+async fn record_ws_pre_upstream_failure(
+    state: &AppState,
+    trace: &PoolUpstreamAttemptTraceContext,
+    failure_kind: &'static str,
+    message: &str,
+) {
+    let now = shanghai_now_string();
+    if let Err(err) = insert_pool_upstream_request_attempt_with_scope(
+        &state.pool,
+        trace,
+        None,
+        None,
+        None,
+        None,
+        1,
+        0,
+        0,
+        Some(now.as_str()),
+        Some(now.as_str()),
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE,
+        Some(POOL_UPSTREAM_REQUEST_ATTEMPT_PHASE_FAILED),
+        None,
+        Some(StatusCode::BAD_REQUEST),
+        Some(failure_kind),
+        Some(message),
+        Some(message),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    {
+        warn!(
+            invoke_id = %trace.invoke_id,
+            error = %err,
+            "failed to record websocket pre-upstream failure"
+        );
+        return;
+    }
+    if let Err(err) = broadcast_pool_upstream_attempts_snapshot(state, &trace.invoke_id).await {
+        warn!(
+            invoke_id = %trace.invoke_id,
+            error = %err,
+            "failed to broadcast websocket pre-upstream failure"
+        );
+    }
+}
+
+async fn proxy_websocket_tunnel_immediate_prepare(
+    state: Arc<AppState>,
+    mut downstream: WebSocket,
+    proxy_request_id: u64,
+    original_uri: Uri,
+    headers: HeaderMap,
+    runtime_timeouts: PoolRoutingTimeoutSettingsResolved,
+    sticky_key: Option<String>,
+    requested_model: Option<String>,
+    header_prompt_cache_key: Option<String>,
+    required_subprotocol: Option<String>,
+    trace: PoolUpstreamAttemptTraceContext,
+    proxy_request_permit: ProxyRequestConcurrencyPermit,
+) {
+    debug!(
+        proxy_request_id,
+        requested_model = ?requested_model,
+        prompt_cache_key_present = header_prompt_cache_key.is_some(),
+        path = %original_uri.path(),
+        "websocket passthrough prepare without response.create first frame"
+    );
+    let (binding_constraint, owner_auto_guard_active, conversation_override) =
+        match load_via_pool_effective_routing(
+            state.as_ref(),
+            header_prompt_cache_key.as_deref(),
+            false,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err((_status, message)) => {
+                let _ = downstream
+                    .send(AxumWsMessage::Close(Some(axum::extract::ws::CloseFrame {
+                        code: axum::extract::ws::close_code::ERROR,
+                        reason: message.into(),
+                    })))
+                    .await;
+                return;
+            }
+        };
+    let prepared = match prepare_upstream_websocket(
+        state.clone(),
+        proxy_request_id,
+        &original_uri,
+        &headers,
+        &runtime_timeouts,
+        sticky_key.as_deref(),
+        requested_model.as_deref(),
+        header_prompt_cache_key.as_deref(),
+        binding_constraint,
+        conversation_override,
+        owner_auto_guard_active,
+        &trace,
+        required_subprotocol.as_deref(),
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(err) => {
+            let close_frame = if err.message == ENCRYPTED_SESSION_OWNER_UNAVAILABLE_MESSAGE {
+                axum::extract::ws::CloseFrame {
+                    code: axum::extract::ws::close_code::AGAIN,
+                    reason: "encrypted_session_owner_unavailable; retry".into(),
+                }
+            } else {
+                axum::extract::ws::CloseFrame {
+                    code: axum::extract::ws::close_code::AGAIN,
+                    reason: "upstream_unavailable; retry".into(),
+                }
+            };
+            let _ = downstream.send(AxumWsMessage::Close(Some(close_frame))).await;
+            return;
+        }
+    };
+    proxy_websocket_tunnel(
+        state,
+        downstream,
+        prepared,
+        proxy_request_permit,
+        None,
     )
     .await;
 }
@@ -1955,6 +2155,7 @@ fn build_upstream_ws_request(
     upstream_url: &Url,
     headers: &HeaderMap,
     account: &PoolResolvedAccount,
+    force_responses_beta: bool,
 ) -> Result<TungsteniteRequest<()>> {
     let mut request = upstream_url
         .as_str()
@@ -1975,10 +2176,12 @@ fn build_upstream_ws_request(
             access_token,
             chatgpt_account_id,
         } => {
-            request.headers_mut().insert(
-                HeaderName::from_static("openai-beta"),
-                HeaderValue::from_static("responses=experimental"),
-            );
+            if force_responses_beta {
+                request.headers_mut().insert(
+                    HeaderName::from_static("openai-beta"),
+                    HeaderValue::from_static("responses=experimental"),
+                );
+            }
             if let Some(account_id) = chatgpt_account_id
                 .as_deref()
                 .map(str::trim)
@@ -2557,6 +2760,7 @@ mod websocket_tests {
             &Url::parse("wss://api.example.test/v1/responses").expect("valid target"),
             &headers,
             &account,
+            true,
         )
         .expect("request");
 
@@ -2596,6 +2800,7 @@ mod websocket_tests {
             &Url::parse("wss://api.example.test/v1/responses").expect("valid target"),
             &headers,
             &account,
+            true,
         )
         .expect("request");
 
@@ -2612,6 +2817,45 @@ mod websocket_tests {
                 .get("openai-beta")
                 .and_then(|value| value.to_str().ok()),
             Some("responses=experimental")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("chatgpt-account-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("acct-test")
+        );
+    }
+
+    #[test]
+    fn upstream_ws_request_preserves_oauth_realtime_beta_header() {
+        let account = oauth_account(Url::parse("https://api.example.test").expect("valid base"));
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("openai-beta"),
+            HeaderValue::from_static("realtime=v1"),
+        );
+        let request = build_upstream_ws_request(
+            &Url::parse("wss://api.example.test/v1/realtime").expect("valid target"),
+            &headers,
+            &account,
+            false,
+        )
+        .expect("request");
+
+        assert_eq!(
+            request
+                .headers()
+                .get(header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer oauth-upstream-token")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("openai-beta")
+                .and_then(|value| value.to_str().ok()),
+            Some("realtime=v1")
         );
         assert_eq!(
             request

--- a/src/tests/slices/pool_failover_window_b.rs
+++ b/src/tests/slices/pool_failover_window_b.rs
@@ -1904,7 +1904,7 @@ async fn websocket_payload_only_prompt_cache_key_routes_first_upgrade_to_owner_a
 
     let attempts = Arc::new(StdMutex::new(HashMap::new()));
     let upstream_app = Router::new()
-        .route("/v1/realtime", get(websocket_echo_upstream))
+        .route("/v1/responses", get(websocket_echo_upstream))
         .with_state(attempts.clone());
     let upstream_listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -1987,7 +1987,7 @@ async fn websocket_payload_only_prompt_cache_key_routes_first_upgrade_to_owner_a
     });
 
     let request = format!(
-        "ws://{proxy_addr}/v1/realtime?model=gpt-5-realtime"
+        "ws://{proxy_addr}/v1/responses?model=gpt-5-realtime"
     )
     .into_client_request()
     .expect("websocket client request");
@@ -2046,6 +2046,228 @@ async fn websocket_payload_only_prompt_cache_key_routes_first_upgrade_to_owner_a
 }
 
 #[tokio::test]
+async fn websocket_realtime_passthrough_does_not_wait_for_response_create_first_frame() {
+    use futures_util::StreamExt;
+    use tokio_tungstenite::connect_async;
+    use tungstenite::Message as TungsteniteMessage;
+
+    async fn realtime_session_upstream(ws: WebSocketUpgrade) -> Response {
+        ws.on_upgrade(move |mut socket| async move {
+            let _ = socket
+                .send(AxumWsMessage::Text(
+                    json!({
+                        "type": "session.created",
+                        "session": {
+                            "id": "sess_passthrough",
+                            "model": "gpt-5-realtime"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .await;
+            let _ = socket.send(AxumWsMessage::Close(None)).await;
+        })
+        .into_response()
+    }
+
+    let upstream_app = Router::new().route("/v1/realtime", get(realtime_session_upstream));
+    let upstream_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind realtime websocket upstream");
+    let upstream_addr = upstream_listener
+        .local_addr()
+        .expect("realtime websocket upstream addr");
+    let upstream_handle = tokio::spawn(async move {
+        axum::serve(upstream_listener, upstream_app)
+            .await
+            .expect("realtime websocket upstream should run");
+    });
+
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse(&format!("http://{upstream_addr}")).expect("valid websocket upstream base url");
+    config.openai_proxy_websocket_enabled = true;
+    config.openai_proxy_upstream_websocket_default_enabled = true;
+    config.openai_proxy_request_read_timeout = Duration::from_millis(80);
+    let state = test_state_from_config_with_pool_no_available_wait(
+        config,
+        true,
+        PoolNoAvailableWaitSettings {
+            timeout: Duration::from_millis(80),
+            poll_interval: Duration::from_millis(10),
+            retry_after_secs: DEFAULT_POOL_NO_AVAILABLE_ACCOUNT_RETRY_AFTER_SECS,
+        },
+    )
+    .await;
+    {
+        let mut settings = state.proxy_model_settings.write().await;
+        settings.websocket_enabled = true;
+        settings.upstream_websocket_default_enabled = true;
+    }
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account_with_options(
+        &state,
+        "Realtime WebSocket",
+        "upstream-realtime",
+        None,
+        None,
+        Some(&format!("http://{upstream_addr}")),
+    )
+    .await;
+
+    let proxy_app = Router::new()
+        .route("/v1/*path", any(proxy_openai_v1_with_connect_info))
+        .with_state(state.clone());
+    let proxy_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind realtime websocket proxy server");
+    let proxy_addr = proxy_listener
+        .local_addr()
+        .expect("realtime websocket proxy server addr");
+    let proxy_handle = tokio::spawn(async move {
+        axum::serve(proxy_listener, proxy_app)
+            .await
+            .expect("realtime websocket proxy server should run");
+    });
+
+    let mut request = format!("ws://{proxy_addr}/v1/realtime?model=gpt-5-realtime")
+        .into_client_request()
+        .expect("realtime websocket client request");
+    request.headers_mut().insert(
+        http_header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer pool-live-key"),
+    );
+
+    let (mut client, response) = connect_async(request)
+        .await
+        .expect("connect realtime websocket proxy");
+    assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+
+    let message = timeout(Duration::from_secs(1), client.next())
+        .await
+        .expect("realtime proxy should not wait for downstream response.create")
+        .expect("receive realtime upstream message")
+        .expect("realtime upstream message should be ok");
+    let TungsteniteMessage::Text(text) = message else {
+        panic!("expected realtime session.created text frame, got {message:?}");
+    };
+    let payload: Value = serde_json::from_str(&text).expect("decode realtime session event");
+    assert_eq!(payload["type"], "session.created");
+    assert_eq!(payload["session"]["id"], "sess_passthrough");
+
+    proxy_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn websocket_response_first_frame_rejection_records_attempt_failure() {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::connect_async;
+    use tungstenite::Message as TungsteniteMessage;
+
+    let mut config = test_config();
+    config.openai_proxy_websocket_enabled = true;
+    config.openai_proxy_upstream_websocket_default_enabled = true;
+    let state = test_state_from_config_with_pool_no_available_wait(
+        config,
+        true,
+        PoolNoAvailableWaitSettings {
+            timeout: Duration::from_millis(80),
+            poll_interval: Duration::from_millis(10),
+            retry_after_secs: DEFAULT_POOL_NO_AVAILABLE_ACCOUNT_RETRY_AFTER_SECS,
+        },
+    )
+    .await;
+    {
+        let mut settings = state.proxy_model_settings.write().await;
+        settings.websocket_enabled = true;
+        settings.upstream_websocket_default_enabled = true;
+    }
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+
+    let proxy_app = Router::new()
+        .route("/v1/*path", any(proxy_openai_v1_with_connect_info))
+        .with_state(state.clone());
+    let proxy_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind websocket proxy server");
+    let proxy_addr = proxy_listener
+        .local_addr()
+        .expect("websocket proxy server addr");
+    let proxy_handle = tokio::spawn(async move {
+        axum::serve(proxy_listener, proxy_app)
+            .await
+            .expect("websocket proxy server should run");
+    });
+
+    let mut request = format!("ws://{proxy_addr}/v1/responses")
+        .into_client_request()
+        .expect("websocket client request");
+    request.headers_mut().insert(
+        http_header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer pool-live-key"),
+    );
+    let (mut client, response) = connect_async(request)
+        .await
+        .expect("connect websocket proxy");
+    assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+
+    client
+        .send(TungsteniteMessage::Text(
+            json!({
+                "type": "conversation.item.create",
+                "item": { "type": "message" }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send rejected websocket first frame");
+
+    let close = client
+        .next()
+        .await
+        .expect("receive websocket close")
+        .expect("websocket close frame");
+    let TungsteniteMessage::Close(Some(frame)) = close else {
+        panic!("expected websocket close frame, got {close:?}");
+    };
+    assert!(frame.reason.contains("response.create"));
+
+    let attempt_row = sqlx::query_as::<_, (String, Option<String>, Option<String>, Option<i64>, Option<i64>)>(
+        r#"
+        SELECT status, failure_kind, error_message, downstream_http_status, upstream_account_id
+        FROM pool_upstream_request_attempts
+        WHERE invoke_id LIKE 'pool-ws-%'
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load websocket pre-upstream failure attempt");
+
+    assert_eq!(
+        attempt_row.0,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE
+    );
+    assert_eq!(
+        attempt_row.1.as_deref(),
+        Some(PROXY_FAILURE_REQUEST_BODY_READ_TIMEOUT)
+    );
+    assert!(
+        attempt_row
+            .2
+            .as_deref()
+            .is_some_and(|message| message.contains("response.create"))
+    );
+    assert_eq!(attempt_row.3, Some(400));
+    assert_eq!(attempt_row.4, None);
+
+    proxy_handle.abort();
+}
+
+#[tokio::test]
 async fn websocket_response_create_turns_persist_usage_per_terminal() {
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::connect_async;
@@ -2090,7 +2312,7 @@ async fn websocket_response_create_turns_persist_usage_per_terminal() {
 
     let turns = Arc::new(AtomicUsize::new(0));
     let upstream_app = Router::new()
-        .route("/v1/realtime", get(websocket_multi_turn_upstream))
+        .route("/v1/responses", get(websocket_multi_turn_upstream))
         .with_state(turns.clone());
     let upstream_listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -2150,7 +2372,7 @@ async fn websocket_response_create_turns_persist_usage_per_terminal() {
             .expect("websocket proxy server should run");
     });
 
-    let mut request = format!("ws://{proxy_addr}/v1/realtime")
+    let mut request = format!("ws://{proxy_addr}/v1/responses")
         .into_client_request()
         .expect("websocket client request");
     request.headers_mut().insert(
@@ -2253,7 +2475,7 @@ async fn websocket_downstream_disconnect_drains_terminal_usage() {
         .into_response()
     }
 
-    let upstream_app = Router::new().route("/v1/realtime", get(websocket_delayed_terminal_upstream));
+    let upstream_app = Router::new().route("/v1/responses", get(websocket_delayed_terminal_upstream));
     let upstream_listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind websocket upstream");
@@ -2312,7 +2534,7 @@ async fn websocket_downstream_disconnect_drains_terminal_usage() {
             .expect("websocket proxy server should run");
     });
 
-    let mut request = format!("ws://{proxy_addr}/v1/realtime")
+    let mut request = format!("ws://{proxy_addr}/v1/responses")
         .into_client_request()
         .expect("websocket client request");
     request.headers_mut().insert(
@@ -2392,7 +2614,7 @@ async fn websocket_upstream_close_before_terminal_sends_retryable_close() {
         .into_response()
     }
 
-    let upstream_app = Router::new().route("/v1/realtime", get(websocket_preterminal_close_upstream));
+    let upstream_app = Router::new().route("/v1/responses", get(websocket_preterminal_close_upstream));
     let upstream_listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind websocket upstream");
@@ -2451,7 +2673,7 @@ async fn websocket_upstream_close_before_terminal_sends_retryable_close() {
             .expect("websocket proxy server should run");
     });
 
-    let mut request = format!("ws://{proxy_addr}/v1/realtime")
+    let mut request = format!("ws://{proxy_addr}/v1/responses")
         .into_client_request()
         .expect("websocket client request");
     request.headers_mut().insert(
@@ -2581,7 +2803,7 @@ async fn websocket_handshake_failure_retries_next_candidate_with_retained_first_
 
     let failed_attempts = Arc::new(AtomicUsize::new(0));
     let failing_app = Router::new()
-        .route("/v1/realtime", get(failing_ws_handshake))
+        .route("/v1/responses", get(failing_ws_handshake))
         .with_state(failed_attempts.clone());
     let failing_listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -2597,7 +2819,7 @@ async fn websocket_handshake_failure_retries_next_candidate_with_retained_first_
 
     let first_frames = Arc::new(StdMutex::new(Vec::new()));
     let success_app = Router::new()
-        .route("/v1/realtime", get(successful_ws_upstream))
+        .route("/v1/responses", get(successful_ws_upstream))
         .with_state(first_frames.clone());
     let success_listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -2670,7 +2892,7 @@ async fn websocket_handshake_failure_retries_next_candidate_with_retained_first_
             .expect("websocket proxy server should run");
     });
 
-    let mut request = format!("ws://{proxy_addr}/v1/realtime")
+    let mut request = format!("ws://{proxy_addr}/v1/responses")
         .into_client_request()
         .expect("websocket client request");
     request.headers_mut().insert(
@@ -2813,7 +3035,7 @@ async fn websocket_deferred_prepare_requires_upstream_subprotocol_match_before_r
 
     let captured_protocols = Arc::new(StdMutex::new(Vec::new()));
     let upstream_app = Router::new()
-        .route("/v1/realtime", get(websocket_protocol_capture_upstream))
+        .route("/v1/responses", get(websocket_protocol_capture_upstream))
         .with_state(captured_protocols.clone());
     let upstream_listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -2873,7 +3095,7 @@ async fn websocket_deferred_prepare_requires_upstream_subprotocol_match_before_r
             .expect("websocket proxy server should run");
     });
 
-    let mut request = format!("ws://{proxy_addr}/v1/realtime")
+    let mut request = format!("ws://{proxy_addr}/v1/responses")
         .into_client_request()
         .expect("websocket client request");
     request.headers_mut().insert(


### PR DESCRIPTION
## Summary
- split WebSocket routing so `/v1/responses` keeps turn-aware `response.create` handling while non-Responses routes such as `/v1/realtime` connect upstream immediately
- preserve server-first Realtime events like `session.created` instead of timing out while waiting for a downstream `response.create`
- record `/v1/responses` pre-upstream first-frame failures into pool attempts for better production diagnosis

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test websocket_ -- --nocapture`

## 101 Read-only Diagnosis
- Production container is healthy on `ghcr.io/ivanli-cn/codex-vibe-monitor:latest` with runtime WebSocket settings enabled in SQLite.
- Historical WebSocket failures observed on 101 were `/v1/responses` attempts against third-party `api_key_codex` compatible upstreams, with `426 Upgrade Required` or close-before-terminal behavior.
- This PR fixes the proxy-side `/v1/realtime` server-first passthrough defect and adds attempt visibility for `/v1/responses` failures before upstream connection.

## References
- Spec: `docs/specs/w5s2x-openai-websocket-proxy/SPEC.md`
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions: -
- Solutions Sync: n/a(no related solution change)
- Project Docs: -
- Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
