### PR TITLE
chore(proxy): close stream root-cause diagnostics

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,7 +5,7 @@ pre-commit:
       glob: "web/**/*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
       run: cd web && bun run lint -- --max-warnings=0
     typecheck-web:
-      run: cd web && bun tsc -b
+      run: cd web && bunx tsc -b
     format-markdown:
       files: git diff --cached --name-only --diff-filter=ACMR -- '*.md'
       run: ./node_modules/.bin/dprint fmt {files}

--- a/src/http_stream_tracking.rs
+++ b/src/http_stream_tracking.rs
@@ -56,7 +56,6 @@ pub(crate) struct DownstreamRequestObserver {
 pub(crate) struct DownstreamWriteErrorSnapshot {
     pub(crate) request_seq: u64,
     pub(crate) kind: &'static str,
-    pub(crate) message: String,
 }
 
 impl DownstreamTransportObserver {
@@ -101,8 +100,6 @@ impl DownstreamTransportObserver {
         if notify_reset_monitor {
             self.inner.reset_monitor_notify.notify_waiters();
         }
-        #[cfg(test)]
-        eprintln!("[DEBUG-stream-rootcause-20260706] begin_request request_seq={request_seq}");
         DownstreamRequestObserver {
             observer: self.clone(),
             request_seq,
@@ -195,7 +192,7 @@ impl DownstreamTransportObserver {
             && state.active_reset_monitor_request_seq == Some(request_seq)
     }
 
-    fn record_write_error(&self, kind: &'static str, message: String) {
+    fn record_write_error(&self, kind: &'static str) {
         let request_seq = {
             let state = self
                 .inner
@@ -207,15 +204,10 @@ impl DownstreamTransportObserver {
         let Some(request_seq) = request_seq else {
             return;
         };
-        self.record_write_error_for_request(request_seq, kind, message);
+        self.record_write_error_for_request(request_seq, kind);
     }
 
-    fn record_write_error_for_request(
-        &self,
-        request_seq: u64,
-        kind: &'static str,
-        message: String,
-    ) {
+    fn record_write_error_for_request(&self, request_seq: u64, kind: &'static str) {
         let mut state = self
             .inner
             .state
@@ -231,15 +223,7 @@ impl DownstreamTransportObserver {
         {
             return;
         }
-        state.last_write_error = Some(DownstreamWriteErrorSnapshot {
-            request_seq,
-            kind,
-            message,
-        });
-        #[cfg(test)]
-        eprintln!(
-            "[DEBUG-stream-rootcause-20260706] record_write_error request_seq={request_seq} kind={kind}"
-        );
+        state.last_write_error = Some(DownstreamWriteErrorSnapshot { request_seq, kind });
         drop(state);
         self.inner.notify.notify_waiters();
     }
@@ -283,58 +267,26 @@ impl DownstreamRequestObserver {
         grace_period: Duration,
     ) -> Option<DownstreamWriteErrorSnapshot> {
         if let Some(snapshot) = self.observer.current_write_error_for(self.request_seq) {
-            #[cfg(test)]
-            eprintln!(
-                "[DEBUG-stream-rootcause-20260706] wait_window immediate_hit request_seq={} kind={}",
-                self.request_seq, snapshot.kind
-            );
             return Some(snapshot);
         }
         if self.observer.request_advanced_past(self.request_seq) || grace_period.is_zero() {
-            #[cfg(test)]
-            eprintln!(
-                "[DEBUG-stream-rootcause-20260706] wait_window short_circuit request_seq={}",
-                self.request_seq
-            );
             return None;
         }
         let deadline = Instant::now() + grace_period;
         loop {
             let notified = self.observer.inner.notify.notified();
             if let Some(snapshot) = self.observer.current_write_error_for(self.request_seq) {
-                #[cfg(test)]
-                eprintln!(
-                    "[DEBUG-stream-rootcause-20260706] wait_window notified_hit request_seq={} kind={}",
-                    self.request_seq, snapshot.kind
-                );
                 return Some(snapshot);
             }
             if self.observer.request_advanced_past(self.request_seq) {
-                #[cfg(test)]
-                eprintln!(
-                    "[DEBUG-stream-rootcause-20260706] wait_window advanced request_seq={}",
-                    self.request_seq
-                );
                 return None;
             }
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
                 let snapshot = self.observer.current_write_error_for(self.request_seq);
-                #[cfg(test)]
-                eprintln!(
-                    "[DEBUG-stream-rootcause-20260706] wait_window deadline request_seq={} hit={}",
-                    self.request_seq,
-                    snapshot.is_some()
-                );
                 return snapshot;
             };
             if tokio::time::timeout(remaining, notified).await.is_err() {
                 let snapshot = self.observer.current_write_error_for(self.request_seq);
-                #[cfg(test)]
-                eprintln!(
-                    "[DEBUG-stream-rootcause-20260706] wait_window timeout request_seq={} hit={}",
-                    self.request_seq,
-                    snapshot.is_some()
-                );
                 return snapshot;
             }
         }
@@ -354,7 +306,7 @@ impl ObservedTcpStream {
 
     fn record_write_error(&self, err: &io::Error) {
         self.observer
-            .record_write_error(downstream_transport_write_error_kind(err), err.to_string());
+            .record_write_error(downstream_transport_write_error_kind(err));
     }
 
     fn record_pending_socket_error(&self) {
@@ -508,7 +460,6 @@ async fn monitor_downstream_reset_stream(
             observer.record_write_error_for_request(
                 request_seq,
                 downstream_transport_write_error_kind(&err),
-                format!("socket_take_error:{err}"),
             );
             break;
         }
@@ -522,7 +473,6 @@ async fn monitor_downstream_reset_stream(
                 observer.record_write_error_for_request(
                     request_seq,
                     downstream_transport_write_error_kind(&err),
-                    format!("socket_peek_error:{err}"),
                 );
                 break;
             }
@@ -611,10 +561,7 @@ where
                 tokio::select! {
                     result = connection.as_mut() => {
                         if let Err(err) = result {
-                            observer_for_task.record_write_error(
-                                "connection_driver",
-                                format!("serve_connection:{err}"),
-                            );
+                            observer_for_task.record_write_error("connection_driver");
                             trace!("failed to serve connection: {err:#}");
                         }
                         break;
@@ -648,7 +595,7 @@ mod tests {
         let first_request = observer.begin_request();
         let second_request = observer.begin_request();
 
-        observer.record_write_error("connection_reset", "late reset".to_string());
+        observer.record_write_error("connection_reset");
 
         assert!(
             first_request

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -2227,16 +2227,6 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                 last_upstream_chunk_gap_ms = last_upstream_chunk_received_at
                     .map(|instant| instant.elapsed().as_millis() as u64);
             }
-            warn!(
-                proxy_request_id,
-                invoke_id = %invoke_id_for_task,
-                request_seq = write_error.request_seq,
-                downstream_write_error_kind = write_error.kind,
-                downstream_write_error = %write_error.message,
-                forwarded_chunks,
-                forwarded_bytes,
-                "[DEBUG-stream-rootcause-20260706] observed downstream transport write error after response body drained"
-            );
         }
         if let Some(observation) = downstream_request_observer_for_task.as_ref() {
             observation.finish_response_monitoring();
@@ -2397,30 +2387,6 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         } else {
             "after_first_byte"
         });
-        if had_stream_error || had_logical_stream_failure || pure_downstream_closed {
-            warn!(
-                invoke_id = %invoke_id_for_task,
-                failure_kind,
-                stream_failure_origin,
-                upstream_read_error_kind,
-                content_encoding_chain = response_content_encoding.as_str(),
-                forwarded_chunks,
-                forwarded_bytes,
-                usage_observed,
-                downstream_close_phase,
-                downstream_write_error_kind,
-                last_upstream_chunk_gap_ms,
-                request_user_agent = request_chain_metadata_for_task.user_agent.as_deref(),
-                request_x_forwarded_for = request_chain_metadata_for_task
-                    .x_forwarded_for
-                    .as_deref(),
-                request_forwarded = request_chain_metadata_for_task.forwarded.as_deref(),
-                request_x_real_ip = request_chain_metadata_for_task.x_real_ip.as_deref(),
-                stream_terminal_event = response_info.stream_terminal_event.as_deref(),
-                usage_missing_reason = response_info.usage_missing_reason.as_deref(),
-                "[DEBUG-stream-rootcause-20260706] proxy stream failure classified"
-            );
-        }
         let pending_pool_attempt_terminal_reason = if pool_account_for_task.is_none() {
             None
         } else if had_stream_error {

--- a/src/tests/slices/pool_failover_window_c.rs
+++ b/src/tests/slices/pool_failover_window_c.rs
@@ -2169,11 +2169,6 @@ async fn pool_openai_v1_responses_network_marks_after_first_byte_downstream_clos
 
     wait_for_codex_invocations(&state.pool, 1).await;
     let (row, payload) = load_latest_invocation_payload_row(state.as_ref()).await;
-    eprintln!(
-        "[DEBUG-stream-rootcause-20260706] row status={:?} failure_kind={:?} payload={payload}",
-        row.status,
-        row.failure_kind,
-    );
     assert_eq!(row.status.as_deref(), Some("failed"));
     assert_eq!(
         row.failure_kind.as_deref(),


### PR DESCRIPTION
## Summary
- Remove temporary `[DEBUG-stream-rootcause-20260706]` app logs after the fourth-round gateway correlation pass.
- Keep the long-term structured failure payload fields intact (`streamFailureOrigin`, downstream close phase/kind, forwarded chunk/byte counters, usage observation, request chain metadata).
- Fix the pre-commit web typecheck command from `bun tsc -b` to `bunx tsc -b`, matching the actual Bun binary invocation.

## 101 Evidence
- Gateway JSON access log was enabled in `/home/ivan/srv` for the investigation and documented in ops commits `e342ec3` and `26380cc`.
- Traefik cannot provide a route-only file sink in this setup, so the fallback is global/websecure JSON filtered by `RouterName=ai-codex-vibe-api@docker` and `RequestPath=/v1/responses`.
- Header logging was tightened to allow-list mode: `User-Agent`, `X-Forwarded-For`, `Forwarded`, `X-Real-Ip`, `X-Cvm-Invoke-Id`, plus redacted `Authorization` only.
- In the post-access-log window, 10 fresh `downstream_closed` samples were correlated across DB payload, app failure log, and gateway access log by `x-cvm-invoke-id`: `AB5U8TUYEW`, `D5CX3298SG`, `N6DH9JSZBJ`, `D462WQM2HP`, `73KTQX7PMQ`, `K6YKEM3DF8`, `J8VRQY2BH9`, `JKF3PEB8UZ`, `B8R5BQQ9ZG`, `ZKVMJ753TE`.
- All matched samples had app payload `streamFailureOrigin=downstream_write`, `downstreamClosePhase=after_first_byte`, `downstreamWriteErrorKind=body_dropped`, `usageObserved=true`; gateway showed `DownstreamStatus=200`, `OriginStatus=0`, and `DownstreamContentSize == forwardedBytes`.
- Matched sample `lastUpstreamChunkGapMs` range was 11-96ms, which does not support a proxy-side long stall before close.
- In the same access-log window, no final `upstream_stream_error` cluster reappeared; the upstream sticky escape fix remains effective.

Conclusion: the remaining `downstream_closed` cluster is externally triggered from the app perspective. Traefik accepted response headers/body bytes from `codex-vibe-monitor`; responsibility boundary is client vs gateway/middlebox, not app routing, upstream account selection, or stream forwarding.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `rg "\\[DEBUG-stream-rootcause-20260706\\]" src`
- `cargo test pool_openai_v1_responses_network_marks_after_first_byte_downstream_close`
- `cargo test persist_proxy_capture_runtime_record_preserves_downstream_closed_as_client_abort`
- `cargo test capture_target_pool_route_marks_response_failed_stream_as_route_failure`
- `cargo test pool_route_surfaces_last_upstream_error_when_failover_is_exhausted`
- `cargo test resolver_non_explicit_sticky_escape_cuts_out_after_two_recent_upstream_stream_errors`
- `cargo test resolver_prompt_cache_group_binding_reselects_within_group_after_recent_stream_errors`
- `cargo test resolver_explicit_prompt_cache_account_binding_keeps_operator_override_after_recent_stream_errors`
- `cd web && bunx tsc -b`
- pre-commit hook: `fmt`, `check`, `typecheck-web` passed during commit
- commit-msg hook: `commitlint` passed during commit

## References
- Specs: -
- Solutions: -
- Project Docs: remote ops docs updated in `/home/ivan/srv/gateway/traefik.md` and `/home/ivan/srv/maintenance/2026-07-07-ops-gateway-traefik-codex-vibe-access-log.md`

## Disposition
- `spec_disposition=not_needed`
- `solution_disposition=none`
- `project_doc_disposition=none` for this app repo; 101 ops docs were updated in the srv repo.
