### PR TITLE
feat(dashboard): surface manual bindings on working conversations

### DIFF
--- a/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/detail_queries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/detail_queries.rs
@@ -379,6 +379,47 @@ pub(crate) async fn query_prompt_cache_conversation_upstream_account_summaries(
         .map_err(Into::into)
 }
 
+pub(crate) async fn query_prompt_cache_conversation_manual_binding_summaries(
+    pool: &Pool<Sqlite>,
+    selected_keys: &[String],
+) -> Result<Vec<PromptCacheConversationManualBindingSummaryRow>> {
+    if selected_keys.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT binding.prompt_cache_key, \
+             binding.binding_kind, \
+             binding.group_name, \
+             binding.upstream_account_id, \
+             account.display_name AS upstream_account_name \
+         FROM prompt_cache_conversation_bindings AS binding \
+         LEFT JOIN pool_upstream_accounts AS account \
+           ON account.id = binding.upstream_account_id \
+         WHERE binding.prompt_cache_key IN (",
+    );
+
+    {
+        let mut separated = query.separated(", ");
+        for key in selected_keys {
+            separated.push_bind(key);
+        }
+    }
+
+    query
+        .push(") AND binding.binding_kind IN (")
+        .push_bind(PROMPT_CACHE_BINDING_KIND_GROUP)
+        .push(", ")
+        .push_bind(PROMPT_CACHE_BINDING_KIND_UPSTREAM_ACCOUNT)
+        .push(") ORDER BY binding.prompt_cache_key ASC");
+
+    query
+        .build_query_as::<PromptCacheConversationManualBindingSummaryRow>()
+        .fetch_all(pool)
+        .await
+        .map_err(Into::into)
+}
+
 pub(crate) async fn query_prompt_cache_conversation_encrypted_owner_summaries(
     pool: &Pool<Sqlite>,
     selected_keys: &[String],

--- a/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/hydration.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/hydration.rs
@@ -169,6 +169,9 @@ pub(crate) async fn hydrate_prompt_cache_conversations(
     } else {
         Vec::new()
     };
+    let manual_binding_rows =
+        query_prompt_cache_conversation_manual_binding_summaries(&state.pool, &selected_keys)
+            .await?;
 
     let mut grouped_events: HashMap<String, Vec<PromptCacheConversationRequestPointResponse>> =
         HashMap::new();
@@ -339,6 +342,15 @@ pub(crate) async fn hydrate_prompt_cache_conversations(
         .into_iter()
         .map(|row| (row.prompt_cache_key.clone(), row))
         .collect();
+    let mut manual_binding_by_key: HashMap<String, PromptCacheConversationManualBindingResponse> =
+        manual_binding_rows
+            .into_iter()
+            .filter_map(prompt_cache_manual_binding_response_from_row)
+            .map(|binding| {
+                let prompt_cache_key = binding.prompt_cache_key.clone();
+                (prompt_cache_key, binding.response)
+            })
+            .collect();
 
     let conversations = aggregates
         .into_iter()
@@ -364,6 +376,7 @@ pub(crate) async fn hydrate_prompt_cache_conversations(
                 encrypted_owner_group_name: owner
                     .as_ref()
                     .and_then(|value| value.owner_group_name.clone()),
+                manual_binding: manual_binding_by_key.remove(&row.prompt_cache_key),
                 upstream_accounts: grouped_upstream_accounts
                     .remove(&row.prompt_cache_key)
                     .unwrap_or_default(),
@@ -411,6 +424,53 @@ pub(crate) async fn hydrate_prompt_cache_conversations(
     }
 
     Ok(conversations)
+}
+
+struct PromptCacheManualBindingResponseByKey {
+    prompt_cache_key: String,
+    response: PromptCacheConversationManualBindingResponse,
+}
+
+fn prompt_cache_manual_binding_response_from_row(
+    row: PromptCacheConversationManualBindingSummaryRow,
+) -> Option<PromptCacheManualBindingResponseByKey> {
+    let prompt_cache_key = row.prompt_cache_key.trim().to_string();
+    if prompt_cache_key.is_empty() {
+        return None;
+    }
+
+    match row.binding_kind.as_str() {
+        PROMPT_CACHE_BINDING_KIND_GROUP => {
+            let group_name = normalize_trimmed_optional_string(row.group_name)?;
+            Some(PromptCacheManualBindingResponseByKey {
+                prompt_cache_key,
+                response: PromptCacheConversationManualBindingResponse {
+                    binding_kind: "group".to_string(),
+                    group_name: Some(group_name),
+                    upstream_account_id: None,
+                    upstream_account_name: None,
+                },
+            })
+        }
+        PROMPT_CACHE_BINDING_KIND_UPSTREAM_ACCOUNT => {
+            let upstream_account_name =
+                normalize_trimmed_optional_string(row.upstream_account_name.clone());
+            let upstream_account_id = row.upstream_account_id;
+            if upstream_account_name.is_none() && upstream_account_id.is_none() {
+                return None;
+            }
+            Some(PromptCacheManualBindingResponseByKey {
+                prompt_cache_key,
+                response: PromptCacheConversationManualBindingResponse {
+                    binding_kind: "upstreamAccount".to_string(),
+                    group_name: None,
+                    upstream_account_id,
+                    upstream_account_name,
+                },
+            })
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn overlay_runtime_prompt_cache_invocation_previews(

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -736,9 +736,20 @@ pub(crate) struct PromptCacheConversationResponse {
     pub(crate) encrypted_owner_account_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) encrypted_owner_group_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) manual_binding: Option<PromptCacheConversationManualBindingResponse>,
     pub(crate) upstream_accounts: Vec<PromptCacheConversationUpstreamAccountResponse>,
     pub(crate) recent_invocations: Vec<PromptCacheConversationInvocationPreviewResponse>,
     pub(crate) last24h_requests: Vec<PromptCacheConversationRequestPointResponse>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PromptCacheConversationManualBindingResponse {
+    pub(crate) binding_kind: String,
+    pub(crate) group_name: Option<String>,
+    pub(crate) upstream_account_id: Option<i64>,
+    pub(crate) upstream_account_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1383,6 +1394,15 @@ pub(crate) struct PromptCacheConversationEncryptedOwnerSummaryRow {
     pub(crate) owner_upstream_account_id: i64,
     pub(crate) owner_upstream_account_name: Option<String>,
     pub(crate) owner_group_name: Option<String>,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub(crate) struct PromptCacheConversationManualBindingSummaryRow {
+    pub(crate) prompt_cache_key: String,
+    pub(crate) binding_kind: String,
+    pub(crate) group_name: Option<String>,
+    pub(crate) upstream_account_id: Option<i64>,
+    pub(crate) upstream_account_name: Option<String>,
 }
 
 #[derive(Debug, FromRow)]

--- a/src/tests/stateful_sqlite/prompt_cache_conversation_queries.rs
+++ b/src/tests/stateful_sqlite/prompt_cache_conversation_queries.rs
@@ -714,6 +714,207 @@ async fn prompt_cache_conversations_include_recent_invocation_previews_with_limi
 }
 
 #[tokio::test]
+async fn prompt_cache_conversations_include_manual_binding_summaries() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let now = Utc::now();
+
+    async fn insert_row(
+        pool: &Pool<Sqlite>,
+        invoke_id: &str,
+        occurred_at: DateTime<Utc>,
+        key: &str,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response, created_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            "#,
+        )
+        .bind(invoke_id)
+        .bind(format_naive(
+            occurred_at.with_timezone(&Shanghai).naive_local(),
+        ))
+        .bind(SOURCE_PROXY)
+        .bind("success")
+        .bind(24_i64)
+        .bind(0.24_f64)
+        .bind(json!({ "promptCacheKey": key }).to_string())
+        .bind("{}")
+        .bind(format_utc_iso_millis(occurred_at))
+        .execute(pool)
+        .await
+        .expect("insert invocation row");
+    }
+
+    for (offset_minutes, key) in [
+        (4_i64, "pck-binding-group"),
+        (3_i64, "pck-binding-account"),
+        (2_i64, "pck-binding-none"),
+        (1_i64, "pck-binding-empty-group"),
+    ] {
+        insert_row(
+            &state.pool,
+            &format!("invoke-{key}"),
+            now - ChronoDuration::minutes(offset_minutes),
+            key,
+        )
+        .await;
+    }
+
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_accounts (
+            id, kind, provider, display_name, group_name, status, enabled, plan_type, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
+        "#,
+    )
+    .bind(512_i64)
+    .bind("oauth_codex")
+    .bind("codex")
+    .bind("Codex Pro - Tokyo")
+    .bind("Tokyo")
+    .bind("active")
+    .bind(1_i64)
+    .bind("team")
+    .bind(format_utc_iso(now))
+    .execute(&state.pool)
+    .await
+    .expect("insert bound upstream account");
+
+    sqlx::query(
+        r#"
+        INSERT INTO prompt_cache_conversation_bindings (
+            prompt_cache_key,
+            binding_kind,
+            group_name,
+            upstream_account_id,
+            created_at,
+            updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))
+        "#,
+    )
+    .bind("pck-binding-group")
+    .bind(PROMPT_CACHE_BINDING_KIND_GROUP)
+    .bind("CIII")
+    .bind(None::<i64>)
+    .execute(&state.pool)
+    .await
+    .expect("insert group manual binding");
+
+    sqlx::query(
+        r#"
+        INSERT INTO prompt_cache_conversation_bindings (
+            prompt_cache_key,
+            binding_kind,
+            group_name,
+            upstream_account_id,
+            created_at,
+            updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))
+        "#,
+    )
+    .bind("pck-binding-account")
+    .bind(PROMPT_CACHE_BINDING_KIND_UPSTREAM_ACCOUNT)
+    .bind(None::<String>)
+    .bind(Some(512_i64))
+    .execute(&state.pool)
+    .await
+    .expect("insert account manual binding");
+
+    sqlx::query(
+        r#"
+        INSERT INTO prompt_cache_conversation_bindings (
+            prompt_cache_key,
+            binding_kind,
+            group_name,
+            upstream_account_id,
+            created_at,
+            updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))
+        "#,
+    )
+    .bind("pck-binding-empty-group")
+    .bind(PROMPT_CACHE_BINDING_KIND_GROUP)
+    .bind("   ")
+    .bind(None::<i64>)
+    .execute(&state.pool)
+    .await
+    .expect("insert empty group manual binding");
+
+    materialize_prompt_cache_hourly_rollups(&state.pool).await;
+
+    let Json(response) = fetch_prompt_cache_conversations(
+        State(state.clone()),
+        Query(PromptCacheConversationsQuery {
+            limit: Some(20),
+            activity_hours: None,
+            activity_minutes: None,
+            page_size: None,
+            cursor: None,
+            snapshot_at: None,
+            detail: None,
+            recent_invocation_limit: None,
+        }),
+    )
+    .await
+    .expect("prompt cache conversation stats should succeed");
+
+    let group_conversation = response
+        .conversations
+        .iter()
+        .find(|item| item.prompt_cache_key == "pck-binding-group")
+        .expect("group conversation should be included");
+    let group_binding = group_conversation
+        .manual_binding
+        .as_ref()
+        .expect("group manual binding should be present");
+    assert_eq!(group_binding.binding_kind, "group");
+    assert_eq!(group_binding.group_name.as_deref(), Some("CIII"));
+    assert_eq!(group_binding.upstream_account_id, None);
+    assert_eq!(group_binding.upstream_account_name, None);
+
+    let account_conversation = response
+        .conversations
+        .iter()
+        .find(|item| item.prompt_cache_key == "pck-binding-account")
+        .expect("account conversation should be included");
+    let account_binding = account_conversation
+        .manual_binding
+        .as_ref()
+        .expect("account manual binding should be present");
+    assert_eq!(account_binding.binding_kind, "upstreamAccount");
+    assert_eq!(account_binding.group_name, None);
+    assert_eq!(account_binding.upstream_account_id, Some(512));
+    assert_eq!(
+        account_binding.upstream_account_name.as_deref(),
+        Some("Codex Pro - Tokyo")
+    );
+
+    let none_conversation = response
+        .conversations
+        .iter()
+        .find(|item| item.prompt_cache_key == "pck-binding-none")
+        .expect("unbound conversation should be included");
+    assert!(none_conversation.manual_binding.is_none());
+
+    let empty_group_conversation = response
+        .conversations
+        .iter()
+        .find(|item| item.prompt_cache_key == "pck-binding-empty-group")
+        .expect("empty-group conversation should be included");
+    assert!(empty_group_conversation.manual_binding.is_none());
+}
+
+#[tokio::test]
 async fn prompt_cache_recent_invocations_keep_per_key_limits_for_snapshot_and_proxy_scope() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.stories.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   type ReactNode,
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
@@ -208,6 +209,7 @@ function createConversation(
     lastTerminalAt: overrides.lastTerminalAt ?? lastTerminalPreview?.occurredAt ?? null,
     lastInFlightAt: overrides.lastInFlightAt ?? lastInFlightPreview?.occurredAt ?? null,
     cursor: overrides.cursor ?? promptCacheKey,
+    manualBinding: overrides.manualBinding ?? null,
     upstreamAccounts: overrides.upstreamAccounts ?? [],
     recentInvocations,
     last24hRequests: overrides.last24hRequests ?? [],
@@ -2039,12 +2041,14 @@ function DrawerPreviewStory({
   const [selectedConversation, setSelectedConversation] = useState<{
     conversationSequenceId: string;
     promptCacheKey: string;
+    tab: "overview" | "calls" | "settings";
   } | null>(() => {
     const initialCard = cards.find((card) => card.promptCacheKey === initialConversationKey);
     return initialCard
       ? {
           conversationSequenceId: initialCard.conversationSequenceId,
           promptCacheKey: initialCard.promptCacheKey,
+          tab: initialConversationTab,
         }
       : null;
   });
@@ -2055,47 +2059,47 @@ function DrawerPreviewStory({
   } | null>(null);
   const promptCacheBindingStateRef = useRef<Map<string, Record<string, unknown>>>(new Map());
 
-  const buildPromptCacheBindingResponse = (
-    promptCacheKey: string,
-    overrides: Record<string, unknown> = {},
-  ) => ({
-    promptCacheKey,
-    bindingKind: "none",
-    groupName: null,
-    upstreamAccountId: null,
-    upstreamAccountName: null,
-    hasEncryptedSessionOwner: true,
-    encryptedOwnerAccountId: 21,
-    encryptedOwnerAccountName: "growth.6vv4@relay.example",
-    encryptedOwnerGroupName: "CIII",
-    timeouts: {
-      responsesFirstByteTimeoutSecs: 120,
-      compactFirstByteTimeoutSecs: 300,
-      responsesStreamTimeoutSecs: 300,
-      compactStreamTimeoutSecs: 300,
-    },
-    timeoutFieldSources: {
-      responsesFirstByteTimeoutSecs: "account",
-      compactFirstByteTimeoutSecs: "group",
-      responsesStreamTimeoutSecs: "account",
-      compactStreamTimeoutSecs: "root",
-    },
-    allowSwitchUpstream: false,
-    fastModeRewriteMode: "inherit",
-    imageToolRewriteMode: "inherit",
-    availableModels: ["gpt-5.5", "gpt-5.5-mini"],
-    forwardProxyKey: null,
-    forwardProxyKeys: [],
-    policyFieldSources: {
-      allowSwitchUpstream: "conversation",
-      fastModeRewriteMode: "account",
-      imageToolRewriteMode: "group",
-      availableModels: "conversation",
-      forwardProxyKey: "account",
-    },
-    updatedAt: "2026-05-12T16:15:57Z",
-    ...overrides,
-  });
+  const buildPromptCacheBindingResponse = useCallback(
+    (promptCacheKey: string, overrides: Record<string, unknown> = {}) => ({
+      promptCacheKey,
+      bindingKind: "none",
+      groupName: null,
+      upstreamAccountId: null,
+      upstreamAccountName: null,
+      hasEncryptedSessionOwner: true,
+      encryptedOwnerAccountId: 21,
+      encryptedOwnerAccountName: "growth.6vv4@relay.example",
+      encryptedOwnerGroupName: "CIII",
+      timeouts: {
+        responsesFirstByteTimeoutSecs: 120,
+        compactFirstByteTimeoutSecs: 300,
+        responsesStreamTimeoutSecs: 300,
+        compactStreamTimeoutSecs: 300,
+      },
+      timeoutFieldSources: {
+        responsesFirstByteTimeoutSecs: "account",
+        compactFirstByteTimeoutSecs: "group",
+        responsesStreamTimeoutSecs: "account",
+        compactStreamTimeoutSecs: "root",
+      },
+      allowSwitchUpstream: false,
+      fastModeRewriteMode: "inherit",
+      imageToolRewriteMode: "inherit",
+      availableModels: ["gpt-5.5", "gpt-5.5-mini"],
+      forwardProxyKey: null,
+      forwardProxyKeys: [],
+      policyFieldSources: {
+        allowSwitchUpstream: "conversation",
+        fastModeRewriteMode: "account",
+        imageToolRewriteMode: "group",
+        availableModels: "conversation",
+        forwardProxyKey: "account",
+      },
+      updatedAt: "2026-05-12T16:15:57Z",
+      ...overrides,
+    }),
+    [],
+  );
 
   useEffect(() => {
     setSelectedInvocation(resolveInitialSelection(cards, initialSelection));
@@ -2105,11 +2109,12 @@ function DrawerPreviewStory({
         ? {
             conversationSequenceId: initialCard.conversationSequenceId,
             promptCacheKey: initialCard.promptCacheKey,
+            tab: initialConversationTab,
           }
         : null,
     );
     setSelectedAccount(null);
-  }, [cards, initialConversationKey, initialSelection]);
+  }, [cards, initialConversationKey, initialConversationTab, initialSelection]);
 
   const promptCacheConversationPage = selectedConversation ? (
     <div className="min-h-screen bg-base-200 p-3 text-base-content min-[769px]:p-6">
@@ -2121,7 +2126,7 @@ function DrawerPreviewStory({
           conversationLabel={formatDashboardWorkingConversationSequenceId(
             selectedConversation.conversationSequenceId,
           )}
-          initialTab={initialConversationTab}
+          initialTab={selectedConversation.tab}
           onClose={() => setSelectedConversation(null)}
           t={t}
           onOpenUpstreamAccount={(
@@ -2428,7 +2433,7 @@ function DrawerPreviewStory({
         window.fetch = originalFetchRef.current;
       }
     };
-  }, [storyMocks, upstreamAccountActivity, buildPromptCacheBindingResponse]);
+  }, [buildPromptCacheBindingResponse, storyMocks, upstreamAccountActivity]);
 
   return (
     <>
@@ -2463,7 +2468,11 @@ function DrawerPreviewStory({
           onOpenConversation={(selection) => {
             setSelectedInvocation(null);
             setSelectedAccount(null);
-            setSelectedConversation(selection);
+            setSelectedConversation({
+              conversationSequenceId: selection.conversationSequenceId,
+              promptCacheKey: selection.promptCacheKey,
+              tab: selection.tab ?? "overview",
+            });
           }}
           onOpenInvocation={(selection) => {
             setSelectedConversation(null);
@@ -2502,7 +2511,7 @@ function DrawerPreviewStory({
                 )
               : null
           }
-          initialTab={initialConversationTab}
+          initialTab={selectedConversation?.tab ?? initialConversationTab}
           onClose={() => setSelectedConversation(null)}
           t={t}
           onOpenUpstreamAccount={(
@@ -2618,6 +2627,111 @@ export const CurrentOnlyPlaceholder: Story = {
     cards: buildCards(currentOnlyResponse),
     isLoading: false,
     error: null,
+  },
+};
+
+export const ManualBindingBadges: Story = {
+  args: {
+    activeRange: "today",
+    cards: [],
+    isLoading: false,
+    error: null,
+  },
+  render: () => (
+    <DrawerPreviewStory
+      response={createResponse([
+        createConversation(
+          "pck-story-manual-binding-group",
+          [
+            createPreview({
+              id: 8101,
+              invokeId: "story-manual-binding-group",
+              occurredAt: createRelativeStoryIso(-5_000),
+              status: "running",
+              upstreamAccountId: 42,
+              upstreamAccountName: "pool-alpha@example.com",
+            }),
+            createPreview({
+              id: 8100,
+              invokeId: "story-manual-binding-group-prev",
+              occurredAt: createRelativeStoryIso(-(2 * 60_000 + 5_000)),
+              status: "completed",
+            }),
+          ],
+          {
+            manualBinding: {
+              bindingKind: "group",
+              groupName: "CIII",
+              upstreamAccountId: null,
+              upstreamAccountName: null,
+            },
+          },
+        ),
+        createConversation(
+          "pck-story-manual-binding-account",
+          [
+            createPreview({
+              id: 8201,
+              invokeId: "story-manual-binding-account",
+              occurredAt: createRelativeStoryIso(-35_000),
+              status: "completed",
+              upstreamAccountId: 108,
+              upstreamAccountName: "Codex Pro - Tokyo",
+            }),
+          ],
+          {
+            manualBinding: {
+              bindingKind: "upstreamAccount",
+              groupName: null,
+              upstreamAccountId: 108,
+              upstreamAccountName: "Codex Pro - Tokyo",
+            },
+          },
+        ),
+        createConversation(
+          "pck-story-manual-binding-long-account",
+          [
+            createPreview({
+              id: 8301,
+              invokeId: "story-manual-binding-long-account",
+              occurredAt: createRelativeStoryIso(-65_000),
+              status: "completed",
+              upstreamAccountId: 219,
+            }),
+          ],
+          {
+            manualBinding: {
+              bindingKind: "upstreamAccount",
+              groupName: null,
+              upstreamAccountId: 219,
+              upstreamAccountName:
+                "paisleeeinar5710 Team sandbox workflow monitor with an intentionally long account label",
+            },
+          },
+        ),
+      ])}
+      theme="vibe-dark"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const badgeButtons = canvas.getAllByTestId(
+      "dashboard-working-conversation-manual-binding-badge",
+    );
+    await expect(badgeButtons[0]).toHaveTextContent("CIII");
+    await expect(badgeButtons[1]).toHaveTextContent("Codex Pro - Tokyo");
+    await expect(badgeButtons[2]).toHaveAttribute(
+      "title",
+      expect.stringContaining(
+        "paisleeeinar5710 Team sandbox workflow monitor with an intentionally long account label",
+      ),
+    );
+
+    await userEvent.click(badgeButtons[0]);
+
+    await expect(
+      within(document.body).getByRole("tab", { name: /设置|settings/i }),
+    ).toHaveAttribute("aria-selected", "true");
   },
 };
 

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.test.tsx
@@ -176,18 +176,29 @@ function createPreview(
 function createConversation(
   promptCacheKey: string,
   recentInvocations: PromptCacheConversationInvocationPreview[],
+  overrides: Partial<PromptCacheConversation> = {},
 ): PromptCacheConversation {
   return {
     promptCacheKey,
-    requestCount: recentInvocations.length,
-    totalTokens: 200,
-    totalCost: 0.02,
+    requestCount: overrides.requestCount ?? recentInvocations.length,
+    totalTokens: overrides.totalTokens ?? 200,
+    totalCost: overrides.totalCost ?? 0.02,
     createdAt:
-      recentInvocations[recentInvocations.length - 1]?.occurredAt ?? "2026-04-04T10:00:00Z",
-    lastActivityAt: recentInvocations[0]?.occurredAt ?? "2026-04-04T10:00:00Z",
-    upstreamAccounts: [],
+      overrides.createdAt ??
+      recentInvocations[recentInvocations.length - 1]?.occurredAt ??
+      "2026-04-04T10:00:00Z",
+    lastActivityAt:
+      overrides.lastActivityAt ?? recentInvocations[0]?.occurredAt ?? "2026-04-04T10:00:00Z",
+    lastTerminalAt: overrides.lastTerminalAt ?? null,
+    lastInFlightAt: overrides.lastInFlightAt ?? null,
+    hasEncryptedSessionOwner: overrides.hasEncryptedSessionOwner ?? false,
+    encryptedOwnerAccountId: overrides.encryptedOwnerAccountId ?? null,
+    encryptedOwnerAccountName: overrides.encryptedOwnerAccountName ?? null,
+    encryptedOwnerGroupName: overrides.encryptedOwnerGroupName ?? null,
+    manualBinding: overrides.manualBinding ?? null,
+    upstreamAccounts: overrides.upstreamAccounts ?? [],
     recentInvocations,
-    last24hRequests: [],
+    last24hRequests: overrides.last24hRequests ?? [],
   };
 }
 
@@ -456,6 +467,7 @@ function renderSection(
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
+      tab?: "overview" | "calls" | "settings";
     }) => void;
     onOpenInvocation?: (selection: {
       slotKind: "current" | "previous";
@@ -486,6 +498,7 @@ function renderSectionWithCards(
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
+      tab?: "overview" | "calls" | "settings";
     }) => void;
     onOpenInvocation?: (selection: {
       slotKind: "current" | "previous";
@@ -567,6 +580,7 @@ function rerenderSection(
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
+      tab?: "overview" | "calls" | "settings";
     }) => void;
     onOpenInvocation?: (selection: {
       slotKind: "current" | "previous";
@@ -598,6 +612,7 @@ function rerenderSectionWithCards(
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
+      tab?: "overview" | "calls" | "settings";
     }) => void;
     onOpenInvocation?: (selection: {
       slotKind: "current" | "previous";
@@ -2769,7 +2784,7 @@ describe("DashboardWorkingConversationsSection", () => {
     expect(onOpenInvocation).not.toHaveBeenCalled();
   });
 
-  it("renders interrupted slots with the dedicated interrupted label", () => {
+  it("renders interrupted slots with the dedicated interrupted status icon semantics", () => {
     renderSection(
       createResponse([
         createConversation("pck-interrupted", [
@@ -2793,9 +2808,21 @@ describe("DashboardWorkingConversationsSection", () => {
       ]),
     );
 
-    const text = host?.textContent ?? "";
-    expect(text).toContain("已中断");
-    expect(text).not.toContain("失败");
+    const card = host?.querySelector('[data-testid="dashboard-working-conversation-card"]');
+    if (!(card instanceof HTMLElement)) {
+      throw new Error("missing interrupted conversation card");
+    }
+
+    const headerStatusIcon = card.querySelector(
+      '[data-testid="dashboard-inline-invocation-status"]',
+    );
+    if (!(headerStatusIcon instanceof HTMLElement)) {
+      throw new Error("missing interrupted header status icon");
+    }
+
+    expect(headerStatusIcon.getAttribute("aria-label")).toContain("已中断");
+    expect(headerStatusIcon.getAttribute("aria-label")).not.toContain("失败");
+    expect(card.textContent ?? "").not.toContain("已中断");
   });
 
   it("keeps upstream account buttons interactive so the shared drawer can open", () => {
@@ -3421,6 +3448,218 @@ describe("DashboardWorkingConversationsSection", () => {
 
     expect(onOpenInvocation).toHaveBeenCalledTimes(1);
     expect(onOpenConversation).not.toHaveBeenCalled();
+  });
+
+  it("renders a manual binding badge beside the sequence id and opens settings directly", () => {
+    const onOpenInvocation = vi.fn();
+    const onOpenConversation = vi.fn();
+    const response = createResponse([
+      createConversation(
+        "pck-manual-binding-open",
+        [
+          createPreview({
+            id: 2,
+            invokeId: "invoke-manual-binding-current",
+            occurredAt: "2026-04-04T10:04:00Z",
+            status: "running",
+          }),
+          createPreview({
+            id: 1,
+            invokeId: "invoke-manual-binding-previous",
+            occurredAt: "2026-04-04T10:02:00Z",
+            status: "completed",
+          }),
+        ],
+        {
+          manualBinding: {
+            bindingKind: "group",
+            groupName: "CIII",
+            upstreamAccountId: null,
+            upstreamAccountName: null,
+          },
+        },
+      ),
+    ]);
+
+    const cards = renderSection(response, {
+      onOpenConversation,
+      onOpenInvocation,
+    });
+
+    const badgeButton = host?.querySelector(
+      '[data-testid="dashboard-working-conversation-manual-binding-badge"]',
+    );
+    if (!(badgeButton instanceof HTMLButtonElement)) {
+      throw new Error("missing manual binding badge");
+    }
+
+    expect(badgeButton.textContent).toContain("CIII");
+    expect(badgeButton.getAttribute("aria-label")).toContain("打开对话设置");
+    expect(badgeButton.getAttribute("aria-label")).toContain("当前：分组 CIII");
+    expect(badgeButton.className).toContain("max-w-[20rem]");
+
+    act(() => {
+      badgeButton.click();
+    });
+
+    expect(onOpenConversation).toHaveBeenCalledWith({
+      conversationSequenceId: cards[0]?.conversationSequenceId,
+      promptCacheKey: "pck-manual-binding-open",
+      tab: "settings",
+    });
+    expect(onOpenConversation).toHaveBeenCalledTimes(1);
+    expect(onOpenInvocation).not.toHaveBeenCalled();
+  });
+
+  it("uses distinct manual binding badge tones and keeps account badges capped at 20rem", () => {
+    renderSection(
+      createResponse([
+        createConversation(
+          "pck-manual-binding-group-tone",
+          [
+            createPreview({
+              id: 2,
+              invokeId: "invoke-manual-binding-group-tone",
+              occurredAt: "2026-04-04T10:04:00Z",
+              status: "completed",
+            }),
+          ],
+          {
+            manualBinding: {
+              bindingKind: "group",
+              groupName: "CIII",
+              upstreamAccountId: null,
+              upstreamAccountName: null,
+            },
+          },
+        ),
+        createConversation(
+          "pck-manual-binding-account-tone",
+          [
+            createPreview({
+              id: 3,
+              invokeId: "invoke-manual-binding-account-tone",
+              occurredAt: "2026-04-04T10:05:00Z",
+              status: "completed",
+            }),
+          ],
+          {
+            manualBinding: {
+              bindingKind: "upstreamAccount",
+              groupName: null,
+              upstreamAccountId: 108,
+              upstreamAccountName:
+                "paisleeeinar5710 Team sandbox workflow monitor with an intentionally long account label",
+            },
+          },
+        ),
+      ]),
+    );
+
+    const badges = host?.querySelectorAll(
+      '[data-testid="dashboard-working-conversation-manual-binding-badge"]',
+    );
+    const badgeArray = Array.from(badges ?? []);
+    const groupBadge = badgeArray.find((badge) => badge.textContent?.includes("CIII"));
+    const accountBadge = badgeArray.find((badge) =>
+      badge.textContent?.includes("paisleeeinar5710"),
+    );
+
+    expect(groupBadge).toBeInstanceOf(HTMLSpanElement);
+    expect(accountBadge).toBeInstanceOf(HTMLSpanElement);
+    expect(groupBadge?.className).toContain("text-info");
+    expect(accountBadge?.className).toContain("text-secondary");
+    expect(groupBadge?.className).toContain("text-[10.5px]");
+    expect(accountBadge?.className).toContain("text-[10.5px]");
+
+    const groupBadgeText = groupBadge?.firstElementChild;
+    const accountBadgeText = accountBadge?.firstElementChild;
+
+    expect(groupBadgeText?.className).toContain("max-w-[20rem]");
+    expect(accountBadgeText?.className).toContain("max-w-[20rem]");
+    expect(accountBadgeText?.textContent).toContain("paisleeeinar5710");
+  });
+
+  it("keeps the full sequence id visible and only truncates the binding target", () => {
+    const cards = mapPromptCacheConversationsToDashboardCards(
+      createResponse([
+        createConversation(
+          "pck-manual-binding-long-sequence",
+          [
+            createPreview({
+              id: 5,
+              invokeId: "invoke-manual-binding-long-sequence",
+              occurredAt: "2026-04-04T10:05:00Z",
+              status: "completed",
+            }),
+          ],
+          {
+            manualBinding: {
+              bindingKind: "upstreamAccount",
+              groupName: null,
+              upstreamAccountId: 219,
+              upstreamAccountName:
+                "paisleeeinar5710 Team sandbox workflow monitor with an intentionally long account label",
+            },
+          },
+        ),
+      ]),
+    ).map((card) => ({
+      ...card,
+      conversationSequenceId: "WC-COLLIDE-ABC123",
+    }));
+
+    renderSectionWithCards(cards, { onOpenConversation: vi.fn() });
+
+    const sequenceButton = host?.querySelector(
+      '[data-testid="dashboard-working-conversation-sequence-button"]',
+    );
+    const badge = host?.querySelector(
+      '[data-testid="dashboard-working-conversation-manual-binding-badge"]',
+    );
+    const badgeText = badge?.firstElementChild?.firstElementChild;
+
+    expect(sequenceButton).toBeInstanceOf(HTMLButtonElement);
+    expect(sequenceButton?.textContent).toBe("COLLIDE-ABC123");
+    expect(sequenceButton?.className).toContain("shrink-0");
+    expect(sequenceButton?.className).toContain("whitespace-nowrap");
+    expect(sequenceButton?.className).not.toContain("min-w-0");
+    expect(sequenceButton?.querySelector("span")?.className).not.toContain("truncate");
+
+    expect(badge).toBeInstanceOf(HTMLButtonElement);
+    expect(badge?.className).toContain("max-w-[20rem]");
+    expect(badgeText?.className).toContain("truncate");
+    expect(badgeText?.className).toContain("max-w-[20rem]");
+  });
+
+  it("renders the card header status as the same icon-only affordance used by invocation records", () => {
+    renderSection(
+      createResponse([
+        createConversation("pck-card-header-status-icon", [
+          createPreview({
+            id: 91,
+            invokeId: "invoke-card-header-status-icon",
+            occurredAt: "2026-04-04T10:05:00Z",
+            status: "success",
+          }),
+        ]),
+      ]),
+    );
+
+    const card = host?.querySelector('[data-testid="dashboard-working-conversation-card"]');
+    if (!(card instanceof HTMLElement)) {
+      throw new Error("missing working conversation card");
+    }
+
+    const headerStatusIcon = card.querySelector(
+      '[data-testid="dashboard-inline-invocation-status"]',
+    );
+    if (!(headerStatusIcon instanceof HTMLElement)) {
+      throw new Error("missing card header status icon");
+    }
+
+    expect(headerStatusIcon.getAttribute("aria-label")).toContain("成功");
+    expect(card.textContent).not.toContain("成功");
   });
 
   it("uses theme-aware surface classes instead of a hardcoded dark canvas surface", () => {

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.tsx
@@ -125,6 +125,7 @@ interface DashboardWorkingConversationsSectionProps {
 export interface DashboardWorkingConversationSelection {
   conversationSequenceId: string;
   promptCacheKey: string;
+  tab?: "overview" | "calls" | "settings";
 }
 
 const ACCOUNT_CARD_CLASS_NAME =
@@ -151,6 +152,46 @@ const DASHBOARD_ACCOUNT_RECENT_SKELETON_IDS = [
 ];
 const UPSTREAM_ACCOUNT_REFRESH_CHIP_SHOW_DELAY_MS = 300;
 const UPSTREAM_ACCOUNT_REFRESH_CHIP_MIN_VISIBLE_MS = 600;
+const MANUAL_BINDING_BADGE_CLASS_NAME =
+  "inline-flex min-w-0 max-w-full items-center rounded-full border px-2 py-0.5 text-[10.5px] font-medium leading-4";
+const MANUAL_BINDING_BADGE_BUTTON_CLASS_NAME =
+  "inline-flex min-w-0 max-w-[20rem] shrink appearance-none rounded-full border-0 bg-transparent p-0 text-left transition-opacity duration-200 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
+const MANUAL_BINDING_BADGE_TEXT_CLASS_NAME =
+  "block min-w-0 max-w-[20rem] truncate whitespace-nowrap";
+
+type DashboardManualBindingBadgeMeta = {
+  displayValue: string;
+  accessibleLabel: string;
+  toneClassName: string;
+};
+
+function resolveDashboardManualBindingBadgeMeta(
+  binding: DashboardWorkingConversationCardModel["manualBinding"],
+  t: (key: TranslationKey, params?: Record<string, string | number>) => string,
+): DashboardManualBindingBadgeMeta | null {
+  if (!binding) return null;
+  if (binding.bindingKind === "group") {
+    const groupName = binding.groupName?.trim();
+    if (!groupName) return null;
+    return {
+      displayValue: groupName,
+      accessibleLabel: t("live.conversations.drawer.binding.currentGroup", { group: groupName }),
+      toneClassName: "border-info/35 bg-info/15 text-info",
+    };
+  }
+
+  const upstreamAccountLabel =
+    binding.upstreamAccountName?.trim() ||
+    (binding.upstreamAccountId != null ? `#${binding.upstreamAccountId}` : "");
+  if (!upstreamAccountLabel) return null;
+  return {
+    displayValue: upstreamAccountLabel,
+    accessibleLabel: t("live.conversations.drawer.binding.currentAccount", {
+      account: upstreamAccountLabel,
+    }),
+    toneClassName: "border-secondary/45 bg-secondary/14 text-secondary",
+  };
+}
 
 type StatusMeta = {
   badgeVariant: "default" | "secondary" | "success" | "warning" | "error" | "info";
@@ -165,7 +206,6 @@ type StatusMeta = {
   label?: string;
   cardToneClassName: string;
   slotSurfaceClassName: string;
-  beaconClassName: string;
 };
 
 const CARD_CLASS_NAME =
@@ -210,7 +250,6 @@ const STATUS_META: Record<DashboardWorkingConversationTone, StatusMeta> = {
     labelKey: "table.status.running",
     cardToneClassName: CARD_SURFACE_CLASS_NAME,
     slotSurfaceClassName: INVOCATION_SURFACE_CLASS_NAME,
-    beaconClassName: "bg-primary/85",
   },
   pending: {
     badgeVariant: "warning",
@@ -218,7 +257,6 @@ const STATUS_META: Record<DashboardWorkingConversationTone, StatusMeta> = {
     labelKey: "table.status.pending",
     cardToneClassName: CARD_SURFACE_CLASS_NAME,
     slotSurfaceClassName: INVOCATION_SURFACE_CLASS_NAME,
-    beaconClassName: "bg-warning/85",
   },
   success: {
     badgeVariant: "success",
@@ -226,14 +264,12 @@ const STATUS_META: Record<DashboardWorkingConversationTone, StatusMeta> = {
     labelKey: "table.status.success",
     cardToneClassName: CARD_SURFACE_CLASS_NAME,
     slotSurfaceClassName: INVOCATION_SURFACE_CLASS_NAME,
-    beaconClassName: "bg-success/85",
   },
   warning: {
     badgeVariant: "warning",
     icon: "alert-outline",
     cardToneClassName: CARD_SURFACE_CLASS_NAME,
     slotSurfaceClassName: INVOCATION_SURFACE_CLASS_NAME,
-    beaconClassName: "bg-warning/85",
   },
   error: {
     badgeVariant: "error",
@@ -241,7 +277,6 @@ const STATUS_META: Record<DashboardWorkingConversationTone, StatusMeta> = {
     labelKey: "table.status.failed",
     cardToneClassName: CARD_SURFACE_CLASS_NAME,
     slotSurfaceClassName: INVOCATION_SURFACE_CLASS_NAME,
-    beaconClassName: "bg-error/90",
   },
   neutral: {
     badgeVariant: "secondary",
@@ -249,7 +284,6 @@ const STATUS_META: Record<DashboardWorkingConversationTone, StatusMeta> = {
     labelKey: "table.status.unknown",
     cardToneClassName: CARD_SURFACE_CLASS_NAME,
     slotSurfaceClassName: INVOCATION_SURFACE_CLASS_NAME,
-    beaconClassName: "bg-base-content/55",
   },
 };
 
@@ -3964,6 +3998,13 @@ export function DashboardWorkingConversationsSection({
                             ? timestampFormatter.format(new Date(card.sortAnchorEpoch))
                             : FALLBACK_CELL;
                         const sequenceConversationActionLabel = `${t("dashboard.workingConversations.openConversation")} · ${displaySequenceId} · ${card.promptCacheKey}`;
+                        const manualBindingBadgeMeta = resolveDashboardManualBindingBadgeMeta(
+                          card.manualBinding,
+                          t,
+                        );
+                        const manualBindingActionLabel = manualBindingBadgeMeta
+                          ? `${t("dashboard.workingConversations.openConversationSettings")} · ${manualBindingBadgeMeta.accessibleLabel}`
+                          : null;
 
                         return (
                           <article
@@ -3980,27 +4021,74 @@ export function DashboardWorkingConversationsSection({
                           >
                             <div className="relative">
                               <div className="flex min-w-0 items-center justify-between gap-3">
-                                {onOpenConversation ? (
-                                  <button
-                                    type="button"
-                                    data-testid="dashboard-working-conversation-sequence-button"
-                                    className="inline-flex min-w-0 shrink cursor-pointer appearance-none items-center border-0 bg-transparent p-0 text-left font-mono text-[0.95rem] font-semibold tracking-[0.08em] text-base-content transition-opacity duration-200 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                                    aria-label={sequenceConversationActionLabel}
-                                    title={sequenceConversationActionLabel}
-                                    onClick={() => {
-                                      onOpenConversation({
-                                        conversationSequenceId: card.conversationSequenceId,
-                                        promptCacheKey: card.promptCacheKey,
-                                      });
-                                    }}
-                                  >
-                                    <span className="min-w-0 truncate">{displaySequenceId}</span>
-                                  </button>
-                                ) : (
-                                  <div className="min-w-0 shrink truncate font-mono text-[0.95rem] font-semibold tracking-[0.08em] text-base-content">
-                                    {displaySequenceId}
-                                  </div>
-                                )}
+                                <div className="flex min-w-0 flex-1 items-center gap-2">
+                                  {onOpenConversation ? (
+                                    <button
+                                      type="button"
+                                      data-testid="dashboard-working-conversation-sequence-button"
+                                      className="inline-flex shrink-0 cursor-pointer appearance-none items-center whitespace-nowrap border-0 bg-transparent p-0 text-left font-mono text-[0.95rem] font-semibold tracking-[0.08em] text-base-content transition-opacity duration-200 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                                      aria-label={sequenceConversationActionLabel}
+                                      title={sequenceConversationActionLabel}
+                                      onClick={() => {
+                                        onOpenConversation({
+                                          conversationSequenceId: card.conversationSequenceId,
+                                          promptCacheKey: card.promptCacheKey,
+                                        });
+                                      }}
+                                    >
+                                      <span className="block whitespace-nowrap">
+                                        {displaySequenceId}
+                                      </span>
+                                    </button>
+                                  ) : (
+                                    <div className="shrink-0 whitespace-nowrap font-mono text-[0.95rem] font-semibold tracking-[0.08em] text-base-content">
+                                      {displaySequenceId}
+                                    </div>
+                                  )}
+                                  {manualBindingBadgeMeta ? (
+                                    onOpenConversation ? (
+                                      <button
+                                        type="button"
+                                        data-testid="dashboard-working-conversation-manual-binding-badge"
+                                        className={MANUAL_BINDING_BADGE_BUTTON_CLASS_NAME}
+                                        aria-label={manualBindingActionLabel ?? undefined}
+                                        title={manualBindingActionLabel ?? undefined}
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          onOpenConversation({
+                                            conversationSequenceId: card.conversationSequenceId,
+                                            promptCacheKey: card.promptCacheKey,
+                                            tab: "settings",
+                                          });
+                                        }}
+                                      >
+                                        <span
+                                          className={cn(
+                                            MANUAL_BINDING_BADGE_CLASS_NAME,
+                                            manualBindingBadgeMeta.toneClassName,
+                                          )}
+                                        >
+                                          <span className={MANUAL_BINDING_BADGE_TEXT_CLASS_NAME}>
+                                            {manualBindingBadgeMeta.displayValue}
+                                          </span>
+                                        </span>
+                                      </button>
+                                    ) : (
+                                      <span
+                                        data-testid="dashboard-working-conversation-manual-binding-badge"
+                                        className={cn(
+                                          MANUAL_BINDING_BADGE_CLASS_NAME,
+                                          manualBindingBadgeMeta.toneClassName,
+                                        )}
+                                        title={manualBindingBadgeMeta.accessibleLabel}
+                                      >
+                                        <span className={MANUAL_BINDING_BADGE_TEXT_CLASS_NAME}>
+                                          {manualBindingBadgeMeta.displayValue}
+                                        </span>
+                                      </span>
+                                    )
+                                  ) : null}
+                                </div>
                                 <div className="flex shrink-0 items-center justify-end gap-2 whitespace-nowrap text-[10px] text-base-content/62">
                                   <span className="font-mono">{sortAnchorLabel}</span>
                                   {card.currentInvocation.livePhase ? (
@@ -4011,18 +4099,11 @@ export function DashboardWorkingConversationsSection({
                                       showLabel={false}
                                     />
                                   ) : (
-                                    <>
-                                      <span className="font-semibold uppercase tracking-[0.14em] text-base-content/76">
-                                        {currentStatusLabel}
-                                      </span>
-                                      <span
-                                        className={cn(
-                                          "inline-flex h-2 w-2 rounded-full",
-                                          currentStatusMeta.beaconClassName,
-                                        )}
-                                        aria-hidden
-                                      />
-                                    </>
+                                    <InlineInvocationStatus
+                                      meta={currentStatusMeta}
+                                      label={currentStatusLabel}
+                                      showLabel={false}
+                                    />
                                   )}
                                 </div>
                               </div>

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1698,6 +1698,7 @@ const baseTranslations = {
     "dashboard.workingConversations.currentInvocation": "Current invocation",
     "dashboard.workingConversations.previousInvocation": "Previous invocation",
     "dashboard.workingConversations.openConversation": "Open conversation details",
+    "dashboard.workingConversations.openConversationSettings": "Open conversation settings",
     "dashboard.workingConversations.openInvocation": "Open invocation details",
     "dashboard.workingConversations.placeholderBadge": "Waiting",
     "dashboard.workingConversations.previousPlaceholder":
@@ -3976,6 +3977,7 @@ const baseTranslations = {
     "dashboard.workingConversations.currentInvocation": "当前调用",
     "dashboard.workingConversations.previousInvocation": "上一条调用",
     "dashboard.workingConversations.openConversation": "打开对话详情",
+    "dashboard.workingConversations.openConversationSettings": "打开对话设置",
     "dashboard.workingConversations.openInvocation": "打开调用详情",
     "dashboard.workingConversations.placeholderBadge": "占位",
     "dashboard.workingConversations.previousPlaceholder": "这条对话还没有可展示的上一条调用。",

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -2672,6 +2672,12 @@ describe("account pool frontend API helpers", () => {
               totalCost: 0.12,
               createdAt: "2026-03-10T22:00:00Z",
               lastActivityAt: "2026-03-10T23:00:00Z",
+              manualBinding: {
+                bindingKind: "upstreamAccount",
+                groupName: null,
+                upstreamAccountId: 42,
+                upstreamAccountName: "Pool Alpha",
+              },
               upstreamAccounts: [
                 {
                   upstreamAccountId: 42,
@@ -2742,6 +2748,12 @@ describe("account pool frontend API helpers", () => {
     expect(response.implicitFilter.kind).toBe("cappedTo50");
     expect(response.implicitFilter.filteredCount).toBe(7);
     expect(response.conversations[0]?.promptCacheKey).toBe("pck-001");
+    expect(response.conversations[0]?.manualBinding).toEqual({
+      bindingKind: "upstreamAccount",
+      groupName: null,
+      upstreamAccountId: 42,
+      upstreamAccountName: "Pool Alpha",
+    });
     expect(response.conversations[0]?.upstreamAccounts[0]?.upstreamAccountName).toBe("Pool Alpha");
     expect(response.conversations[0]?.recentInvocations[0]?.invokeId).toBe("invoke-17");
     expect(response.conversations[0]?.recentInvocations[0]?.failureClass).toBe("none");

--- a/web/src/lib/api/core-foundation.ts
+++ b/web/src/lib/api/core-foundation.ts
@@ -1277,6 +1277,15 @@ export interface PromptCacheConversationUpstreamAccount {
   lastActivityAt: string;
 }
 
+export type PromptCacheConversationManualBindingKind = "group" | "upstreamAccount";
+
+export interface PromptCacheConversationManualBinding {
+  bindingKind: PromptCacheConversationManualBindingKind;
+  groupName: string | null;
+  upstreamAccountId: number | null;
+  upstreamAccountName: string | null;
+}
+
 export interface PromptCacheConversationInvocationPreview {
   id: number;
   invokeId: string;
@@ -1345,6 +1354,7 @@ export interface PromptCacheConversation {
   encryptedOwnerAccountId?: number | null;
   encryptedOwnerAccountName?: string | null;
   encryptedOwnerGroupName?: string | null;
+  manualBinding?: PromptCacheConversationManualBinding | null;
   upstreamAccounts: PromptCacheConversationUpstreamAccount[];
   recentInvocations: PromptCacheConversationInvocationPreview[];
   last24hRequests: PromptCacheConversationRequestPoint[];
@@ -2344,6 +2354,7 @@ function normalizePromptCacheConversation(raw: unknown): PromptCacheConversation
       typeof payload.encryptedOwnerGroupName === "string" && payload.encryptedOwnerGroupName.trim()
         ? payload.encryptedOwnerGroupName.trim()
         : null,
+    manualBinding: normalizePromptCacheConversationManualBinding(payload.manualBinding),
     upstreamAccounts: upstreamAccountsRaw
       .map(normalizePromptCacheConversationUpstreamAccount)
       .filter((item): item is PromptCacheConversationUpstreamAccount => item != null),
@@ -2353,6 +2364,46 @@ function normalizePromptCacheConversation(raw: unknown): PromptCacheConversation
     last24hRequests: requestsRaw
       .map(normalizePromptCacheConversationRequestPoint)
       .filter((item): item is PromptCacheConversationRequestPoint => item != null),
+  };
+}
+
+function normalizePromptCacheConversationManualBinding(
+  raw: unknown,
+): PromptCacheConversationManualBinding | null {
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  const bindingKind =
+    payload.bindingKind === "group" || payload.bindingKind === "upstreamAccount"
+      ? payload.bindingKind
+      : null;
+  if (!bindingKind) return null;
+
+  const groupName =
+    typeof payload.groupName === "string" && payload.groupName.trim()
+      ? payload.groupName.trim()
+      : null;
+  const upstreamAccountId = normalizeFiniteNumber(payload.upstreamAccountId) ?? null;
+  const upstreamAccountName =
+    typeof payload.upstreamAccountName === "string" && payload.upstreamAccountName.trim()
+      ? payload.upstreamAccountName.trim()
+      : null;
+
+  if (bindingKind === "group" && !groupName) {
+    return null;
+  }
+  if (
+    bindingKind === "upstreamAccount" &&
+    upstreamAccountId == null &&
+    upstreamAccountName == null
+  ) {
+    return null;
+  }
+
+  return {
+    bindingKind,
+    groupName,
+    upstreamAccountId,
+    upstreamAccountName,
   };
 }
 

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -133,6 +133,8 @@ export type {
   PromptCacheConversationImplicitFilter,
   PromptCacheConversationImplicitFilterKind,
   PromptCacheConversationInvocationPreview,
+  PromptCacheConversationManualBinding,
+  PromptCacheConversationManualBindingKind,
   PromptCacheConversationPageQuery,
   PromptCacheConversationRequestPoint,
   PromptCacheConversationRewriteMode,

--- a/web/src/lib/dashboardWorkingConversations.test.ts
+++ b/web/src/lib/dashboardWorkingConversations.test.ts
@@ -69,6 +69,7 @@ function createConversation(
       overrides.lastActivityAt ?? recentInvocations[0]?.occurredAt ?? "2026-04-04T10:00:00Z",
     lastTerminalAt: hasLastTerminalAt ? (overrides.lastTerminalAt ?? null) : undefined,
     lastInFlightAt: hasLastInFlightAt ? (overrides.lastInFlightAt ?? null) : undefined,
+    manualBinding: overrides.manualBinding ?? null,
     upstreamAccounts: overrides.upstreamAccounts ?? [],
     recentInvocations,
     last24hRequests: overrides.last24hRequests ?? [],
@@ -115,6 +116,39 @@ describe("mapPromptCacheConversationsToDashboardCards", () => {
     expect(first[0]?.conversationSequenceId).toMatch(/^WC-[A-F0-9]{6}$/);
     expect(first[0]?.conversationSequenceId).toBe(second[0]?.conversationSequenceId);
     expect(first[0]?.hasPreviousPlaceholder).toBe(true);
+  });
+
+  it("preserves manual binding summaries for dashboard badge rendering", () => {
+    const response = createResponse([
+      createConversation(
+        "pck-manual-binding",
+        [
+          createPreview({
+            id: 1,
+            invokeId: "invoke-manual-binding",
+            occurredAt: "2026-04-04T10:04:00Z",
+            status: "completed",
+          }),
+        ],
+        {
+          manualBinding: {
+            bindingKind: "upstreamAccount",
+            groupName: null,
+            upstreamAccountId: 88,
+            upstreamAccountName: "Codex Pro - Tokyo",
+          },
+        },
+      ),
+    ]);
+
+    const cards = mapPromptCacheConversationsToDashboardCards(response);
+
+    expect(cards[0]?.manualBinding).toEqual({
+      bindingKind: "upstreamAccount",
+      groupName: null,
+      upstreamAccountId: 88,
+      upstreamAccountName: "Codex Pro - Tokyo",
+    });
   });
 
   it("appends a stable short suffix when visible WC short ids collide", () => {

--- a/web/src/lib/dashboardWorkingConversations.ts
+++ b/web/src/lib/dashboardWorkingConversations.ts
@@ -2,6 +2,7 @@ import type {
   ApiInvocation,
   PromptCacheConversation,
   PromptCacheConversationInvocationPreview,
+  PromptCacheConversationManualBinding,
   PromptCacheConversationsResponse,
 } from "./api";
 import { resolveInvocationLivePhase } from "./invocationPhase";
@@ -39,6 +40,7 @@ export interface DashboardWorkingConversationCardModel {
   promptCacheKey: string;
   normalizedPromptCacheKey: string;
   conversationSequenceId: string;
+  manualBinding?: PromptCacheConversationManualBinding | null;
   createdAtEpoch: number | null;
   currentInvocation: DashboardWorkingConversationInvocationModel;
   previousInvocation: DashboardWorkingConversationInvocationModel | null;
@@ -193,6 +195,7 @@ function buildPendingCardModel(
   return {
     promptCacheKey: conversation.promptCacheKey,
     normalizedPromptCacheKey,
+    manualBinding: conversation.manualBinding ?? null,
     createdAtEpoch: parseEpoch(conversation.createdAt),
     currentInvocation,
     previousInvocation,

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -137,6 +137,7 @@ vi.mock("../features/dashboard/DashboardWorkingConversationsSection", () => ({
     onOpenConversation?: (selection: {
       conversationSequenceId: string;
       promptCacheKey: string;
+      tab?: "overview" | "calls" | "settings";
     }) => void;
     onOpenInvocation?: (selection: {
       slotKind: "current" | "previous";
@@ -170,6 +171,19 @@ vi.mock("../features/dashboard/DashboardWorkingConversationsSection", () => ({
             }
           >
             open conversation
+          </button>
+          <button
+            type="button"
+            data-testid="dashboard-open-conversation-settings"
+            onClick={() =>
+              onOpenConversation?.({
+                conversationSequenceId: cards[0].conversationSequenceId,
+                promptCacheKey: cards[0].promptCacheKey,
+                tab: "settings",
+              })
+            }
+          >
+            open conversation settings
           </button>
           <button
             type="button"
@@ -214,12 +228,14 @@ vi.mock("../features/prompt-cache/PromptCacheConversationTable", () => ({
     open,
     conversationKey,
     conversationLabel,
+    initialTab,
     onClose,
     onOpenUpstreamAccount,
   }: {
     open: boolean;
     conversationKey: string | null;
     conversationLabel?: string | null;
+    initialTab?: "overview" | "calls" | "settings";
     onClose: () => void;
     onOpenUpstreamAccount?: (
       accountId: number,
@@ -231,6 +247,7 @@ vi.mock("../features/prompt-cache/PromptCacheConversationTable", () => ({
       <div data-testid="dashboard-conversation-history-drawer-mock">
         <span data-testid="dashboard-conversation-drawer-key">{conversationKey}</span>
         <span data-testid="dashboard-conversation-drawer-label">{conversationLabel}</span>
+        <span data-testid="dashboard-conversation-drawer-tab">{initialTab ?? "overview"}</span>
         <button type="button" data-testid="dashboard-conversation-drawer-close" onClick={onClose}>
           close conversation drawer
         </button>
@@ -978,6 +995,104 @@ describe("DashboardPage", () => {
       host?.querySelector('[data-testid="shared-upstream-account-detail-drawer-mock"]'),
     ).toBeNull();
     expect(host?.querySelector('[data-testid="dashboard-location-search"]')?.textContent).toBe("");
+  });
+
+  it("opens the conversation drawer directly on settings when requested by the badge route", () => {
+    installSummaryMocks();
+    hookMocks.useDashboardWorkingConversations.mockReturnValue({
+      cards: [createWorkingConversationCard()],
+      totalMatched: 1,
+      hasMore: false,
+      isLoading: false,
+      isLoadingMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      setRefreshTargetCount: vi.fn(),
+    });
+
+    render(<DashboardPage />);
+
+    const openConversationSettingsButton = host?.querySelector(
+      '[data-testid="dashboard-open-conversation-settings"]',
+    );
+    if (!(openConversationSettingsButton instanceof HTMLButtonElement)) {
+      throw new Error("missing conversation settings trigger");
+    }
+
+    act(() => {
+      openConversationSettingsButton.click();
+    });
+
+    expect(
+      host?.querySelector('[data-testid="dashboard-conversation-history-drawer-mock"]'),
+    ).not.toBeNull();
+    expect(
+      host?.querySelector('[data-testid="dashboard-conversation-drawer-tab"]')?.textContent,
+    ).toBe("settings");
+    expect(host?.querySelector('[data-testid="dashboard-location-search"]')?.textContent).toBe(
+      "?promptCacheConversationKey=pck-drawer-switch&promptCacheConversationTab=settings",
+    );
+  });
+
+  it("keeps the settings-tab conversation route when the dashboard switches into compact page mode", () => {
+    const previousMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    try {
+      installSummaryMocks();
+      hookMocks.useDashboardWorkingConversations.mockReturnValue({
+        cards: [createWorkingConversationCard()],
+        totalMatched: 1,
+        hasMore: false,
+        isLoading: false,
+        isLoadingMore: false,
+        error: null,
+        loadMore: vi.fn(),
+        setRefreshTargetCount: vi.fn(),
+      });
+
+      render(<DashboardPage />);
+
+      const openConversationSettingsButton = host?.querySelector(
+        '[data-testid="dashboard-open-conversation-settings"]',
+      );
+      if (!(openConversationSettingsButton instanceof HTMLButtonElement)) {
+        throw new Error("missing compact conversation settings trigger");
+      }
+
+      act(() => {
+        openConversationSettingsButton.click();
+      });
+
+      expect(
+        host?.querySelector('[data-testid="dashboard-conversation-history-drawer-mock"]'),
+      ).not.toBeNull();
+      expect(
+        host?.querySelector('[data-testid="dashboard-conversation-drawer-tab"]')?.textContent,
+      ).toBe("settings");
+      expect(host?.querySelector('[data-testid="dashboard-location-search"]')?.textContent).toBe(
+        "?promptCacheConversationKey=pck-drawer-switch&promptCacheConversationTab=settings",
+      );
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: previousMatchMedia,
+      });
+    }
   });
 
   it("passes refresh target updates from the working conversations section back into the hook", () => {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -215,6 +215,7 @@ export default function DashboardPage() {
             return;
           }
           openPromptCacheConversation(selection.promptCacheKey, {
+            tab: selection.tab,
             clearUpstreamAccount: true,
           });
         }}


### PR DESCRIPTION
## Summary
- extend prompt cache conversation hydration to include optional manual binding summaries for dashboard cards
- render clickable manual-binding badges beside the full conversation ID and route badge clicks directly to the settings tab
- align badge truncation, tone, and header status icon behavior; update tests and Storybook coverage

## Verification
- `cargo test prompt_cache_conversations_include_manual_binding_summaries`
- `cd web && bun run test -- src/features/dashboard/DashboardWorkingConversationsSection.test.tsx src/pages/Dashboard.test.tsx src/lib/dashboardWorkingConversations.test.ts`
- `bun run lint:web` (existing repository warnings only; no blocking errors)

## Visual Evidence
- owner-approved local evidence captured during implementation: `manual-binding-badge-font-smaller.png`

## References
- Specs: -
- Solutions: -
- Project Docs: -