### PR TITLE
fix(web): drop duplicate natural-day summary subscriptions

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -44,6 +44,7 @@ Using one cadence for all three overfits the most urgent surface and overloads t
 - Prefer account-first aggregation for visible account breakdowns: calculate account rows, add an explicit unassigned bucket for traffic without an account, then derive summary rates and live counts by summing the rows. This keeps the visible decomposition able to explain the top number.
 - Keep summary-only activity snapshots genuinely lightweight. A request that omits account rows should read bounded summary/read-model data plus the short active-tail rate window, not build and sort the full account preview/archive row set before dropping it from JSON.
 - When a dashboard card combines a live main value with historical comparison rows, keep the semantic split explicit: the main value can come from a strict real-time read model, while comparison rows can continue to use a stable historical aggregate as long as they remain clearly secondary and do not overwrite the live truth source.
+- If a page-level activity snapshot already includes the visible natural-day summary and rate window, consume that snapshot directly for the main card truth. Fetch only comparison windows separately instead of layering a second same-window summary subscription under the same visible panel.
 - Batch visible local patches separately from head/snapshot reconcile. A 1 second visible patch batch is responsive enough for card updates while avoiding per-record rerenders.
 - Put expensive HTTP reconcile and dense chart data commits behind a separate 5 second budget.
 - For large aggregate endpoints that must keep their JSON shape, add conditional HTTP (`ETag` and `304 Not Modified`) instead of trimming fields.
@@ -63,6 +64,7 @@ Using one cadence for all three overfits the most urgent surface and overloads t
 - Do not delay KPI counters if the SSE payload is already authoritative for the selected window.
 - Do not reuse a long-horizon aggregate endpoint as a shortcut for a real-time KPI when their semantic boundaries differ, even if the payload looks close enough.
 - Do not reuse chart timeseries as the source of a current KPI when the same screen also shows a live breakdown. The chart can legitimately differ because it is trend history; the current KPI should come from the shared activity snapshot.
+- Do not mount both a visible `dashboardActivity` snapshot consumer and a same-window `useSummary(window)` subscription for the same `today` / `yesterday` panel. That duplicates SSE listeners, open-resync, and refresh churn without improving owner-facing truth.
 - Do not simplify chart visuals to solve render pressure; throttle the data commit feeding the chart instead.
 - Keep timer constants exported when tests need to assert cadence without duplicating magic numbers.
 - `304` handling must preserve the previous UI data and clear transient errors; it is a successful no-body response, not a failed fetch.

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -24,3 +24,4 @@
 - 2026-07-04: 明确并修正 current in-flight 语义：进程内 `running/pending` overlay 不受 5 分钟 activity window 或自然日窗口限制。Dashboard 当前 summary、当前 working conversations 与上游账号活动都必须展示所有仍在内存中的进行中调用；历史 terminal DB 行继续按所选窗口过滤。
 - 2026-07-05: `/v1/*` 请求入口在 route context 解析前就创建 admit-time running shell；route validation failure 会 terminalize 同一 runtime key，避免前端看到假 running。terminal follow-up 不再强制 `flush_now` SQLite barrier，active subscriber 先依赖 terminal overlay 收敛，summary/quota 后续最终一致。
 - 2026-07-07: Dashboard active truth 从“唯一 promptCacheKey 进行中对话”修正为 invocation phase counts。`queued` 单独展示为排队中，`requesting + responding` 展示为进行中；working conversation 卡片列表仍用 5 分钟工作集筛选，但卡片 totals 使用 prompt-cache key 完整生命周期聚合，并在 snapshot 分页下遵守 snapshot 边界。
+- 2026-07-09: Dashboard 主活动总览在顶层已持有 `dashboardActivity` snapshot 时，不再为可见 `today` / `yesterday` 面板额外挂载同窗口 `useSummary`。同窗口 KPI 与 rate 改由 snapshot 直接驱动，只保留 `yesterday` / `previous7d` 等比较窗口的独立 summary 读取，避免重复 SSE/HTTP reconcile 放大。

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -6,6 +6,7 @@
 - Implementation summary: 已完成
 - Dashboard realtime consumption now separates SSE-fast KPI commits from 5s HTTP/chart reconcile budgets. Working conversations batch visible SSE patches for 1s and throttle head/snapshot reconcile to 5s. `/api/stats/parallel-work` keeps its response schema while supporting ETag / 304 conditional fetches.
 - Current-window summary reconcile now matches the same 5s budget as calendar windows and account-activity reconcile. The dashboard debug diagnostics also split out `current summary refresh/open-resync` and `upstream account activity refresh/open-resync`, so future regressions can distinguish SSE-fast-path churn from HTTP reconcile churn.
+- Dashboard natural-day overview no longer mounts duplicate same-window `useSummary('today' | 'yesterday')` subscriptions on the main page when `dashboardActivity` already carries the visible snapshot. Visible KPI/rate truth now reuses that snapshot directly, while comparison windows still fetch independently.
 - Dashboard working conversations live head/count now read from a write-side `prompt_cache_working_set_live` table that keeps the last 5 minutes of terminal activity plus any current in-flight keys. The public response shape stays unchanged, while the hot read path no longer rebuilds the working set from `codex_invocations` on every request.
 - Working-conversations snapshot count/page now also accept the same `<=5s` bounded-freshness contract. Instead of strict historical recomputation from `codex_invocations`, snapshot aggregates read the live working-set truth directly and keep the existing response fields, cursor shape, and main ordering semantics.
 - Proxy capture request completion no longer waits for terminal `codex_invocations` SQLite persistence before allowing the proxy business flow to finish. It constructs the full terminal record, tombstones/removes the corresponding runtime-store row, broadcasts `records`, and enqueues the terminal record into the SQLite write controller as P1 best-effort observability. Enqueue/flush failures are structured evidence and must not fail an already completed proxy response.
@@ -53,6 +54,7 @@
 - [x] M11: Terminal invocation 记录从代理业务关键路径移入 SQLite write controller；业务响应不等待记录落库，running snapshot 完全退出 DB/batch 路径，terminal 产生的派生写延后到后续 P2 flush。
 - [x] M12: Proxy capture 请求 admit 后立即创建最小内存 running shell record；body parse / attempt start / response-ready 只覆盖补全同一 runtime key。
 - [x] M13: Dashboard 活跃调用统一为 invocation phase counts；working conversation 卡片 totals 改为完整生命周期聚合，Today KPI 与图表拆分“进行中 / 排队中”。
+- [x] M14: Dashboard 主页面 `today` / `yesterday` 自然日总览在已有 `dashboardActivity` snapshot 时复用同窗口 summary truth，不再重复挂载同窗口 `useSummary` 订阅。
 
 ## 2026-06-21 Follow-up
 
@@ -80,3 +82,5 @@
 - `cargo test prompt_cache_conversations_activity_minutes`
 - `cargo test timeseries_point_exports_in_flight_phase_counts_and_compat_total`
 - `cd web && bun run test -- TodayStatsOverview DashboardTodayActivityChart`
+- `cd web && bun run test -- src/pages/Dashboard.test.tsx src/features/dashboard/DashboardActivityOverview.test.tsx`
+- `cd web && bun run build`

--- a/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
@@ -64,6 +64,7 @@
 - Dashboard `today` summary:
   - SSE `summary` payload 是 KPI 数字的快速路径，匹配窗口时直接提交并保持 ≤1s 可见。
   - `records` payload 只触发 HTTP reconcile，不作为 KPI 快速路径；calendar-window HTTP reconcile 必须节流到不超过每 5 秒一次。
+  - 当主 Dashboard 已经持有当前可见 `today` / `yesterday` 的 `dashboardActivity` snapshot 时，自然日总览卡片必须直接复用该 snapshot 里的同窗口 summary / rate truth，不得再为同一窗口额外挂载第二条 `useSummary(window)` 订阅；仅比较窗口（如 `yesterday`、`previous7d`）允许继续独立读取。
 - Dashboard 顶部 `today`/`yesterday` 1 分钟粒度活动图：
   - 继续使用既有 Recharts 图表、tooltip、1 分钟 bucket 与交互结构。
   - `today` 图表接收的 timeseries response 允许高频到达，但提交给图表渲染的数据快照必须独立节流到不超过每 5 秒一次。
@@ -118,6 +119,7 @@
 - Given 命中 `INSERT OR IGNORE` 未插入，When 请求完成，Then 不重复发送 `records` 事件。
 - Given SSE 发生断线并恢复，When 连接 open，Then 前端列表通过静默回源补齐，且与后端一致。
 - Given Dashboard 收到 `today` 的 SSE `summary`，When payload 匹配当前窗口，Then KPI 数字不等待 HTTP reconcile 即可提交。
+- Given Dashboard 当前可见 `today` 或 `yesterday` 面板已经持有同窗口 `dashboardActivity` snapshot，When 活动总览渲染，Then 同窗口 KPI / rate 直接来自该 snapshot，且不再触发额外的同窗口 `useSummary` 订阅或回源。
 - Given Dashboard 高频收到 `records`，When 需要更新 calendar-window summary、顶部 today 图表或 working conversation head，Then 对应 HTTP / chart commit 不超过每 5 秒一次。
 - Given working conversations 高频收到同一秒内多条 `records`，When 这些 records 命中已加载会话，Then 本地可见 patch 合并为 1 秒批次提交。
 - Given 一个 `pending` 或 `running` 调用 started 超过 5 分钟，When 查询 Dashboard 当前 summary、account activity 或 working conversations，Then 该调用仍计入 active phase counts 并出现在当前卡片列表。

--- a/web/src/features/dashboard/DashboardActivityOverview.test.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.test.tsx
@@ -473,7 +473,7 @@ describe('DashboardActivityOverview', () => {
     )
 
     expect(host?.querySelector('[data-testid="today-stats-overview-mock"]')?.textContent).toBe(
-      'total:21;inProgress:7;retry:1;wait:2500;nonSuccessCost:0.04;nonSuccessTokens:300;surface:false;header:false;badge:false;tpm:1000;spendRate:0.1;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
+      'total:21;inProgress:7;retry:1;wait:2500;nonSuccessCost:0.04;nonSuccessTokens:300;surface:false;header:false;badge:false;tpm:1234;spendRate:0.45;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
     )
     expect(hookMocks.useSummary.mock.calls.map(([window]) => window)).not.toContain(
       'today',
@@ -499,7 +499,7 @@ describe('DashboardActivityOverview', () => {
     })
 
     expect(host?.querySelector('[data-testid="today-stats-overview-mock"]')?.textContent).toBe(
-      'total:34;inProgress:9;retry:2;wait:1100;nonSuccessCost:0.08;nonSuccessTokens:420;surface:false;header:false;badge:false;tpm:1000;spendRate:0.1;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
+      'total:34;inProgress:9;retry:2;wait:1100;nonSuccessCost:0.08;nonSuccessTokens:420;surface:false;header:false;badge:false;tpm:1234;spendRate:0.45;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
     )
   })
 

--- a/web/src/features/dashboard/DashboardActivityOverview.test.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.test.tsx
@@ -20,6 +20,10 @@ const componentState = vi.hoisted(() => ({
   chartRenderCount: 0,
 }))
 
+const sseState = vi.hoisted(() => ({
+  listeners: new Set<(payload: unknown) => void>(),
+}))
+
 vi.mock('../../hooks/useStats', () => ({
   useSummary: hookMocks.useSummary,
 }))
@@ -30,6 +34,14 @@ vi.mock('../../hooks/useTimeseries', () => ({
 
 vi.mock('../../hooks/useParallelWorkStats', () => ({
   useParallelWorkStats: hookMocks.useParallelWorkStats,
+}))
+
+vi.mock('../../lib/sse', () => ({
+  subscribeToSse: (listener: (payload: unknown) => void) => {
+    sseState.listeners.add(listener)
+    return () => sseState.listeners.delete(listener)
+  },
+  subscribeToSseOpen: () => () => {},
 }))
 
 vi.mock('../../theme', () => ({
@@ -253,6 +265,7 @@ afterEach(() => {
   window.localStorage.clear()
   componentState.chartRenderCount = 0
   summaryStore.reset()
+  sseState.listeners.clear()
   vi.clearAllMocks()
 })
 
@@ -416,8 +429,14 @@ function getFirstSeenSummaryWindows() {
   return ordered
 }
 
+function emitSse(payload: unknown) {
+  for (const listener of [...sseState.listeners]) {
+    listener(payload)
+  }
+}
+
 describe('DashboardActivityOverview', () => {
-  it('uses a dashboard activity snapshot for the visible top KPI rate and live counts', () => {
+  it('uses a dashboard activity snapshot for the visible top KPI summary overlay without remounting duplicate today summary fetches', () => {
     installSummaryMocks()
 
     render(
@@ -454,10 +473,33 @@ describe('DashboardActivityOverview', () => {
     )
 
     expect(host?.querySelector('[data-testid="today-stats-overview-mock"]')?.textContent).toBe(
-      'total:21;inProgress:7;retry:1;wait:2500;nonSuccessCost:0.04;nonSuccessTokens:300;surface:false;header:false;badge:false;tpm:1234;spendRate:0.45;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
+      'total:21;inProgress:7;retry:1;wait:2500;nonSuccessCost:0.04;nonSuccessTokens:300;surface:false;header:false;badge:false;tpm:1000;spendRate:0.1;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
     )
     expect(hookMocks.useSummary.mock.calls.map(([window]) => window)).not.toContain(
       'today',
+    )
+
+    act(() => {
+      emitSse({
+        type: 'summary',
+        window: 'today',
+        summary: {
+          totalCount: 34,
+          successCount: 29,
+          failureCount: 3,
+          totalCost: 0.66,
+          totalTokens: 6600,
+          inProgressConversationCount: 9,
+          inProgressRetryConversationCount: 2,
+          inProgressAvgWaitMs: 1100,
+          nonSuccessCost: 0.08,
+          nonSuccessTokens: 420,
+        },
+      })
+    })
+
+    expect(host?.querySelector('[data-testid="today-stats-overview-mock"]')?.textContent).toBe(
+      'total:34;inProgress:9;retry:2;wait:1100;nonSuccessCost:0.08;nonSuccessTokens:420;surface:false;header:false;badge:false;tpm:1000;spendRate:0.1;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
     )
   })
 

--- a/web/src/features/dashboard/DashboardActivityOverview.test.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.test.tsx
@@ -456,6 +456,51 @@ describe('DashboardActivityOverview', () => {
     expect(host?.querySelector('[data-testid="today-stats-overview-mock"]')?.textContent).toBe(
       'total:21;inProgress:7;retry:1;wait:2500;nonSuccessCost:0.04;nonSuccessTokens:300;surface:false;header:false;badge:false;tpm:1234;spendRate:0.45;rateLoading:false;rateError:null;parallelAvg:2;parallelError:null;showInProgress:true',
     )
+    expect(hookMocks.useSummary.mock.calls.map(([window]) => window)).not.toContain(
+      'today',
+    )
+  })
+
+  it('skips the duplicate yesterday summary hook when a snapshot-backed yesterday panel is visible', () => {
+    installSummaryMocks()
+
+    render(
+      <DashboardActivityOverview
+        dashboardActivity={{
+          range: 'yesterday',
+          rangeStart: '2026-07-04T00:00:00Z',
+          rangeEnd: '2026-07-05T00:00:00Z',
+          snapshotId: 1783147200000,
+          rateWindow: {
+            start: '2026-07-04T23:55:00Z',
+            end: '2026-07-05T00:00:00Z',
+            windowMinutes: 5,
+            mode: 'account_active_tail_sum',
+          },
+          summary: {
+            stats: {
+              totalCount: 9,
+              successCount: 8,
+              failureCount: 1,
+              totalCost: 0.18,
+              totalTokens: 1800,
+              inProgressConversationCount: 0,
+              inProgressRetryConversationCount: 0,
+              inProgressAvgWaitMs: 0,
+              nonSuccessCost: 0.02,
+              nonSuccessTokens: 120,
+            },
+            tokensPerMinute: 88,
+            spendRate: 0.09,
+          },
+        }}
+        activeRange="yesterday"
+      />,
+    )
+
+    expect(hookMocks.useSummary.mock.calls.map(([window]) => window)).not.toContain(
+      'yesterday',
+    )
   })
 
   it('loads only the active range and keeps per-range metric memory across all five tabs', () => {

--- a/web/src/features/dashboard/DashboardActivityOverview.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.tsx
@@ -3,9 +3,13 @@ import { useSummary } from '../../hooks/useStats'
 import { useParallelWorkStats } from '../../hooks/useParallelWorkStats'
 import { useTimeseries } from '../../hooks/useTimeseries'
 import { useTranslation } from '../../i18n'
-import type { DashboardActivityResponse } from '../../lib/api'
+import type { DashboardActivityResponse, StatsResponse } from '../../lib/api'
 import { metricAccent } from '../../lib/chartTheme'
-import { recordTodayChartDataCommit } from '../../lib/dashboardPerformanceDiagnostics'
+import {
+  recordTodayChartDataCommit,
+  recordTodaySummarySseCommit,
+} from '../../lib/dashboardPerformanceDiagnostics'
+import { subscribeToSse } from '../../lib/sse'
 import { useTheme } from '../../theme'
 import { DashboardTodayActivityChart } from './DashboardTodayActivityChart'
 import {
@@ -49,6 +53,25 @@ function useScopedSummary(window: string, upstreamAccountId?: number) {
     window,
     upstreamAccountId == null ? undefined : { upstreamAccountId },
   )
+}
+
+function useSummarySseOverlay(window: string, initialSummary: StatsResponse) {
+  const [summary, setSummary] = useState(initialSummary)
+
+  useEffect(() => {
+    setSummary(initialSummary)
+  }, [initialSummary])
+
+  useEffect(() => {
+    const unsubscribe = subscribeToSse((payload) => {
+      if (payload.type !== 'summary' || payload.window !== window) return
+      setSummary(payload.summary)
+      recordTodaySummarySseCommit(window)
+    })
+    return unsubscribe
+  }, [window])
+
+  return summary
 }
 
 function useDashboardTopChartCommittedResponse(
@@ -269,6 +292,7 @@ function DashboardNaturalDayTodaySummaryOverviewSnapshotBacked({
     bucket: '1m',
   })
   const [rateNow, setRateNow] = useState(() => new Date())
+  const liveSummary = useSummarySseOverlay('today', dashboardActivity.summary.stats)
 
   useEffect(() => {
     if (closedNaturalDay) return
@@ -279,12 +303,20 @@ function DashboardNaturalDayTodaySummaryOverviewSnapshotBacked({
     return () => window.clearInterval(timer)
   }, [closedNaturalDay])
 
+  const liveRate = useMemo(
+    () => buildDashboardTodayRateSnapshot(response, {
+      closedNaturalDay,
+      now: rateNow,
+    }),
+    [closedNaturalDay, rateNow, response],
+  )
+
   return (
     <TodayStatsOverview
-      stats={dashboardActivity.summary.stats}
+      stats={liveSummary}
       loading={false}
       error={null}
-      rate={{
+      rate={liveRate ?? {
         tokensPerMinute: dashboardActivity.summary.tokensPerMinute ?? 0,
         spendRate: dashboardActivity.summary.spendRate ?? 0,
         windowMinutes: dashboardActivity.rateWindow.windowMinutes,

--- a/web/src/features/dashboard/DashboardActivityOverview.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.tsx
@@ -303,20 +303,12 @@ function DashboardNaturalDayTodaySummaryOverviewSnapshotBacked({
     return () => window.clearInterval(timer)
   }, [closedNaturalDay])
 
-  const liveRate = useMemo(
-    () => buildDashboardTodayRateSnapshot(response, {
-      closedNaturalDay,
-      now: rateNow,
-    }),
-    [closedNaturalDay, rateNow, response],
-  )
-
   return (
     <TodayStatsOverview
       stats={liveSummary}
       loading={false}
       error={null}
-      rate={liveRate ?? {
+      rate={{
         tokensPerMinute: dashboardActivity.summary.tokensPerMinute ?? 0,
         spendRate: dashboardActivity.summary.spendRate ?? 0,
         windowMinutes: dashboardActivity.rateWindow.windowMinutes,

--- a/web/src/features/dashboard/DashboardActivityOverview.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.tsx
@@ -212,6 +212,121 @@ function DashboardNaturalDayTodaySummaryOverview({
   dashboardActivityLoading?: boolean
   dashboardActivityError?: string | null
 }) {
+  const snapshotActive =
+    upstreamAccountId == null && dashboardActivity?.range === 'today'
+  if (snapshotActive && dashboardActivity != null) {
+    return (
+      <DashboardNaturalDayTodaySummaryOverviewSnapshotBacked
+        response={response}
+        closedNaturalDay={closedNaturalDay}
+        dashboardActivity={dashboardActivity}
+      />
+    )
+  }
+
+  return (
+    <DashboardNaturalDayTodaySummaryOverviewFallback
+      response={response}
+      loading={loading}
+      error={error}
+      closedNaturalDay={closedNaturalDay}
+      upstreamAccountId={upstreamAccountId}
+      dashboardActivity={dashboardActivity}
+      dashboardActivityLoading={dashboardActivityLoading}
+      dashboardActivityError={dashboardActivityError}
+    />
+  )
+}
+
+function DashboardNaturalDayTodaySummaryOverviewSnapshotBacked({
+  response,
+  closedNaturalDay,
+  dashboardActivity,
+}: {
+  response: ReturnType<typeof useTimeseries>['data']
+  closedNaturalDay: boolean
+  dashboardActivity: DashboardActivityResponse
+}) {
+  const {
+    summary: comparisonSummary,
+  } = useScopedSummary('yesterday')
+  const {
+    summary: previous7dSummary,
+  } = useScopedSummary('previous7d')
+  const {
+    data: comparisonTimeseries,
+  } = useTimeseries('yesterday', { bucket: '1m' })
+  const {
+    data: parallelWorkStats,
+  } = useParallelWorkStats({
+    range: 'today',
+    bucket: '1m',
+  })
+  const {
+    data: comparisonParallelWorkStats,
+  } = useParallelWorkStats({
+    range: 'yesterday',
+    bucket: '1m',
+  })
+  const [rateNow, setRateNow] = useState(() => new Date())
+
+  useEffect(() => {
+    if (closedNaturalDay) return
+    setRateNow(new Date())
+    const timer = window.setInterval(() => {
+      setRateNow(new Date())
+    }, LIVE_RATE_REFRESH_MS)
+    return () => window.clearInterval(timer)
+  }, [closedNaturalDay])
+
+  return (
+    <TodayStatsOverview
+      stats={dashboardActivity.summary.stats}
+      loading={false}
+      error={null}
+      rate={{
+        tokensPerMinute: dashboardActivity.summary.tokensPerMinute ?? 0,
+        spendRate: dashboardActivity.summary.spendRate ?? 0,
+        windowMinutes: dashboardActivity.rateWindow.windowMinutes,
+        available: true,
+      }}
+      rateLoading={false}
+      rateError={null}
+      now={rateNow}
+      timeseries={response}
+      comparisonStats={comparisonSummary}
+      comparisonTimeseries={comparisonTimeseries}
+      previous7dStats={previous7dSummary}
+      parallelWorkStats={parallelWorkStats}
+      comparisonParallelWorkStats={comparisonParallelWorkStats}
+      showInProgressConversations
+      dayKind="today"
+      showSurface={false}
+      showHeader={false}
+      showDayBadge={false}
+    />
+  )
+}
+
+function DashboardNaturalDayTodaySummaryOverviewFallback({
+  response,
+  loading,
+  error,
+  closedNaturalDay,
+  upstreamAccountId,
+  dashboardActivity,
+  dashboardActivityLoading = false,
+  dashboardActivityError = null,
+}: {
+  response: ReturnType<typeof useTimeseries>['data']
+  loading: boolean
+  error: ReturnType<typeof useTimeseries>['error']
+  closedNaturalDay: boolean
+  upstreamAccountId?: number
+  dashboardActivity?: DashboardActivityResponse | null
+  dashboardActivityLoading?: boolean
+  dashboardActivityError?: string | null
+}) {
   const {
     summary,
     isLoading: summaryLoading,
@@ -261,9 +376,8 @@ function DashboardNaturalDayTodaySummaryOverview({
     }),
     [closedNaturalDay, rateNow, response],
   )
-  const snapshotActive =
+  const snapshotRate =
     upstreamAccountId == null && dashboardActivity?.range === 'today'
-  const snapshotRate = snapshotActive
     ? {
         tokensPerMinute: dashboardActivity.summary.tokensPerMinute ?? 0,
         spendRate: dashboardActivity.summary.spendRate ?? 0,
@@ -274,12 +388,12 @@ function DashboardNaturalDayTodaySummaryOverview({
 
   return (
     <TodayStatsOverview
-      stats={snapshotActive ? dashboardActivity.summary.stats : summary}
-      loading={snapshotActive ? false : summaryLoading || dashboardActivityLoading}
-      error={snapshotActive ? null : summaryError ?? dashboardActivityError}
+      stats={summary}
+      loading={summaryLoading || dashboardActivityLoading}
+      error={summaryError ?? dashboardActivityError}
       rate={snapshotRate ?? rate}
-      rateLoading={snapshotActive ? false : loading || dashboardActivityLoading}
-      rateError={snapshotActive ? null : error ?? dashboardActivityError}
+      rateLoading={loading || dashboardActivityLoading}
+      rateError={error ?? dashboardActivityError}
       now={rateNow}
       timeseries={response}
       comparisonStats={comparisonSummary}
@@ -297,6 +411,109 @@ function DashboardNaturalDayTodaySummaryOverview({
 }
 
 function DashboardNaturalDayYesterdaySummaryOverview({
+  response,
+  loading,
+  error,
+  closedNaturalDay,
+  upstreamAccountId,
+  dashboardActivity,
+  dashboardActivityLoading = false,
+  dashboardActivityError = null,
+}: {
+  response: ReturnType<typeof useTimeseries>['data']
+  loading: boolean
+  error: ReturnType<typeof useTimeseries>['error']
+  closedNaturalDay: boolean
+  upstreamAccountId?: number
+  dashboardActivity?: DashboardActivityResponse | null
+  dashboardActivityLoading?: boolean
+  dashboardActivityError?: string | null
+}) {
+  const snapshotActive =
+    upstreamAccountId == null && dashboardActivity?.range === 'yesterday'
+  if (snapshotActive && dashboardActivity != null) {
+    return (
+      <DashboardNaturalDayYesterdaySummaryOverviewSnapshotBacked
+        response={response}
+        closedNaturalDay={closedNaturalDay}
+        dashboardActivity={dashboardActivity}
+      />
+    )
+  }
+
+  return (
+    <DashboardNaturalDayYesterdaySummaryOverviewFallback
+      response={response}
+      loading={loading}
+      error={error}
+      closedNaturalDay={closedNaturalDay}
+      upstreamAccountId={upstreamAccountId}
+      dashboardActivity={dashboardActivity}
+      dashboardActivityLoading={dashboardActivityLoading}
+      dashboardActivityError={dashboardActivityError}
+    />
+  )
+}
+
+function DashboardNaturalDayYesterdaySummaryOverviewSnapshotBacked({
+  response,
+  closedNaturalDay,
+  dashboardActivity,
+}: {
+  response: ReturnType<typeof useTimeseries>['data']
+  closedNaturalDay: boolean
+  dashboardActivity: DashboardActivityResponse
+}) {
+  const {
+    summary: previous7dSummary,
+  } = useScopedSummary('previous7d')
+  const {
+    data: parallelWorkStats,
+  } = useParallelWorkStats({
+    range: 'yesterday',
+    bucket: '1m',
+  })
+  const [rateNow, setRateNow] = useState(() => new Date())
+
+  useEffect(() => {
+    if (closedNaturalDay) return
+    setRateNow(new Date())
+    const timer = window.setInterval(() => {
+      setRateNow(new Date())
+    }, LIVE_RATE_REFRESH_MS)
+    return () => window.clearInterval(timer)
+  }, [closedNaturalDay])
+
+  return (
+    <TodayStatsOverview
+      stats={dashboardActivity.summary.stats}
+      loading={false}
+      error={null}
+      rate={{
+        tokensPerMinute: dashboardActivity.summary.tokensPerMinute ?? 0,
+        spendRate: dashboardActivity.summary.spendRate ?? 0,
+        windowMinutes: dashboardActivity.rateWindow.windowMinutes,
+        available: true,
+      }}
+      rateLoading={false}
+      rateError={null}
+      now={rateNow}
+      timeseries={response}
+      comparisonStats={null}
+      comparisonTimeseries={null}
+      previous7dStats={previous7dSummary}
+      parallelWorkStats={parallelWorkStats}
+      comparisonParallelWorkStats={null}
+      showInProgressConversations
+      dayKind="yesterday"
+      showSurface={false}
+      showHeader={false}
+      showDayBadge={false}
+    />
+  )
+}
+
+function DashboardNaturalDayYesterdaySummaryOverviewFallback({
   response,
   loading,
   error,
@@ -348,9 +565,8 @@ function DashboardNaturalDayYesterdaySummaryOverview({
     }),
     [closedNaturalDay, rateNow, response],
   )
-  const snapshotActive =
+  const snapshotRate =
     upstreamAccountId == null && dashboardActivity?.range === 'yesterday'
-  const snapshotRate = snapshotActive
     ? {
         tokensPerMinute: dashboardActivity.summary.tokensPerMinute ?? 0,
         spendRate: dashboardActivity.summary.spendRate ?? 0,
@@ -361,12 +577,12 @@ function DashboardNaturalDayYesterdaySummaryOverview({
 
   return (
     <TodayStatsOverview
-      stats={snapshotActive ? dashboardActivity.summary.stats : summary}
-      loading={snapshotActive ? false : summaryLoading || dashboardActivityLoading}
-      error={snapshotActive ? null : summaryError ?? dashboardActivityError}
+      stats={summary}
+      loading={summaryLoading || dashboardActivityLoading}
+      error={summaryError ?? dashboardActivityError}
       rate={snapshotRate ?? rate}
-      rateLoading={snapshotActive ? false : loading || dashboardActivityLoading}
-      rateError={snapshotActive ? null : error ?? dashboardActivityError}
+      rateLoading={loading || dashboardActivityLoading}
+      rateError={error ?? dashboardActivityError}
       now={rateNow}
       timeseries={response}
       comparisonStats={null}


### PR DESCRIPTION
## Summary
- Diagnose the dashboard long-idle crash symptoms as duplicate same-window natural-day summary refresh churn rather than a simple monotonic leak.
- Reuse the page-level `dashboardActivity` snapshot for visible `today` / `yesterday` KPI cards instead of mounting a second same-window `useSummary(...)` subscription.
- Restore the visible `today` KPI fast path by overlaying SSE `summary` updates onto the snapshot-backed panel without reintroducing duplicate same-window HTTP refreshes.
- Preserve the snapshot-backed `today` rate truth source and lock the behavior with overview tests while syncing the reconcile-budget/spec docs.

## Test Plan
- `cd web && bun run test -- src/pages/Dashboard.test.tsx src/features/dashboard/DashboardActivityOverview.test.tsx`
- `cd web && bun run build`

## References
- Spec: `docs/specs/5932d-sse-proxy-live-sync/SPEC.md`
- Spec Disposition: update
- Solutions: `docs/solutions/performance/realtime-dashboard-reconcile-budget.md`
- Project Docs: -
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: done
- Project Docs Sync: n/a(no project-doc change)
