### PR TITLE
docs(spec): record web demo delivery

### DIFF
--- a/docs/specs/ykhfu-web-demo/HISTORY.md
+++ b/docs/specs/ykhfu-web-demo/HISTORY.md
@@ -6,6 +6,7 @@
 
 - Demo is a distinct build-time runtime selected by `VITE_APP_RUNTIME`, not a route-level switch.
 - GitHub Pages hosts docs, Storybook and the demo as separate static surfaces in one assembled artifact.
+- 2026-07-10: PR #582 merged the demo runtime and Pages delivery as `main@80a248cc891f74111f9d403c9d915a1f340a72d5`, then published `v2.22.0`.
 
 ## Key Reasons / Replacements
 

--- a/docs/specs/ykhfu-web-demo/IMPLEMENTATION.md
+++ b/docs/specs/ykhfu-web-demo/IMPLEMENTATION.md
@@ -4,9 +4,9 @@
 
 ## Current Status
 
-- Implementation: 已完成，待 PR convergence
+- Implementation: 已完成并发布
 - Lifecycle: active
-- Catalog note: Browser-only demo runtime and Pages delivery are introduced together; live runtime remains backend-bound and does not initialize MSW.
+- Catalog note: Browser-only demo runtime and Pages delivery shipped in `v2.22.0`; live runtime remains backend-bound and does not initialize MSW.
 
 ## Coverage / rollout summary
 
@@ -17,14 +17,17 @@
 - Pages assembly 把 `web/demo-dist/` 放入 `/demo/`。demo API/SSE、MSW worker 和 public branding assets 全部使用 `VITE_DEPLOY_BASE` 的 repo-subpath，避免 Pages worker scope 外溢到站点根 API。
 - `Records Overlay E2E` 在保留原 live Vite regression 的同时运行 demo route matrix、Inspector sharing/SSE 与 simulated external-key write。
 - `SPEC.md` 的 `## Visual Evidence` 保存 Dashboard operational、账号池 attention 与 Records network-failure 的桌面和移动 mock-only 证据，绑定 `8b0aa929b9738fd0d535784e4b89c75ce54e28ae`。
+- PR #582 已合并为 `main@80a248cc891f74111f9d403c9d915a1f340a72d5`，并发布为 `v2.22.0`。
 
 ## Remaining Gaps
 
-- PR 和远端 convergence 尚未开始。
+- None
 
 ## Related Changes
 
-- Local verification: `bun run lint`, `bun run test`, `bun run test-storybook`, `bun run demo:build`, `bun run storybook:build`, Pages assembly smoke, route matrix E2E and Records Overlay E2E.
+- PR #582: `feat(web): add mock-only product demo`
+- Release: `v2.22.0`
+- Verification: `bun run lint`, `bun run test`, `bun run test-storybook`, `bun run demo:build`, `bun run storybook:build`, Pages assembly smoke, route matrix E2E and Records Overlay E2E.
 
 ## References
 

--- a/docs/specs/ykhfu-web-demo/SPEC.md
+++ b/docs/specs/ykhfu-web-demo/SPEC.md
@@ -130,7 +130,7 @@
 
 ## Related PRs
 
-- None
+- [#582 feat(web): add mock-only product demo](https://github.com/IvanLi-CN/codex-vibe-monitor/pull/582)
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 


### PR DESCRIPTION
## Summary
- Mark the mock-only Web Demo implementation as merged and published.
- Link PR #582 and release v2.22.0 from the canonical topic spec.
- Remove the stale remote-convergence gap without changing the demo contract or visual evidence.

## Test Plan
- `git diff --check`
- `dprint check` for the three spec documents
- `spec_drift_check.sh --base-ref origin/main --spec-path docs/specs/ykhfu-web-demo/SPEC.md`
- pre-commit `format-markdown` and `typecheck-web`

## References
Spec: `docs/specs/ykhfu-web-demo/SPEC.md`
Spec Disposition: link
Solutions: `docs/solutions/workflow/mock-only-web-demo-runtime.md`
Project Docs: -

Spec Sync: done
Spec Drift: none
Solutions Sync: n/a(no solution change)
Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->