### PR TITLE
feat(web): open routing tab from dashboard badges

### DIFF
--- a/web/src/components/DashboardWorkingConversationsSection.stories.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.stories.tsx
@@ -42,7 +42,8 @@ function StorySurface({ children }: { children: ReactNode }) {
 function useStoryTheme(theme?: "vibe-light" | "vibe-dark") {
   useLayoutEffect(() => {
     if (!theme) return;
-    const previousHtmlTheme = document.documentElement.getAttribute("data-theme");
+    const previousHtmlTheme =
+      document.documentElement.getAttribute("data-theme");
     const previousBodyTheme = document.body.getAttribute("data-theme");
     document.documentElement.setAttribute("data-theme", theme);
     document.body.setAttribute("data-theme", theme);
@@ -90,7 +91,9 @@ function createPreview(
     routeMode: overrides.routeMode ?? "pool",
     model: overrides.model ?? "gpt-5.4",
     requestModel:
-      "requestModel" in overrides ? (overrides.requestModel ?? null) : "gpt-5.4",
+      "requestModel" in overrides
+        ? (overrides.requestModel ?? null)
+        : "gpt-5.4",
     responseModel:
       "responseModel" in overrides
         ? (overrides.responseModel ?? null)
@@ -304,7 +307,8 @@ function createUpstreamAccountActivityStoryResponse(
       createPreview({
         id: 9901 + index,
         invokeId: `story-account-${index + 1}`,
-        promptCacheKey: promptCacheKeys[index] ?? `pck-story-account-${index + 1}`,
+        promptCacheKey:
+          promptCacheKeys[index] ?? `pck-story-account-${index + 1}`,
         occurredAt: `2026-04-04T10:${String(Math.max(0, 5 - index)).padStart(2, "0")}:00Z`,
         status: statuses[index] ?? "success",
         livePhase:
@@ -812,7 +816,8 @@ function buildDashboardHistoryEvidenceFixtures() {
       const baseTokens = 82_000 + (recordIndex % 11) * 3_700;
       const totalTokens = baseTokens + (cycle % 2 === 0 ? 37 : 348);
       const cost = Number((0.062 + (recordIndex % 7) * 0.0037).toFixed(4));
-      const durationBase = slot.kind === "first" || slotIndex > 0 ? 46_000 : 17_000;
+      const durationBase =
+        slot.kind === "first" || slotIndex > 0 ? 46_000 : 17_000;
 
       if (slot.kind === "first") {
         fillerRecords.push(
@@ -987,7 +992,9 @@ function buildDashboardHistoryEvidenceFixtures() {
         ],
       }),
     ]),
-    historyInvocationsByPromptCacheKey: new Map([[promptCacheKey, historyInvocations]]),
+    historyInvocationsByPromptCacheKey: new Map([
+      [promptCacheKey, historyInvocations],
+    ]),
   };
 }
 
@@ -1517,73 +1524,73 @@ function buildStoryMockData(
     conversation: PromptCacheConversation,
     preview: PromptCacheConversationInvocationPreview,
   ) => {
-      const record = {
-        ...buildRecordFromPreview(preview),
-        promptCacheKey: conversation.promptCacheKey,
-      };
-      recordsByInvokeId.set(record.invokeId, record);
-      const promptCacheKey = record.promptCacheKey?.trim();
-      if (promptCacheKey) {
-        recordsByPromptCacheKey.set(promptCacheKey, [
-          ...(recordsByPromptCacheKey.get(promptCacheKey) ?? []),
-          record,
-        ]);
-      }
+    const record = {
+      ...buildRecordFromPreview(preview),
+      promptCacheKey: conversation.promptCacheKey,
+    };
+    recordsByInvokeId.set(record.invokeId, record);
+    const promptCacheKey = record.promptCacheKey?.trim();
+    if (promptCacheKey) {
+      recordsByPromptCacheKey.set(promptCacheKey, [
+        ...(recordsByPromptCacheKey.get(promptCacheKey) ?? []),
+        record,
+      ]);
+    }
 
-      const normalizedStatus = (record.status ?? "").trim().toLowerCase();
-      const isAbnormal =
-        record.failureClass === "service_failure" ||
-        normalizedStatus === "failed" ||
-        normalizedStatus.startsWith("http_");
+    const normalizedStatus = (record.status ?? "").trim().toLowerCase();
+    const isAbnormal =
+      record.failureClass === "service_failure" ||
+      normalizedStatus === "failed" ||
+      normalizedStatus.startsWith("http_");
 
-      if (isAbnormal) {
-        detailByRecordId.set(record.id, {
-          id: record.id,
-          abnormalResponseBody: {
-            available: true,
-            previewText: JSON.stringify({
-              error: {
-                message: record.errorMessage ?? "upstream failure",
-              },
-            }),
-            hasMore: false,
-          },
-        });
-        responseBodyByRecordId.set(record.id, {
+    if (isAbnormal) {
+      detailByRecordId.set(record.id, {
+        id: record.id,
+        abnormalResponseBody: {
           available: true,
-          bodyText: JSON.stringify({
+          previewText: JSON.stringify({
             error: {
               message: record.errorMessage ?? "upstream failure",
             },
-            invokeId: record.invokeId,
           }),
-        });
-      }
-
-      if (
-        (record.routeMode ?? "").trim().toLowerCase() === "pool" &&
-        typeof record.upstreamAccountId === "number"
-      ) {
-        poolAttemptsByInvokeId.set(record.invokeId, [
-          {
-            id: record.id * 10 + 1,
-            invokeId: record.invokeId,
-            occurredAt: record.occurredAt,
-            endpoint: record.endpoint ?? "/v1/responses",
-            attemptIndex: 1,
-            distinctAccountIndex: 1,
-            sameAccountRetryIndex: 1,
-            status: isAbnormal ? "failed" : "success",
-            httpStatus: normalizedStatus.startsWith("http_")
-              ? Number(normalizedStatus.slice("http_".length))
-              : 200,
-            createdAt: record.createdAt,
-            upstreamAccountId: record.upstreamAccountId ?? null,
-            upstreamAccountName: record.upstreamAccountName ?? null,
-            firstByteLatencyMs: record.tUpstreamTtfbMs ?? null,
+          hasMore: false,
+        },
+      });
+      responseBodyByRecordId.set(record.id, {
+        available: true,
+        bodyText: JSON.stringify({
+          error: {
+            message: record.errorMessage ?? "upstream failure",
           },
-        ]);
-      }
+          invokeId: record.invokeId,
+        }),
+      });
+    }
+
+    if (
+      (record.routeMode ?? "").trim().toLowerCase() === "pool" &&
+      typeof record.upstreamAccountId === "number"
+    ) {
+      poolAttemptsByInvokeId.set(record.invokeId, [
+        {
+          id: record.id * 10 + 1,
+          invokeId: record.invokeId,
+          occurredAt: record.occurredAt,
+          endpoint: record.endpoint ?? "/v1/responses",
+          attemptIndex: 1,
+          distinctAccountIndex: 1,
+          sameAccountRetryIndex: 1,
+          status: isAbnormal ? "failed" : "success",
+          httpStatus: normalizedStatus.startsWith("http_")
+            ? Number(normalizedStatus.slice("http_".length))
+            : 200,
+          createdAt: record.createdAt,
+          upstreamAccountId: record.upstreamAccountId ?? null,
+          upstreamAccountName: record.upstreamAccountName ?? null,
+          firstByteLatencyMs: record.tUpstreamTtfbMs ?? null,
+        },
+      ]);
+    }
   };
 
   for (const conversation of response.conversations) {
@@ -1593,7 +1600,6 @@ function buildStoryMockData(
     for (const preview of historyInvocations) {
       ingestPreview(conversation, preview);
     }
-
   }
 
   return {
@@ -1638,8 +1644,10 @@ function buildStoryInvocationSummary(records: ApiInvocation[]) {
   const avgTotalMs =
     totalMsRecords.length === 0
       ? null
-      : totalMsRecords.reduce((sum, record) => sum + (record.tTotalMs ?? 0), 0) /
-        totalMsRecords.length;
+      : totalMsRecords.reduce(
+          (sum, record) => sum + (record.tTotalMs ?? 0),
+          0,
+        ) / totalMsRecords.length;
 
   return {
     snapshotId: 1,
@@ -1661,8 +1669,10 @@ function buildStoryInvocationSummary(records: ApiInvocation[]) {
       avgTokensPerRequest:
         records.length === 0
           ? 0
-          : records.reduce((sum, record) => sum + (record.totalTokens ?? 0), 0) /
-            records.length,
+          : records.reduce(
+              (sum, record) => sum + (record.totalTokens ?? 0),
+              0,
+            ) / records.length,
       cacheInputTokens: records.reduce(
         (sum, record) => sum + (record.cacheInputTokens ?? 0),
         0,
@@ -1722,7 +1732,7 @@ function StoryAccountDrawer({
   account,
   onClose,
 }: {
-  account: { id: number; label: string } | null;
+  account: { id: number; label: string; tab: "overview" | "routing" } | null;
   onClose: () => void;
 }) {
   const titleId = useId();
@@ -1753,6 +1763,12 @@ function StoryAccountDrawer({
             <p className="font-mono text-sm text-base-content/60">
               Account ID {account.id}
             </p>
+            <p
+              data-testid="story-account-drawer-tab"
+              className="font-mono text-sm text-base-content/60"
+            >
+              Tab {account.tab}
+            </p>
           </div>
           <p className="text-sm leading-6 text-base-content/70">
             Mock shared account detail drawer used to verify that Dashboard
@@ -1774,10 +1790,14 @@ class StoryNoopEventSource implements EventTarget {
   readonly withCredentials = false;
   readyState = StoryNoopEventSource.CONNECTING;
   onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
-  onmessage: ((this: EventSource, ev: MessageEvent<string>) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent<string>) => unknown) | null =
+    null;
   onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
 
-  private listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+  private listeners = new Map<
+    string,
+    Set<EventListenerOrEventListenerObject>
+  >();
 
   constructor(url: string | URL) {
     this.url = typeof url === "string" ? url : url.toString();
@@ -1862,11 +1882,7 @@ function DrawerPreviewStory({
   const { t } = useTranslation();
   const cards = useMemo(() => buildCards(response), [response]);
   const storyMocks = useMemo(
-    () =>
-      buildStoryMockData(
-        response,
-        historyInvocationsByPromptCacheKey,
-      ),
+    () => buildStoryMockData(response, historyInvocationsByPromptCacheKey),
     [historyInvocationsByPromptCacheKey, response],
   );
   const originalFetchRef = useRef<typeof window.fetch | null>(null);
@@ -1892,6 +1908,7 @@ function DrawerPreviewStory({
   const [selectedAccount, setSelectedAccount] = useState<{
     id: number;
     label: string;
+    tab: "overview" | "routing";
   } | null>(null);
 
   useEffect(() => {
@@ -1926,8 +1943,9 @@ function DrawerPreviewStory({
     if (!originalFetchRef.current) {
       originalFetchRef.current = window.fetch.bind(window);
     }
-    (window as typeof window & { __dashboardStoryFetchLog?: string[] })
-      .__dashboardStoryFetchLog = [];
+    (
+      window as typeof window & { __dashboardStoryFetchLog?: string[] }
+    ).__dashboardStoryFetchLog = [];
 
     window.fetch = async (input, init) => {
       const request =
@@ -1937,10 +1955,11 @@ function DrawerPreviewStory({
             ? input.toString()
             : input.url;
       const url = new URL(request, window.location.origin);
-      (window as typeof window & { __dashboardStoryFetchLog?: string[] })
-        .__dashboardStoryFetchLog?.push(
-          `${url.pathname}?${url.searchParams.toString()}`,
-        );
+      (
+        window as typeof window & { __dashboardStoryFetchLog?: string[] }
+      ).__dashboardStoryFetchLog?.push(
+        `${url.pathname}?${url.searchParams.toString()}`,
+      );
 
       if (url.pathname === "/api/invocations") {
         const requestId = url.searchParams.get("requestId");
@@ -1961,9 +1980,13 @@ function DrawerPreviewStory({
             1,
             Number(url.searchParams.get("pageSize") ?? "200"),
           );
-          const records = (storyMocks.recordsByPromptCacheKey.get(promptCacheKey) ?? [])
+          const records = (
+            storyMocks.recordsByPromptCacheKey.get(promptCacheKey) ?? []
+          )
             .slice()
-            .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt));
+            .sort((left, right) =>
+              right.occurredAt.localeCompare(left.occurredAt),
+            );
           const start = (page - 1) * pageSize;
           return jsonResponse({
             snapshotId: 1,
@@ -2038,7 +2061,8 @@ function DrawerPreviewStory({
                 0,
               ),
               inProgressConversationCount: activity.accounts.reduce(
-                (sum, account) => sum + (account.inProgressInvocationCount ?? 0),
+                (sum, account) =>
+                  sum + (account.inProgressInvocationCount ?? 0),
                 0,
               ),
             },
@@ -2116,10 +2140,18 @@ function DrawerPreviewStory({
         cards={cards}
         isLoading={false}
         error={null}
-        onOpenUpstreamAccount={(accountId, accountLabel) => {
+        onOpenUpstreamAccount={(
+          accountId: number,
+          accountLabel: string,
+          options?: { tab?: "overview" | "routing" },
+        ) => {
           setSelectedInvocation(null);
           setSelectedConversation(null);
-          setSelectedAccount({ id: accountId, label: accountLabel });
+          setSelectedAccount({
+            id: accountId,
+            label: accountLabel,
+            tab: options?.tab ?? "overview",
+          });
         }}
         onOpenConversation={(selection) => {
           setSelectedInvocation(null);
@@ -2136,10 +2168,18 @@ function DrawerPreviewStory({
         open={selectedInvocation != null}
         selection={selectedInvocation}
         onClose={() => setSelectedInvocation(null)}
-        onOpenUpstreamAccount={(accountId, accountLabel) => {
+        onOpenUpstreamAccount={(
+          accountId: number,
+          accountLabel: string,
+          options?: { tab?: "overview" | "routing" },
+        ) => {
           setSelectedInvocation(null);
           setSelectedConversation(null);
-          setSelectedAccount({ id: accountId, label: accountLabel });
+          setSelectedAccount({
+            id: accountId,
+            label: accountLabel,
+            tab: options?.tab ?? "overview",
+          });
         }}
       />
       <PromptCacheConversationHistoryDrawer
@@ -2154,10 +2194,18 @@ function DrawerPreviewStory({
         }
         onClose={() => setSelectedConversation(null)}
         t={t}
-        onOpenUpstreamAccount={(accountId, accountLabel) => {
+        onOpenUpstreamAccount={(
+          accountId: number,
+          accountLabel: string,
+          options?: { tab?: "overview" | "routing" },
+        ) => {
           setSelectedInvocation(null);
           setSelectedConversation(null);
-          setSelectedAccount({ id: accountId, label: accountLabel });
+          setSelectedAccount({
+            id: accountId,
+            label: accountLabel,
+            tab: options?.tab ?? "overview",
+          });
         }}
       />
       <StoryAccountDrawer
@@ -2172,7 +2220,7 @@ function DrawerPreviewStory({
             : selectedConversation
               ? `conversation:${selectedConversation.promptCacheKey}`
               : selectedAccount
-                ? `account:${selectedAccount.id}`
+                ? `account:${selectedAccount.id}:${selectedAccount.tab}`
                 : "none"}
         </span>
       </div>
@@ -2223,7 +2271,10 @@ export const CurrentAndPrevious: Story = {
     const responseLatency = currentSlot.querySelector(
       '[data-testid="dashboard-compact-latency-response-time"]',
     );
-    if (!(firstByteLatency instanceof HTMLElement) || !(responseLatency instanceof HTMLElement)) {
+    if (
+      !(firstByteLatency instanceof HTMLElement) ||
+      !(responseLatency instanceof HTMLElement)
+    ) {
       throw new Error("missing compact latency readings");
     }
     const slotHeader = currentSlot.querySelector(
@@ -2287,7 +2338,9 @@ export const RunningOnlyConversation: Story = {
       "grid-cols-[auto_minmax(0,1fr)]",
     );
     expect(
-      currentSlotHeader?.querySelector('[data-testid="invocation-phase-badge"]'),
+      currentSlotHeader?.querySelector(
+        '[data-testid="invocation-phase-badge"]',
+      ),
     ).toBeInstanceOf(HTMLElement);
 
     const phaseLabels = Array.from(
@@ -2332,7 +2385,9 @@ export const AccountPlanBadges: Story = {
       expect.arrayContaining(["Ent", "Team", "Plus", "Free"]),
     );
     expect(
-      badges.find((badge) => badge.textContent === "Ent")?.getAttribute("title"),
+      badges
+        .find((badge) => badge.textContent === "Ent")
+        ?.getAttribute("title"),
     ).toBe("enterprise");
   },
 };
@@ -2511,7 +2566,7 @@ export const FailedWithClickableAccount: Story = {
       );
     });
     await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
-      "account:77",
+      "account:77:overview",
     );
   },
 };
@@ -2546,9 +2601,8 @@ export const SequenceButtonOpensConversationHistory: Story = {
 
     await waitFor(() => {
       expect(
-        document.body.querySelector(
-          '[data-testid="story-drawer-state"]',
-        )?.textContent,
+        document.body.querySelector('[data-testid="story-drawer-state"]')
+          ?.textContent,
       ).toContain("conversation:pck-dashboard-history-realistic");
     });
     await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
@@ -2571,7 +2625,9 @@ export const SequenceButtonOpensConversationHistory: Story = {
     const dialog = within(document.body).getByRole("dialog");
     expect(within(dialog).queryByRole("button", { name: "今日" })).toBeNull();
     expect(within(dialog).queryByRole("button", { name: "昨日" })).toBeNull();
-    expect(within(dialog).queryByRole("button", { name: "24 小时" })).toBeNull();
+    expect(
+      within(dialog).queryByRole("button", { name: "24 小时" }),
+    ).toBeNull();
     expect(within(dialog).queryByRole("button", { name: "7 日" })).toBeNull();
     expect(within(dialog).queryByRole("button", { name: "历史" })).toBeNull();
     await waitFor(() => {
@@ -2671,9 +2727,9 @@ export const UpstreamAccountTab: Story = {
     await expect(recentBreakdown).toHaveTextContent(/请求中\s*3/);
     await expect(recentBreakdown).toHaveTextContent(/响应中\s*4/);
     await expect(recentBreakdown).toHaveTextContent(/成功\s*6/);
-    await expect(canvas.getByTestId("dashboard-upstream-account-policy-badges")).toHaveTextContent(
-      "Fast",
-    );
+    await expect(
+      canvas.getByTestId("dashboard-upstream-account-policy-badges"),
+    ).toHaveTextContent("Fast");
     await expect(canvas.getByText("story-account-1")).toBeInTheDocument();
     await expect(canvas.getByText("gpt-5.5-mini")).toBeInTheDocument();
     await expect(canvas.getByText("gpt-5.5")).toBeInTheDocument();
@@ -2689,7 +2745,10 @@ export const UpstreamAccountTab: Story = {
     const responseLatency = firstRecentRow.querySelector(
       '[data-testid="dashboard-compact-latency-response-time"]',
     );
-    if (!(firstByteLatency instanceof HTMLElement) || !(responseLatency instanceof HTMLElement)) {
+    if (
+      !(firstByteLatency instanceof HTMLElement) ||
+      !(responseLatency instanceof HTMLElement)
+    ) {
       throw new Error("missing upstream compact latency readings");
     }
     await expect(firstByteLatency.className).not.toMatch(/rounded|border|bg-/);
@@ -2713,11 +2772,15 @@ export const UpstreamAccountTab: Story = {
     const identityChips = canvas.getAllByTestId(
       "dashboard-upstream-account-recent-identity-chip",
     );
-    await expect(new Set(identityChips.map((chip) => chip.className)).size).toBe(4);
+    await expect(
+      new Set(identityChips.map((chip) => chip.className)).size,
+    ).toBe(4);
     await expect(canvas.queryByText("按调用计数，不按对话去重")).toBeNull();
     await expect(canvas.queryByText("仍在重试链路中的调用")).toBeNull();
     await expect(
-      canvas.queryByText("最近 4 条调用里仍有活动或异常，优先从下方最近记录继续排查。"),
+      canvas.queryByText(
+        "最近 4 条调用里仍有活动或异常，优先从下方最近记录继续排查。",
+      ),
     ).toBeNull();
     const identityChip = canvas.getAllByTestId(
       "dashboard-upstream-account-recent-identity-chip",
@@ -2736,6 +2799,60 @@ export const UpstreamAccountTab: Story = {
       description: {
         story:
           "Dashboard workspace section switched to the upstream-account tab, showing one enlarged active-account card with account-level KPIs and the dynamic recent invocation window in the selected range, including lightweight short conversation identity chips and request/response model mismatch rows.",
+      },
+    },
+  },
+};
+
+export const UpstreamAccountRoutingBadgesOpenRoutingTab: Story = {
+  args: UpstreamAccountTab.args,
+  render: () => (
+    <DrawerPreviewStory
+      response={createResponse([
+        createConversation("pck-story-upstream-routing-badges", [
+          createPreview({
+            id: 9861,
+            invokeId: "story-working-routing-badges",
+            occurredAt: "2026-04-04T10:05:00Z",
+            status: "running",
+            upstreamAccountId: 42,
+            upstreamAccountName: "Pool Alpha",
+          }),
+        ]),
+      ])}
+      upstreamAccountActivity={createUpstreamAccountActivityStoryResponse()}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const accountTab = await canvas.findByRole("tab", { name: "上游账号" });
+    await userEvent.click(accountTab);
+
+    const statusBadge = await canvas.findByTestId(
+      "dashboard-upstream-account-status",
+    );
+    await userEvent.click(statusBadge);
+    await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
+      "account:42:routing",
+    );
+    await expect(
+      within(document.body).getByTestId("story-account-drawer-tab"),
+    ).toHaveTextContent("Tab routing");
+
+    const policyBadge = await canvas.findByTestId(
+      "dashboard-upstream-account-policy-badge",
+    );
+    await userEvent.click(policyBadge);
+    await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
+      "account:42:routing",
+    );
+  },
+  parameters: {
+    viewport: { defaultViewport: "desktop1660" },
+    docs: {
+      description: {
+        story:
+          "Status and routing-policy badges in the upstream-account dashboard card open the shared account drawer directly on the routing tab, while the account name keeps the default overview entry.",
       },
     },
   },
@@ -2798,15 +2915,39 @@ export const UpstreamAccountMetricTooltips: Story = {
       await userEvent.unhover(trigger);
     };
 
-    await assertMetricTooltip("latency", ["首字用时", "2.87 s", "响应时间", "阶段首字节"]);
-    await assertMetricTooltip("requests", ["请求数", "成功率", "75%", "非成功率"]);
-    await assertMetricTooltip("cost", ["成本", "0.72", "失败成本", "失败成本比率", "30.6%", "成功/其他成本", "单次均价"]);
-    await assertMetricTooltip("token", ["Token", "缓存命中率", "成功 Token", "单请求 Token"]);
+    await assertMetricTooltip("latency", [
+      "首字用时",
+      "2.87 s",
+      "响应时间",
+      "阶段首字节",
+    ]);
+    await assertMetricTooltip("requests", [
+      "请求数",
+      "成功率",
+      "75%",
+      "非成功率",
+    ]);
+    await assertMetricTooltip("cost", [
+      "成本",
+      "0.72",
+      "失败成本",
+      "失败成本比率",
+      "30.6%",
+      "成功/其他成本",
+      "单次均价",
+    ]);
+    await assertMetricTooltip("token", [
+      "Token",
+      "缓存命中率",
+      "成功 Token",
+      "单请求 Token",
+    ]);
 
     const finalTrigger = canvasElement.querySelector(
       '[data-testid="dashboard-upstream-account-metric-card"][data-metric="cost"]',
     );
-    if (finalTrigger instanceof HTMLElement) await userEvent.click(finalTrigger);
+    if (finalTrigger instanceof HTMLElement)
+      await userEvent.click(finalTrigger);
   },
   parameters: {
     viewport: { defaultViewport: "desktop1660" },
@@ -2853,16 +2994,17 @@ export const UpstreamAccountRecentIdentityChipOpensConversation: Story = {
     await userEvent.click(identityChip);
     await waitFor(() => {
       expect(
-        document.body.querySelector(
-          '[data-testid="story-drawer-state"]',
-        )?.textContent,
+        document.body.querySelector('[data-testid="story-drawer-state"]')
+          ?.textContent,
       ).toContain("conversation:pck-upstream-running");
     });
     await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
       "conversation:pck-upstream-running",
     );
 
-    const firstRow = canvas.getAllByTestId("dashboard-upstream-account-recent-row")[0];
+    const firstRow = canvas.getAllByTestId(
+      "dashboard-upstream-account-recent-row",
+    )[0];
     if (!(firstRow instanceof HTMLButtonElement)) {
       throw new Error("expected upstream recent row button");
     }
@@ -2870,9 +3012,8 @@ export const UpstreamAccountRecentIdentityChipOpensConversation: Story = {
     await userEvent.click(firstRow);
     await waitFor(() => {
       expect(
-        document.body.querySelector(
-          '[data-testid="story-drawer-state"]',
-        )?.textContent,
+        document.body.querySelector('[data-testid="story-drawer-state"]')
+          ?.textContent,
       ).toContain("invocation:acct-invoke-1");
     });
     await expect(canvas.getByTestId("story-drawer-state")).toHaveTextContent(
@@ -2922,7 +3063,9 @@ export const UpstreamAccountTabDynamicSeven: Story = {
     const identityChips = canvas.getAllByTestId(
       "dashboard-upstream-account-recent-identity-chip",
     );
-    await expect(new Set(identityChips.map((chip) => chip.className)).size).toBeGreaterThan(3);
+    await expect(
+      new Set(identityChips.map((chip) => chip.className)).size,
+    ).toBeGreaterThan(3);
   },
   parameters: {
     viewport: { defaultViewport: "desktop1660" },

--- a/web/src/components/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.test.tsx
@@ -1,7 +1,15 @@
 /** @vitest-environment jsdom */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { fireEvent, waitFor } from "@testing-library/dom";
 import { I18nProvider } from "../i18n";
 import type {
@@ -16,7 +24,10 @@ import {
   mapPromptCacheConversationsToDashboardCards,
   type DashboardWorkingConversationCardModel,
 } from "../lib/dashboardWorkingConversations";
-import { DashboardWorkingConversationsSection } from "./DashboardWorkingConversationsSection";
+import {
+  DashboardWorkingConversationsSection,
+  type DashboardOpenUpstreamAccountOptions,
+} from "./DashboardWorkingConversationsSection";
 import {
   DASHBOARD_WORKSPACE_VIEW_STORAGE_KEY,
   readPersistedDashboardWorkspaceView,
@@ -25,16 +36,14 @@ import {
 const virtualizerMocks = vi.hoisted(() => ({
   rowIndexes: null as number[] | null,
   totalSize: null as number | null,
-  customVirtualItems: null as
-    | Array<{
-        key: number;
-        index: number;
-        start: number;
-        size: number;
-        end: number;
-        translateStart?: number;
-      }>
-    | null,
+  customVirtualItems: null as Array<{
+    key: number;
+    index: number;
+    start: number;
+    size: number;
+    end: number;
+    translateStart?: number;
+  }> | null,
 }));
 
 vi.mock("@tanstack/react-virtual", () => ({
@@ -90,7 +99,8 @@ vi.mock("../hooks/useDashboardUpstreamAccountActivity", () => ({
       recentInvocationLimit:
         upstreamAccountActivityMock.resolvedRecentInvocationLimit ??
         recentInvocationLimit ??
-        upstreamAccountActivityMock.data?.accounts[0]?.recentInvocations.length ??
+        upstreamAccountActivityMock.data?.accounts[0]?.recentInvocations
+          .length ??
         4,
       hasActivated: enabled,
       reload: vi.fn(),
@@ -117,7 +127,9 @@ function createPreview(
     routeMode: overrides.routeMode ?? "pool",
     model: overrides.model ?? "gpt-5.4",
     requestModel:
-      "requestModel" in overrides ? (overrides.requestModel ?? null) : "gpt-5.4",
+      "requestModel" in overrides
+        ? (overrides.requestModel ?? null)
+        : "gpt-5.4",
     responseModel:
       "responseModel" in overrides
         ? (overrides.responseModel ?? null)
@@ -231,6 +243,46 @@ function createUpstreamAccountActivityResponse(): UpstreamAccountActivityRespons
         inProgressInvocationCount: 3,
         inProgressPhaseCounts: { queued: 1, requesting: 1, responding: 1 },
         retryInvocationCount: 1,
+        effectiveRoutingRule: {
+          blockNewConversations: true,
+          allowCutOut: true,
+          allowCutIn: false,
+          priorityTier: "primary",
+          fastModeRewriteMode: "force_add",
+          imageToolRewriteMode: "keep_original",
+          concurrencyLimit: 3,
+          upstream429RetryEnabled: false,
+          upstream429MaxRetries: 0,
+          availableModels: [],
+          availableModelsDefined: false,
+          systemDeniedModels: [],
+          sourceTagIds: [],
+          sourceTagNames: [],
+          fieldSources: {
+            blockNewConversations: "account",
+            allowCutOut: "root",
+            allowCutIn: "account",
+            priorityTier: "group",
+            fastModeRewriteMode: "account",
+            imageToolRewriteMode: "root",
+            concurrencyLimit: "group",
+            upstream429Retry: "root",
+            availableModels: "root",
+            systemDeniedModels: "root",
+          },
+          timeouts: {
+            responsesFirstByteTimeoutSecs: 120,
+            compactFirstByteTimeoutSecs: 120,
+            responsesStreamTimeoutSecs: 600,
+            compactStreamTimeoutSecs: 600,
+          },
+          timeoutFieldSources: {
+            responsesFirstByteTimeoutSecs: "root",
+            compactFirstByteTimeoutSecs: "root",
+            responsesStreamTimeoutSecs: "root",
+            compactStreamTimeoutSecs: "root",
+          },
+        },
         recentInvocations: [
           createPreview({
             id: 9001,
@@ -351,7 +403,11 @@ function renderSection(
     recentPreviewLimit?: number;
     onLoadMore?: () => void;
     setRefreshTargetCount?: (count: number) => void;
-    onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+    onOpenUpstreamAccount?: (
+      accountId: number,
+      accountLabel: string,
+      options?: DashboardOpenUpstreamAccountOptions,
+    ) => void;
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
@@ -380,7 +436,11 @@ function renderSectionWithCards(
     totalMatched?: number;
     onLoadMore?: () => void;
     setRefreshTargetCount?: (count: number) => void;
-    onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+    onOpenUpstreamAccount?: (
+      accountId: number,
+      accountLabel: string,
+      options?: DashboardOpenUpstreamAccountOptions,
+    ) => void;
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
@@ -459,7 +519,11 @@ function rerenderSection(
     recentPreviewLimit?: number;
     onLoadMore?: () => void;
     setRefreshTargetCount?: (count: number) => void;
-    onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+    onOpenUpstreamAccount?: (
+      accountId: number,
+      accountLabel: string,
+      options?: DashboardOpenUpstreamAccountOptions,
+    ) => void;
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
@@ -489,7 +553,11 @@ function rerenderSectionWithCards(
     recentPreviewLimit?: number;
     onLoadMore?: () => void;
     setRefreshTargetCount?: (count: number) => void;
-    onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+    onOpenUpstreamAccount?: (
+      accountId: number,
+      accountLabel: string,
+      options?: DashboardOpenUpstreamAccountOptions,
+    ) => void;
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
@@ -553,9 +621,9 @@ describe("DashboardWorkingConversationsSection", () => {
     });
     expect(host?.textContent).toContain("当前对话 1 条");
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -576,12 +644,13 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(host?.textContent).toContain("最近 4 条调用");
     expect(host?.textContent).not.toContain("账号状态");
     expect(
-      host?.querySelector('[data-testid="dashboard-upstream-account-card"]')?.getAttribute(
-        "data-account-status",
-      ),
+      host
+        ?.querySelector('[data-testid="dashboard-upstream-account-card"]')
+        ?.getAttribute("data-account-status"),
     ).toBe("busy");
     expect(
-      host?.querySelector('[data-testid="dashboard-upstream-account-card"]')?.className,
+      host?.querySelector('[data-testid="dashboard-upstream-account-card"]')
+        ?.className,
     ).toContain("desktop1660:min-h-[31.5rem]");
     expect(host?.textContent).toContain("繁忙");
     expect(host?.textContent).not.toContain("渠道 Pool Alpha");
@@ -590,8 +659,9 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(host?.textContent).not.toContain("仍在重试链路中的调用");
     expect(host?.textContent).not.toContain("最近 4 条调用里仍有活动或异常");
     expect(
-      host?.querySelectorAll('[data-testid="dashboard-upstream-account-recent-row"]')
-        .length,
+      host?.querySelectorAll(
+        '[data-testid="dashboard-upstream-account-recent-row"]',
+      ).length,
     ).toBe(4);
     expect(
       host?.querySelectorAll(
@@ -599,7 +669,9 @@ describe("DashboardWorkingConversationsSection", () => {
       ).length,
     ).toBe(4);
     expect(
-      host?.querySelector('[data-testid="dashboard-upstream-account-header-row"]'),
+      host?.querySelector(
+        '[data-testid="dashboard-upstream-account-header-row"]',
+      ),
     ).not.toBeNull();
     const firstRecentRow = host?.querySelector(
       '[data-testid="dashboard-upstream-account-recent-row"]',
@@ -609,13 +681,25 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(firstRecentRow?.textContent).not.toContain("RQ ");
     expect(firstRecentRow?.textContent).not.toContain("UP ");
     expect(firstRecentRow?.textContent).not.toContain("ED ");
-    expect(firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-first-byte"]')).not.toBeNull();
-    expect(firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-response-time"]')).not.toBeNull();
     expect(
-      firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-first-byte"]')?.className,
+      firstRecentRow?.querySelector(
+        '[data-testid="dashboard-compact-latency-first-byte"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      firstRecentRow?.querySelector(
+        '[data-testid="dashboard-compact-latency-response-time"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      firstRecentRow?.querySelector(
+        '[data-testid="dashboard-compact-latency-first-byte"]',
+      )?.className,
     ).not.toMatch(/rounded|border|bg-/);
     expect(
-      firstRecentRow?.querySelector('[data-testid="dashboard-compact-latency-response-time"]')?.className,
+      firstRecentRow?.querySelector(
+        '[data-testid="dashboard-compact-latency-response-time"]',
+      )?.className,
     ).not.toMatch(/rounded|border|bg-/);
     expect(
       firstRecentRow
@@ -624,9 +708,13 @@ describe("DashboardWorkingConversationsSection", () => {
     ).toMatch(/首字用时|Time to first byte/i);
 
     expect(
-      host?.querySelector('[data-testid="dashboard-upstream-account-live-call-breakdown"]'),
+      host?.querySelector(
+        '[data-testid="dashboard-upstream-account-live-call-breakdown"]',
+      ),
     ).toBeNull();
-    const accountHeader = host?.querySelector('[data-testid="dashboard-upstream-account-header-row"]');
+    const accountHeader = host?.querySelector(
+      '[data-testid="dashboard-upstream-account-header-row"]',
+    );
     const accountHeaderText = accountHeader?.textContent;
     expect(accountHeaderText).toContain("3");
     expect(accountHeaderText).not.toContain("并行对话");
@@ -635,7 +723,9 @@ describe("DashboardWorkingConversationsSection", () => {
       ".upstream-plan-badge[data-plan='enterprise']",
     );
     expect(headerPlanBadge?.textContent).toBe("Ent");
-    expect(accountHeader?.querySelector('[aria-label="进行中调用 3"]')).not.toBeNull();
+    expect(
+      accountHeader?.querySelector('[aria-label="进行中调用 3"]'),
+    ).not.toBeNull();
     expect(
       accountHeader?.querySelector('[aria-label="TPM 640"]'),
     ).not.toBeNull();
@@ -646,7 +736,8 @@ describe("DashboardWorkingConversationsSection", () => {
       '[data-testid="dashboard-upstream-account-latency-breakdown"]',
     );
     expect(
-      host?.querySelector('[data-testid="dashboard-upstream-account-card"]')?.textContent,
+      host?.querySelector('[data-testid="dashboard-upstream-account-card"]')
+        ?.textContent,
     ).toContain("2.87 s");
     expect(latencyBreakdown?.textContent).toContain("860");
 
@@ -660,16 +751,23 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(requestBreakdown?.textContent).not.toContain("非");
 
     const requestSegments = Array.from(
-      requestBreakdown?.querySelectorAll('[data-testid="dashboard-upstream-account-segment"]') ??
-        [],
+      requestBreakdown?.querySelectorAll(
+        '[data-testid="dashboard-upstream-account-segment"]',
+      ) ?? [],
     );
     expect(requestSegments).toHaveLength(3);
     expect(requestSegments[0]?.textContent).toContain("6");
     expect(requestSegments[1]?.textContent).toContain("2");
     expect(requestSegments[2]?.textContent).toContain("0");
-    expect(requestSegments[0]?.parentElement?.getAttribute("aria-label")).toContain("成功 6");
-    expect(requestSegments[1]?.parentElement?.getAttribute("aria-label")).toContain("失败 2");
-    expect(requestSegments[2]?.parentElement?.getAttribute("aria-label")).toContain("其他 0");
+    expect(
+      requestSegments[0]?.parentElement?.getAttribute("aria-label"),
+    ).toContain("成功 6");
+    expect(
+      requestSegments[1]?.parentElement?.getAttribute("aria-label"),
+    ).toContain("失败 2");
+    expect(
+      requestSegments[2]?.parentElement?.getAttribute("aria-label"),
+    ).toContain("其他 0");
 
     const costBreakdown = host?.querySelector(
       '[data-testid="dashboard-upstream-account-cost-breakdown"]',
@@ -682,10 +780,14 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(costBreakdown?.textContent).toContain("$0.22");
     expect(costBreakdown?.textContent).toContain("30.6%");
     expect(
-      host?.querySelector('[data-testid="dashboard-upstream-account-cost-icon"]'),
+      host?.querySelector(
+        '[data-testid="dashboard-upstream-account-cost-icon"]',
+      ),
     ).not.toBeNull();
     expect(
-      host?.querySelector('[data-testid="dashboard-upstream-account-token-icon"]'),
+      host?.querySelector(
+        '[data-testid="dashboard-upstream-account-token-icon"]',
+      ),
     ).not.toBeNull();
 
     const tokenBreakdown = host?.querySelector(
@@ -735,9 +837,9 @@ describe("DashboardWorkingConversationsSection", () => {
       { activeRange: "yesterday" },
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -746,9 +848,13 @@ describe("DashboardWorkingConversationsSection", () => {
       fireEvent.click(accountTab);
     });
 
-    const accountHeader = host?.querySelector('[data-testid="dashboard-upstream-account-header-row"]');
+    const accountHeader = host?.querySelector(
+      '[data-testid="dashboard-upstream-account-header-row"]',
+    );
     const accountHeaderText = accountHeader?.textContent;
-    expect(accountHeader?.querySelector('[aria-label="进行中调用 —"]')).not.toBeNull();
+    expect(
+      accountHeader?.querySelector('[aria-label="进行中调用 —"]'),
+    ).not.toBeNull();
     expect(accountHeaderText).toContain("—");
     expect(accountHeaderText).not.toContain("并行对话");
   });
@@ -769,9 +875,9 @@ describe("DashboardWorkingConversationsSection", () => {
       ]),
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -781,7 +887,9 @@ describe("DashboardWorkingConversationsSection", () => {
     });
 
     expect(
-      host?.querySelectorAll('[data-testid="dashboard-upstream-account-metric-card"]'),
+      host?.querySelectorAll(
+        '[data-testid="dashboard-upstream-account-metric-card"]',
+      ),
     ).toHaveLength(4);
 
     const costTrigger = host?.querySelector(
@@ -897,9 +1005,9 @@ describe("DashboardWorkingConversationsSection", () => {
       ]),
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -927,7 +1035,9 @@ describe("DashboardWorkingConversationsSection", () => {
 
     await waitFor(() => {
       const tooltip = Array.from(
-        document.body.querySelectorAll('[data-testid="dashboard-upstream-account-metric-tooltip"]'),
+        document.body.querySelectorAll(
+          '[data-testid="dashboard-upstream-account-metric-tooltip"]',
+        ),
       ).find((node) => node.textContent?.includes("失败成本"));
       const tooltipText = tooltip?.textContent ?? "";
       expect(tooltipText).toContain("失败成本");
@@ -955,9 +1065,9 @@ describe("DashboardWorkingConversationsSection", () => {
       { recentPreviewLimit: 7 },
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1010,9 +1120,9 @@ describe("DashboardWorkingConversationsSection", () => {
       { recentPreviewLimit: 4 },
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1023,7 +1133,9 @@ describe("DashboardWorkingConversationsSection", () => {
 
     expect(host?.textContent).toContain("最近 9 条调用");
     expect(
-      host?.querySelectorAll('[data-testid="dashboard-upstream-account-recent-row"]'),
+      host?.querySelectorAll(
+        '[data-testid="dashboard-upstream-account-recent-row"]',
+      ),
     ).toHaveLength(9);
   });
 
@@ -1043,9 +1155,9 @@ describe("DashboardWorkingConversationsSection", () => {
 
     renderSection(response);
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1060,9 +1172,9 @@ describe("DashboardWorkingConversationsSection", () => {
     });
 
     expect(host?.textContent).toContain("当前对话 1 条");
-    const accountTabAfter = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTabAfter = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     expect(accountTabAfter?.disabled).toBe(true);
   });
 
@@ -1082,9 +1194,9 @@ describe("DashboardWorkingConversationsSection", () => {
 
     renderSection(response);
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1126,9 +1238,9 @@ describe("DashboardWorkingConversationsSection", () => {
 
     renderSection(response);
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1171,9 +1283,9 @@ describe("DashboardWorkingConversationsSection", () => {
       "展示最近 5 分钟内有终态调用，或当前仍处于运行中 / 排队中的对话。",
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1209,9 +1321,9 @@ describe("DashboardWorkingConversationsSection", () => {
       { onOpenConversation, onOpenInvocation },
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1221,7 +1333,9 @@ describe("DashboardWorkingConversationsSection", () => {
     });
 
     const rows = Array.from(
-      host?.querySelectorAll('[data-testid="dashboard-upstream-account-recent-row"]') ?? [],
+      host?.querySelectorAll(
+        '[data-testid="dashboard-upstream-account-recent-row"]',
+      ) ?? [],
     );
     const firstRow = rows[0];
     if (!(firstRow instanceof HTMLButtonElement)) {
@@ -1297,9 +1411,9 @@ describe("DashboardWorkingConversationsSection", () => {
       { onOpenConversation, onOpenInvocation },
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1380,7 +1494,8 @@ describe("DashboardWorkingConversationsSection", () => {
           spendRate: 0.12,
           firstByteAvgMs: 420,
           avgTotalMs: 860,
-          inProgressInvocationCount: UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.length,
+          inProgressInvocationCount:
+            UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.length,
           retryInvocationCount: 0,
           recentInvocations: UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.map(
             (promptCacheKey, index) =>
@@ -1411,9 +1526,9 @@ describe("DashboardWorkingConversationsSection", () => {
       { recentPreviewLimit: UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.length },
     );
 
-    const accountTab = Array.from(host?.querySelectorAll('button[role="tab"]') ?? []).find(
-      (node) => node.textContent?.includes("上游账号"),
-    );
+    const accountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((node) => node.textContent?.includes("上游账号"));
     if (!(accountTab instanceof HTMLButtonElement)) {
       throw new Error("missing upstream account tab");
     }
@@ -1423,10 +1538,13 @@ describe("DashboardWorkingConversationsSection", () => {
     });
 
     const identityChips = Array.from(
-      host?.querySelectorAll('[data-testid="dashboard-upstream-account-recent-identity-chip"]') ??
-        [],
+      host?.querySelectorAll(
+        '[data-testid="dashboard-upstream-account-recent-identity-chip"]',
+      ) ?? [],
     );
-    expect(identityChips).toHaveLength(UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.length);
+    expect(identityChips).toHaveLength(
+      UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.length,
+    );
 
     const toneClassNames = identityChips.map((chip) => chip.className);
     expect(new Set(toneClassNames).size).toBeGreaterThanOrEqual(4);
@@ -1676,16 +1794,24 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(currentSlot.textContent).not.toContain("ED ");
     expect(currentSlot.textContent).not.toContain("TT ");
     expect(
-      currentSlot.querySelector('[data-testid="dashboard-compact-latency-first-byte"]'),
+      currentSlot.querySelector(
+        '[data-testid="dashboard-compact-latency-first-byte"]',
+      ),
     ).not.toBeNull();
     expect(
-      currentSlot.querySelector('[data-testid="dashboard-compact-latency-response-time"]'),
+      currentSlot.querySelector(
+        '[data-testid="dashboard-compact-latency-response-time"]',
+      ),
     ).not.toBeNull();
     expect(
-      currentSlot.querySelector('[data-testid="dashboard-compact-latency-first-byte"]')?.className,
+      currentSlot.querySelector(
+        '[data-testid="dashboard-compact-latency-first-byte"]',
+      )?.className,
     ).not.toMatch(/rounded|border|bg-/);
     expect(
-      currentSlot.querySelector('[data-testid="dashboard-compact-latency-response-time"]')?.className,
+      currentSlot.querySelector(
+        '[data-testid="dashboard-compact-latency-response-time"]',
+      )?.className,
     ).not.toMatch(/rounded|border|bg-/);
   });
 
@@ -1745,7 +1871,9 @@ describe("DashboardWorkingConversationsSection", () => {
       '[data-testid="dashboard-image-tool-icon-badge"]',
     );
     expect(badges?.length ?? 0).toBe(1);
-    expect(badges?.[0]?.getAttribute("aria-label")).toMatch(/图片工具|Image tool/);
+    expect(badges?.[0]?.getAttribute("aria-label")).toMatch(
+      /图片工具|Image tool/,
+    );
     expect(badges?.[0]?.textContent).not.toMatch(/图片工具|Image tool/);
     expect(badges?.[0]?.className).toContain("rounded-full");
     expect(badges?.[0]?.className).toContain("border");
@@ -1775,12 +1903,17 @@ describe("DashboardWorkingConversationsSection", () => {
       '[data-testid="dashboard-image-tool-icon-badge"][data-image-intent-kind="direct_image"]',
     );
 
-    if (!(remoteBadge instanceof HTMLElement) || !(imageBadge instanceof HTMLElement)) {
+    if (
+      !(remoteBadge instanceof HTMLElement) ||
+      !(imageBadge instanceof HTMLElement)
+    ) {
       throw new Error("missing mixed-signal badges");
     }
 
     expect(remoteBadge.textContent).toMatch(/远程压缩V2|Remote compaction V2/);
-    expect(imageBadge.getAttribute("aria-label")).toMatch(/图片工具|Image tool/);
+    expect(imageBadge.getAttribute("aria-label")).toMatch(
+      /图片工具|Image tool/,
+    );
     expect(imageBadge.textContent).not.toMatch(/图片工具|Image tool/);
   });
 
@@ -1847,7 +1980,9 @@ describe("DashboardWorkingConversationsSection", () => {
     );
     const labels = planBadges.map((badge) => badge.textContent);
 
-    expect(labels).toEqual(expect.arrayContaining(["Ent", "Plus", "Free", "Pro"]));
+    expect(labels).toEqual(
+      expect.arrayContaining(["Ent", "Plus", "Free", "Pro"]),
+    );
     expect(labels).not.toContain("enterprise");
     expect(labels).not.toContain("local");
 
@@ -2499,6 +2634,86 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(onOpenInvocation).not.toHaveBeenCalled();
   });
 
+  it("opens the routing tab when clicking an upstream account status badge", async () => {
+    const onOpenUpstreamAccount = vi.fn();
+    const onOpenInvocation = vi.fn();
+    upstreamAccountActivityMock.data = createUpstreamAccountActivityResponse();
+
+    renderSection(createResponse([]), {
+      onOpenUpstreamAccount,
+      onOpenInvocation,
+    });
+
+    const upstreamAccountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((candidate) =>
+      /上游账号|upstream account/i.test(candidate.textContent ?? ""),
+    );
+    if (!(upstreamAccountTab instanceof HTMLButtonElement)) {
+      throw new Error("missing upstream account tab");
+    }
+
+    act(() => {
+      upstreamAccountTab.click();
+    });
+
+    const statusBadge = host?.querySelector(
+      '[data-testid="dashboard-upstream-account-status"]',
+    );
+    if (!(statusBadge instanceof HTMLButtonElement)) {
+      throw new Error("missing upstream account status badge");
+    }
+
+    act(() => {
+      statusBadge.click();
+    });
+
+    expect(onOpenUpstreamAccount).toHaveBeenCalledWith(42, "Pool Alpha", {
+      tab: "routing",
+    });
+    expect(onOpenInvocation).not.toHaveBeenCalled();
+  });
+
+  it("opens the routing tab when clicking an upstream account policy badge", async () => {
+    const onOpenUpstreamAccount = vi.fn();
+    const onOpenInvocation = vi.fn();
+    upstreamAccountActivityMock.data = createUpstreamAccountActivityResponse();
+
+    renderSection(createResponse([]), {
+      onOpenUpstreamAccount,
+      onOpenInvocation,
+    });
+
+    const upstreamAccountTab = Array.from(
+      host?.querySelectorAll('button[role="tab"]') ?? [],
+    ).find((candidate) =>
+      /上游账号|upstream account/i.test(candidate.textContent ?? ""),
+    );
+    if (!(upstreamAccountTab instanceof HTMLButtonElement)) {
+      throw new Error("missing upstream account tab");
+    }
+
+    act(() => {
+      upstreamAccountTab.click();
+    });
+
+    const policyBadge = host?.querySelector(
+      '[data-testid="dashboard-upstream-account-policy-badge"]',
+    );
+    if (!(policyBadge instanceof HTMLButtonElement)) {
+      throw new Error("missing upstream account policy badge");
+    }
+
+    act(() => {
+      policyBadge.click();
+    });
+
+    expect(onOpenUpstreamAccount).toHaveBeenCalledWith(42, "Pool Alpha", {
+      tab: "routing",
+    });
+    expect(onOpenInvocation).not.toHaveBeenCalled();
+  });
+
   it("keeps the concrete upstream account label on assigned-account blocked dashboard cards", () => {
     renderSection(
       createResponse([
@@ -2720,11 +2935,15 @@ describe("DashboardWorkingConversationsSection", () => {
       '[data-testid="invocation-phase-badge"]',
     );
     if (!(statusLabel instanceof HTMLElement)) {
-      throw new Error(`missing phase label in slot: ${currentSlot.textContent ?? ""}`);
+      throw new Error(
+        `missing phase label in slot: ${currentSlot.textContent ?? ""}`,
+      );
     }
     expect(
       slotHeader
-        .querySelector('[data-testid="dashboard-working-conversation-slot-label"]')
+        .querySelector(
+          '[data-testid="dashboard-working-conversation-slot-label"]',
+        )
         ?.textContent?.trim(),
     ).toBe("当前调用");
     expect(

--- a/web/src/components/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.test.tsx
@@ -1373,7 +1373,7 @@ describe("DashboardWorkingConversationsSection", () => {
     );
     const endpointBadge = Array.from(firstRow.querySelectorAll("span")).find(
       (element) => element.textContent?.trim() === "Responses",
-    );
+    )?.parentElement;
     expect(reasoningBadge?.className).toContain("min-h-5");
     expect(endpointBadge?.className).toContain("min-h-5");
 

--- a/web/src/components/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.test.tsx
@@ -1373,7 +1373,7 @@ describe("DashboardWorkingConversationsSection", () => {
     );
     const endpointBadge = Array.from(firstRow.querySelectorAll("span")).find(
       (element) => element.textContent?.trim() === "Responses",
-    )?.parentElement;
+    );
     expect(reasoningBadge?.className).toContain("min-h-5");
     expect(endpointBadge?.className).toContain("min-h-5");
 

--- a/web/src/components/DashboardWorkingConversationsSection.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.tsx
@@ -653,6 +653,34 @@ function AccountStatusBadge({
     success: "bg-success/90",
   }[variant];
 
+  if (clickable && onClick) {
+    return (
+      <button
+        type="button"
+        data-testid="dashboard-upstream-account-status"
+        className={cn(
+          "inline-flex min-h-6 cursor-pointer items-center gap-2 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold text-base-content transition-opacity duration-200 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+          surfaceClassName,
+        )}
+        title={description}
+        aria-label={`${label} · 打开账号路由详情`}
+        onClick={(event) => {
+          event.stopPropagation();
+          onClick();
+        }}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        <span
+          className={cn("h-1.5 w-1.5 rounded-full", dotClassName)}
+          aria-hidden="true"
+        />
+        <span>{label}</span>
+      </button>
+    );
+  }
+
   const badge = (
     <Badge
       variant="secondary"
@@ -661,7 +689,6 @@ function AccountStatusBadge({
       data-motion-surface
       className={cn(
         "min-h-6 gap-2 border px-2.5 py-0.5 text-[11px] font-semibold text-base-content transition-opacity duration-200",
-        clickable ? "pointer-events-none group-hover:opacity-80" : null,
         surfaceClassName,
       )}
     >
@@ -673,28 +700,7 @@ function AccountStatusBadge({
     </Badge>
   );
 
-  if (!clickable || !onClick) {
-    return <div data-testid="dashboard-upstream-account-status">{badge}</div>;
-  }
-
-  return (
-    <button
-      type="button"
-      data-testid="dashboard-upstream-account-status"
-      className="group inline-flex cursor-pointer appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-      title={description}
-      aria-label={`${label} · 打开账号路由详情`}
-      onClick={(event) => {
-        event.stopPropagation();
-        onClick();
-      }}
-      onKeyDown={(event) => {
-        event.stopPropagation();
-      }}
-    >
-      {badge}
-    </button>
-  );
+  return <div data-testid="dashboard-upstream-account-status">{badge}</div>;
 }
 
 function AccountPolicyBadges({
@@ -720,42 +726,49 @@ function AccountPolicyBadges({
       className="flex min-w-0 flex-wrap items-center gap-1.5 overflow-hidden"
     >
       {badges.map((badge) => {
-        const renderedBadge = (
+        if (clickable && onBadgeClick) {
+          return (
+            <button
+              key={`policy:${badge.key}`}
+              type="button"
+              data-testid="dashboard-upstream-account-policy-badge"
+              data-policy-key={badge.key}
+              className={cn(
+                "inline-flex cursor-pointer items-center whitespace-nowrap rounded-full border px-2 py-px text-[11px] font-medium leading-4 transition-opacity duration-200 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                badge.variant === "secondary"
+                  ? "border-base-300 bg-base-200/70 text-base-content/85"
+                  : badge.variant === "warning"
+                    ? "border-warning/45 bg-warning/12 text-base-content"
+                    : badge.variant === "info"
+                      ? "border-info/35 bg-info/15 text-info"
+                      : badge.variant === "accent"
+                        ? "border-accent/35 bg-accent/15 text-accent-content"
+                        : "border-primary/40 bg-primary/10 text-primary",
+              )}
+              title={badge.title ?? badge.label}
+              aria-label={`${badge.label} · 打开账号路由详情`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onBadgeClick();
+              }}
+              onKeyDown={(event) => {
+                event.stopPropagation();
+              }}
+            >
+              {badge.label}
+            </button>
+          );
+        }
+
+        return (
           <Badge
+            key={`policy:${badge.key}`}
             variant={badge.variant}
-            className={cn(
-              "shrink-0 whitespace-nowrap px-2 py-px text-[11px] font-medium leading-4 transition-opacity duration-200",
-              clickable ? "pointer-events-none group-hover:opacity-80" : null,
-            )}
+            className="shrink-0 whitespace-nowrap px-2 py-px text-[11px] font-medium leading-4 transition-opacity duration-200"
             title={badge.title ?? badge.label}
           >
             {badge.label}
           </Badge>
-        );
-
-        if (!clickable || !onBadgeClick) {
-          return <div key={`policy:${badge.key}`}>{renderedBadge}</div>;
-        }
-
-        return (
-          <button
-            key={`policy:${badge.key}`}
-            type="button"
-            data-testid="dashboard-upstream-account-policy-badge"
-            data-policy-key={badge.key}
-            className="group inline-flex cursor-pointer appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-            title={badge.title ?? badge.label}
-            aria-label={`${badge.label} · 打开账号路由详情`}
-            onClick={(event) => {
-              event.stopPropagation();
-              onBadgeClick();
-            }}
-            onKeyDown={(event) => {
-              event.stopPropagation();
-            }}
-          >
-            {renderedBadge}
-          </button>
         );
       })}
     </div>

--- a/web/src/components/DashboardWorkingConversationsSection.tsx
+++ b/web/src/components/DashboardWorkingConversationsSection.tsx
@@ -67,6 +67,10 @@ import {
   type DashboardWorkspaceView,
 } from "./dashboardActivityRange";
 
+export interface DashboardOpenUpstreamAccountOptions {
+  tab?: "overview" | "routing";
+}
+
 interface DashboardWorkingConversationsSectionProps {
   activeRange: DashboardActivityRangeKey;
   cards: DashboardWorkingConversationCardModel[];
@@ -78,8 +82,14 @@ interface DashboardWorkingConversationsSectionProps {
   error?: string | null;
   onLoadMore?: () => void;
   setRefreshTargetCount?: (count: number) => void;
-  onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
-  onOpenConversation?: (selection: DashboardWorkingConversationSelection) => void;
+  onOpenUpstreamAccount?: (
+    accountId: number,
+    accountLabel: string,
+    options?: DashboardOpenUpstreamAccountOptions,
+  ) => void;
+  onOpenConversation?: (
+    selection: DashboardWorkingConversationSelection,
+  ) => void;
   onOpenInvocation?: (
     selection: DashboardWorkingConversationInvocationSelection,
   ) => void;
@@ -103,12 +113,7 @@ const ACCOUNT_CARD_INNER_RING_CLASS_NAME = "ring-[rgba(148,163,184,0.22)]";
 
 type StatusMeta = {
   badgeVariant:
-    | "default"
-    | "secondary"
-    | "success"
-    | "warning"
-    | "error"
-    | "info";
+    "default" | "secondary" | "success" | "warning" | "error" | "info";
   icon:
     | "loading"
     | "timer-refresh-outline"
@@ -154,7 +159,10 @@ function resolveConversationIdentityToneClassName(seed: string) {
   const hash = hashDashboardWorkingConversationKey(seed);
   const hashValue = Number.parseInt(hash, 16) >>> 0;
   const mixedHash =
-    (hashValue ^ (hashValue >>> 7) ^ (hashValue >>> 13) ^ (hashValue >>> 21)) >>>
+    (hashValue ^
+      (hashValue >>> 7) ^
+      (hashValue >>> 13) ^
+      (hashValue >>> 21)) >>>
     0;
   const toneIndex =
     mixedHash % UPSTREAM_ACCOUNT_RECENT_IDENTITY_TONE_CLASSNAMES.length;
@@ -281,14 +289,24 @@ function CompactLatencyPills({
         data-testid="dashboard-compact-latency-first-byte"
         className="inline-flex min-w-0 items-center gap-1 text-secondary"
       >
-        <AppIcon name="timer-outline" className="h-3.5 w-3.5 shrink-0" aria-hidden />
-        <span className="truncate whitespace-nowrap">{firstResponseByteTotalValue}</span>
+        <AppIcon
+          name="timer-outline"
+          className="h-3.5 w-3.5 shrink-0"
+          aria-hidden
+        />
+        <span className="truncate whitespace-nowrap">
+          {firstResponseByteTotalValue}
+        </span>
       </span>
       <span
         data-testid="dashboard-compact-latency-response-time"
         className="inline-flex min-w-0 items-center gap-1 text-primary"
       >
-        <AppIcon name="speedometer" className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <AppIcon
+          name="speedometer"
+          className="h-3.5 w-3.5 shrink-0"
+          aria-hidden
+        />
         <span className="truncate whitespace-nowrap">{responseTimeValue}</span>
       </span>
     </div>
@@ -339,7 +357,8 @@ function renderUpstreamAccountRecentModelDisplay(
   responseModelValue: string,
   t: ReturnType<typeof useTranslation>["t"],
 ) {
-  const shouldRenderMismatch = hasMismatch &&
+  const shouldRenderMismatch =
+    hasMismatch &&
     requestModelValue !== FALLBACK_CELL &&
     responseModelValue !== FALLBACK_CELL;
 
@@ -538,7 +557,10 @@ function finiteNumber(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function accountCostShare(numerator: number | null | undefined, total: number | null | undefined) {
+function accountCostShare(
+  numerator: number | null | undefined,
+  total: number | null | undefined,
+) {
   const resolvedNumerator = finiteNumber(numerator);
   const resolvedTotal = finiteNumber(total);
   if (resolvedNumerator == null || resolvedTotal == null) return null;
@@ -586,15 +608,16 @@ type AccountActivityStatus = {
   summary: string;
 };
 
-const ACCOUNT_METRIC_VALUE_TONE_CLASSNAMES: Record<AccountMetricTone, string> = {
-  neutral: "text-base-content",
-  primary: "text-primary",
-  secondary: "text-secondary",
-  success: "text-success",
-  warning: "text-accent",
-  error: "text-error",
-  info: "text-info",
-};
+const ACCOUNT_METRIC_VALUE_TONE_CLASSNAMES: Record<AccountMetricTone, string> =
+  {
+    neutral: "text-base-content",
+    primary: "text-primary",
+    secondary: "text-secondary",
+    success: "text-success",
+    warning: "text-accent",
+    error: "text-error",
+    info: "text-info",
+  };
 
 const ACCOUNT_METRIC_DOT_TONE_CLASSNAMES: Record<AccountMetricTone, string> = {
   neutral: "bg-base-content/38",
@@ -610,10 +633,14 @@ function AccountStatusBadge({
   label,
   variant,
   description,
+  clickable = false,
+  onClick,
 }: {
   label: string;
   variant: AccountActivityStatus["badgeVariant"];
   description?: string;
+  clickable?: boolean;
+  onClick?: () => void;
 }) {
   const surfaceClassName = {
     info: "border-[rgba(148,163,184,0.26)] bg-base-100/86",
@@ -626,32 +653,65 @@ function AccountStatusBadge({
     success: "bg-success/90",
   }[variant];
 
-  return (
+  const badge = (
     <Badge
       variant="secondary"
-      data-testid="dashboard-upstream-account-status"
       title={description}
       aria-label={description ? `${label} · ${description}` : label}
       data-motion-surface
       className={cn(
-        "min-h-6 gap-2 border px-2.5 py-0.5 text-[11px] font-semibold text-base-content",
+        "min-h-6 gap-2 border px-2.5 py-0.5 text-[11px] font-semibold text-base-content transition-opacity duration-200",
+        clickable ? "pointer-events-none group-hover:opacity-80" : null,
         surfaceClassName,
       )}
     >
-      <span className={cn("h-1.5 w-1.5 rounded-full", dotClassName)} aria-hidden="true" />
+      <span
+        className={cn("h-1.5 w-1.5 rounded-full", dotClassName)}
+        aria-hidden="true"
+      />
       {label}
     </Badge>
+  );
+
+  if (!clickable || !onClick) {
+    return <div data-testid="dashboard-upstream-account-status">{badge}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="dashboard-upstream-account-status"
+      className="group inline-flex cursor-pointer appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      title={description}
+      aria-label={`${label} · 打开账号路由详情`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      onKeyDown={(event) => {
+        event.stopPropagation();
+      }}
+    >
+      {badge}
+    </button>
   );
 }
 
 function AccountPolicyBadges({
   account,
+  clickable = false,
+  onBadgeClick,
 }: {
   account: UpstreamAccountActivityAccount;
+  clickable?: boolean;
+  onBadgeClick?: () => void;
 }) {
-  const badges = resolveActiveRoutingPolicyBadges(account.effectiveRoutingRule, {
-    policyForbidNewConversation: "禁新对话",
-  });
+  const badges = resolveActiveRoutingPolicyBadges(
+    account.effectiveRoutingRule,
+    {
+      policyForbidNewConversation: "禁新对话",
+    },
+  );
   if (badges.length === 0) return null;
 
   return (
@@ -659,16 +719,45 @@ function AccountPolicyBadges({
       data-testid="dashboard-upstream-account-policy-badges"
       className="flex min-w-0 flex-wrap items-center gap-1.5 overflow-hidden"
     >
-      {badges.map((badge) => (
-        <Badge
-          key={`policy:${badge.key}`}
-          variant={badge.variant}
-          className="shrink-0 whitespace-nowrap px-2 py-px text-[11px] font-medium leading-4"
-          title={badge.title ?? badge.label}
-        >
-          {badge.label}
-        </Badge>
-      ))}
+      {badges.map((badge) => {
+        const renderedBadge = (
+          <Badge
+            variant={badge.variant}
+            className={cn(
+              "shrink-0 whitespace-nowrap px-2 py-px text-[11px] font-medium leading-4 transition-opacity duration-200",
+              clickable ? "pointer-events-none group-hover:opacity-80" : null,
+            )}
+            title={badge.title ?? badge.label}
+          >
+            {badge.label}
+          </Badge>
+        );
+
+        if (!clickable || !onBadgeClick) {
+          return <div key={`policy:${badge.key}`}>{renderedBadge}</div>;
+        }
+
+        return (
+          <button
+            key={`policy:${badge.key}`}
+            type="button"
+            data-testid="dashboard-upstream-account-policy-badge"
+            data-policy-key={badge.key}
+            className="group inline-flex cursor-pointer appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            title={badge.title ?? badge.label}
+            aria-label={`${badge.label} · 打开账号路由详情`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onBadgeClick();
+            }}
+            onKeyDown={(event) => {
+              event.stopPropagation();
+            }}
+          >
+            {renderedBadge}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -693,12 +782,30 @@ function AccountHeroMetric({
   children?: ReactNode;
 }) {
   const toneSurfaceClassName = {
-    neutral: cn("bg-base-100/72 ring-1 ring-inset", ACCOUNT_CARD_INNER_RING_CLASS_NAME),
-    primary: cn("bg-base-100/72 ring-1 ring-inset", ACCOUNT_CARD_INNER_RING_CLASS_NAME),
-    secondary: cn("bg-base-100/72 ring-1 ring-inset", ACCOUNT_CARD_INNER_RING_CLASS_NAME),
-    success: cn("bg-base-100/72 ring-1 ring-inset", ACCOUNT_CARD_INNER_RING_CLASS_NAME),
-    warning: cn("bg-base-100/72 ring-1 ring-inset", ACCOUNT_CARD_INNER_RING_CLASS_NAME),
-    info: cn("bg-base-100/72 ring-1 ring-inset", ACCOUNT_CARD_INNER_RING_CLASS_NAME),
+    neutral: cn(
+      "bg-base-100/72 ring-1 ring-inset",
+      ACCOUNT_CARD_INNER_RING_CLASS_NAME,
+    ),
+    primary: cn(
+      "bg-base-100/72 ring-1 ring-inset",
+      ACCOUNT_CARD_INNER_RING_CLASS_NAME,
+    ),
+    secondary: cn(
+      "bg-base-100/72 ring-1 ring-inset",
+      ACCOUNT_CARD_INNER_RING_CLASS_NAME,
+    ),
+    success: cn(
+      "bg-base-100/72 ring-1 ring-inset",
+      ACCOUNT_CARD_INNER_RING_CLASS_NAME,
+    ),
+    warning: cn(
+      "bg-base-100/72 ring-1 ring-inset",
+      ACCOUNT_CARD_INNER_RING_CLASS_NAME,
+    ),
+    info: cn(
+      "bg-base-100/72 ring-1 ring-inset",
+      ACCOUNT_CARD_INNER_RING_CLASS_NAME,
+    ),
   }[tone];
   const valueClassName =
     value === FALLBACK_CELL
@@ -720,9 +827,7 @@ function AccountHeroMetric({
       data-motion-surface
       className={cn(
         "h-full w-full rounded-[0.85rem] px-3 py-2.5 transition-colors duration-200",
-        detailSections?.length
-          ? "cursor-help focus-within:outline-none"
-          : null,
+        detailSections?.length ? "cursor-help focus-within:outline-none" : null,
         toneSurfaceClassName,
       )}
     >
@@ -732,13 +837,20 @@ function AccountHeroMetric({
       <div className="mt-1 flex min-w-0 items-center gap-1.5">
         <span
           aria-hidden
-          data-testid={metricKey ? `dashboard-upstream-account-${metricKey}-icon` : undefined}
+          data-testid={
+            metricKey
+              ? `dashboard-upstream-account-${metricKey}-icon`
+              : undefined
+          }
           className={cn(
             "flex h-[1.35rem] w-[1.35rem] shrink-0 items-center justify-center text-[1.22rem] leading-none",
             iconClassName,
           )}
         >
-          <AppIcon name={iconName} className={cn(iconName === "send" && "-rotate-45")} />
+          <AppIcon
+            name={iconName}
+            className={cn(iconName === "send" && "-rotate-45")}
+          />
         </span>
         <div
           className={cn(
@@ -750,7 +862,9 @@ function AccountHeroMetric({
         </div>
       </div>
       {hint ? (
-        <div className="mt-1 text-[11px] leading-4 text-base-content/58">{hint}</div>
+        <div className="mt-1 text-[11px] leading-4 text-base-content/58">
+          {hint}
+        </div>
       ) : null}
       {children ? <div className="mt-1.5">{children}</div> : null}
     </div>
@@ -796,7 +910,10 @@ function AccountMetricDetailTooltip({
   sections: AccountMetricDetailSection[];
 }) {
   return (
-    <div data-testid="dashboard-upstream-account-metric-tooltip" className="space-y-3">
+    <div
+      data-testid="dashboard-upstream-account-metric-tooltip"
+      className="space-y-3"
+    >
       <div className="flex min-w-0 items-baseline justify-between gap-4 border-b border-base-300/45 pb-2">
         <div className="min-w-0 text-[11px] font-semibold leading-4 text-base-content/62">
           {label}
@@ -827,7 +944,9 @@ function AccountMetricDetailTooltip({
                 <span
                   className={cn(
                     "min-w-0 max-w-[12rem] truncate text-right font-mono text-[11px] font-semibold leading-4 text-base-content",
-                    row.tone ? ACCOUNT_METRIC_VALUE_TONE_CLASSNAMES[row.tone] : null,
+                    row.tone
+                      ? ACCOUNT_METRIC_VALUE_TONE_CLASSNAMES[row.tone]
+                      : null,
                   )}
                 >
                   {row.value}
@@ -870,7 +989,10 @@ function AccountInlineMetric({
           iconClassName,
         )}
       >
-        <AppIcon name={iconName} className={cn(iconName === "send" && "-rotate-45")} />
+        <AppIcon
+          name={iconName}
+          className={cn(iconName === "send" && "-rotate-45")}
+        />
       </span>
       <span
         className={cn(
@@ -995,7 +1117,10 @@ function AccountSegmentList({
               content={
                 <span className="font-medium">
                   {segment.label}
-                  <span className="font-mono font-semibold"> {String(segment.value)}</span>
+                  <span className="font-mono font-semibold">
+                    {" "}
+                    {String(segment.value)}
+                  </span>
                 </span>
               }
               clickToOpen
@@ -1025,7 +1150,9 @@ function AccountRecentInvocationRow({
   locale: "zh" | "en";
   nowMs: number;
   onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
-  onOpenConversation?: (selection: DashboardWorkingConversationSelection) => void;
+  onOpenConversation?: (
+    selection: DashboardWorkingConversationSelection,
+  ) => void;
   onOpenInvocation?: (
     selection: DashboardWorkingConversationInvocationSelection,
   ) => void;
@@ -1237,7 +1364,9 @@ function AccountRecentInvocationRow({
                       conversationIdentityToneClassName,
                     )}
                     aria-label={conversationActionLabel ?? undefined}
-                    title={conversationActionLabel ?? displayConversationSequenceId}
+                    title={
+                      conversationActionLabel ?? displayConversationSequenceId
+                    }
                     onClick={handleIdentityChipClick}
                     onKeyDown={handleIdentityChipKeyDown}
                   >
@@ -1283,7 +1412,9 @@ function AccountRecentInvocationRow({
             />
             {fastIndicator}
             <CompactLatencyPills
-              firstResponseByteTotalValue={viewModel.firstResponseByteTotalValue}
+              firstResponseByteTotalValue={
+                viewModel.firstResponseByteTotalValue
+              }
               responseTimeValue={viewModel.totalLatencyValue}
               t={t}
             />
@@ -1303,7 +1434,9 @@ function AccountRecentInvocationRow({
             {viewModel.reasoningEffortValue !== FALLBACK_CELL ? (
               <>
                 <span className="text-base-content/28">·</span>
-                <CompactReasoningEffortBadge value={viewModel.reasoningEffortValue} />
+                <CompactReasoningEffortBadge
+                  value={viewModel.reasoningEffortValue}
+                />
               </>
             ) : null}
           </div>
@@ -1312,7 +1445,9 @@ function AccountRecentInvocationRow({
           <div className="font-mono text-[12px] font-semibold text-base-content/88">
             {viewModel.totalTokensValue}
           </div>
-          <div className="text-[10.5px] text-base-content/62">{compactCostValue}</div>
+          <div className="text-[10.5px] text-base-content/62">
+            {compactCostValue}
+          </div>
         </div>
       </div>
       <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 font-mono text-[10.5px] leading-[1.45] text-base-content/74">
@@ -1974,8 +2109,14 @@ function DashboardUpstreamAccountActivityCard({
   localeTag: string;
   nowMs: number;
   recentPreviewLimit: number;
-  onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
-  onOpenConversation?: (selection: DashboardWorkingConversationSelection) => void;
+  onOpenUpstreamAccount?: (
+    accountId: number,
+    accountLabel: string,
+    options?: DashboardOpenUpstreamAccountOptions,
+  ) => void;
+  onOpenConversation?: (
+    selection: DashboardWorkingConversationSelection,
+  ) => void;
   onOpenInvocation?: (
     selection: DashboardWorkingConversationInvocationSelection,
   ) => void;
@@ -1983,8 +2124,9 @@ function DashboardUpstreamAccountActivityCard({
   const { t } = useTranslation();
   const recentInvocations = useMemo(
     () =>
-      account.recentInvocations.map((preview: DashboardWorkingConversationInvocationModel["preview"]) =>
-        buildDashboardWorkingConversationInvocationModel(preview),
+      account.recentInvocations.map(
+        (preview: DashboardWorkingConversationInvocationModel["preview"]) =>
+          buildDashboardWorkingConversationInvocationModel(preview),
       ),
     [account.recentInvocations],
   );
@@ -1992,6 +2134,12 @@ function DashboardUpstreamAccountActivityCard({
     () => resolveAccountActivityStatus({ account, locale, localeTag }),
     [account, locale, localeTag],
   );
+  const handleOpenRoutingTab = useCallback(() => {
+    if (account.upstreamAccountId == null) return;
+    onOpenUpstreamAccount?.(account.upstreamAccountId, account.displayName, {
+      tab: "routing",
+    });
+  }, [account.displayName, account.upstreamAccountId, onOpenUpstreamAccount]);
   const requestSummarySegments = useMemo(
     () => [
       {
@@ -2014,26 +2162,32 @@ function DashboardUpstreamAccountActivityCard({
         tone: "warning" as const,
       },
     ],
-    [account.failureCount, account.nonSuccessCount, account.successCount, locale, localeTag],
+    [
+      account.failureCount,
+      account.nonSuccessCount,
+      account.successCount,
+      locale,
+      localeTag,
+    ],
   );
-  const costSummarySegments = useMemo(
-    () => {
-      const failureCostShare = accountCostShare(account.failureCost, account.totalCost);
-      return [
-        {
-          label: locale === "zh" ? "失败" : "Failure",
-          value: formatAccountCurrencyValue(account.failureCost, localeTag, 2),
-          tone: "error" as const,
-        },
-        {
-          label: locale === "zh" ? "失败成本比率" : "Failure cost ratio",
-          value: formatAccountPercentValue(failureCostShare, localeTag),
-          tone: "error" as const,
-        },
-      ];
-    },
-    [account.failureCost, account.totalCost, locale, localeTag],
-  );
+  const costSummarySegments = useMemo(() => {
+    const failureCostShare = accountCostShare(
+      account.failureCost,
+      account.totalCost,
+    );
+    return [
+      {
+        label: locale === "zh" ? "失败" : "Failure",
+        value: formatAccountCurrencyValue(account.failureCost, localeTag, 2),
+        tone: "error" as const,
+      },
+      {
+        label: locale === "zh" ? "失败成本比率" : "Failure cost ratio",
+        value: formatAccountPercentValue(failureCostShare, localeTag),
+        tone: "error" as const,
+      },
+    ];
+  }, [account.failureCost, account.totalCost, locale, localeTag]);
   const tokenSummarySegments = useMemo(
     () => [
       {
@@ -2080,7 +2234,13 @@ function DashboardUpstreamAccountActivityCard({
       });
     }
     return segments;
-  }, [account.failureCount, account.nonSuccessCount, account.successCount, locale, localeTag]);
+  }, [
+    account.failureCount,
+    account.nonSuccessCount,
+    account.successCount,
+    locale,
+    localeTag,
+  ]);
   const firstByteValue =
     (account.firstResponseByteTotalAvgMs ?? account.firstByteAvgMs) == null
       ? FALLBACK_CELL
@@ -2088,10 +2248,25 @@ function DashboardUpstreamAccountActivityCard({
           account.firstResponseByteTotalAvgMs ?? account.firstByteAvgMs,
           localeTag,
         );
-  const avgTotalValue = formatAccountDurationValue(account.avgTotalMs, localeTag);
-  const totalRequestValue = formatAccountNumberValue(account.requestCount, localeTag, 0);
-  const totalCostValue = formatAccountCurrencyAmountValue(account.totalCost, localeTag, 2);
-  const totalTokenValue = formatAccountNumberValue(account.totalTokens, localeTag, 0);
+  const avgTotalValue = formatAccountDurationValue(
+    account.avgTotalMs,
+    localeTag,
+  );
+  const totalRequestValue = formatAccountNumberValue(
+    account.requestCount,
+    localeTag,
+    0,
+  );
+  const totalCostValue = formatAccountCurrencyAmountValue(
+    account.totalCost,
+    localeTag,
+    2,
+  );
+  const totalTokenValue = formatAccountNumberValue(
+    account.totalTokens,
+    localeTag,
+    0,
+  );
   const latencyDetailSections = useMemo<AccountMetricDetailSection[]>(() => {
     const firstByteMs = finiteNumber(
       account.firstResponseByteTotalAvgMs ?? account.firstByteAvgMs,
@@ -2111,7 +2286,12 @@ function DashboardUpstreamAccountActivityCard({
         tone: "secondary",
       });
     }
-    if (firstByteMs != null && avgTotalMs != null && avgTotalMs > 0 && firstByteMs <= avgTotalMs) {
+    if (
+      firstByteMs != null &&
+      avgTotalMs != null &&
+      avgTotalMs > 0 &&
+      firstByteMs <= avgTotalMs
+    ) {
       relatedRows.push({
         label: locale === "zh" ? "首字占比" : "First-byte share",
         value: formatAccountPercentValue(firstByteMs / avgTotalMs, localeTag),
@@ -2155,11 +2335,18 @@ function DashboardUpstreamAccountActivityCard({
     t,
   ]);
   const requestDetailSections = useMemo<AccountMetricDetailSection[]>(() => {
-    const otherCount = Math.max(0, account.nonSuccessCount - account.failureCount);
+    const otherCount = Math.max(
+      0,
+      account.nonSuccessCount - account.failureCount,
+    );
     const successRate =
-      account.requestCount > 0 ? account.successCount / account.requestCount : null;
+      account.requestCount > 0
+        ? account.successCount / account.requestCount
+        : null;
     const nonSuccessRate =
-      account.requestCount > 0 ? account.nonSuccessCount / account.requestCount : null;
+      account.requestCount > 0
+        ? account.nonSuccessCount / account.requestCount
+        : null;
 
     return [
       {
@@ -2213,10 +2400,15 @@ function DashboardUpstreamAccountActivityCard({
     totalRequestValue,
   ]);
   const costDetailSections = useMemo<AccountMetricDetailSection[]>(() => {
-    const failureCostShare = accountCostShare(account.failureCost, account.totalCost);
+    const failureCostShare = accountCostShare(
+      account.failureCost,
+      account.totalCost,
+    );
     const nonFailureCost = account.totalCost - account.failureCost;
     const averageCost =
-      account.requestCount > 0 ? account.totalCost / account.requestCount : null;
+      account.requestCount > 0
+        ? account.totalCost / account.requestCount
+        : null;
 
     return [
       {
@@ -2229,7 +2421,11 @@ function DashboardUpstreamAccountActivityCard({
           },
           {
             label: locale === "zh" ? "失败成本" : "Failure cost",
-            value: formatAccountCurrencyValue(account.failureCost, localeTag, 2),
+            value: formatAccountCurrencyValue(
+              account.failureCost,
+              localeTag,
+              2,
+            ),
             tone: "error" as const,
           },
           {
@@ -2265,7 +2461,9 @@ function DashboardUpstreamAccountActivityCard({
   ]);
   const tokenDetailSections = useMemo<AccountMetricDetailSection[]>(() => {
     const averageTokens =
-      account.requestCount > 0 ? account.totalTokens / account.requestCount : null;
+      account.requestCount > 0
+        ? account.totalTokens / account.requestCount
+        : null;
 
     return [
       {
@@ -2283,7 +2481,11 @@ function DashboardUpstreamAccountActivityCard({
           },
           {
             label: locale === "zh" ? "失败 Token" : "Failure tokens",
-            value: formatAccountNumberValue(account.failureTokens, localeTag, 0),
+            value: formatAccountNumberValue(
+              account.failureTokens,
+              localeTag,
+              0,
+            ),
             tone: "error" as const,
           },
         ],
@@ -2293,12 +2495,20 @@ function DashboardUpstreamAccountActivityCard({
         rows: [
           {
             label: locale === "zh" ? "成功 Token" : "Success tokens",
-            value: formatAccountNumberValue(account.successTokens, localeTag, 0),
+            value: formatAccountNumberValue(
+              account.successTokens,
+              localeTag,
+              0,
+            ),
             tone: "success" as const,
           },
           {
             label: locale === "zh" ? "非成功 Token" : "Non-success tokens",
-            value: formatAccountNumberValue(account.nonSuccessTokens, localeTag, 0),
+            value: formatAccountNumberValue(
+              account.nonSuccessTokens,
+              localeTag,
+              0,
+            ),
             tone: "warning" as const,
           },
           {
@@ -2344,7 +2554,10 @@ function DashboardUpstreamAccountActivityCard({
               )}
               onClick={() => {
                 if (account.upstreamAccountId == null) return;
-                onOpenUpstreamAccount?.(account.upstreamAccountId, account.displayName);
+                onOpenUpstreamAccount?.(
+                  account.upstreamAccountId,
+                  account.displayName,
+                );
               }}
             >
               <span className="truncate">{account.displayName}</span>
@@ -2353,10 +2566,15 @@ function DashboardUpstreamAccountActivityCard({
               label={accountStatus.label}
               variant={accountStatus.badgeVariant}
               description={accountStatus.summary}
+              clickable={account.upstreamAccountId != null}
+              onClick={handleOpenRoutingTab}
             />
             {shouldShowUpstreamPlanBadge(account.planType) ? (
               <Badge
-                variant={upstreamPlanBadgeRecipe(account.planType)?.variant ?? "secondary"}
+                variant={
+                  upstreamPlanBadgeRecipe(account.planType)?.variant ??
+                  "secondary"
+                }
                 data-plan={upstreamPlanBadgeRecipe(account.planType)?.dataPlan}
                 className={cn(
                   "h-5 px-2 py-0 text-[10px] font-semibold",
@@ -2366,30 +2584,48 @@ function DashboardUpstreamAccountActivityCard({
                 {compactUpstreamPlanLabel(account.planType)}
               </Badge>
             ) : null}
-            <AccountPolicyBadges account={account} />
+            <AccountPolicyBadges
+              account={account}
+              clickable={account.upstreamAccountId != null}
+              onBadgeClick={handleOpenRoutingTab}
+            />
           </div>
         </div>
         <div className="flex min-w-0 flex-1 flex-wrap items-start justify-end gap-x-5 gap-y-1.5 text-right">
           <AccountInlineMetric
             label={t("dashboard.today.inProgressConversations")}
-            value={formatAccountNumberValue(account.inProgressInvocationCount, localeTag, 0)}
+            value={formatAccountNumberValue(
+              account.inProgressInvocationCount,
+              localeTag,
+              0,
+            )}
             tone="secondary"
             iconName="send"
           />
           <AccountInlineMetric
             label="TPM"
-            value={formatAccountNumberValue(account.tokensPerMinute, localeTag, 0)}
+            value={formatAccountNumberValue(
+              account.tokensPerMinute,
+              localeTag,
+              0,
+            )}
             tone="primary"
             iconName="speedometer"
           />
           <AccountInlineMetric
             label={t("dashboard.today.spendRate")}
-            value={formatAccountCurrencyAmountValue(account.spendRate, localeTag, 2)}
+            value={formatAccountCurrencyAmountValue(
+              account.spendRate,
+              localeTag,
+              2,
+            )}
             tone="warning"
             iconName="cash-clock"
           />
           <div className="shrink-0 font-mono text-xs font-semibold text-base-content/72">
-            {account.upstreamAccountId == null ? "—" : `#${account.upstreamAccountId}`}
+            {account.upstreamAccountId == null
+              ? "—"
+              : `#${account.upstreamAccountId}`}
           </div>
         </div>
       </div>
@@ -2492,17 +2728,19 @@ function DashboardUpstreamAccountActivityCard({
           </div>
         </div>
         <div className="grid flex-1 auto-rows-fr gap-1.5">
-          {recentInvocations.map((invocation: DashboardWorkingConversationInvocationModel) => (
-            <AccountRecentInvocationRow
-              key={`${invocation.record.invokeId}:${invocation.record.occurredAt}:${invocation.record.id}`}
-              invocation={invocation}
-              locale={locale}
-              nowMs={nowMs}
-              onOpenUpstreamAccount={onOpenUpstreamAccount}
-              onOpenConversation={onOpenConversation}
-              onOpenInvocation={onOpenInvocation}
-            />
-          ))}
+          {recentInvocations.map(
+            (invocation: DashboardWorkingConversationInvocationModel) => (
+              <AccountRecentInvocationRow
+                key={`${invocation.record.invokeId}:${invocation.record.occurredAt}:${invocation.record.id}`}
+                invocation={invocation}
+                locale={locale}
+                nowMs={nowMs}
+                onOpenUpstreamAccount={onOpenUpstreamAccount}
+                onOpenConversation={onOpenConversation}
+                onOpenInvocation={onOpenInvocation}
+              />
+            ),
+          )}
         </div>
       </div>
     </article>
@@ -2517,8 +2755,7 @@ function readDashboardWorkingConversationAnchorKey(card: HTMLElement) {
   return (
     (card as DashboardWorkingConversationAnchorCardElement)
       .__dashboardWorkingConversationAnchorKey ?? ""
-  )
-    .trim();
+  ).trim();
 }
 
 function captureVisibleCardAnchor(
@@ -2528,7 +2765,9 @@ function captureVisibleCardAnchor(
   const containerRect = container.getBoundingClientRect();
   const topBoundary = Math.max(0, containerRect.top);
   const viewportBottom =
-    typeof window === "undefined" ? Number.POSITIVE_INFINITY : window.innerHeight;
+    typeof window === "undefined"
+      ? Number.POSITIVE_INFINITY
+      : window.innerHeight;
   const cards = Array.from(
     container.querySelectorAll<HTMLElement>(
       '[data-testid="dashboard-working-conversation-card"]',
@@ -2576,8 +2815,9 @@ export function DashboardWorkingConversationsSection({
   onUpstreamAccountActivityEnabledChange,
 }: DashboardWorkingConversationsSectionProps) {
   const { t, locale } = useTranslation();
-  const [preferredView, setPreferredView] = useState<DashboardWorkspaceView>(() =>
-    readPersistedDashboardWorkspaceView(DASHBOARD_WORKSPACE_VIEW_STORAGE_KEY),
+  const [preferredView, setPreferredView] = useState<DashboardWorkspaceView>(
+    () =>
+      readPersistedDashboardWorkspaceView(DASHBOARD_WORKSPACE_VIEW_STORAGE_KEY),
   );
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [containerWidth, setContainerWidth] = useState(0);
@@ -2645,16 +2885,16 @@ export function DashboardWorkingConversationsSection({
     recentPreviewLimit,
   );
   const upstreamAccountActivity = hasExternalUpstreamAccountActivity
-    ? externalUpstreamAccountActivity ?? null
+    ? (externalUpstreamAccountActivity ?? null)
     : hookUpstreamAccountActivity.data;
   const upstreamAccountActivityLoading = hasExternalUpstreamAccountActivity
     ? externalUpstreamAccountActivityLoading === true
     : hookUpstreamAccountActivity.isLoading;
   const upstreamAccountActivityError = hasExternalUpstreamAccountActivity
-    ? externalUpstreamAccountActivityError ?? null
+    ? (externalUpstreamAccountActivityError ?? null)
     : hookUpstreamAccountActivity.error;
   const upstreamAccountRecentPreviewLimit = hasExternalUpstreamAccountActivity
-    ? externalUpstreamAccountRecentPreviewLimit ?? recentPreviewLimit
+    ? (externalUpstreamAccountRecentPreviewLimit ?? recentPreviewLimit)
     : hookUpstreamAccountActivity.recentInvocationLimit;
   useEffect(() => {
     onUpstreamAccountActivityEnabledChange?.(upstreamAccountActivityEnabled);
@@ -2669,8 +2909,10 @@ export function DashboardWorkingConversationsSection({
         const leftRecent = left.recentInvocations[0]?.occurredAt ?? "";
         const recentCompare = rightRecent.localeCompare(leftRecent);
         if (recentCompare !== 0) return recentCompare;
-        return (right.upstreamAccountId ?? Number.MIN_SAFE_INTEGER) -
-          (left.upstreamAccountId ?? Number.MIN_SAFE_INTEGER);
+        return (
+          (right.upstreamAccountId ?? Number.MIN_SAFE_INTEGER) -
+          (left.upstreamAccountId ?? Number.MIN_SAFE_INTEGER)
+        );
       }),
     [upstreamAccountActivity],
   );
@@ -2784,9 +3026,7 @@ export function DashboardWorkingConversationsSection({
       const nextScrollMargin =
         gridElement.getBoundingClientRect().top + window.scrollY;
       setScrollMargin((current) =>
-        Math.abs(current - nextScrollMargin) > 0.5
-          ? nextScrollMargin
-          : current,
+        Math.abs(current - nextScrollMargin) > 0.5 ? nextScrollMargin : current,
       );
     };
 
@@ -2840,7 +3080,8 @@ export function DashboardWorkingConversationsSection({
       if (containerRect.bottom <= 0) {
         return;
       }
-      const sectionStartsBelowFold = containerRect.top >= window.innerHeight - 1;
+      const sectionStartsBelowFold =
+        containerRect.top >= window.innerHeight - 1;
       if (trigger === "mount" && sectionStartsBelowFold) {
         return;
       }
@@ -2896,7 +3137,11 @@ export function DashboardWorkingConversationsSection({
         container.querySelectorAll<HTMLElement>(
           '[data-testid="dashboard-working-conversation-card"]',
         ),
-      ).find((card) => readDashboardWorkingConversationAnchorKey(card) === pendingAnchor.anchorKey);
+      ).find(
+        (card) =>
+          readDashboardWorkingConversationAnchorKey(card) ===
+          pendingAnchor.anchorKey,
+      );
       if (anchoredCard) {
         const containerTopBoundary = Math.max(
           0,
@@ -2949,9 +3194,7 @@ export function DashboardWorkingConversationsSection({
             <h2 className="section-title">
               {t("dashboard.section.workingConversationsTitle")}
             </h2>
-            <p className="section-description">
-              {sectionSubtitle}
-            </p>
+            <p className="section-description">{sectionSubtitle}</p>
           </div>
           <div className="ml-auto flex shrink-0 items-center justify-end gap-2 self-start">
             <Badge
@@ -3009,7 +3252,8 @@ export function DashboardWorkingConversationsSection({
                 </span>
               </div>
             ) : null}
-            {!upstreamAccountActivityLoading && upstreamAccounts.length === 0 ? (
+            {!upstreamAccountActivityLoading &&
+            upstreamAccounts.length === 0 ? (
               <div className="rounded-2xl border border-dashed border-base-300/75 bg-base-100/45 px-5 py-8 text-sm text-base-content/65">
                 {t("dashboard.upstreamAccounts.empty")}
               </div>
@@ -3021,7 +3265,11 @@ export function DashboardWorkingConversationsSection({
               >
                 {upstreamAccountRows.flat().map((account) => (
                   <DashboardUpstreamAccountActivityCard
-                    key={account.accountKey ?? account.upstreamAccountId ?? "unassigned"}
+                    key={
+                      account.accountKey ??
+                      account.upstreamAccountId ??
+                      "unassigned"
+                    }
                     account={account}
                     locale={locale}
                     localeTag={localeTag}

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -22,10 +22,14 @@ const badgeVariants = cva(
   },
 )
 
-export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
 }
 
 export { Badge }

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -22,14 +22,10 @@ const badgeVariants = cva(
   },
 )
 
-export interface BadgeProps
-  extends React.HTMLAttributes<HTMLSpanElement>,
-    VariantProps<typeof badgeVariants> {}
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <span className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />
 }
 
 export { Badge }

--- a/web/src/hooks/useUpstreamAccountDetailRoute.test.tsx
+++ b/web/src/hooks/useUpstreamAccountDetailRoute.test.tsx
@@ -1,0 +1,163 @@
+/** @vitest-environment jsdom */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { useUpstreamAccountDetailRoute } from "./useUpstreamAccountDetailRoute";
+
+function RouteProbe() {
+  const location = useLocation();
+  const {
+    upstreamAccountId,
+    upstreamAccountTab,
+    openUpstreamAccount,
+    closeUpstreamAccount,
+  } = useUpstreamAccountDetailRoute();
+
+  return (
+    <div>
+      <div data-testid="route-search">{location.search}</div>
+      <div data-testid="route-account-id">{String(upstreamAccountId)}</div>
+      <div data-testid="route-account-tab">{upstreamAccountTab}</div>
+      <button
+        type="button"
+        data-testid="open-routing"
+        onClick={() => openUpstreamAccount(42, { tab: "routing" })}
+      >
+        open routing
+      </button>
+      <button
+        type="button"
+        data-testid="open-overview"
+        onClick={() => openUpstreamAccount(77)}
+      >
+        open overview
+      </button>
+      <button
+        type="button"
+        data-testid="close-account"
+        onClick={() => closeUpstreamAccount()}
+      >
+        close
+      </button>
+    </div>
+  );
+}
+
+let host: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    writable: true,
+    value: true,
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  host?.remove();
+  host = null;
+  root = null;
+});
+
+function render(initialEntry = "/dashboard") {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root?.render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/dashboard" element={<RouteProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  });
+}
+
+describe("useUpstreamAccountDetailRoute", () => {
+  it("parses the upstream account id and routing tab from the URL", () => {
+    render("/dashboard?upstreamAccountId=42&upstreamAccountTab=routing");
+
+    expect(
+      host?.querySelector('[data-testid="route-account-id"]')?.textContent,
+    ).toBe("42");
+    expect(
+      host?.querySelector('[data-testid="route-account-tab"]')?.textContent,
+    ).toBe("routing");
+  });
+
+  it("falls back to overview when the query tab is invalid", () => {
+    render("/dashboard?upstreamAccountId=42&upstreamAccountTab=healthEvents");
+
+    expect(
+      host?.querySelector('[data-testid="route-account-id"]')?.textContent,
+    ).toBe("42");
+    expect(
+      host?.querySelector('[data-testid="route-account-tab"]')?.textContent,
+    ).toBe("overview");
+  });
+
+  it("writes and clears the routing tab query parameters", () => {
+    render("/dashboard");
+
+    const openRoutingButton = host?.querySelector(
+      '[data-testid="open-routing"]',
+    );
+    if (!(openRoutingButton instanceof HTMLButtonElement)) {
+      throw new Error("missing open routing button");
+    }
+
+    act(() => {
+      openRoutingButton.click();
+    });
+
+    expect(
+      host?.querySelector('[data-testid="route-search"]')?.textContent,
+    ).toBe("?upstreamAccountId=42&upstreamAccountTab=routing");
+    expect(
+      host?.querySelector('[data-testid="route-account-tab"]')?.textContent,
+    ).toBe("routing");
+
+    const openOverviewButton = host?.querySelector(
+      '[data-testid="open-overview"]',
+    );
+    if (!(openOverviewButton instanceof HTMLButtonElement)) {
+      throw new Error("missing open overview button");
+    }
+
+    act(() => {
+      openOverviewButton.click();
+    });
+
+    expect(
+      host?.querySelector('[data-testid="route-search"]')?.textContent,
+    ).toBe("?upstreamAccountId=77");
+    expect(
+      host?.querySelector('[data-testid="route-account-tab"]')?.textContent,
+    ).toBe("overview");
+
+    const closeButton = host?.querySelector('[data-testid="close-account"]');
+    if (!(closeButton instanceof HTMLButtonElement)) {
+      throw new Error("missing close button");
+    }
+
+    act(() => {
+      closeButton.click();
+    });
+
+    expect(
+      host?.querySelector('[data-testid="route-search"]')?.textContent,
+    ).toBe("");
+    expect(
+      host?.querySelector('[data-testid="route-account-id"]')?.textContent,
+    ).toBe("null");
+    expect(
+      host?.querySelector('[data-testid="route-account-tab"]')?.textContent,
+    ).toBe("overview");
+  });
+});

--- a/web/src/hooks/useUpstreamAccountDetailRoute.ts
+++ b/web/src/hooks/useUpstreamAccountDetailRoute.ts
@@ -1,45 +1,77 @@
-import { useCallback, useMemo } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 
-const UPSTREAM_ACCOUNT_ID_PARAM = 'upstreamAccountId'
+const UPSTREAM_ACCOUNT_ID_PARAM = "upstreamAccountId";
+const UPSTREAM_ACCOUNT_TAB_PARAM = "upstreamAccountTab";
+
+export type UpstreamAccountDetailRouteTab = "overview" | "routing";
+
+function parseUpstreamAccountTab(
+  raw: string | null,
+): UpstreamAccountDetailRouteTab {
+  if (raw === "routing") return "routing";
+  return "overview";
+}
 
 function parseUpstreamAccountId(raw: string | null) {
-  if (!raw) return null
-  const parsed = Number(raw)
-  if (!Number.isFinite(parsed)) return null
-  const accountId = Math.trunc(parsed)
-  return accountId > 0 ? accountId : null
+  if (!raw) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return null;
+  const accountId = Math.trunc(parsed);
+  return accountId > 0 ? accountId : null;
 }
 
 export function useUpstreamAccountDetailRoute() {
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams();
   const upstreamAccountId = useMemo(
     () => parseUpstreamAccountId(searchParams.get(UPSTREAM_ACCOUNT_ID_PARAM)),
     [searchParams],
-  )
+  );
+  const upstreamAccountTab = useMemo(
+    () => parseUpstreamAccountTab(searchParams.get(UPSTREAM_ACCOUNT_TAB_PARAM)),
+    [searchParams],
+  );
 
   const openUpstreamAccount = useCallback(
-    (accountId: number, options?: { replace?: boolean }) => {
-      const next = new URLSearchParams(searchParams)
-      next.set(UPSTREAM_ACCOUNT_ID_PARAM, String(Math.trunc(accountId)))
-      setSearchParams(next, { replace: options?.replace ?? false })
+    (
+      accountId: number,
+      options?: {
+        replace?: boolean;
+        tab?: UpstreamAccountDetailRouteTab;
+      },
+    ) => {
+      const next = new URLSearchParams(searchParams);
+      next.set(UPSTREAM_ACCOUNT_ID_PARAM, String(Math.trunc(accountId)));
+      if ((options?.tab ?? "overview") === "routing") {
+        next.set(UPSTREAM_ACCOUNT_TAB_PARAM, "routing");
+      } else {
+        next.delete(UPSTREAM_ACCOUNT_TAB_PARAM);
+      }
+      setSearchParams(next, { replace: options?.replace ?? false });
     },
     [searchParams, setSearchParams],
-  )
+  );
 
   const closeUpstreamAccount = useCallback(
     (options?: { replace?: boolean }) => {
-      if (!searchParams.has(UPSTREAM_ACCOUNT_ID_PARAM)) return
-      const next = new URLSearchParams(searchParams)
-      next.delete(UPSTREAM_ACCOUNT_ID_PARAM)
-      setSearchParams(next, { replace: options?.replace ?? false })
+      if (
+        !searchParams.has(UPSTREAM_ACCOUNT_ID_PARAM) &&
+        !searchParams.has(UPSTREAM_ACCOUNT_TAB_PARAM)
+      ) {
+        return;
+      }
+      const next = new URLSearchParams(searchParams);
+      next.delete(UPSTREAM_ACCOUNT_ID_PARAM);
+      next.delete(UPSTREAM_ACCOUNT_TAB_PARAM);
+      setSearchParams(next, { replace: options?.replace ?? false });
     },
     [searchParams, setSearchParams],
-  )
+  );
 
   return {
     upstreamAccountId,
+    upstreamAccountTab,
     openUpstreamAccount,
     closeUpstreamAccount,
-  }
+  };
 }

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { DashboardWorkingConversationCardModel } from "../lib/dashboardWorkingConversations";
 import {
@@ -139,7 +139,11 @@ vi.mock("../components/DashboardWorkingConversationsSection", () => ({
   }: {
     cards: DashboardWorkingConversationCardModel[];
     setRefreshTargetCount?: (count: number) => void;
-    onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+    onOpenUpstreamAccount?: (
+      accountId: number,
+      accountLabel: string,
+      options?: { tab?: "overview" | "routing" },
+    ) => void;
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
@@ -202,6 +206,17 @@ vi.mock("../components/DashboardWorkingConversationsSection", () => ({
           >
             open account
           </button>
+          <button
+            type="button"
+            data-testid="dashboard-open-account-routing"
+            onClick={() =>
+              onOpenUpstreamAccount?.(77, "section-account@example.com", {
+                tab: "routing",
+              })
+            }
+          >
+            open account routing
+          </button>
         </>
       ) : null}
     </div>
@@ -220,7 +235,11 @@ vi.mock("../components/PromptCacheConversationTable", () => ({
     conversationKey: string | null;
     conversationLabel?: string | null;
     onClose: () => void;
-    onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+    onOpenUpstreamAccount?: (
+      accountId: number,
+      accountLabel: string,
+      options?: { tab?: "overview" | "routing" },
+    ) => void;
   }) =>
     open ? (
       <div data-testid="dashboard-conversation-history-drawer-mock">
@@ -260,7 +279,11 @@ vi.mock("../components/DashboardInvocationDetailDrawer", () => ({
     open: boolean;
     selection: { invocation: { record: { invokeId: string } } } | null;
     onClose: () => void;
-    onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
+    onOpenUpstreamAccount?: (
+      accountId: number,
+      accountLabel: string,
+      options?: { tab?: "overview" | "routing" },
+    ) => void;
   }) =>
     open ? (
       <div data-testid="dashboard-invocation-detail-drawer-mock">
@@ -291,16 +314,21 @@ vi.mock("./account-pool/UpstreamAccounts", () => ({
   SharedUpstreamAccountDetailDrawer: ({
     open,
     accountId,
+    initialTab,
     onClose,
   }: {
     open: boolean;
     accountId: number | null;
+    initialTab?: "overview" | "routing";
     onClose: () => void;
   }) =>
     open ? (
       <div data-testid="shared-upstream-account-detail-drawer-mock">
         <span data-testid="shared-upstream-account-drawer-account-id">
           {accountId}
+        </span>
+        <span data-testid="shared-upstream-account-drawer-tab">
+          {initialTab ?? "overview"}
         </span>
         <button
           type="button"
@@ -357,6 +385,11 @@ const localStorageMock = {
 let host: HTMLDivElement | null = null;
 let root: Root | null = null;
 
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="dashboard-location-search">{location.search}</div>;
+}
+
 beforeAll(() => {
   Object.defineProperty(window, "localStorage", {
     configurable: true,
@@ -382,12 +415,17 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function render(ui: React.ReactNode) {
+function render(ui: React.ReactNode, initialEntry = "/dashboard") {
   host = document.createElement("div");
   document.body.appendChild(host);
   root = createRoot(host);
   act(() => {
-    root?.render(<MemoryRouter>{ui}</MemoryRouter>);
+    root?.render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <LocationProbe />
+        {ui}
+      </MemoryRouter>,
+    );
   });
 }
 
@@ -606,7 +644,9 @@ describe("DashboardPage", () => {
         new Map([
           [
             "pck-drawer-switch",
-            new Map([["invoke-dashboard-current", { totalTokens: 120, cost: 0.01 }]]),
+            new Map([
+              ["invoke-dashboard-current", { totalTokens: 120, cost: 0.01 }],
+            ]),
           ],
         ]),
       );
@@ -859,6 +899,10 @@ describe("DashboardPage", () => {
         '[data-testid="shared-upstream-account-drawer-account-id"]',
       )?.textContent,
     ).toBe("77");
+    expect(
+      host?.querySelector('[data-testid="shared-upstream-account-drawer-tab"]')
+        ?.textContent,
+    ).toBe("overview");
 
     act(() => {
       openInvocationButton.click();
@@ -967,6 +1011,68 @@ describe("DashboardPage", () => {
     ).toBe("99");
   });
 
+  it("opens the shared drawer on the routing tab and keeps the tab in the URL", () => {
+    installSummaryMocks();
+    hookMocks.useDashboardWorkingConversations.mockReturnValue({
+      cards: [createWorkingConversationCard()],
+      totalMatched: 1,
+      hasMore: false,
+      isLoading: false,
+      isLoadingMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      setRefreshTargetCount: vi.fn(),
+    });
+
+    render(<DashboardPage />);
+
+    const openAccountRoutingButton = host?.querySelector(
+      '[data-testid="dashboard-open-account-routing"]',
+    );
+    if (!(openAccountRoutingButton instanceof HTMLButtonElement)) {
+      throw new Error("missing routing account trigger");
+    }
+
+    act(() => {
+      openAccountRoutingButton.click();
+    });
+
+    expect(
+      host?.querySelector(
+        '[data-testid="shared-upstream-account-drawer-account-id"]',
+      )?.textContent,
+    ).toBe("77");
+    expect(
+      host?.querySelector('[data-testid="shared-upstream-account-drawer-tab"]')
+        ?.textContent,
+    ).toBe("routing");
+    expect(
+      host?.querySelector('[data-testid="dashboard-location-search"]')
+        ?.textContent,
+    ).toBe("?upstreamAccountId=77&upstreamAccountTab=routing");
+
+    const closeAccountDrawerButton = host?.querySelector(
+      '[data-testid="shared-upstream-account-drawer-close"]',
+    );
+    if (!(closeAccountDrawerButton instanceof HTMLButtonElement)) {
+      throw new Error("missing account drawer close button");
+    }
+
+    act(() => {
+      closeAccountDrawerButton.click();
+    });
+
+    expect(
+      host?.querySelector(
+        '[data-testid="shared-upstream-account-detail-drawer-mock"]',
+      ),
+    ).toBeNull();
+    expect(
+      host?.querySelector('[data-testid="dashboard-location-search"]')
+        ?.textContent,
+    ).toBe("");
+  });
+
   it("passes refresh target updates from the working conversations section back into the hook", () => {
     installSummaryMocks();
     const setRefreshTargetCount = vi.fn();
@@ -1003,8 +1109,7 @@ describe("DashboardPage", () => {
       cards: [
         createWorkingConversationCard({
           endpoint: "/v1/responses/compact",
-          upstreamAccountName:
-            "paisleeeinar5710 Team sandbox workflow monitor",
+          upstreamAccountName: "paisleeeinar5710 Team sandbox workflow monitor",
         }),
       ],
       totalMatched: 1,

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import {
-  DashboardActivityOverview,
-} from "../components/DashboardActivityOverview";
+import { DashboardActivityOverview } from "../components/DashboardActivityOverview";
 import { DashboardInvocationDetailDrawer } from "../components/DashboardInvocationDetailDrawer";
 import {
   DASHBOARD_ACTIVITY_RANGE_STORAGE_KEY,
@@ -19,15 +17,19 @@ import {
   formatDashboardWorkingConversationSequenceId,
   type DashboardWorkingConversationInvocationSelection,
 } from "../lib/dashboardWorkingConversations";
-import type { DashboardWorkingConversationSelection } from "../components/DashboardWorkingConversationsSection";
+import type {
+  DashboardOpenUpstreamAccountOptions,
+  DashboardWorkingConversationSelection,
+} from "../components/DashboardWorkingConversationsSection";
 import { useTranslation } from "../i18n";
 import { useUpstreamAccountDetailRoute } from "../hooks/useUpstreamAccountDetailRoute";
 import { SharedUpstreamAccountDetailDrawer } from "./account-pool/UpstreamAccounts";
 
 export default function DashboardPage() {
   const { t } = useTranslation();
-  const [activeRange, setActiveRange] = useState<DashboardActivityRangeKey>(() =>
-    readPersistedDashboardActivityRange(DASHBOARD_ACTIVITY_RANGE_STORAGE_KEY),
+  const [activeRange, setActiveRange] = useState<DashboardActivityRangeKey>(
+    () =>
+      readPersistedDashboardActivityRange(DASHBOARD_ACTIVITY_RANGE_STORAGE_KEY),
   );
   const [selectedInvocation, setSelectedInvocation] =
     useState<DashboardWorkingConversationInvocationSelection | null>(null);
@@ -35,8 +37,12 @@ export default function DashboardPage() {
     useState<DashboardWorkingConversationSelection | null>(null);
   const [includeUpstreamAccountActivity, setIncludeUpstreamAccountActivity] =
     useState(false);
-  const { upstreamAccountId, openUpstreamAccount, closeUpstreamAccount } =
-    useUpstreamAccountDetailRoute();
+  const {
+    upstreamAccountId,
+    upstreamAccountTab,
+    openUpstreamAccount,
+    closeUpstreamAccount,
+  } = useUpstreamAccountDetailRoute();
   const {
     cards,
     totalMatched,
@@ -73,8 +79,21 @@ export default function DashboardPage() {
   }, []);
 
   useEffect(() => {
-    persistDashboardActivityRange(DASHBOARD_ACTIVITY_RANGE_STORAGE_KEY, activeRange);
+    persistDashboardActivityRange(
+      DASHBOARD_ACTIVITY_RANGE_STORAGE_KEY,
+      activeRange,
+    );
   }, [activeRange]);
+
+  const handleOpenUpstreamAccount = (
+    accountId: number,
+    _accountLabel: string,
+    options?: DashboardOpenUpstreamAccountOptions,
+  ) => {
+    setSelectedInvocation(null);
+    setSelectedConversation(null);
+    openUpstreamAccount(accountId, { tab: options?.tab });
+  };
 
   return (
     <div className="mx-auto flex w-full max-w-full flex-col gap-6">
@@ -98,11 +117,7 @@ export default function DashboardPage() {
         error={workingCardsError}
         onLoadMore={loadMore}
         setRefreshTargetCount={setRefreshTargetCount}
-        onOpenUpstreamAccount={(accountId) => {
-          setSelectedInvocation(null);
-          setSelectedConversation(null);
-          openUpstreamAccount(accountId);
-        }}
+        onOpenUpstreamAccount={handleOpenUpstreamAccount}
         onOpenConversation={(selection) => {
           closeUpstreamAccount({ replace: true });
           setSelectedInvocation(null);
@@ -126,17 +141,15 @@ export default function DashboardPage() {
         upstreamAccountActivityLoading={dashboardActivityLoading}
         upstreamAccountActivityError={dashboardActivityError}
         upstreamAccountRecentPreviewLimit={upstreamAccountRecentPreviewLimit}
-        onUpstreamAccountActivityEnabledChange={setIncludeUpstreamAccountActivity}
+        onUpstreamAccountActivityEnabledChange={
+          setIncludeUpstreamAccountActivity
+        }
       />
       <DashboardInvocationDetailDrawer
         open={selectedInvocation != null}
         selection={selectedInvocation}
         onClose={() => setSelectedInvocation(null)}
-        onOpenUpstreamAccount={(accountId) => {
-          setSelectedInvocation(null);
-          setSelectedConversation(null);
-          openUpstreamAccount(accountId);
-        }}
+        onOpenUpstreamAccount={handleOpenUpstreamAccount}
       />
       <PromptCacheConversationHistoryDrawer
         open={selectedConversation != null}
@@ -150,16 +163,13 @@ export default function DashboardPage() {
         }
         onClose={() => setSelectedConversation(null)}
         t={t}
-        onOpenUpstreamAccount={(accountId) => {
-          setSelectedInvocation(null);
-          setSelectedConversation(null);
-          openUpstreamAccount(accountId);
-        }}
+        onOpenUpstreamAccount={handleOpenUpstreamAccount}
       />
       {upstreamAccountId != null ? (
         <SharedUpstreamAccountDetailDrawer
           open
           accountId={upstreamAccountId}
+          initialTab={upstreamAccountTab}
           onClose={closeUpstreamAccount}
         />
       ) : null}

--- a/web/src/pages/account-pool/UpstreamAccounts.page-impl.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.page-impl.tsx
@@ -30,13 +30,22 @@ import {
 } from "../../components/ui/dialog";
 import { formFieldSpanVariants } from "../../components/ui/form-control";
 import { SelectField } from "../../components/ui/select-field";
-import { SegmentedControl, SegmentedControlItem } from "../../components/ui/segmented-control";
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from "../../components/ui/segmented-control";
 import { Spinner } from "../../components/ui/spinner";
 import { AccountTagFilterCombobox } from "../../components/AccountTagFilterCombobox";
 import { MultiSelectFilterCombobox } from "../../components/MultiSelectFilterCombobox";
 import { UpstreamAccountGroupCombobox } from "../../components/UpstreamAccountGroupCombobox";
-import { UpstreamAccountsGroupedRoster, type UpstreamAccountsGroupedRosterGroup } from "../../components/UpstreamAccountsGroupedRoster";
-import { UpstreamAccountsTable, type UpstreamAccountsTableLabels } from "../../components/UpstreamAccountsTable";
+import {
+  UpstreamAccountsGroupedRoster,
+  type UpstreamAccountsGroupedRosterGroup,
+} from "../../components/UpstreamAccountsGroupedRoster";
+import {
+  UpstreamAccountsTable,
+  type UpstreamAccountsTableLabels,
+} from "../../components/UpstreamAccountsTable";
 import { usePoolTags } from "../../hooks/usePoolTags";
 import { useUpstreamAccountDetailRoute } from "../../hooks/useUpstreamAccountDetailRoute";
 import { useUpstreamAccounts } from "../../hooks/useUpstreamAccounts";
@@ -61,9 +70,7 @@ import {
   buildGroupOptions,
 } from "../../lib/upstreamAccountGroups";
 import { generatePoolRoutingKey } from "../../lib/poolRouting";
-import {
-  buildAccountPoolGroupSummaries,
-} from "../../lib/accountPoolGroups";
+import { buildAccountPoolGroupSummaries } from "../../lib/accountPoolGroups";
 import { cn } from "../../lib/utils";
 import { useTranslation } from "../../i18n";
 import {
@@ -153,20 +160,27 @@ export default function UpstreamAccountsPage() {
   const location = useLocation();
   const locationState = location.state as UpstreamAccountsLocationState | null;
   const navigate = useNavigate();
-  const { upstreamAccountId, openUpstreamAccount, closeUpstreamAccount } =
-    useUpstreamAccountDetailRoute();
+  const {
+    upstreamAccountId,
+    upstreamAccountTab,
+    openUpstreamAccount,
+    closeUpstreamAccount,
+  } = useUpstreamAccountDetailRoute();
   const [initialFilters] = useState(() =>
     readPersistedUpstreamAccountFilters(),
   );
   const initialGroupFilters = useMemo(
     () =>
-      groupFilterStateToGroupFilters(locationState?.presetGroupFilter).length > 0
+      groupFilterStateToGroupFilters(locationState?.presetGroupFilter).length >
+      0
         ? groupFilterStateToGroupFilters(locationState?.presetGroupFilter)
         : initialFilters.groupFilters,
     [initialFilters.groupFilters, locationState?.presetGroupFilter],
   );
   const [hasTransientPresetGroupFilter, setHasTransientPresetGroupFilter] =
-    useState(() => sanitizePresetGroupFilter(locationState?.presetGroupFilter) != null);
+    useState(
+      () => sanitizePresetGroupFilter(locationState?.presetGroupFilter) != null,
+    );
   const [groupFilters, setGroupFilters] = useState<string[]>(
     () => initialGroupFilters,
   );
@@ -184,8 +198,11 @@ export default function UpstreamAccountsPage() {
   );
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
-  const [rosterViewMode, setRosterViewMode] = useState<AccountRosterViewMode>("grid");
-  const [visibleGroupedAccountIds, setVisibleGroupedAccountIds] = useState<number[]>([]);
+  const [rosterViewMode, setRosterViewMode] =
+    useState<AccountRosterViewMode>("grid");
+  const [visibleGroupedAccountIds, setVisibleGroupedAccountIds] = useState<
+    number[]
+  >([]);
   const [selectedAccountIds, setSelectedAccountIds] = useState<number[]>([]);
   const [, setSelectedAccountSummaries] = useState<
     Record<number, UpstreamAccountSummary>
@@ -437,7 +454,9 @@ export default function UpstreamAccountsPage() {
     if (rosterViewMode === "flat") {
       return visibleRosterItems.map((item) => item.id);
     }
-    const visibleRosterIdSet = new Set(visibleRosterItems.map((item) => item.id));
+    const visibleRosterIdSet = new Set(
+      visibleRosterItems.map((item) => item.id),
+    );
     return Array.from(
       new Set(
         visibleGroupedAccountIds.filter((accountId) =>
@@ -726,7 +745,9 @@ export default function UpstreamAccountsPage() {
     if (!state) return;
 
     const nextSearchParams = new URLSearchParams(location.search);
-    const presetGroupFilters = groupFilterStateToGroupFilters(state.presetGroupFilter);
+    const presetGroupFilters = groupFilterStateToGroupFilters(
+      state.presetGroupFilter,
+    );
     if (
       presetGroupFilters.length > 0 &&
       !areGroupFilterValuesEqual(groupFilters, presetGroupFilters)
@@ -741,6 +762,7 @@ export default function UpstreamAccountsPage() {
         "upstreamAccountId",
         String(state.selectedAccountId),
       );
+      nextSearchParams.delete("upstreamAccountTab");
       openUpstreamAccount(state.selectedAccountId, { replace: true });
     }
     setPostCreateWarning(state.postCreateWarning ?? null);
@@ -1013,14 +1035,22 @@ export default function UpstreamAccountsPage() {
       primary: t("accountPool.upstreamAccounts.primaryWindowLabel"),
       primaryShort: t("accountPool.upstreamAccounts.primaryWindowShortLabel"),
       secondary: t("accountPool.upstreamAccounts.secondaryWindowLabel"),
-      secondaryShort: t("accountPool.upstreamAccounts.secondaryWindowShortLabel"),
+      secondaryShort: t(
+        "accountPool.upstreamAccounts.secondaryWindowShortLabel",
+      ),
       nextReset: t("accountPool.upstreamAccounts.table.nextReset"),
-      nextResetCompact: t("accountPool.upstreamAccounts.table.nextResetCompact"),
+      nextResetCompact: t(
+        "accountPool.upstreamAccounts.table.nextResetCompact",
+      ),
       requestsMetric: t("accountPool.upstreamAccounts.table.requestsMetric"),
       tokensMetric: t("accountPool.upstreamAccounts.table.tokensMetric"),
       costMetric: t("accountPool.upstreamAccounts.table.costMetric"),
-      inputTokensMetric: t("accountPool.upstreamAccounts.table.inputTokensMetric"),
-      outputTokensMetric: t("accountPool.upstreamAccounts.table.outputTokensMetric"),
+      inputTokensMetric: t(
+        "accountPool.upstreamAccounts.table.inputTokensMetric",
+      ),
+      outputTokensMetric: t(
+        "accountPool.upstreamAccounts.table.outputTokensMetric",
+      ),
       cacheInputTokensMetric: t(
         "accountPool.upstreamAccounts.table.cacheInputTokensMetric",
       ),
@@ -1125,7 +1155,9 @@ export default function UpstreamAccountsPage() {
     },
     [t],
   );
-  const groupedRosterGroups = useMemo<UpstreamAccountsGroupedRosterGroup[]>(() => {
+  const groupedRosterGroups = useMemo<
+    UpstreamAccountsGroupedRosterGroup[]
+  >(() => {
     if (hideRosterDerivedUi) {
       return [];
     }
@@ -1139,52 +1171,57 @@ export default function UpstreamAccountsPage() {
           ? t("accountPool.upstreamAccounts.grouped.apiBadge")
           : groupedPlanLabel(planType),
     });
-  }, [forwardProxyNodes, groupedPlanLabel, groups, hideRosterDerivedUi, t, visibleRosterItems]);
-  const {
-    openEditor: openGroupSettingsEditor,
-    dialog: groupSettingsDialog,
-  } = useUpstreamAccountGroupSettingsDialog({
-    writesEnabled,
-    resolveGroupState: useCallback(
-      (groupName) => {
-        const normalizedGroupName = normalizeRosterGroupName(groupName);
-        if (!normalizedGroupName) return null;
-        const groupSummary =
-          groups.find((group) => group.groupName === normalizedGroupName) ??
-          null;
-        return {
-          groupName: normalizedGroupName,
-          note: groupSummary?.note ?? "",
-          existing: groupSummary != null,
-          accountCount: groupSummary?.accountCount ?? 0,
-          concurrencyLimit: groupSummary?.concurrencyLimit ?? 0,
-          boundProxyKeys: groupSummary?.boundProxyKeys ?? [],
-          nodeShuntEnabled: groupSummary?.nodeShuntEnabled ?? false,
-          singleAccountRotationEnabled:
-            groupSummary?.singleAccountRotationEnabled ?? false,
-          upstream429RetryEnabled:
-            groupSummary?.upstream429RetryEnabled ?? false,
-          upstream429MaxRetries: groupSummary?.upstream429MaxRetries ?? 0,
-        };
-      },
-      [groups],
-    ),
-    saveGroupSettings: useCallback(
-      async (groupName, payload) => {
-        await saveGroupNote(groupName, payload);
-      },
-      [saveGroupNote],
-    ),
-    deleteGroupSettings: useCallback(
-      async (groupName: string) => {
-        await deleteGroupNote(groupName);
-        if (normalizeRosterGroupName(bulkGroupName) === groupName) {
-          setBulkGroupName("");
-        }
-      },
-      [bulkGroupName, deleteGroupNote],
-    ),
-  });
+  }, [
+    forwardProxyNodes,
+    groupedPlanLabel,
+    groups,
+    hideRosterDerivedUi,
+    t,
+    visibleRosterItems,
+  ]);
+  const { openEditor: openGroupSettingsEditor, dialog: groupSettingsDialog } =
+    useUpstreamAccountGroupSettingsDialog({
+      writesEnabled,
+      resolveGroupState: useCallback(
+        (groupName) => {
+          const normalizedGroupName = normalizeRosterGroupName(groupName);
+          if (!normalizedGroupName) return null;
+          const groupSummary =
+            groups.find((group) => group.groupName === normalizedGroupName) ??
+            null;
+          return {
+            groupName: normalizedGroupName,
+            note: groupSummary?.note ?? "",
+            existing: groupSummary != null,
+            accountCount: groupSummary?.accountCount ?? 0,
+            concurrencyLimit: groupSummary?.concurrencyLimit ?? 0,
+            boundProxyKeys: groupSummary?.boundProxyKeys ?? [],
+            nodeShuntEnabled: groupSummary?.nodeShuntEnabled ?? false,
+            singleAccountRotationEnabled:
+              groupSummary?.singleAccountRotationEnabled ?? false,
+            upstream429RetryEnabled:
+              groupSummary?.upstream429RetryEnabled ?? false,
+            upstream429MaxRetries: groupSummary?.upstream429MaxRetries ?? 0,
+          };
+        },
+        [groups],
+      ),
+      saveGroupSettings: useCallback(
+        async (groupName, payload) => {
+          await saveGroupNote(groupName, payload);
+        },
+        [saveGroupNote],
+      ),
+      deleteGroupSettings: useCallback(
+        async (groupName: string) => {
+          await deleteGroupNote(groupName);
+          if (normalizeRosterGroupName(bulkGroupName) === groupName) {
+            setBulkGroupName("");
+          }
+        },
+        [bulkGroupName, deleteGroupNote],
+      ),
+    });
   const handleBulkGroupCreateRequest = useCallback(
     (groupName: string) => {
       openGroupSettingsEditor(groupName, {
@@ -1877,7 +1914,9 @@ export default function UpstreamAccountsPage() {
                   <SegmentedControl
                     size="compact"
                     role="tablist"
-                    aria-label={t("accountPool.upstreamAccounts.viewToggleAria")}
+                    aria-label={t(
+                      "accountPool.upstreamAccounts.viewToggleAria",
+                    )}
                   >
                     <SegmentedControlItem
                       type="button"
@@ -2232,7 +2271,9 @@ export default function UpstreamAccountsPage() {
                   selectedAccountIds={selectedAccountIdSet}
                   onSelect={handleSelectAccount}
                   onToggleSelected={handleToggleSelectedAccount}
-                  onToggleSelectAllCurrentPage={handleToggleSelectAllCurrentPage}
+                  onToggleSelectAllCurrentPage={
+                    handleToggleSelectAllCurrentPage
+                  }
                   emptyTitle={t("accountPool.upstreamAccounts.emptyTitle")}
                   emptyDescription={t(
                     "accountPool.upstreamAccounts.emptyDescription",
@@ -2292,11 +2333,21 @@ export default function UpstreamAccountsPage() {
                     selectVisible: t(
                       "accountPool.upstreamAccounts.bulk.selectFiltered",
                     ),
-                    infoTitle: t("accountPool.upstreamAccounts.grouped.infoTitle"),
-                    noteLabel: t("accountPool.upstreamAccounts.grouped.noteLabel"),
-                    noteEmpty: t("accountPool.upstreamAccounts.grouped.noteEmpty"),
-                    proxiesLabel: t("accountPool.upstreamAccounts.grouped.proxiesLabel"),
-                    proxiesEmpty: t("accountPool.upstreamAccounts.grouped.proxiesEmpty"),
+                    infoTitle: t(
+                      "accountPool.upstreamAccounts.grouped.infoTitle",
+                    ),
+                    noteLabel: t(
+                      "accountPool.upstreamAccounts.grouped.noteLabel",
+                    ),
+                    noteEmpty: t(
+                      "accountPool.upstreamAccounts.grouped.noteEmpty",
+                    ),
+                    proxiesLabel: t(
+                      "accountPool.upstreamAccounts.grouped.proxiesLabel",
+                    ),
+                    proxiesEmpty: t(
+                      "accountPool.upstreamAccounts.grouped.proxiesEmpty",
+                    ),
                     settingsLabel: t(
                       "accountPool.upstreamAccounts.groupNotes.actions.edit",
                     ),
@@ -2305,14 +2356,28 @@ export default function UpstreamAccountsPage() {
                     upstream429Disabled: t(
                       "accountPool.groups.upstream429Disabled",
                     ),
-                    policyPriorityPrimary: t("accountPool.policyBadges.primary"),
-                    policyPriorityFallback: t("accountPool.policyBadges.fallback"),
-                    policyFastFillMissing: t("accountPool.policyBadges.fastFill"),
+                    policyPriorityPrimary: t(
+                      "accountPool.policyBadges.primary",
+                    ),
+                    policyPriorityFallback: t(
+                      "accountPool.policyBadges.fallback",
+                    ),
+                    policyFastFillMissing: t(
+                      "accountPool.policyBadges.fastFill",
+                    ),
                     policyFastForceAdd: t("accountPool.policyBadges.fastAdd"),
-                    policyFastForceRemove: t("accountPool.policyBadges.fastRemove"),
-                    policyForbidCutOut: t("accountPool.policyBadges.forbidCutOut"),
-                    policyForbidCutIn: t("accountPool.policyBadges.forbidCutIn"),
-                    policyForbidNewConversation: t("accountPool.policyBadges.forbidNew"),
+                    policyFastForceRemove: t(
+                      "accountPool.policyBadges.fastRemove",
+                    ),
+                    policyForbidCutOut: t(
+                      "accountPool.policyBadges.forbidCutOut",
+                    ),
+                    policyForbidCutIn: t(
+                      "accountPool.policyBadges.forbidCutIn",
+                    ),
+                    policyForbidNewConversation: t(
+                      "accountPool.policyBadges.forbidNew",
+                    ),
                     policyConcurrency: (count) =>
                       t("accountPool.policyBadges.concurrency", { count }),
                     policyRetry: (count) =>
@@ -2472,9 +2537,12 @@ export default function UpstreamAccountsPage() {
                 )}
                 emptyLabel={t("accountPool.upstreamAccounts.groupFilterEmpty")}
                 createLabel={(value) =>
-                  t("accountPool.upstreamAccounts.fields.groupNameConfigureValue", {
-                    value,
-                  })
+                  t(
+                    "accountPool.upstreamAccounts.fields.groupNameConfigureValue",
+                    {
+                      value,
+                    },
+                  )
                 }
                 onCreateRequested={handleBulkGroupCreateRequest}
                 formatAccountCountLabel={formatGroupAccountCountLabel}
@@ -2670,6 +2738,7 @@ export default function UpstreamAccountsPage() {
       <SharedUpstreamAccountDetailDrawer
         open={upstreamAccountId != null}
         accountId={upstreamAccountId}
+        initialTab={upstreamAccountTab}
         initialDeleteConfirmOpen={pendingInitialDeleteConfirm}
         onInitialDeleteConfirmHandled={() =>
           setPendingInitialDeleteConfirm(false)

--- a/web/src/pages/account-pool/UpstreamAccounts.page-local-shared.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.page-local-shared.tsx
@@ -53,9 +53,7 @@ import { Switch } from "../../components/ui/switch";
 import { EffectiveRoutingRuleCard } from "../../components/EffectiveRoutingRuleCard";
 import { ForwardProxyBindingSelector } from "../../components/ForwardProxyBindingSelector";
 import { InvocationTable } from "../../components/InvocationTable";
-import {
-  DashboardActivityOverview,
-} from "../../components/DashboardActivityOverview";
+import { DashboardActivityOverview } from "../../components/DashboardActivityOverview";
 import { ACCOUNT_ACTIVITY_RANGE_STORAGE_KEY_PREFIX } from "../../components/dashboardActivityRange";
 import { UpstreamAccountGroupCombobox } from "../../components/UpstreamAccountGroupCombobox";
 import { UpstreamAccountUsageCard } from "../../components/UpstreamAccountUsageCard";
@@ -240,11 +238,7 @@ type OauthRecoveryHint = {
 };
 
 type AccountDetailTab =
-  | "overview"
-  | "records"
-  | "edit"
-  | "routing"
-  | "healthEvents";
+  "overview" | "records" | "edit" | "routing" | "healthEvents";
 
 const ACCOUNT_DETAIL_TABS_REQUIRING_ROSTER_CONTEXT = new Set<AccountDetailTab>([
   "edit",
@@ -279,7 +273,10 @@ function normalizeProxyKeys(values?: string[]): string[] {
   );
 }
 
-function proxyNodeLabel(node: ForwardProxyBindingNode | undefined, key: string) {
+function proxyNodeLabel(
+  node: ForwardProxyBindingNode | undefined,
+  key: string,
+) {
   if (node) {
     const protocol = node.protocolLabel ? ` · ${node.protocolLabel}` : "";
     return `${node.displayName}${protocol}`;
@@ -1219,9 +1216,9 @@ function SharedUpstreamAccountDetailDrawerInner({
   }, [initialDeleteConfirmOpen, onInitialDeleteConfirmHandled, open]);
 
   useEffect(() => {
-    setDetailTab("overview");
+    setDetailTab(initialTab);
     setExpandedStickyKeys([]);
-  }, [accountId]);
+  }, [accountId, initialTab]);
 
   useEffect(() => {
     setGroupDraftNotes((current) => {
@@ -2319,18 +2316,17 @@ function SharedUpstreamAccountDetailDrawerInner({
     if (saved) {
       setAccountProxyEditorOpen(false);
     }
-  }, [
-    accountProxyDraftKeys,
-    handleSaveAccountProxyBindings,
-    selectedDetail,
-  ]);
+  }, [accountProxyDraftKeys, handleSaveAccountProxyBindings, selectedDetail]);
   const handleSaveInlineAccountPolicy = useCallback(
     async (
       source: UpstreamAccountDetail,
       field: InlinePolicyField,
       payload: UpdateGroupAccountRoutingRulePayload,
     ) => {
-      if (inlinePolicyBusyField != null || hasBusyAccountAction(busyAction, source.id)) {
+      if (
+        inlinePolicyBusyField != null ||
+        hasBusyAccountAction(busyAction, source.id)
+      ) {
         return;
       }
       setInlinePolicyErrors((current) => ({ ...current, [field]: null }));
@@ -2347,7 +2343,9 @@ function SharedUpstreamAccountDetailDrawerInner({
           [field]: err instanceof Error ? err.message : String(err),
         }));
       } finally {
-        setInlinePolicyBusyField((current) => (current === field ? null : current));
+        setInlinePolicyBusyField((current) =>
+          current === field ? null : current,
+        );
       }
     },
     [
@@ -3067,12 +3065,9 @@ function SharedUpstreamAccountDetailDrawerInner({
                         </span>
                       ) : (
                         <span>
-                          {t(
-                            "accountPool.upstreamAccounts.records.allLoaded",
-                            {
-                              count: accountRecords.length,
-                            },
-                          )}
+                          {t("accountPool.upstreamAccounts.records.allLoaded", {
+                            count: accountRecords.length,
+                          })}
                         </span>
                       )}
                     </div>
@@ -3581,10 +3576,7 @@ function SharedUpstreamAccountDetailDrawerInner({
                       disabled: !writesEnabled,
                       onEdit: openAccountProxyEditor,
                       onClear: () =>
-                        void handleSaveAccountProxyBindings(
-                          selectedDetail,
-                          [],
-                        ),
+                        void handleSaveAccountProxyBindings(selectedDetail, []),
                       onRemove: (key) =>
                         void handleSaveAccountProxyBindings(
                           selectedDetail,
@@ -3742,7 +3734,10 @@ function SharedUpstreamAccountDetailDrawerInner({
                         "accountPool.tags.dialog.availableModelsAddCustom",
                       ),
                       availableModelsCustomLabel: (value) =>
-                        t("accountPool.tags.dialog.availableModelsCustomLabel", { value }),
+                        t(
+                          "accountPool.tags.dialog.availableModelsCustomLabel",
+                          { value },
+                        ),
                       availableModelsRemove: t(
                         "accountPool.tags.dialog.availableModelsRemove",
                       ),

--- a/web/src/pages/account-pool/UpstreamAccounts.test.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.test.tsx
@@ -354,6 +354,38 @@ beforeAll(() => {
   });
 });
 
+describe("UpstreamAccountsPage detail route tab query", () => {
+  it("opens the shared drawer on the routing tab when the query requests routing", async () => {
+    mockAccountsPage();
+    render(
+      "/account-pool/upstream-accounts?upstreamAccountId=5&upstreamAccountTab=routing",
+    );
+    await flushAsync();
+
+    expect(document.body.textContent ?? "").toMatch(
+      /最终生效规则|Effective routing rule/,
+    );
+    expect(document.body.textContent ?? "").toMatch(
+      /字段来源明细|Field source breakdown/,
+    );
+  });
+
+  it("defaults to the overview tab when only the account id is present", async () => {
+    mockAccountsPage();
+    render("/account-pool/upstream-accounts?upstreamAccountId=5");
+    await flushAsync();
+
+    const overviewTab = Array.from(
+      document.body.querySelectorAll('button[role="tab"]'),
+    ).find((candidate) => /概览|overview/i.test(candidate.textContent ?? ""));
+    if (!(overviewTab instanceof HTMLButtonElement)) {
+      throw new Error("missing overview tab");
+    }
+
+    expect(overviewTab.getAttribute("aria-selected")).toBe("true");
+  });
+});
+
 beforeEach(() => {
   virtualizerMocks.visibleIndexes = null;
   storage.clear();
@@ -594,9 +626,9 @@ async function flushTimers() {
 
 function setInputValue(selector: string, value: string) {
   const input = document.body.querySelector(selector);
-  if (
-    !(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)
-  ) {
+  if (!(
+    input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement
+  )) {
     throw new Error(`missing input: ${selector}`);
   }
   const prototype =
@@ -1302,6 +1334,11 @@ function mockAccountsPage(options?: {
     stopBulkSyncJob: vi.fn(),
     runSync: vi.fn(),
     removeAccount: vi.fn(),
+    forwardProxyNodes: [],
+    forwardProxyCatalogState: {
+      kind: "loaded",
+      freshness: "fresh",
+    },
     groups,
     routing:
       options && "routing" in options
@@ -2601,7 +2638,9 @@ describe("UpstreamAccountsPage grouped roster toggle", () => {
       sortOrder: "desc",
     });
     expect(renderedInvocationAccountNames()).toContain("Existing OAuth");
-    expect(document.body.textContent).toMatch(/Loading more records|正在加载更多记录/);
+    expect(document.body.textContent).toMatch(
+      /Loading more records|正在加载更多记录/,
+    );
 
     act(() => {
       secondFetch.resolve({


### PR DESCRIPTION
## Summary
- make Dashboard account header badges open the shared account detail drawer on the `routing` tab
- persist the account detail tab in the URL so refresh/back/share restores the selected tab
- wire the account pool page and shared drawer to the same `upstreamAccountTab` query state

## Testing
- `cd web && bun run test -- src/hooks/useUpstreamAccountDetailRoute.test.tsx src/pages/Dashboard.test.tsx src/components/DashboardWorkingConversationsSection.test.tsx src/pages/account-pool/UpstreamAccounts.test.tsx`
- `cd web && bun run build-storybook`

Spec: -
Spec Disposition: not_needed
Spec Sync: n/a(spec-free)
Spec Drift: none
Solutions: -
Solutions Sync: n/a(no solution change)
Project Docs: -
Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
