### PR TITLE
ci: split backend required checks by resource profile

### DIFF
--- a/.github/quality-gates.json
+++ b/.github/quality-gates.json
@@ -22,7 +22,9 @@
           "Lint & Format Check": 15368,
           "Front-end Tests": 15368,
           "Records Overlay E2E": 15368,
-          "Backend Tests": 15368,
+          "Backend Tests (Lightweight)": 15368,
+          "Backend Tests (Stateful SQLite)": 15368,
+          "Backend Tests (Archive / File I/O)": 15368,
           "Build Artifacts": 15368,
           "Review Policy Gate": 15368
         }
@@ -52,7 +54,9 @@
     "Lint & Format Check",
     "Front-end Tests",
     "Records Overlay E2E",
-    "Backend Tests",
+    "Backend Tests (Lightweight)",
+    "Backend Tests (Stateful SQLite)",
+    "Backend Tests (Archive / File I/O)",
     "Build Artifacts",
     "Review Policy Gate"
   ],
@@ -71,7 +75,9 @@
         "Lint & Format Check",
         "Front-end Tests",
         "Records Overlay E2E",
-        "Backend Tests",
+        "Backend Tests (Lightweight)",
+        "Backend Tests (Stateful SQLite)",
+        "Backend Tests (Archive / File I/O)",
         "Build Artifacts"
       ]
     },
@@ -89,7 +95,9 @@
         "Lint & Format Check",
         "Front-end Tests",
         "Records Overlay E2E",
-        "Backend Tests",
+        "Backend Tests (Lightweight)",
+        "Backend Tests (Stateful SQLite)",
+        "Backend Tests (Archive / File I/O)",
         "Release Snapshot"
       ]
     }

--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -433,7 +433,8 @@ def validate_ci_pr(path: Path, contract: ContractModel) -> None:
     require("push" not in on_section, "ci-pr.yml: push must stay disabled")
     require("workflow_dispatch" not in on_section, "ci-pr.yml: workflow_dispatch must stay disabled")
     pull_request_config = event_config(workflow, "pull_request", "ci-pr.yml")
-    assert_event_branches(pull_request_config, {"main"}, "ci-pr.yml.on.pull_request")
+    require("branches" not in pull_request_config, "ci-pr.yml.on.pull_request.branches must stay unset")
+    require("branches-ignore" not in pull_request_config, "ci-pr.yml.on.pull_request.branches-ignore must stay unset")
     assert_event_types(pull_request_config, CI_PULL_REQUEST_TYPES, "ci-pr.yml.on.pull_request")
     merge_group_config = event_config(workflow, "merge_group", "ci-pr.yml")
     assert_event_types(merge_group_config, {"checks_requested"}, "ci-pr.yml.on.merge_group")
@@ -484,7 +485,8 @@ def validate_ci_pr(path: Path, contract: ContractModel) -> None:
 
     live_step = step_config(lint_job, "Quality-gates live rules check", "ci-pr.yml.jobs.lint")
     require(
-        live_step.get("if") == "steps.trusted-quality-gates.outputs.supports_final_topology == 'true'",
+        live_step.get("if")
+        == "steps.trusted-quality-gates.outputs.supports_final_topology == 'true' && (github.event_name != 'pull_request' || github.base_ref == 'main')",
         "ci-pr.yml.jobs.lint: live rules rollout gate drifted",
     )
     live_env = require_mapping(live_step.get("env"), "ci-pr.yml.jobs.lint.steps['Quality-gates live rules check'].env")
@@ -558,7 +560,15 @@ def validate_ci_main(path: Path, contract: ContractModel) -> None:
 
     release_snapshot = named_job_config(workflow, "release-snapshot", expected_jobs, "ci-main.yml")
     require(
-        release_snapshot.get("needs") == ["lint", "frontend-tests", "records-overlay-e2e", "unit-tests"],
+        release_snapshot.get("needs")
+        == [
+            "lint",
+            "frontend-tests",
+            "records-overlay-e2e",
+            "backend-tests-lightweight",
+            "backend-tests-stateful-sqlite",
+            "backend-tests-archive-file-io",
+        ],
         "ci-main.yml.jobs.release-snapshot.needs drifted",
     )
     release_snapshot_permissions = require_mapping(

--- a/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
@@ -220,8 +220,41 @@ jobs:
             kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
           fi
 
-  unit-tests:
-    name: Backend Tests
+  backend-tests-lightweight:
+    name: Backend Tests (Lightweight)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run lightweight backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile lightweight
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -247,13 +280,55 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run cargo test
-        run: cargo test --locked --all-features
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+
+  backend-tests-archive-file-io:
+    name: Backend Tests (Archive / File I/O)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run archive / file I/O backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io
 
   release-snapshot:
     name: Release Snapshot
     runs-on: ubuntu-24.04
-    needs: [lint, frontend-tests, records-overlay-e2e, unit-tests]
+    needs:
+      - lint
+      - frontend-tests
+      - records-overlay-e2e
+      - backend-tests-lightweight
+      - backend-tests-stateful-sqlite
+      - backend-tests-archive-file-io
     permissions:
       actions: read
       contents: write

--- a/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
@@ -2,8 +2,6 @@ name: CI PR
 
 on:
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - reopened
@@ -202,7 +200,7 @@ jobs:
             --metadata-script "${{ steps.trusted-quality-gates.outputs.metadata_script }}"
 
       - name: Quality-gates live rules check
-        if: steps.trusted-quality-gates.outputs.supports_final_topology == 'true'
+        if: steps.trusted-quality-gates.outputs.supports_final_topology == 'true' && (github.event_name != 'pull_request' || github.base_ref == 'main')
         env:
           QUALITY_GATES_LIVE_RULES_MODE: require
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -344,8 +342,41 @@ jobs:
             kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
           fi
 
-  unit-tests:
-    name: Backend Tests
+  backend-tests-lightweight:
+    name: Backend Tests (Lightweight)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run lightweight backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile lightweight
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -371,8 +402,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run cargo test
-        run: cargo test --locked --all-features
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+
+  backend-tests-archive-file-io:
+    name: Backend Tests (Archive / File I/O)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run archive / file I/O backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io
 
   build:
     name: Build Artifacts

--- a/.github/scripts/fixtures/quality-gates-contract/quality-gates.json
+++ b/.github/scripts/fixtures/quality-gates-contract/quality-gates.json
@@ -22,7 +22,9 @@
           "Lint & Format Check": 15368,
           "Front-end Tests": 15368,
           "Records Overlay E2E": 15368,
-          "Backend Tests": 15368,
+          "Backend Tests (Lightweight)": 15368,
+          "Backend Tests (Stateful SQLite)": 15368,
+          "Backend Tests (Archive / File I/O)": 15368,
           "Build Artifacts": 15368,
           "Review Policy Gate": 15368
         }
@@ -52,7 +54,9 @@
     "Lint & Format Check",
     "Front-end Tests",
     "Records Overlay E2E",
-    "Backend Tests",
+    "Backend Tests (Lightweight)",
+    "Backend Tests (Stateful SQLite)",
+    "Backend Tests (Archive / File I/O)",
     "Build Artifacts",
     "Review Policy Gate"
   ],
@@ -71,7 +75,9 @@
         "Lint & Format Check",
         "Front-end Tests",
         "Records Overlay E2E",
-        "Backend Tests",
+        "Backend Tests (Lightweight)",
+        "Backend Tests (Stateful SQLite)",
+        "Backend Tests (Archive / File I/O)",
         "Build Artifacts"
       ]
     },
@@ -89,7 +95,9 @@
         "Lint & Format Check",
         "Front-end Tests",
         "Records Overlay E2E",
-        "Backend Tests",
+        "Backend Tests (Lightweight)",
+        "Backend Tests (Stateful SQLite)",
+        "Backend Tests (Archive / File I/O)",
         "Release Snapshot"
       ]
     }

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
@@ -220,8 +220,41 @@ jobs:
             kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
           fi
 
-  unit-tests:
-    name: Backend Tests
+  backend-tests-lightweight:
+    name: Backend Tests (Lightweight)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run lightweight backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile lightweight
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -247,13 +280,55 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run cargo test
-        run: cargo test --locked --all-features
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+
+  backend-tests-archive-file-io:
+    name: Backend Tests (Archive / File I/O)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run archive / file I/O backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io
 
   release-snapshot:
     name: Release Snapshot
     runs-on: ubuntu-24.04
-    needs: [lint, frontend-tests, records-overlay-e2e, unit-tests]
+    needs:
+      - lint
+      - frontend-tests
+      - records-overlay-e2e
+      - backend-tests-lightweight
+      - backend-tests-stateful-sqlite
+      - backend-tests-archive-file-io
     permissions:
       actions: read
       contents: write

--- a/.github/scripts/fixtures/quality-gates/rules-main-ok.json
+++ b/.github/scripts/fixtures/quality-gates/rules-main-ok.json
@@ -65,7 +65,15 @@
               "integration_id": 15368
             },
             {
-              "context": "Backend Tests",
+              "context": "Backend Tests (Lightweight)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Stateful SQLite)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Archive / File I/O)",
               "integration_id": 15368
             },
             {

--- a/.github/scripts/fixtures/quality-gates/rules-main-review-policy-legacy-source.json
+++ b/.github/scripts/fixtures/quality-gates/rules-main-review-policy-legacy-source.json
@@ -65,7 +65,15 @@
               "integration_id": 15368
             },
             {
-              "context": "Backend Tests",
+              "context": "Backend Tests (Lightweight)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Stateful SQLite)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Archive / File I/O)",
               "integration_id": 15368
             },
             {

--- a/.github/scripts/fixtures/quality-gates/rules-main-status-check-policy-drift.json
+++ b/.github/scripts/fixtures/quality-gates/rules-main-status-check-policy-drift.json
@@ -65,7 +65,15 @@
               "integration_id": 15368
             },
             {
-              "context": "Backend Tests",
+              "context": "Backend Tests (Lightweight)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Stateful SQLite)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Archive / File I/O)",
               "integration_id": 15368
             },
             {

--- a/.github/scripts/fixtures/quality-gates/rules-main-unexpected-merge-queue.json
+++ b/.github/scripts/fixtures/quality-gates/rules-main-unexpected-merge-queue.json
@@ -65,7 +65,15 @@
               "integration_id": 15368
             },
             {
-              "context": "Backend Tests",
+              "context": "Backend Tests (Lightweight)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Stateful SQLite)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Archive / File I/O)",
               "integration_id": 15368
             },
             {

--- a/.github/scripts/fixtures/quality-gates/rules-main-weak-branch-protection.json
+++ b/.github/scripts/fixtures/quality-gates/rules-main-weak-branch-protection.json
@@ -57,7 +57,15 @@
               "integration_id": 15368
             },
             {
-              "context": "Backend Tests",
+              "context": "Backend Tests (Lightweight)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Stateful SQLite)",
+              "integration_id": 15368
+            },
+            {
+              "context": "Backend Tests (Archive / File I/O)",
               "integration_id": 15368
             },
             {

--- a/.github/scripts/run-backend-tests.sh
+++ b/.github/scripts/run-backend-tests.sh
@@ -1,6 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: run-backend-tests.sh [--profile lightweight|stateful-sqlite|archive-file-io]
+
+Profiles:
+  lightweight
+  stateful-sqlite
+  archive-file-io
+
+If --profile is omitted, all three profiles run sequentially.
+EOF
+}
+
+profile="all"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      if [[ $# -lt 2 ]]; then
+        echo "::error::--profile requires a value." >&2
+        usage >&2
+        exit 1
+      fi
+      profile="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
 start_epoch="$(date +%s)"
 
 if ! command -v cargo-nextest >/dev/null 2>&1; then
@@ -8,7 +45,43 @@ if ! command -v cargo-nextest >/dev/null 2>&1; then
   exit 1
 fi
 
-cargo nextest run --locked --all-features --no-fail-fast
+run_profile() {
+  local selected_profile="$1"
+  local filter_expr=""
+
+  case "$selected_profile" in
+    lightweight)
+      filter_expr='(test(/^(tests|upstream_accounts::tests)::lightweight::/)) or (not test(/^(tests|upstream_accounts::tests)::/))'
+      ;;
+    stateful-sqlite)
+      filter_expr='test(/^(tests|upstream_accounts::tests)::stateful_sqlite::/)'
+      ;;
+    archive-file-io)
+      filter_expr='test(/^(tests|upstream_accounts::tests)::archive_file_io::/)'
+      ;;
+    *)
+      echo "::error::unsupported backend test profile: $selected_profile" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+
+  local profile_start_epoch
+  profile_start_epoch="$(date +%s)"
+  echo "backend_test_profile=$selected_profile"
+  cargo nextest run --locked --all-features --no-fail-fast -E "$filter_expr"
+  local profile_end_epoch
+  profile_end_epoch="$(date +%s)"
+  echo "backend_test_profile_seconds_${selected_profile//-/_}=$((profile_end_epoch - profile_start_epoch))"
+}
+
+if [[ "$profile" == "all" ]]; then
+  run_profile lightweight
+  run_profile stateful-sqlite
+  run_profile archive-file-io
+else
+  run_profile "$profile"
+fi
 
 end_epoch="$(date +%s)"
 echo "backend_test_total_seconds=$((end_epoch - start_epoch))"

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -162,14 +162,16 @@ try:
                 "jobs": [
                     {"name": "Release Snapshot", "conclusion": "failure"},
                     {"name": "Lint & Format Check", "conclusion": "success"},
-                    {"name": "Backend Tests", "conclusion": "success"},
+                    {"name": "Backend Tests (Lightweight)", "conclusion": "success"},
+                    {"name": "Backend Tests (Stateful SQLite)", "conclusion": "success"},
+                    {"name": "Backend Tests (Archive / File I/O)", "conclusion": "success"},
                 ]
             }
         if path.endswith("/actions/runs/30/jobs"):
             return {
                 "jobs": [
                     {"name": "Release Snapshot", "conclusion": "skipped"},
-                    {"name": "Backend Tests", "conclusion": "failure"},
+                    {"name": "Backend Tests (Stateful SQLite)", "conclusion": "failure"},
                 ]
             }
         raise AssertionError(f"unexpected GitHub API path: {path}")

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -263,8 +263,41 @@ jobs:
             kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
           fi
 
-  unit-tests:
-    name: Backend Tests
+  backend-tests-lightweight:
+    name: Backend Tests (Lightweight)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run lightweight backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile lightweight
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -293,13 +326,52 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Run cargo test
-        run: bash .github/scripts/run-backend-tests.sh
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+
+  backend-tests-archive-file-io:
+    name: Backend Tests (Archive / File I/O)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run archive / file I/O backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io
 
   release-snapshot:
     name: Release Snapshot
     runs-on: ubuntu-24.04
-    needs: [lint, frontend-tests, records-overlay-e2e, unit-tests]
+    needs:
+      - lint
+      - frontend-tests
+      - records-overlay-e2e
+      - backend-tests-lightweight
+      - backend-tests-stateful-sqlite
+      - backend-tests-archive-file-io
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,8 +2,6 @@ name: CI PR
 
 on:
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - reopened
@@ -203,7 +201,7 @@ jobs:
             --metadata-script "${{ steps.trusted-quality-gates.outputs.metadata_script }}"
 
       - name: Quality-gates live rules check
-        if: steps.trusted-quality-gates.outputs.supports_final_topology == 'true'
+        if: steps.trusted-quality-gates.outputs.supports_final_topology == 'true' && (github.event_name != 'pull_request' || github.base_ref == 'main')
         env:
           QUALITY_GATES_LIVE_RULES_MODE: require
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -345,8 +343,41 @@ jobs:
             kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
           fi
 
-  unit-tests:
-    name: Backend Tests
+  backend-tests-lightweight:
+    name: Backend Tests (Lightweight)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run lightweight backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile lightweight
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -375,8 +406,41 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Run cargo test
-        run: bash .github/scripts/run-backend-tests.sh
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+
+  backend-tests-archive-file-io:
+    name: Backend Tests (Archive / File I/O)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache cargo directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run archive / file I/O backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io
 
   build:
     name: Build Artifacts

--- a/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
+++ b/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
@@ -9,7 +9,8 @@
 ## 核心结论
 
 - 先用 `cargo test --no-run` 生成热缓存 test binary，再直接运行 `target/debug/deps/<bin> <filter> --format=terse`，用 `/usr/bin/time -p` 测单测和全套运行时。
-- CI 总时长优化要以 `Backend Tests` job wall time 为主指标；当单个 libtest binary 的测试名无法均衡分片时，优先用 `cargo nextest run --locked --all-features --no-fail-fast` 保持单个 required check，同时获得单测试调度和耗时输出。
+- CI 总时长优化要以 `CI Main` 里 3 个 backend required jobs 的最慢 wall time 为主指标：`Backend Tests (Lightweight)`、`Backend Tests (Stateful SQLite)`、`Backend Tests (Archive / File I/O)`。
+- backend runner 应固定用 resource-profile filter 跑 `cargo nextest run --locked --all-features --no-fail-fast -E ...`，不要再把整个后端测试树塞回单个 required check。
 - 对只验证 DB 行为、不验证主库文件路径的测试，优先使用唯一命名的 in-memory SQLite，保留 `AppConfig.database_path`、archive/raw 目录形状即可。
 - 文件 SQLite fixture 要限制测试连接池大小；默认 pool 在全套并发下会把每个测试放大成多连接竞争。
 - 如果测试只需要“已 materialized archive metadata”或“缺失 replay marker”状态，直接构造窄表状态，不要为了 setup 跑完整 retention/archive pipeline。
@@ -22,13 +23,15 @@ cargo test --no-run
 bin=$(find target/debug/deps -maxdepth 1 -type f -perm -111 -name 'codex_vibe_monitor-*' | head -1)
 /usr/bin/time -p "$bin" archive_backfill_respects_scan_limit_budget --format=terse
 /usr/bin/time -p "$bin" --test-threads=4 --format=terse
-bash .github/scripts/run-backend-tests.sh
+bash .github/scripts/run-backend-tests.sh --profile lightweight
+bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+bash .github/scripts/run-backend-tests.sh --profile archive-file-io
 ```
 
 ## 常见坑
 
 - 不要把首轮编译时间当成慢测试时间；先分离 compile 和 hot test execution。
-- 不要只报告局部单测变快；PR 要同时报告 GitHub job 总时长、`Run cargo test` step、Rust/test runner finished time 或分片总时长、以及 top offenders 变化。
+- 不要只报告局部单测变快；PR 要同时报告 split 后各 GitHub backend job 总时长、各 profile runner wall time，以及 top offenders 变化。
 - 切换到 nextest 前先修掉并发暴露的测试竞态；真实时间窗口断言要以行为结果为主，毫秒上限只作为防挂死保护。
 - 不要为了速度把所有文件 SQLite 测试切成 in-memory；archive writer/reader、relative path、真实 write-lock 行为需要文件 DB。
 - 单跑很快但全套出现 60s warning，通常是并发资源放大；先看 `sys` time 和 SQLite pool 数量，再决定是否下沉 fixture。

--- a/docs/solutions/workflow/main-branch-protection-quality-gates.md
+++ b/docs/solutions/workflow/main-branch-protection-quality-gates.md
@@ -31,13 +31,17 @@
 - `Lint & Format Check`
 - `Front-end Tests`
 - `Records Overlay E2E`
-- `Backend Tests`
+- `Backend Tests (Lightweight)`
+- `Backend Tests (Stateful SQLite)`
+- `Backend Tests (Archive / File I/O)`
 - `Build Artifacts`
 - `Review Policy Gate`
 
 ## 实施要点
 
 - `.github/quality-gates.json` 与 fixtures 必须同步更新，避免 contract self-test 通过而 live fixtures 仍停留在旧规则。
+- `CI PR` 可以对 same-repo stacked PR 保持开启，但 `Label Gate` 与 `Review Policy` 仍应只对 `base=main` 的 PR 生效；这样 stacked PR 也有服务端 CI 证据，而 owner-facing merge policy 仍只绑定 `main`。
+- live GitHub rules 对齐检查同样只应阻断 `base=main` 的 PR；stacked PR 可以复用当前分支 contract 自检，但不应要求 `main` 的服务端 ruleset 预先反映未合并的拓扑改动。
 - `check_quality_gates_contract.py` 应明确禁止为 PR gate 保留 `informational_checks`。
 - `check_live_quality_gates.py` 的输出需要单独带出 `bypass_actor_status`，方便区分 `verified` 与 `unverified`。
 - 由上游 workflow 触发的发布链路应把上游失败转成显式 failed gate，而不是依赖后续 job 的 `if` 条件自然跳过；否则失败通知通常只监听 `failure`，不会覆盖 `skipped`。

--- a/docs/solutions/workflow/release-queue-ci-main-eligibility.md
+++ b/docs/solutions/workflow/release-queue-ci-main-eligibility.md
@@ -56,7 +56,7 @@ Keep the immutable snapshot queue, but add a second eligibility gate when select
 - Fail open on `unknown` visibility states. Missing workflow-run indexing and transient Actions API read failures are not proof that a pending snapshot became invalid, and treating them as hard failures can silently reorder the release queue.
 - Reuse the exact same success-or-snapshot-only-failure rule for automatic queue selection and manual backfill validation so the release contract stays coherent.
 - Add regression coverage for both cases:
-  - an older pending snapshot is skipped because `Backend Tests` failed;
+  - an older pending snapshot is skipped because one of the split backend jobs such as `Backend Tests (Stateful SQLite)` failed;
   - a snapshot-only `CI Main` failure remains releasable.
   - a pending snapshot stays selectable while `CI Main` visibility is temporarily unknown.
 

--- a/docs/specs/q7yt7-backend-test-resource-profiles/HISTORY.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/HISTORY.md
@@ -9,6 +9,10 @@
 - 2026-07-09：owner-facing backend required checks 冻结为三个 job：`Backend Tests (Lightweight)`、`Backend Tests (Stateful SQLite)`、`Backend Tests (Archive / File I/O)`。
 - 2026-07-09：运行时目标冻结为 `CI Main` 中最慢 backend required job 的 wall time `<= 6m30s`。
 - 2026-07-09：PR1 完成两条测试树的真实模块化入口，`pool_failover_window_*`、`tests_part_*` 与 `parts.rs` 退出代码真相源。
+- 2026-07-09：PR2 将 backend runner 固定为 profile-aware nextest 入口，并把 quality-gates / CI / release snapshot 合同一起切到三路 backend checks。
+- 2026-07-09：review-loop 指出 profile split 漏掉生产模块里的内联 backend unit tests；修复后将这 136 个用例并回 `lightweight` profile，避免 required checks coverage 回归。
+- 2026-07-09：实际打开 stacked PR 后发现 `CI PR` 只对 `base=main` 触发，无法为 PR2 提供服务端 CI 证据；因此放开 `CI PR` 的 `pull_request` base 过滤，同时保留 `Label Gate` / `Review Policy` 与 live rules 对齐检查继续只绑定 `main`。
+- 2026-07-09：修复后的本地热缓存测量显示三个 profile wall time 分别约为 `3.83s`、`66.97s`、`29.14s`，拆分后 critical path 远低于 `6m30s` 预算。
 
 ## Key Reasons / Replacements
 

--- a/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
@@ -4,7 +4,7 @@
 
 ## Current Status
 
-- Implementation: 部分完成（PR1 测试树模块化已落地，PR2 runtime/CI 合同待完成）
+- Implementation: 部分完成（PR1 测试树模块化已落地；PR2 runner / CI / contract 改动已本地验证，并已补齐 stacked PR 的 CI 触发，待新 head push + PR CI 收口）
 - Lifecycle: active
 - Catalog note: 双 PR：先测试树模块化，再 runtime/CI 合同收口
 
@@ -18,16 +18,31 @@
   - `src/upstream_accounts/tests/{lightweight,stateful_sqlite,archive_file_io}`
 - PR1 已移除旧字母/编号切片文件名与 `src/upstream_accounts/tests/parts.rs` 聚合入口。
 - 当前模块树仍通过最小必要的 `pub(crate)` helper 暴露跨文件测试支撑；PR2 不再扩展这类聚合面，只围绕 runner/CI/runtime 收口。
+- PR2 已把 `.github/scripts/run-backend-tests.sh` 收口为 profile-aware runner，稳定入口固定为：
+  - `--profile lightweight`
+  - `--profile stateful-sqlite`
+  - `--profile archive-file-io`
+- PR2 已将不属于 `src/tests/**` / `src/upstream_accounts/tests/**` 的 136 个内联 backend unit tests 并回 `lightweight` profile，避免 profile split 造成 coverage 回归。
+- PR2 已把 owner-facing backend required checks 更新为三个 job，并同步 `.github/quality-gates.json`、contract fixtures、release snapshot 自测与 live quality-gates fixtures。
+- PR2 发现 `CI PR` 仅对 `base=main` 触发，导致 stacked PR 无服务端 checks；现已将 `CI PR` 的 `pull_request` 触发范围放开到所有 PR base，同时保留 `Label Gate` / `Review Policy` 与 live rules 对齐检查只对 `main` 生效。
+- 本地 profile wall time（2026-07-09，热缓存）：
+  - `lightweight`: 281 tests, `real 3.83s`
+  - `stateful_sqlite`: 1040 tests, `real 66.97s`
+  - `archive_file_io`: 195 tests, `real 29.14s`
+- 本地 top offenders 采样：
+  - `lightweight`: `raw_compression_budget_stops_after_first_batch_when_budget_is_exhausted` (`2.229s`)
+  - `stateful_sqlite`: `pool_openai_v1_compact_overload_falls_back_to_alternate_route_before_body_forward` (`15.635s`)
+  - `archive_file_io`: `send_pool_request_with_failover_returns_owner_unavailable_for_encrypted_session_lock` (`11.828s`)
 
 ## Remaining Gaps
 
-- 待补充：三个 backend profiles 的 runner 入口与 nextest 过滤真相源。
-- 待补充：quality-gates / release snapshot / release gate 的 required-check 合同迁移完成度。
-- 待补充：split 后各 profile wall time 与 top offenders 证据。
+- 待补充：PR2 修复 stacked PR CI 触发后的新 head review-loop / PR CI 证据。
+- 待补充：merge 后 `CI Main` 对最慢 backend required job `<= 6m30s` 的最终服务端真相。
 
 ## Related Changes
 
 - PR1 branch: `th/backend-test-modularization`
+- PR2 branch: `th/backend-test-runtime-profiles`
 
 ## References
 

--- a/docs/specs/tr4ev-bun-first-toolchain/IMPLEMENTATION.md
+++ b/docs/specs/tr4ev-bun-first-toolchain/IMPLEMENTATION.md
@@ -37,7 +37,7 @@
 ### Quality checks
 
 - `codex --sandbox read-only -a never review --base origin/main`
-- PR required checks 保持为 `Validate PR labels`、`Lint & Format Check`、`Backend Tests`、`Build Artifacts`、`Review Policy Gate`
+- PR required checks 当前为 `Validate PR labels`、`Lint & Format Check`、`Front-end Tests`、`Records Overlay E2E`、`Backend Tests (Lightweight)`、`Backend Tests (Stateful SQLite)`、`Backend Tests (Archive / File I/O)`、`Build Artifacts`、`Review Policy Gate`
 - quality-gates contract fixtures、release snapshot helper、Docker smoke retry helper 与 live workflows 的 runner / action ref 基线保持一致
 
 ## 实现里程碑（Milestones / Delivery checklist）


### PR DESCRIPTION
## Summary
- split the backend required check into `Backend Tests (Lightweight)`, `Backend Tests (Stateful SQLite)`, and `Backend Tests (Archive / File I/O)`
- make `.github/scripts/run-backend-tests.sh` profile-aware and keep the 136 inline backend unit tests in `lightweight` so coverage does not regress
- sync `CI PR`, `CI Main`, quality-gates fixtures, release-snapshot fixtures, and follow-up docs/spec state to the new contract
- allow `CI PR` to run on same-repo stacked PR bases so this stacked PR also gets service-side CI evidence while `Label Gate` and `Review Policy` stay `main`-only

## Validation
- `bash -n .github/scripts/run-backend-tests.sh`
- `bash .github/scripts/run-backend-tests.sh --profile lightweight`
- `bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite`
- `bash .github/scripts/run-backend-tests.sh --profile archive-file-io`
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo test --locked --all-features`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-release-snapshot.sh`
- `bash .github/scripts/test-live-quality-gates.sh`
- `codex -m gpt-5.5 -c model_reasoning_effort=\"low\" --sandbox read-only -a never review --base origin/th/backend-test-modularization`

## Runtime evidence
- `lightweight`: 281 tests, `real 3.83s`
- `stateful_sqlite`: 1040 tests, `real 66.97s`
- `archive_file_io`: 195 tests, `real 29.14s`
- top offenders:
  - `lightweight`: `raw_compression_budget_stops_after_first_batch_when_budget_is_exhausted` (`2.229s`)
  - `stateful_sqlite`: `pool_openai_v1_compact_overload_falls_back_to_alternate_route_before_body_forward` (`15.635s`)
  - `archive_file_io`: `send_pool_request_with_failover_returns_owner_unavailable_for_encrypted_session_lock` (`11.828s`)
- local hot-cache critical path is well under the `6m30s` target; `CI Main` remains the final truth source after merge

## Stack
- base branch: `th/backend-test-modularization`
- stacked on #576

## References
- Specs:
  - `docs/specs/q7yt7-backend-test-resource-profiles/SPEC.md`
- Solutions:
  - `docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md`
  - `docs/solutions/workflow/main-branch-protection-quality-gates.md`
  - `docs/solutions/workflow/release-queue-ci-main-eligibility.md`
- Project Docs:
  - `-`
