### PR TITLE
docs(spec): record backend test budget evidence

### DIFF
--- a/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
+++ b/docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md
@@ -12,6 +12,7 @@
 - CI 总时长优化要以 `CI Main` 里 3 个 backend required jobs 的最慢 wall time 为主指标：`Backend Tests (Lightweight)`、`Backend Tests (Stateful SQLite)`、`Backend Tests (Archive / File I/O)`。
 - backend runner 应固定用 resource-profile filter 跑 `cargo nextest run --locked --all-features --no-fail-fast -E ...`，不要再把整个后端测试树塞回单个 required check。
 - 当完整 stateful SQLite suite 的隔离性已由多档并发全量验证后，可为该 profile 固定一个保守的 `--test-threads` 上限。当前 1048 个 stateful 用例在 4、6、8 threads 下均通过，6 threads 在保留余量的同时将本地热执行降到约 102s。
+- `CI Main` run `29074132864` 验证了该选择：lightweight、stateful SQLite、archive / file I/O 分别为 `3m10s`、`6m00s`、`4m50s`，最慢 job 比 `6m30s` 预算低 `30s`。
 - 对只验证 DB 行为、不验证主库文件路径的测试，优先使用唯一命名的 in-memory SQLite，保留 `AppConfig.database_path`、archive/raw 目录形状即可。
 - 文件 SQLite fixture 要限制测试连接池大小；默认 pool 在全套并发下会把每个测试放大成多连接竞争。
 - 如果测试只需要“已 materialized archive metadata”或“缺失 replay marker”状态，直接构造窄表状态，不要为了 setup 跑完整 retention/archive pipeline。

--- a/docs/specs/q7yt7-backend-test-resource-profiles/HISTORY.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/HISTORY.md
@@ -14,6 +14,7 @@
 - 2026-07-09：实际打开 stacked PR 后发现 `CI PR` 只对 `base=main` 触发，无法为 PR2 提供服务端 CI 证据；因此放开 `CI PR` 的 `pull_request` base 过滤，同时保留 `Label Gate` / `Review Policy` 与 live rules 对齐检查继续只绑定 `main`。
 - 2026-07-09：修复后的本地热缓存测量显示三个 profile wall time 分别约为 `3.83s`、`66.97s`、`29.14s`，拆分后 critical path 远低于 `6m30s` 预算。
 - 2026-07-10：PR #576 合并后的 CI Main 实测 Stateful SQLite job 为 `6m45s`，比预算高 `15s`；完整 1048 个 stateful 用例在本地 4、6、8 threads 下均通过，采用保守的 6-thread runner 上限收敛预算。
+- 2026-07-10：PR #579 的 CI Main run `29074132864` 实测三路 backend job 为 `3m10s`、`6m00s`、`4m50s`；Stateful SQLite 最慢 job 比 `6m30s` 预算低 `30s`，runtime budget 完成收口。
 
 ## Key Reasons / Replacements
 

--- a/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
@@ -4,9 +4,9 @@
 
 ## Current Status
 
-- Implementation: 运行时预算收口中（测试树、profile-aware runner 与三路 required checks 已随 PR #576 发布为 `v2.21.1`；Stateful SQLite job 仍需压回预算）
+- Implementation: 已完成（测试树、profile-aware runner、三路 required checks 与 Stateful SQLite runtime budget 已完成服务端验证）
 - Lifecycle: active
-- Catalog note: 双 PR 主体已完成；预算偏差由独立的 runner-only follow-up 收口
+- Catalog note: 双 PR 主体与 runner-only runtime follow-up 均已完成
 
 ## Coverage / rollout summary
 
@@ -31,6 +31,11 @@
   - `stateful_sqlite`: `6m45s`
   - `archive_file_io`: `4m27s`
 - Stateful SQLite 的 `6m45s` 比 `6m30s` 目标高 `15s`。完整本地 profile 在 4、6、8 nextest threads 下都通过；热执行时间分别为 `155.979s`、`102.461s`、`89.940s`。follow-up 固定为 6 threads，避免使用 8 threads 的更高资源放大。
+- PR #579 已合并为 `main@8ceeb9bb097ea1f33e4ece9765d82a6b643d5652`。其 CI Main run `29074132864` 验证了 6-thread runner：
+  - `lightweight`: `3m10s`
+  - `stateful_sqlite`: `6m00s`
+  - `archive_file_io`: `4m50s`
+- 最慢的 Stateful SQLite job 为 `6m00s`，比 `6m30s` 预算低 `30s`，完成 runtime budget 收口。
 - 本地 profile wall time（2026-07-09，热缓存）：
   - `lightweight`: 281 tests, `real 3.83s`
   - `stateful_sqlite`: 1040 tests, `real 66.97s`
@@ -42,12 +47,12 @@
 
 ## Remaining Gaps
 
-- 待补充：6-thread stateful runner follow-up 的 PR/CI Main 证据，确认最慢 backend required job 回到 `<= 6m30s`。
+- 本轮范围内无剩余缺口；后续运行时优化应作为独立主题，以新的 CI Main 基线重新评估。
 
 ## Related Changes
 
 - PR #576: `refactor: modularize backend test trees by resource profile`
-- Follow-up branch: `th/ci-stateful-test-budget`
+- PR #579: `perf(ci): bound stateful test concurrency`
 
 ## References
 


### PR DESCRIPTION
## Summary
- Record the CI Main runtime proof for the six-thread Stateful SQLite runner.
- Mark the backend test resource-profile runtime budget as complete.
- Refresh the reusable performance feedback loop with the validated CI wall times.

## Evidence
- [CI Main run 29074132864](https://github.com/IvanLi-CN/codex-vibe-monitor/actions/runs/29074132864): Lightweight `3m10s`, Stateful SQLite `6m00s`, Archive / File I/O `4m50s`.
- The slowest required backend job is 30 seconds below the `6m30s` ceiling.
- [Release v2.21.2](https://github.com/IvanLi-CN/codex-vibe-monitor/releases/tag/v2.21.2) published the runner change.

## Validation
- `git diff --check`
- pre-commit `format-markdown`
- pre-commit `typecheck-web`
- commit-msg `commitlint`

## References
- Specs: `docs/specs/q7yt7-backend-test-resource-profiles/`
- Solutions: `docs/solutions/performance/rust-backend-test-runtime-feedback-loop.md`
- Project Docs: -