### PR TITLE
perf(ci): bound stateful test concurrency

### DIFF
--- a/.github/scripts/run-backend-tests.sh
+++ b/.github/scripts/run-backend-tests.sh
@@ -48,6 +48,7 @@ fi
 run_profile() {
   local selected_profile="$1"
   local filter_expr=""
+  local test_threads=""
 
   case "$selected_profile" in
     lightweight)
@@ -55,6 +56,8 @@ run_profile() {
       ;;
     stateful-sqlite)
       filter_expr='test(/^(tests|upstream_accounts::tests)::stateful_sqlite::/)'
+      # Stateful tests use isolated in-memory SQLite pools and benefit from bounded I/O concurrency.
+      test_threads="6"
       ;;
     archive-file-io)
       filter_expr='test(/^(tests|upstream_accounts::tests)::archive_file_io::/)'
@@ -69,7 +72,12 @@ run_profile() {
   local profile_start_epoch
   profile_start_epoch="$(date +%s)"
   echo "backend_test_profile=$selected_profile"
-  cargo nextest run --locked --all-features --no-fail-fast -E "$filter_expr"
+  if [[ -n "$test_threads" ]]; then
+    echo "backend_test_profile_test_threads_${selected_profile//-/_}=$test_threads"
+    cargo nextest run --locked --all-features --no-fail-fast --test-threads "$test_threads" -E "$filter_expr"
+  else
+    cargo nextest run --locked --all-features --no-fail-fast -E "$filter_expr"
+  fi
   local profile_end_epoch
   profile_end_epoch="$(date +%s)"
   echo "backend_test_profile_seconds_${selected_profile//-/_}=$((profile_end_epoch - profile_start_epoch))"

--- a/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
+++ b/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
@@ -11,6 +11,7 @@
 - 先用 `cargo test --no-run` 生成热缓存 test binary，再直接运行 `target/debug/deps/<bin> <filter> --format=terse`，用 `/usr/bin/time -p` 测单测和全套运行时。
 - CI 总时长优化要以 `CI Main` 里 3 个 backend required jobs 的最慢 wall time 为主指标：`Backend Tests (Lightweight)`、`Backend Tests (Stateful SQLite)`、`Backend Tests (Archive / File I/O)`。
 - backend runner 应固定用 resource-profile filter 跑 `cargo nextest run --locked --all-features --no-fail-fast -E ...`，不要再把整个后端测试树塞回单个 required check。
+- 当完整 stateful SQLite suite 的隔离性已由多档并发全量验证后，可为该 profile 固定一个保守的 `--test-threads` 上限。当前 1048 个 stateful 用例在 4、6、8 threads 下均通过，6 threads 在保留余量的同时将本地热执行降到约 102s。
 - 对只验证 DB 行为、不验证主库文件路径的测试，优先使用唯一命名的 in-memory SQLite，保留 `AppConfig.database_path`、archive/raw 目录形状即可。
 - 文件 SQLite fixture 要限制测试连接池大小；默认 pool 在全套并发下会把每个测试放大成多连接竞争。
 - 如果测试只需要“已 materialized archive metadata”或“缺失 replay marker”状态，直接构造窄表状态，不要为了 setup 跑完整 retention/archive pipeline。
@@ -34,5 +35,6 @@ bash .github/scripts/run-backend-tests.sh --profile archive-file-io
 - 不要只报告局部单测变快；PR 要同时报告 split 后各 GitHub backend job 总时长、各 profile runner wall time，以及 top offenders 变化。
 - 切换到 nextest 前先修掉并发暴露的测试竞态；真实时间窗口断言要以行为结果为主，毫秒上限只作为防挂死保护。
 - 不要为了速度把所有文件 SQLite 测试切成 in-memory；archive writer/reader、relative path、真实 write-lock 行为需要文件 DB。
+- 先验证 4、6、8 等候选并发档位的完整 profile；选择能明显缩短 critical path 的最小档位，而不是直接采用最快的本机结果。
 - 单跑很快但全套出现 60s warning，通常是并发资源放大；先看 `sys` time 和 SQLite pool 数量，再决定是否下沉 fixture。
 - 直接构造窄状态时要保留被测语义，例如 materialized archive 需要 `historical_rollups_materialized_at` 和必要 replay marker 状态，否则测试会误触发 archive 文件读取。

--- a/docs/specs/q7yt7-backend-test-resource-profiles/HISTORY.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/HISTORY.md
@@ -13,6 +13,7 @@
 - 2026-07-09：review-loop 指出 profile split 漏掉生产模块里的内联 backend unit tests；修复后将这 136 个用例并回 `lightweight` profile，避免 required checks coverage 回归。
 - 2026-07-09：实际打开 stacked PR 后发现 `CI PR` 只对 `base=main` 触发，无法为 PR2 提供服务端 CI 证据；因此放开 `CI PR` 的 `pull_request` base 过滤，同时保留 `Label Gate` / `Review Policy` 与 live rules 对齐检查继续只绑定 `main`。
 - 2026-07-09：修复后的本地热缓存测量显示三个 profile wall time 分别约为 `3.83s`、`66.97s`、`29.14s`，拆分后 critical path 远低于 `6m30s` 预算。
+- 2026-07-10：PR #576 合并后的 CI Main 实测 Stateful SQLite job 为 `6m45s`，比预算高 `15s`；完整 1048 个 stateful 用例在本地 4、6、8 threads 下均通过，采用保守的 6-thread runner 上限收敛预算。
 
 ## Key Reasons / Replacements
 

--- a/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
@@ -4,9 +4,9 @@
 
 ## Current Status
 
-- Implementation: 部分完成（PR1 测试树模块化已落地；PR2 runner / CI / contract 改动已本地验证，并已补齐 stacked PR 的 CI 触发，待新 head push + PR CI 收口）
+- Implementation: 运行时预算收口中（测试树、profile-aware runner 与三路 required checks 已随 PR #576 发布为 `v2.21.1`；Stateful SQLite job 仍需压回预算）
 - Lifecycle: active
-- Catalog note: 双 PR：先测试树模块化，再 runtime/CI 合同收口
+- Catalog note: 双 PR 主体已完成；预算偏差由独立的 runner-only follow-up 收口
 
 ## Coverage / rollout summary
 
@@ -25,6 +25,12 @@
 - PR2 已将不属于 `src/tests/**` / `src/upstream_accounts/tests/**` 的 136 个内联 backend unit tests 并回 `lightweight` profile，避免 profile split 造成 coverage 回归。
 - PR2 已把 owner-facing backend required checks 更新为三个 job，并同步 `.github/quality-gates.json`、contract fixtures、release snapshot 自测与 live quality-gates fixtures。
 - PR2 发现 `CI PR` 仅对 `base=main` 触发，导致 stacked PR 无服务端 checks；现已将 `CI PR` 的 `pull_request` 触发范围放开到所有 PR base，同时保留 `Label Gate` / `Review Policy` 与 live rules 对齐检查只对 `main` 生效。
+- PR #576 已合并为 `main@405dfe7b8d4e44b33c25836528c936a9a6341704` 并发布为 `v2.21.1`；`CI Main` run `29072008929` 的三路 backend job 都通过。
+- 该 CI Main 的 backend job wall time 为：
+  - `lightweight`: `3m19s`
+  - `stateful_sqlite`: `6m45s`
+  - `archive_file_io`: `4m27s`
+- Stateful SQLite 的 `6m45s` 比 `6m30s` 目标高 `15s`。完整本地 profile 在 4、6、8 nextest threads 下都通过；热执行时间分别为 `155.979s`、`102.461s`、`89.940s`。follow-up 固定为 6 threads，避免使用 8 threads 的更高资源放大。
 - 本地 profile wall time（2026-07-09，热缓存）：
   - `lightweight`: 281 tests, `real 3.83s`
   - `stateful_sqlite`: 1040 tests, `real 66.97s`
@@ -36,13 +42,12 @@
 
 ## Remaining Gaps
 
-- 待补充：PR2 修复 stacked PR CI 触发后的新 head review-loop / PR CI 证据。
-- 待补充：merge 后 `CI Main` 对最慢 backend required job `<= 6m30s` 的最终服务端真相。
+- 待补充：6-thread stateful runner follow-up 的 PR/CI Main 证据，确认最慢 backend required job 回到 `<= 6m30s`。
 
 ## Related Changes
 
-- PR1 branch: `th/backend-test-modularization`
-- PR2 branch: `th/backend-test-runtime-profiles`
+- PR #576: `refactor: modularize backend test trees by resource profile`
+- Follow-up branch: `th/ci-stateful-test-budget`
 
 ## References
 


### PR DESCRIPTION
## Summary
- Run the isolated Stateful SQLite backend profile with a conservative six-thread nextest limit.
- Preserve the three required backend profile checks and all test selection semantics.
- Record the measured baseline, concurrency trials, and CI Main verification requirement.

## Runtime Evidence
- Baseline [CI Main run 29072008929](https://github.com/IvanLi-CN/codex-vibe-monitor/actions/runs/29072008929): Lightweight `3m19s`, Stateful SQLite `6m45s`, Archive / File I/O `4m27s`; Stateful exceeded the `6m30s` ceiling by 15 seconds.
- Complete local Stateful SQLite profile (1048 tests): 4 threads `155.979s`, 6 threads `102.461s`, 8 threads `89.940s`; six threads is the selected conservative setting.
- CI Main is the final runtime authority; this PR does not claim the ceiling until that run completes.

## Validation
- `bash .github/scripts/run-backend-tests.sh --profile lightweight`
- `bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite`
- `bash .github/scripts/run-backend-tests.sh --profile archive-file-io`
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo test`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-release-snapshot.sh`
- `bash .github/scripts/test-live-quality-gates.sh`

## References
- Specs: `docs/specs/q7yt7-backend-test-resource-profiles/`
- Solutions: `docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md`
- Project Docs: -