### PR TITLE
feat: unify owner-facing attempt short ids

### DIFF
--- a/docs/specs/z9h7v-invocation-log-observability/HISTORY.md
+++ b/docs/specs/z9h7v-invocation-log-observability/HISTORY.md
@@ -7,6 +7,7 @@
 - 诊断证据改为当前记录下方的全宽展开区，避免将关键排障信息压缩在错误列的局部入口中。
 - 路由调用事件新增可空 `attempt_id` 精确关联；旧事件保持可见但不可跳转。
 - 尝试列表的模型投影保持从 invocation payload 读取，兼容未包含独立 request/response model 列的既有 SQLite 数据库；健康事件以 `attempt_id` 作为可见定位标识，不再显示空的最终调用 ID。
+- owner-facing attempt 标识收口为持久化短 `attemptId`：live / archive `pool_upstream_request_attempts` 统一新增 `attempt_public_id`，新写入即生成，启动期顺序回填历史主库与 archive batch；账号详情、健康事件与 Records 新入口不再暴露纯数字 attempt 主键。
 
 ## Migration
 
@@ -48,3 +49,4 @@
 - 2026-07-10: 账号详情调用 ID 固化为单行完整展示，并通过表面专属列宽与单层非布局高亮避免截断、换行和焦点轮廓叠加。
 - 2026-07-13: Dashboard 活动快照新增成功已计费调用的响应模型/思考程度性能聚合，统一 TPM、首字与费用速率的完整周期展示口径，并在总览和账号卡提供桌面浮层与窄屏抽屉入口。
 - 2026-07-15: 将 Dashboard 模型性能总计 `usageDurationMs` 从简单求和改为范围内调用时间并集；模型行保持原有累加口径，因此总计允许小于下方模型行加总。
+- 2026-07-15: Attempt owner-facing 合同改为持久化 8 位短 `attemptId`；账号详情、健康与事件、Records 新跳转统一改用 `attemptId`，并新增启动期 live/archive backfill 补齐历史 `attempt_public_id`。

--- a/docs/specs/z9h7v-invocation-log-observability/IMPLEMENTATION.md
+++ b/docs/specs/z9h7v-invocation-log-observability/IMPLEMENTATION.md
@@ -19,8 +19,9 @@
 - 本次修复是 future-only：不改 SQLite schema，不对历史 invocation 回填 `imageIntent` 或 `compactionRequestKind`。
 - 运行态 V2 识别来自 request body 的 `context_management[type=compaction][compact_threshold]`，终态识别来自响应内实际出现的 compaction item；两者独立写入 payload，不回填历史记录。
 - raw request/response payload 的完整保留合同不作为 SQLite 止血牺牲项；本轮只补充 raw file write 的 `raw_kind`、codec、file bytes、observed bytes、truncated、path 与 elapsed 证据，并继续同步持久化 terminal usage/status/failure/raw metadata。
-- 账号详情调用记录现显示可选择的 `invokeId`；健康与事件的调用 ID 通过 `/api/invocations/locate` 获取目标所在 retained/runtime 分页窗口及短生命周期 `anchorId`，后续页复用冻结 runtime overlay，再由共享虚拟表格定位目标行。
-- 账号详情调用列表使用表面专属列宽，并按容器实际宽度自动缩小超长 `invokeId` 字号，以完整单行展示 ID；桌面与移动定位态均采用单层非布局型高亮并抑制默认 outline，其他共享 `InvocationTable` 使用方保持原布局。
+- `pool_upstream_request_attempts` live + archive 现已统一持久化 `attempt_public_id`，使用 8 位 Base58 风格短串生成；生成结果强制至少包含一个字母，避免 owner-facing 纯数字 ID。新写入在入库时生成，启动期 backfill 会顺序补齐 live 表与 archive manifest 指向的历史 gzip sqlite。
+- 账号详情调用记录现显示并跳转 `attemptId`；健康与事件的上游尝试入口、账号详情尝试列表与 Records 新链接统一使用该短 ID。`invokeId` 只保留在诊断上下文，不再承担 attempt 主入口。
+- `/api/invocations/locate` 现接受显式 `attemptId`，先解析父 `invokeId` 再返回目标分页窗口与精确 attempt 高亮所需上下文；旧 `requestId` 入口继续兼容读取，但新 UI 不再生成它作为 attempt 跳转参数。
 - 账号活动聚合、按模型用量分组、受限 recent 读取与路由 sticky escape 检测现在会在超过 1 秒时输出结构化 warn；日志只含 endpoint/operation、范围、候选或返回行数、阶段与耗时，不含 SQL、payload 或账号敏感内容。
 - 账号详情已将最终调用记录表替换为真实上游调用表：按账号从 `pool_upstream_request_attempts` 读取最近 7 天主库数据，按 `occurred_at DESC, id DESC` 分页。每行只显示本次调用的时间、ID、请求模型与响应模型、状态、代理、三段延迟和错误；不显示 endpoint，也不混入重试序号、最终调用 tokens/费用或其他调用上下文。列表以 `(invoke_id, occurred_at)` 关联 invocation payload 的 `requestModel` / `responseModel`，请求模型缺失时回退 `model`，避免依赖旧数据库不存在的列。
 - Dashboard 活动快照现额外返回全局与账号级的模型性能分组。仅状态成功、失败分类为 `none` 且 `cost` 非空的调用参与 TPM、流式响应速率、响应时长、首字用时和使用时长；零费用成功调用保留。模型按响应模型归属，空思考程度在前端显示“未指定”。模型行 `usageDurationMs` 继续累加各自的 `t_total_ms`，但 `total.usageDurationMs` 会对同一范围内的合格调用区间做裁剪后并集。

--- a/docs/specs/z9h7v-invocation-log-observability/SPEC.md
+++ b/docs/specs/z9h7v-invocation-log-observability/SPEC.md
@@ -28,13 +28,14 @@
 - Live 展开详情与 Dashboard 调用详情抽屉必须共用同一套调用详情组件，并按“快速排障”组织信息：请求身份、路由与模型、失败信号、细节保留、阶段耗时分组展示。
 - 新 HTTP proxy invocation 的 `invokeId` 必须使用 10 位 NanoID 风格短格式，去掉历史 `proxy-...` 前缀、内部 counter 与时间戳尾巴；历史 `proxy-...` 记录继续兼容查询和展示。
 - 账号详情“上游调用尝试”必须按真实 `pool_upstream_request_attempts` 行展示请求、重试、失败与成功；概览统计继续采用最终调用口径。
-- 账号上游调用记录必须采用表格展示；每行仅表达一次真实上游调用，直接列出时间、调用 ID、请求模型与响应模型、结果/HTTP 状态、代理、连接/首字节/流式延迟和错误。不得显示 endpoint、重试序号、最终 invocation 的 tokens/费用或其他非本次调用字段。
+- 账号上游调用记录必须采用表格展示；每行仅表达一次真实上游调用，直接列出时间、上游尝试短 ID、请求模型与响应模型、结果/HTTP 状态、代理、连接/首字节/流式延迟和错误。不得显示 endpoint、重试序号、最终 invocation 的 tokens/费用或其他非本次调用字段。
 - 结果列的 HTTP 值必须明确标记为上游 HTTP；仅当与上游不同才在当前记录下方的全宽诊断展开区显示下游 HTTP。错误主列显示失败分类与两行摘要；失败或状态不一致时以紧凑元数据带展示完整错误、复制命令、上游请求 ID、路由键与代理绑定键，不得挤在错误列角落或为正常成功行额外占用高度。
 - 桌面保留完整诊断表；窄屏仍采用表格，首屏优先时间、调用/模型、结果和错误摘要，代理、三段延迟与完整错误证据收进可展开区。代理优先显示解析后的节点名，不能解析时显示截短绑定键并保留完整值提示。
 - 新产生的路由调用事件必须携带精确 `attemptId`，健康与事件只能用该 ID 定位同账号的尝试；缺少 `attemptId` 的历史事件必须明确不可定位，不做 `invokeId` 模糊跳转。
+- owner-facing attempt 标识统一使用持久化 8 位短 `attemptId`。该 ID 存于 `pool_upstream_request_attempts.attempt_public_id`，live 与 archive 都要求非空；内部数值主键仅保留给 DB join / FK / 维护逻辑，不得直接暴露。
 - 尝试列表与定位只查询主库最近 7 天，按 `occurredAt DESC, id DESC` 稳定分页，不读取 archive。
-- 尝试详情必须提供到 `/records?requestId=...` 的全局调用总览入口，并自动展开该最终调用的完整尝试链。
-- 账号详情调用记录中的 `invokeId` 必须使用等宽字体单行完整展示，不得换行或截断；该表面可使用专用列宽回收用时、输入与输出列空间，但不得改变其他共享调用列表的默认布局。
+- 尝试详情必须提供到 `/records?attemptId=...` 的全局调用总览入口，并自动展开该最终调用的完整尝试链；旧 `requestId` 型入口只保留兼容读取，不再作为新 UI 的 attempt 跳转合同。
+- 账号详情调用记录中的 owner-facing 主入口必须显示 `attemptId` 而不是 `invokeId`；`invokeId` 如保留只能降级为诊断上下文，不能继续承担 attempt 主标识角色。
 - 号池调用处于 `running` / `pending` 且已携带 `upstreamAccountName` 或 `upstreamAccountId` 时，所有共享 invocation 展示面必须用当前上游账号替代“号池路由中”fallback，并以蓝色呼吸文本表达正在路由中。
 - Dashboard 当前时间范围新增按“响应模型 / 思考程度”分组的性能明细，覆盖 TPM、流式响应速率、平均响应时长、平均首字用时与累计使用时长；明细及对应 TPM、首字卡面仅统计成功且已计费调用。
 
@@ -153,7 +154,8 @@
 
 - `pool_upstream_account_events.attempt_id` 为可空精确关联；只为新产生且调用链路已拿到尝试主键的路由事件写入，不回填历史事件。
 - `GET /api/pool/upstream-accounts/{accountId}/call-attempts` Query: `page?: number`、`pageSize?: number`；Response: `items`、`total`、`page`、`pageSize`。
-- `GET /api/pool/upstream-accounts/{accountId}/call-attempts/locate` Query: `attemptId: number`、`pageSize?: number`；目标必须属于当前账号且处于 7 天主库窗口内。
+- `GET /api/pool/upstream-accounts/{accountId}/call-attempts/locate` Query: `attemptId: string`、`pageSize?: number`；目标必须属于当前账号且处于 7 天主库窗口内。
+- 尝试对象必须返回 `attemptId: string`，映射自持久化 `attempt_public_id`；不得返回纯数字主键作为 owner-facing attempt 标识。
 - 尝试对象额外返回 `requestModel?: string | null` 与 `responseModel?: string | null`；两个字段从关联 invocation 的 `payload.requestModel` / `payload.responseModel` 投影，请求模型缺失时回退 `model`，缺少匹配 invocation 时保持空值。该查询不得依赖新增 SQLite 列。
 
 ### `GET /api/settings` / `PUT /api/settings/proxy` 新增字段
@@ -181,8 +183,8 @@
 
 ### `GET /api/invocations/locate` 锚点分页
 
-- Query: `requestId: string`、`upstreamAccountId: number`、`pageSize?: number`（默认 `50`）。
-- Response: 沿用 `snapshotId`、`total`、`page`、`pageSize`、`records`，并增加 `anchorId: string`、`targetIndex: number` 与 `targetAbsoluteIndex: number`。
+- Query: `requestId?: string`、`attemptId?: string`、`upstreamAccountId?: number`、`pageSize?: number`（默认 `50`）；至少提供一个定位键，显式 `attemptId` 优先用于解析父 invocation。
+- Response: 沿用 `snapshotId`、`total`、`page`、`pageSize`、`records`，并增加 `anchorId: string`、`requestId: string`、`attemptId?: string | null`、`targetIndex: number` 与 `targetAbsoluteIndex: number`。
 - 后续双向分页继续调用 `GET /api/invocations`，携带定位响应的 `snapshotId`、`anchorId`、相邻 `page`、相同 `pageSize` 与 `upstreamAccountId`；服务端用 `anchorId` 复现定位时冻结的 runtime overlay，令所有页边界一致。
 
 ## 验收标准（Acceptance Criteria）

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -52,7 +52,7 @@ const INVOCATION_ANCHOR_CACHE_LIMIT: usize = 32;
 #[derive(Clone)]
 struct InvocationAnchorSnapshot {
     snapshot_id: i64,
-    upstream_account_id: i64,
+    upstream_account_id: Option<i64>,
     runtime_records: Vec<ApiInvocation>,
     expires_at: Instant,
 }
@@ -63,7 +63,7 @@ static INVOCATION_ANCHOR_SNAPSHOTS: once_cell::sync::Lazy<
 
 fn store_invocation_anchor_snapshot(
     snapshot_id: i64,
-    upstream_account_id: i64,
+    upstream_account_id: Option<i64>,
     runtime_records: Vec<ApiInvocation>,
 ) -> String {
     let anchor_id = nanoid::nanoid!(16);
@@ -107,7 +107,7 @@ fn load_invocation_anchor_runtime_records(
         .get(&anchor_id)
         .ok_or_else(|| ApiError::bad_request(anyhow!("invocation anchor expired or not found")))?;
     if params.snapshot_id != Some(snapshot.snapshot_id)
-        || params.upstream_account_id != Some(snapshot.upstream_account_id)
+        || params.upstream_account_id != snapshot.upstream_account_id
     {
         return Err(ApiError::bad_request(anyhow!(
             "invocation anchor does not match snapshot or account"
@@ -2191,6 +2191,8 @@ async fn list_invocations_with_runtime_overlay(
 pub(crate) struct LocateInvocationResponse {
     pub(crate) anchor_id: String,
     pub(crate) snapshot_id: i64,
+    pub(crate) request_id: String,
+    pub(crate) attempt_id: Option<String>,
     pub(crate) total: i64,
     pub(crate) page: i64,
     pub(crate) page_size: i64,
@@ -2205,19 +2207,32 @@ struct InvocationLocateRow {
     occurred_at: String,
 }
 
+#[derive(Debug, FromRow)]
+struct InvocationLocateAttemptRow {
+    invoke_id: String,
+    upstream_account_id: Option<i64>,
+}
+
 pub(crate) async fn locate_invocation_page(
     state: Arc<AppState>,
     params: &LocateInvocationQuery,
 ) -> Result<Option<LocateInvocationResponse>, ApiError> {
-    let request_id = params.request_id.trim();
-    if request_id.is_empty() {
-        return Err(ApiError::bad_request(anyhow!("requestId is required")));
-    }
-    if params.upstream_account_id <= 0 {
+    let request_id = normalize_query_text(params.request_id.as_deref());
+    let attempt_id = normalize_query_text(params.attempt_id.as_deref());
+    if request_id.is_none() && attempt_id.is_none() {
         return Err(ApiError::bad_request(anyhow!(
-            "upstreamAccountId must be positive"
+            "requestId or attemptId is required"
         )));
     }
+    let upstream_account_id = match params.upstream_account_id {
+        Some(value) if value > 0 => Some(value),
+        Some(_) => {
+            return Err(ApiError::bad_request(anyhow!(
+                "upstreamAccountId must be positive"
+            )));
+        }
+        None => None,
+    };
 
     let page_size = params
         .page_size
@@ -2225,13 +2240,40 @@ pub(crate) async fn locate_invocation_page(
         .clamp(1, state.config.list_limit_max as i64);
     let source_scope = resolve_default_source_scope(&state.pool).await?;
     let snapshot_id = resolve_invocation_snapshot_id(&state.pool, source_scope).await?;
+    let (request_id, resolved_attempt_id, upstream_account_id) =
+        if let Some(attempt_public_id) = attempt_id.as_deref() {
+            let target = sqlx::query_as::<_, InvocationLocateAttemptRow>(
+                r#"
+                SELECT invoke_id, upstream_account_id
+                FROM pool_upstream_request_attempts
+                WHERE attempt_public_id = ?1
+                LIMIT 1
+                "#,
+            )
+            .bind(attempt_public_id)
+            .fetch_optional(&state.pool)
+            .await?;
+            let Some(target) = target else {
+                return Ok(None);
+            };
+            if upstream_account_id.is_some() && upstream_account_id != target.upstream_account_id {
+                return Ok(None);
+            }
+            (
+                target.invoke_id,
+                Some(attempt_public_id.to_string()),
+                upstream_account_id.or(target.upstream_account_id),
+            )
+        } else {
+            (request_id.unwrap_or_default(), None, upstream_account_id)
+        };
     let base_filters = InvocationRecordsFilters {
-        upstream_account_id: Some(params.upstream_account_id),
+        upstream_account_id,
         ..Default::default()
     };
     let runtime_records = runtime_overlay_snapshot(state.as_ref());
     let runtime_target = runtime_records.iter().find(|record| {
-        runtime_text_equals(Some(record.invoke_id.as_str()), request_id)
+        runtime_text_equals(Some(record.invoke_id.as_str()), request_id.as_str())
             && runtime_record_matches_filters(record, &base_filters, source_scope)
     });
 
@@ -2245,7 +2287,7 @@ pub(crate) async fn locate_invocation_page(
     );
     target_query
         .push(" AND invoke_id = ")
-        .push_bind(request_id.to_string())
+        .push_bind(request_id.clone())
         .push(" ORDER BY occurred_at DESC, id DESC LIMIT 1");
     let db_target = target_query
         .build_query_as::<InvocationLocateRow>()
@@ -2375,25 +2417,25 @@ pub(crate) async fn locate_invocation_page(
                 snapshot_id: Some(snapshot_id),
                 sort_by: Some("occurredAt".to_string()),
                 sort_order: Some("desc".to_string()),
-                upstream_account_id: Some(params.upstream_account_id),
+                upstream_account_id,
                 ..Default::default()
             },
             Some(anchor_runtime_records.clone()),
         )
         .await?;
-        if let Some(target_index) = response
-            .records
-            .iter()
-            .position(|record| runtime_text_equals(Some(record.invoke_id.as_str()), request_id))
-        {
+        if let Some(target_index) = response.records.iter().position(|record| {
+            runtime_text_equals(Some(record.invoke_id.as_str()), request_id.as_str())
+        }) {
             let anchor_id = store_invocation_anchor_snapshot(
                 snapshot_id,
-                params.upstream_account_id,
+                upstream_account_id,
                 anchor_runtime_records.clone(),
             );
             return Ok(Some(LocateInvocationResponse {
                 anchor_id,
                 snapshot_id: response.snapshot_id,
+                request_id: request_id.clone(),
+                attempt_id: resolved_attempt_id.clone(),
                 total: response.total,
                 page: response.page,
                 page_size: response.page_size,
@@ -2419,7 +2461,8 @@ pub(crate) async fn locate_invocation(
             Json(json!({
                 "code": "invocation_not_found",
                 "message": "invocation record not found",
-                "requestId": params.request_id.trim(),
+                "requestId": normalize_query_text(params.request_id.as_deref()),
+                "attemptId": normalize_query_text(params.attempt_id.as_deref()),
             })),
         )
             .into_response()),

--- a/src/api/slices/prompt_cache_and_timeseries/shared.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/shared.rs
@@ -234,6 +234,7 @@ pub(crate) async fn query_pool_attempt_records_from_live(
         r#"
         SELECT
             attempts.id,
+            attempts.attempt_public_id AS attempt_id,
             attempts.invoke_id,
             attempts.occurred_at,
             attempts.endpoint,

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -7,7 +7,9 @@ use tokio::sync::watch;
 #[derive(Debug, Clone, Serialize, FromRow)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ApiPoolUpstreamRequestAttempt {
+    #[serde(skip_serializing)]
     pub(crate) id: i64,
+    pub(crate) attempt_id: String,
     pub(crate) invoke_id: String,
     #[serde(serialize_with = "serialize_local_naive_to_utc_iso")]
     pub(crate) occurred_at: String,
@@ -1466,8 +1468,9 @@ pub(crate) struct ListQuery {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LocateInvocationQuery {
-    pub(crate) request_id: String,
-    pub(crate) upstream_account_id: i64,
+    pub(crate) request_id: Option<String>,
+    pub(crate) attempt_id: Option<String>,
+    pub(crate) upstream_account_id: Option<i64>,
     pub(crate) page_size: Option<i64>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,9 @@ const STARTUP_BACKFILL_TASK_REQUESTED_SERVICE_TIER: &str = "proxy_requested_serv
 const STARTUP_BACKFILL_TASK_INVOCATION_SERVICE_TIER: &str = "invocation_service_tier_v1";
 const STARTUP_BACKFILL_TASK_REASONING_EFFORT: &str = "proxy_reasoning_effort_v1";
 const STARTUP_BACKFILL_TASK_FAILURE_CLASSIFICATION: &str = "failure_classification_v1";
+const STARTUP_BACKFILL_TASK_POOL_ATTEMPT_PUBLIC_ID_LIVE: &str = "pool_attempt_public_id_live_v1";
+const STARTUP_BACKFILL_TASK_POOL_ATTEMPT_PUBLIC_ID_ARCHIVES: &str =
+    "pool_attempt_public_id_archives_v1";
 const STARTUP_BACKFILL_TASK_POOL_UPSTREAM_NODE_HEALTH_ARCHIVES: &str =
     "pool_upstream_node_health_archives_v1";
 const STARTUP_BACKFILL_TASK_HISTORICAL_ROLLUPS: &str = "historical_rollup_materialization_v1";

--- a/src/maintenance/archive/writers.rs
+++ b/src/maintenance/archive/writers.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 #[derive(Debug, Clone, FromRow)]
 pub(crate) struct PoolUpstreamRequestAttemptArchiveRow {
     id: i64,
+    attempt_public_id: Option<String>,
     invoke_id: String,
     occurred_at: String,
     endpoint: String,
@@ -84,6 +85,7 @@ pub(crate) async fn ensure_pool_upstream_request_attempts_archive_schema_direct(
         .filter_map(|row| row.try_get::<String, _>("name").ok())
         .collect::<HashSet<_>>();
     for (column, ty) in [
+        ("attempt_public_id", "TEXT"),
         ("upstream_route_key", "TEXT"),
         ("phase", "TEXT"),
         ("downstream_http_status", "INTEGER"),
@@ -104,7 +106,159 @@ pub(crate) async fn ensure_pool_upstream_request_attempts_archive_schema_direct(
                 })?;
         }
     }
+    sqlx::query(
+        r#"
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_pool_upstream_request_attempts_public_id
+        ON pool_upstream_request_attempts (attempt_public_id)
+        WHERE attempt_public_id IS NOT NULL
+        "#,
+    )
+    .execute(&mut *conn)
+    .await
+    .context("failed to ensure idx_pool_upstream_request_attempts_public_id")?;
     Ok(())
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PoolAttemptPublicIdArchiveBackfillSummary {
+    pub(crate) scanned_batches: u64,
+    pub(crate) updated_batches: u64,
+    pub(crate) scanned_rows: u64,
+    pub(crate) updated_rows: u64,
+}
+
+#[derive(Debug, FromRow)]
+struct PoolAttemptPublicIdArchiveBatchRow {
+    id: i64,
+    file_path: String,
+}
+
+pub(crate) async fn backfill_pool_upstream_request_attempt_archive_public_ids_from_batch_cursor(
+    pool: &Pool<Sqlite>,
+    start_after_batch_id: i64,
+    scan_limit: Option<u64>,
+    max_elapsed: Option<Duration>,
+) -> Result<BackfillBatchOutcome<PoolAttemptPublicIdArchiveBackfillSummary>> {
+    let started_at = Instant::now();
+    let mut summary = PoolAttemptPublicIdArchiveBackfillSummary::default();
+    let mut last_seen_batch_id = start_after_batch_id;
+    let mut hit_budget = false;
+    let mut samples = Vec::new();
+
+    loop {
+        if startup_backfill_budget_reached(
+            started_at,
+            summary.scanned_batches,
+            scan_limit,
+            max_elapsed,
+        ) {
+            hit_budget = true;
+            break;
+        }
+
+        let rows = sqlx::query_as::<_, PoolAttemptPublicIdArchiveBatchRow>(
+            r#"
+            SELECT id, file_path
+            FROM archive_batches
+            WHERE dataset = 'pool_upstream_request_attempts'
+              AND status = ?1
+              AND id > ?2
+            ORDER BY id ASC
+            LIMIT ?3
+            "#,
+        )
+        .bind(ARCHIVE_STATUS_COMPLETED)
+        .bind(last_seen_batch_id)
+        .bind(startup_backfill_query_limit(
+            summary.scanned_batches,
+            scan_limit,
+        ))
+        .fetch_all(pool)
+        .await?;
+
+        if rows.is_empty() {
+            break;
+        }
+
+        for batch in rows {
+            last_seen_batch_id = batch.id;
+            summary.scanned_batches += 1;
+            let archive_path = PathBuf::from(&batch.file_path);
+            let suffix = retention_temp_suffix();
+            let work_path = PathBuf::from(format!("{}.{}.sqlite", batch.file_path, suffix));
+            let temp_gzip_path = PathBuf::from(format!("{}.{}.tmp", batch.file_path, suffix));
+            let _ = fs::remove_file(&work_path);
+            let _ = fs::remove_file(&temp_gzip_path);
+
+            inflate_gzip_sqlite_file(&archive_path, &work_path)?;
+
+            let backfill_outcome = async {
+                let mut conn = open_archive_sqlite_connection(&work_path).await?;
+                ensure_pool_upstream_request_attempts_archive_schema_direct(&mut conn).await?;
+                let outcome = backfill_pool_upstream_request_attempt_public_ids_on_connection(
+                    &mut conn, 0, None, None,
+                )
+                .await?;
+                conn.close().await?;
+                Ok::<BackfillBatchOutcome<PoolAttemptPublicIdBackfillSummary>, anyhow::Error>(
+                    outcome,
+                )
+            }
+            .await;
+
+            let outcome = match backfill_outcome {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    let _ = fs::remove_file(&work_path);
+                    let _ = fs::remove_file(&temp_gzip_path);
+                    return Err(err);
+                }
+            };
+
+            summary.scanned_rows += outcome.summary.scanned;
+            summary.updated_rows += outcome.summary.updated;
+            if outcome.summary.updated > 0 {
+                summary.updated_batches += 1;
+                push_backfill_sample(
+                    &mut samples,
+                    format!("batch_id={} rows={}", batch.id, outcome.summary.updated),
+                );
+            }
+
+            if let Err(err) = finalize_archive_sqlite_file(&work_path).await {
+                let _ = fs::remove_file(&work_path);
+                let _ = fs::remove_file(&temp_gzip_path);
+                return Err(err);
+            }
+            if let Err(err) = deflate_sqlite_file_to_gzip(&work_path, &temp_gzip_path) {
+                let _ = fs::remove_file(&work_path);
+                let _ = fs::remove_file(&temp_gzip_path);
+                return Err(err);
+            }
+            fs::rename(&temp_gzip_path, &archive_path).with_context(|| {
+                format!(
+                    "failed to move pool_upstream_request_attempts archive batch into place: {} -> {}",
+                    temp_gzip_path.display(),
+                    archive_path.display()
+                )
+            })?;
+            let _ = fs::remove_file(&work_path);
+
+            let sha256 = sha256_hex_file(&archive_path)?;
+            sqlx::query("UPDATE archive_batches SET sha256 = ?1 WHERE id = ?2")
+                .bind(&sha256)
+                .bind(batch.id)
+                .execute(pool)
+                .await?;
+        }
+    }
+
+    Ok(BackfillBatchOutcome {
+        summary,
+        next_cursor_id: last_seen_batch_id,
+        hit_budget,
+        samples,
+    })
 }
 
 pub(crate) async fn archive_pool_upstream_request_attempt_rows_into_month_batch(
@@ -155,6 +309,7 @@ pub(crate) async fn archive_pool_upstream_request_attempt_rows_into_month_batch(
         insert.push_values(chunk, |mut builder, row| {
             builder
                 .push_bind(row.id)
+                .push_bind(&row.attempt_public_id)
                 .push_bind(&row.invoke_id)
                 .push_bind(&row.occurred_at)
                 .push_bind(&row.endpoint)

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -2224,6 +2224,7 @@ pub(crate) async fn ensure_pool_upstream_request_attempts_archive_schema(
     )
     .await?;
     for (column, ty) in [
+        ("attempt_public_id", "TEXT"),
         ("upstream_route_key", "TEXT"),
         ("phase", "TEXT"),
         ("downstream_http_status", "INTEGER"),
@@ -2247,6 +2248,16 @@ pub(crate) async fn ensure_pool_upstream_request_attempts_archive_schema(
                 })?;
         }
     }
+    sqlx::query(
+        r#"
+        CREATE UNIQUE INDEX IF NOT EXISTS archive_db.idx_pool_upstream_request_attempts_public_id
+        ON pool_upstream_request_attempts (attempt_public_id)
+        WHERE attempt_public_id IS NOT NULL
+        "#,
+    )
+    .execute(&mut *conn)
+    .await
+    .context("failed to ensure archive_db.idx_pool_upstream_request_attempts_public_id")?;
     Ok(())
 }
 
@@ -2257,6 +2268,7 @@ pub(crate) async fn ensure_pool_upstream_request_attempts_archive_schema_in_plac
         load_sqlite_table_columns_from_connection(conn, None, "pool_upstream_request_attempts")
             .await?;
     for (column, ty) in [
+        ("attempt_public_id", "TEXT"),
         ("upstream_route_key", "TEXT"),
         ("phase", "TEXT"),
         ("downstream_http_status", "INTEGER"),
@@ -2279,6 +2291,16 @@ pub(crate) async fn ensure_pool_upstream_request_attempts_archive_schema_in_plac
                 })?;
         }
     }
+    sqlx::query(
+        r#"
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_pool_upstream_request_attempts_public_id
+        ON pool_upstream_request_attempts (attempt_public_id)
+        WHERE attempt_public_id IS NOT NULL
+        "#,
+    )
+    .execute(&mut *conn)
+    .await
+    .context("failed to ensure idx_pool_upstream_request_attempts_public_id")?;
     Ok(())
 }
 

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -444,7 +444,7 @@ pub(crate) struct DryRunBatchCount {
 pub(crate) const CODEX_INVOCATIONS_ARCHIVE_COLUMNS: &str = "id, invoke_id, occurred_at, source, model, input_tokens, output_tokens, cache_input_tokens, reasoning_tokens, total_tokens, cost, cost_input, cost_cache_write, cost_cache_read, cost_output, cost_reasoning, status, error_message, failure_kind, failure_class, is_actionable, payload, raw_response, cost_estimated, price_version, request_raw_path, request_raw_codec, request_raw_size, request_raw_truncated, request_raw_truncated_reason, response_raw_path, response_raw_codec, response_raw_size, response_raw_truncated, response_raw_truncated_reason, detail_level, detail_pruned_at, detail_prune_reason, t_total_ms, t_req_read_ms, t_req_parse_ms, t_upstream_connect_ms, t_upstream_ttfb_ms, t_upstream_stream_ms, t_resp_parse_ms, t_persist_ms, created_at";
 pub(crate) const FORWARD_PROXY_ATTEMPTS_ARCHIVE_COLUMNS: &str =
     "id, proxy_key, occurred_at, is_success, latency_ms, failure_kind, is_probe";
-pub(crate) const POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_COLUMNS: &str = "id, invoke_id, occurred_at, endpoint, route_mode, sticky_key, group_name_snapshot, proxy_binding_key_snapshot, upstream_account_id, upstream_route_key, attempt_index, distinct_account_index, same_account_retry_index, requester_ip, started_at, finished_at, status, phase, http_status, downstream_http_status, failure_kind, error_message, downstream_error_message, connect_latency_ms, first_byte_latency_ms, stream_latency_ms, upstream_request_id, compact_support_status, compact_support_reason, created_at";
+pub(crate) const POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_COLUMNS: &str = "id, attempt_public_id, invoke_id, occurred_at, endpoint, route_mode, sticky_key, group_name_snapshot, proxy_binding_key_snapshot, upstream_account_id, upstream_route_key, attempt_index, distinct_account_index, same_account_retry_index, requester_ip, started_at, finished_at, status, phase, http_status, downstream_http_status, failure_kind, error_message, downstream_error_message, connect_latency_ms, first_byte_latency_ms, stream_latency_ms, upstream_request_id, compact_support_status, compact_support_reason, created_at";
 pub(crate) const CODEX_QUOTA_SNAPSHOTS_ARCHIVE_COLUMNS: &str = "id, captured_at, amount_limit, used_amount, remaining_amount, period, period_reset_time, expire_time, is_active, total_cost, total_requests, total_tokens, last_request_time, billing_type, remaining_count, used_count, sub_type_name";
 
 pub(crate) const CODEX_INVOCATIONS_ARCHIVE_CREATE_SQL: &str = r#"
@@ -515,6 +515,7 @@ CREATE TABLE IF NOT EXISTS archive_db.forward_proxy_attempts (
 pub(crate) const POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_CREATE_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS archive_db.pool_upstream_request_attempts (
     id INTEGER PRIMARY KEY,
+    attempt_public_id TEXT,
     invoke_id TEXT NOT NULL,
     occurred_at TEXT NOT NULL,
     endpoint TEXT NOT NULL,

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -15,6 +15,8 @@ pub(crate) enum StartupBackfillTask {
     InvocationServiceTier,
     ReasoningEffort,
     FailureClassification,
+    PoolAttemptPublicIdLive,
+    PoolAttemptPublicIdArchives,
     UpstreamActivityLive,
     UpstreamActivityArchives,
     PoolUpstreamNodeHealthArchives,
@@ -31,6 +33,8 @@ impl StartupBackfillTask {
             Self::ProxyCost,
             Self::ReasoningEffort,
             Self::FailureClassification,
+            Self::PoolAttemptPublicIdLive,
+            Self::PoolAttemptPublicIdArchives,
             Self::UpstreamActivityLive,
             Self::UpstreamActivityArchives,
             Self::PoolUpstreamNodeHealthArchives,
@@ -47,6 +51,10 @@ impl StartupBackfillTask {
             Self::InvocationServiceTier => STARTUP_BACKFILL_TASK_INVOCATION_SERVICE_TIER,
             Self::ReasoningEffort => STARTUP_BACKFILL_TASK_REASONING_EFFORT,
             Self::FailureClassification => STARTUP_BACKFILL_TASK_FAILURE_CLASSIFICATION,
+            Self::PoolAttemptPublicIdLive => STARTUP_BACKFILL_TASK_POOL_ATTEMPT_PUBLIC_ID_LIVE,
+            Self::PoolAttemptPublicIdArchives => {
+                STARTUP_BACKFILL_TASK_POOL_ATTEMPT_PUBLIC_ID_ARCHIVES
+            }
             Self::UpstreamActivityLive => STARTUP_BACKFILL_TASK_UPSTREAM_ACTIVITY_LIVE,
             Self::UpstreamActivityArchives => STARTUP_BACKFILL_TASK_UPSTREAM_ACTIVITY_ARCHIVES,
             Self::PoolUpstreamNodeHealthArchives => {
@@ -65,6 +73,8 @@ impl StartupBackfillTask {
             Self::InvocationServiceTier => "invocation service tier",
             Self::ReasoningEffort => "proxy reasoning effort",
             Self::FailureClassification => "invocation failure classification",
+            Self::PoolAttemptPublicIdLive => "pool attempt public id live rows",
+            Self::PoolAttemptPublicIdArchives => "pool attempt public id archives",
             Self::UpstreamActivityLive => "upstream activity live rows",
             Self::UpstreamActivityArchives => "upstream activity archives",
             Self::PoolUpstreamNodeHealthArchives => "pool upstream node health archives",
@@ -782,6 +792,50 @@ pub(crate) async fn run_startup_backfill_task(
                     samples: outcome.samples,
                 },
                 "failure classification recalculated".to_string(),
+            ))
+        }
+        StartupBackfillTask::PoolAttemptPublicIdLive => {
+            let outcome = backfill_pool_upstream_request_attempt_public_ids_from_cursor(
+                &state.pool,
+                cursor_id,
+                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                max_elapsed,
+            )
+            .await?;
+            Ok((
+                StartupBackfillRunState {
+                    next_cursor_id: outcome.next_cursor_id,
+                    scanned: outcome.summary.scanned,
+                    updated: outcome.summary.updated,
+                    hit_scan_limit: outcome.hit_budget,
+                    force_idle: false,
+                    samples: outcome.samples,
+                },
+                "attempt_public_id live rows".to_string(),
+            ))
+        }
+        StartupBackfillTask::PoolAttemptPublicIdArchives => {
+            let outcome =
+                backfill_pool_upstream_request_attempt_archive_public_ids_from_batch_cursor(
+                    &state.pool,
+                    cursor_id,
+                    Some(1),
+                    max_elapsed,
+                )
+                .await?;
+            Ok((
+                StartupBackfillRunState {
+                    next_cursor_id: outcome.next_cursor_id,
+                    scanned: outcome.summary.scanned_batches,
+                    updated: outcome.summary.updated_rows,
+                    hit_scan_limit: outcome.hit_budget,
+                    force_idle: false,
+                    samples: outcome.samples,
+                },
+                format!(
+                    "updated_batches={} updated_rows={}",
+                    outcome.summary.updated_batches, outcome.summary.updated_rows
+                ),
             ))
         }
         StartupBackfillTask::UpstreamActivityLive => {

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -69,6 +69,156 @@ pub(crate) fn terminal_pool_upstream_request_attempt_phase(status: &str) -> &'st
     }
 }
 
+pub(crate) const POOL_UPSTREAM_REQUEST_ATTEMPT_PUBLIC_ID_LENGTH: usize = 8;
+const POOL_UPSTREAM_REQUEST_ATTEMPT_PUBLIC_ID_RETRY_LIMIT: usize = 16;
+const POOL_UPSTREAM_REQUEST_ATTEMPT_PUBLIC_ID_ALPHABET: [char; 58] = [
+    '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K',
+    'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e',
+    'f', 'g', 'h', 'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y',
+    'z',
+];
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PoolAttemptPublicIdBackfillSummary {
+    pub(crate) scanned: u64,
+    pub(crate) updated: u64,
+}
+
+pub(crate) fn pool_upstream_request_attempt_public_id_has_alpha(value: &str) -> bool {
+    value.chars().any(|char| char.is_ascii_alphabetic())
+}
+
+pub(crate) fn generate_pool_upstream_request_attempt_public_id() -> String {
+    loop {
+        let candidate = nanoid::nanoid!(
+            POOL_UPSTREAM_REQUEST_ATTEMPT_PUBLIC_ID_LENGTH,
+            &POOL_UPSTREAM_REQUEST_ATTEMPT_PUBLIC_ID_ALPHABET
+        );
+        if pool_upstream_request_attempt_public_id_has_alpha(&candidate) {
+            return candidate;
+        }
+    }
+}
+
+fn is_pool_upstream_request_attempt_public_id_collision(error: &sqlx::Error) -> bool {
+    let sqlx::Error::Database(database_error) = error else {
+        return false;
+    };
+    let code_matches = database_error
+        .code()
+        .as_deref()
+        .is_some_and(|code| code == "1555" || code == "2067");
+    let message = database_error.message().to_ascii_lowercase();
+    code_matches
+        && (message.contains("attempt_public_id")
+            || message.contains("idx_pool_upstream_request_attempts_public_id"))
+}
+
+pub(crate) async fn assign_pool_upstream_request_attempt_public_id_if_missing(
+    conn: &mut SqliteConnection,
+    attempt_row_id: i64,
+) -> Result<bool> {
+    for _ in 0..POOL_UPSTREAM_REQUEST_ATTEMPT_PUBLIC_ID_RETRY_LIMIT {
+        let attempt_public_id = generate_pool_upstream_request_attempt_public_id();
+        match sqlx::query(
+            r#"
+            UPDATE pool_upstream_request_attempts
+            SET attempt_public_id = ?1
+            WHERE id = ?2
+              AND TRIM(COALESCE(attempt_public_id, '')) = ''
+            "#,
+        )
+        .bind(&attempt_public_id)
+        .bind(attempt_row_id)
+        .execute(&mut *conn)
+        .await
+        {
+            Ok(result) => return Ok(result.rows_affected() > 0),
+            Err(error) if is_pool_upstream_request_attempt_public_id_collision(&error) => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    bail!(
+        "failed to allocate unique attempt_public_id for pool_upstream_request_attempts row {}",
+        attempt_row_id
+    );
+}
+
+pub(crate) async fn backfill_pool_upstream_request_attempt_public_ids_on_connection(
+    conn: &mut SqliteConnection,
+    start_after_id: i64,
+    scan_limit: Option<u64>,
+    max_elapsed: Option<Duration>,
+) -> Result<BackfillBatchOutcome<PoolAttemptPublicIdBackfillSummary>> {
+    let started_at = Instant::now();
+    let mut summary = PoolAttemptPublicIdBackfillSummary::default();
+    let mut last_seen_id = start_after_id;
+    let mut hit_budget = false;
+    let mut samples = Vec::new();
+
+    loop {
+        if startup_backfill_budget_reached(started_at, summary.scanned, scan_limit, max_elapsed) {
+            hit_budget = true;
+            break;
+        }
+
+        let rows = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT id
+            FROM pool_upstream_request_attempts
+            WHERE id > ?1
+              AND TRIM(COALESCE(attempt_public_id, '')) = ''
+            ORDER BY id ASC
+            LIMIT ?2
+            "#,
+        )
+        .bind(last_seen_id)
+        .bind(startup_backfill_query_limit(summary.scanned, scan_limit))
+        .fetch_all(&mut *conn)
+        .await?;
+
+        if rows.is_empty() {
+            break;
+        }
+
+        if let Some(last) = rows.last() {
+            last_seen_id = *last;
+        }
+        summary.scanned += rows.len() as u64;
+
+        for row_id in rows {
+            if assign_pool_upstream_request_attempt_public_id_if_missing(conn, row_id).await? {
+                summary.updated += 1;
+                push_backfill_sample(&mut samples, format!("id={row_id}"));
+            }
+        }
+    }
+
+    Ok(BackfillBatchOutcome {
+        summary,
+        next_cursor_id: last_seen_id,
+        hit_budget,
+        samples,
+    })
+}
+
+pub(crate) async fn backfill_pool_upstream_request_attempt_public_ids_from_cursor(
+    pool: &Pool<Sqlite>,
+    start_after_id: i64,
+    scan_limit: Option<u64>,
+    max_elapsed: Option<Duration>,
+) -> Result<BackfillBatchOutcome<PoolAttemptPublicIdBackfillSummary>> {
+    let mut conn = pool.acquire().await?;
+    backfill_pool_upstream_request_attempt_public_ids_on_connection(
+        &mut conn,
+        start_after_id,
+        scan_limit,
+        max_elapsed,
+    )
+    .await
+}
+
 pub(crate) async fn insert_pool_upstream_request_attempt_with_scope(
     pool: &Pool<Sqlite>,
     trace: &PoolUpstreamAttemptTraceContext,
@@ -95,74 +245,85 @@ pub(crate) async fn insert_pool_upstream_request_attempt_with_scope(
     compact_support_status: Option<&str>,
     compact_support_reason: Option<&str>,
 ) -> Result<i64> {
-    let result = sqlx::query(
-        r#"
-        INSERT INTO pool_upstream_request_attempts (
-            invoke_id,
-            occurred_at,
-            endpoint,
-            route_mode,
-            sticky_key,
-            group_name_snapshot,
-            proxy_binding_key_snapshot,
-            upstream_account_id,
-            upstream_route_key,
-            attempt_index,
-            distinct_account_index,
-            same_account_retry_index,
-            requester_ip,
-            started_at,
-            finished_at,
-            status,
-            phase,
-            http_status,
-            downstream_http_status,
-            failure_kind,
-            error_message,
-            downstream_error_message,
-            connect_latency_ms,
-            first_byte_latency_ms,
-            stream_latency_ms,
-            upstream_request_id,
-            compact_support_status,
-            compact_support_reason
+    for _ in 0..POOL_UPSTREAM_REQUEST_ATTEMPT_PUBLIC_ID_RETRY_LIMIT {
+        let attempt_public_id = generate_pool_upstream_request_attempt_public_id();
+        let result = sqlx::query(
+            r#"
+            INSERT INTO pool_upstream_request_attempts (
+                attempt_public_id,
+                invoke_id,
+                occurred_at,
+                endpoint,
+                route_mode,
+                sticky_key,
+                group_name_snapshot,
+                proxy_binding_key_snapshot,
+                upstream_account_id,
+                upstream_route_key,
+                attempt_index,
+                distinct_account_index,
+                same_account_retry_index,
+                requester_ip,
+                started_at,
+                finished_at,
+                status,
+                phase,
+                http_status,
+                downstream_http_status,
+                failure_kind,
+                error_message,
+                downstream_error_message,
+                connect_latency_ms,
+                first_byte_latency_ms,
+                stream_latency_ms,
+                upstream_request_id,
+                compact_support_status,
+                compact_support_reason
+            )
+            VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29
+            )
+            "#,
         )
-        VALUES (
-            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28
-        )
-        "#,
-    )
-    .bind(&trace.invoke_id)
-    .bind(&trace.occurred_at)
-    .bind(&trace.endpoint)
-    .bind(INVOCATION_ROUTE_MODE_POOL)
-    .bind(trace.sticky_key.as_deref())
-    .bind(group_name_snapshot)
-    .bind(proxy_binding_key_snapshot)
-    .bind(upstream_account_id)
-    .bind(upstream_route_key)
-    .bind(attempt_index)
-    .bind(distinct_account_index)
-    .bind(same_account_retry_index)
-    .bind(trace.requester_ip.as_deref())
-    .bind(started_at)
-    .bind(finished_at)
-    .bind(status)
-    .bind(phase)
-    .bind(http_status.map(|value| i64::from(value.as_u16())))
-    .bind(downstream_http_status.map(|value| i64::from(value.as_u16())))
-    .bind(failure_kind)
-    .bind(error_message)
-    .bind(downstream_error_message)
-    .bind(connect_latency_ms)
-    .bind(first_byte_latency_ms)
-    .bind(stream_latency_ms)
-    .bind(upstream_request_id)
-    .bind(compact_support_status)
-    .bind(compact_support_reason)
-    .execute(pool)
-    .await?;
-    Ok(result.last_insert_rowid())
+        .bind(&attempt_public_id)
+        .bind(&trace.invoke_id)
+        .bind(&trace.occurred_at)
+        .bind(&trace.endpoint)
+        .bind(INVOCATION_ROUTE_MODE_POOL)
+        .bind(trace.sticky_key.as_deref())
+        .bind(group_name_snapshot)
+        .bind(proxy_binding_key_snapshot)
+        .bind(upstream_account_id)
+        .bind(upstream_route_key)
+        .bind(attempt_index)
+        .bind(distinct_account_index)
+        .bind(same_account_retry_index)
+        .bind(trace.requester_ip.as_deref())
+        .bind(started_at)
+        .bind(finished_at)
+        .bind(status)
+        .bind(phase)
+        .bind(http_status.map(|value| i64::from(value.as_u16())))
+        .bind(downstream_http_status.map(|value| i64::from(value.as_u16())))
+        .bind(failure_kind)
+        .bind(error_message)
+        .bind(downstream_error_message)
+        .bind(connect_latency_ms)
+        .bind(first_byte_latency_ms)
+        .bind(stream_latency_ms)
+        .bind(upstream_request_id)
+        .bind(compact_support_status)
+        .bind(compact_support_reason)
+        .execute(pool)
+        .await;
+        match result {
+            Ok(result) => return Ok(result.last_insert_rowid()),
+            Err(error) if is_pool_upstream_request_attempt_public_id_collision(&error) => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    bail!("failed to allocate unique attempt_public_id for pool_upstream_request_attempts insert")
 }
 
 pub(crate) async fn insert_pool_upstream_request_attempt(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2901,6 +2901,7 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         r#"
         CREATE TABLE IF NOT EXISTS pool_upstream_request_attempts (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            attempt_public_id TEXT,
             invoke_id TEXT NOT NULL,
             occurred_at TEXT NOT NULL,
             endpoint TEXT NOT NULL,
@@ -3022,6 +3023,7 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     let existing_pool_attempt_columns =
         load_sqlite_table_columns(pool, "pool_upstream_request_attempts").await?;
     for (column, ty) in [
+        ("attempt_public_id", "TEXT"),
         ("upstream_route_key", "TEXT"),
         ("phase", "TEXT"),
         ("downstream_http_status", "INTEGER"),
@@ -3102,6 +3104,17 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     .execute(pool)
     .await
     .context("failed to ensure index idx_forward_proxy_attempts_time_proxy")?;
+
+    sqlx::query(
+        r#"
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_pool_upstream_request_attempts_public_id
+        ON pool_upstream_request_attempts (attempt_public_id)
+        WHERE attempt_public_id IS NOT NULL
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure index idx_pool_upstream_request_attempts_public_id")?;
 
     sqlx::query(
         r#"

--- a/src/tests/stateful_sqlite/invocation_query_filters_and_schema_migrations.rs
+++ b/src/tests/stateful_sqlite/invocation_query_filters_and_schema_migrations.rs
@@ -120,8 +120,9 @@ async fn locate_invocation_returns_account_scoped_anchor_pages() {
         let response = locate_invocation_page(
             state.clone(),
             &LocateInvocationQuery {
-                request_id: request_id.to_string(),
-                upstream_account_id: 17,
+                request_id: Some(request_id.to_string()),
+                attempt_id: None,
+                upstream_account_id: Some(17),
                 page_size: Some(50),
             },
         )
@@ -140,8 +141,9 @@ async fn locate_invocation_returns_account_scoped_anchor_pages() {
     let account_mismatch = locate_invocation_page(
         state.clone(),
         &LocateInvocationQuery {
-            request_id: "locate-060".to_string(),
-            upstream_account_id: 18,
+            request_id: Some("locate-060".to_string()),
+            attempt_id: None,
+            upstream_account_id: Some(18),
             page_size: Some(50),
         },
     )
@@ -152,8 +154,9 @@ async fn locate_invocation_returns_account_scoped_anchor_pages() {
     let anchored = locate_invocation_page(
         state.clone(),
         &LocateInvocationQuery {
-            request_id: "locate-060".to_string(),
-            upstream_account_id: 17,
+            request_id: Some("locate-060".to_string()),
+            attempt_id: None,
+            upstream_account_id: Some(17),
             page_size: Some(50),
         },
     )

--- a/src/tests/stateful_sqlite/runtime_overlay_and_group_rule_behaviors.rs
+++ b/src/tests/stateful_sqlite/runtime_overlay_and_group_rule_behaviors.rs
@@ -4102,8 +4102,9 @@ async fn locate_invocation_finds_runtime_only_account_record() {
     let response = locate_invocation_page(
         state.clone(),
         &LocateInvocationQuery {
-            request_id: invoke_id.to_string(),
-            upstream_account_id: 17,
+            request_id: Some(invoke_id.to_string()),
+            attempt_id: None,
+            upstream_account_id: Some(17),
             page_size: Some(50),
         },
     )
@@ -4197,8 +4198,9 @@ async fn locate_invocation_finds_runtime_only_account_record() {
     let stable_response = locate_invocation_page(
         state.clone(),
         &LocateInvocationQuery {
-            request_id: "locate-stable-target".to_string(),
-            upstream_account_id: 17,
+            request_id: Some("locate-stable-target".to_string()),
+            attempt_id: None,
+            upstream_account_id: Some(17),
             page_size: Some(50),
         },
     )

--- a/src/upstream_accounts/core_models_rows.rs
+++ b/src/upstream_accounts/core_models_rows.rs
@@ -757,7 +757,7 @@ pub(crate) struct UpstreamAccountActionEventRow {
     pub(crate) http_status: Option<i64>,
     pub(crate) failure_kind: Option<String>,
     pub(crate) invoke_id: Option<String>,
-    pub(crate) attempt_id: Option<i64>,
+    pub(crate) attempt_public_id: Option<String>,
     pub(crate) sticky_key: Option<String>,
     pub(crate) created_at: String,
 }

--- a/src/upstream_accounts/core_runtime_types.rs
+++ b/src/upstream_accounts/core_runtime_types.rs
@@ -944,7 +944,7 @@ pub(crate) struct UpstreamAccountAttemptListResponse {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LocateUpstreamAccountAttemptQuery {
-    pub(crate) attempt_id: i64,
+    pub(crate) attempt_id: String,
     pub(crate) page_size: Option<usize>,
 }
 
@@ -1582,7 +1582,7 @@ pub(crate) struct UpstreamAccountActionEvent {
     pub(crate) http_status: Option<u16>,
     pub(crate) failure_kind: Option<String>,
     pub(crate) invoke_id: Option<String>,
-    pub(crate) attempt_id: Option<i64>,
+    pub(crate) attempt_id: Option<String>,
     pub(crate) sticky_key: Option<String>,
     pub(crate) created_at: String,
 }

--- a/src/upstream_accounts/crud_group_notes.rs
+++ b/src/upstream_accounts/crud_group_notes.rs
@@ -49,12 +49,12 @@ pub(crate) async fn locate_upstream_account_attempt(
         r#"
         SELECT occurred_at
         FROM pool_upstream_request_attempts
-        WHERE id = ?1
+        WHERE attempt_public_id = ?1
           AND upstream_account_id = ?2
           AND occurred_at >= ?3
         "#,
     )
-    .bind(params.attempt_id)
+    .bind(&params.attempt_id)
     .bind(account_id)
     .bind(&cutoff)
     .fetch_optional(&state.pool)
@@ -72,13 +72,23 @@ pub(crate) async fn locate_upstream_account_attempt(
         FROM pool_upstream_request_attempts
         WHERE upstream_account_id = ?1
           AND occurred_at >= ?2
-          AND (occurred_at > ?3 OR (occurred_at = ?3 AND id > ?4))
+          AND (
+                occurred_at > ?3
+                OR (
+                    occurred_at = ?3
+                    AND id > (
+                        SELECT id
+                        FROM pool_upstream_request_attempts
+                        WHERE attempt_public_id = ?4
+                    )
+                )
+              )
         "#,
     )
     .bind(account_id)
     .bind(&cutoff)
     .bind(&target_occurred_at)
-    .bind(params.attempt_id)
+    .bind(&params.attempt_id)
     .fetch_one(&state.pool)
     .await
     .map_err(internal_error_tuple)?
@@ -115,6 +125,7 @@ async fn load_upstream_account_attempt_page(
         r#"
         SELECT
             attempts.id,
+            attempts.attempt_public_id AS attempt_id,
             attempts.invoke_id,
             attempts.occurred_at,
             attempts.endpoint,
@@ -372,11 +383,12 @@ pub(crate) async fn list_upstream_account_action_events_from_params(
             event.http_status,
             event.failure_kind,
             event.invoke_id,
-            event.attempt_id,
+            attempts.attempt_public_id,
             event.sticky_key,
             event.created_at
         FROM pool_upstream_account_events event
         INNER JOIN pool_upstream_accounts account ON account.id = event.account_id
+        LEFT JOIN pool_upstream_request_attempts attempts ON attempts.id = event.attempt_id
         {where_clause}
         ORDER BY event.occurred_at DESC, event.id DESC
         LIMIT ? OFFSET ?

--- a/src/upstream_accounts/sync_account_imports_tags.rs
+++ b/src/upstream_accounts/sync_account_imports_tags.rs
@@ -3100,11 +3100,12 @@ pub(crate) async fn load_upstream_account_detail_with_options(
                 event.http_status,
                 event.failure_kind,
                 event.invoke_id,
-                event.attempt_id,
+                attempts.attempt_public_id,
                 event.sticky_key,
                 event.created_at
             FROM pool_upstream_account_events event
             INNER JOIN pool_upstream_accounts account ON account.id = event.account_id
+            LEFT JOIN pool_upstream_request_attempts attempts ON attempts.id = event.attempt_id
             WHERE event.account_id = ?1
             ORDER BY event.occurred_at DESC, event.id DESC
             LIMIT 20

--- a/src/upstream_accounts/sync_group_sessions.rs
+++ b/src/upstream_accounts/sync_group_sessions.rs
@@ -769,7 +769,7 @@ pub(crate) fn build_action_event_from_row(
         http_status: row.http_status.and_then(|value| u16::try_from(value).ok()),
         failure_kind: row.failure_kind.clone(),
         invoke_id: row.invoke_id.clone(),
-        attempt_id: row.attempt_id,
+        attempt_id: row.attempt_public_id.clone(),
         sticky_key: row.sticky_key.clone(),
         created_at: row.created_at.clone(),
     }

--- a/web/src/features/account-pool/UpstreamAccountAttemptTimeline.test.tsx
+++ b/web/src/features/account-pool/UpstreamAccountAttemptTimeline.test.tsx
@@ -24,7 +24,7 @@ const fetchBindingNodesMock = vi.mocked(fetchForwardProxyBindingNodes);
 let host: HTMLDivElement | null = null;
 let root: Root | null = null;
 
-function renderTimeline(focusedAttemptId: number | null = null) {
+function renderTimeline(focusedAttemptId: string | null = null) {
   if (!host) {
     host = document.createElement("div");
     document.body.appendChild(host);
@@ -89,7 +89,7 @@ describe("UpstreamAccountAttemptTimeline", () => {
     fetchAttemptsMock.mockResolvedValue({
       items: [
         {
-          id: 1,
+          attemptId: "4V7MYPJG",
           invokeId: "POOLCALL001",
           occurredAt: "2026-07-11T12:00:00.000Z",
           endpoint: "/v1/responses",
@@ -136,7 +136,7 @@ describe("UpstreamAccountAttemptTimeline", () => {
     expect(mobileTable?.querySelector("a")?.className).not.toContain("truncate");
 
     const disclosure = host?.querySelector<HTMLDetailsElement>(
-      '[data-testid="account-attempt-evidence-1"]',
+      '[data-testid="account-attempt-evidence-4V7MYPJG"]',
     );
     expect(disclosure).not.toBeNull();
     expect(disclosure?.closest("td")?.colSpan).toBe(7);
@@ -158,7 +158,7 @@ describe("UpstreamAccountAttemptTimeline", () => {
     fetchAttemptsMock.mockResolvedValue({
       items: [
         {
-          id: 2,
+          attemptId: "QADKN5Z9",
           invokeId: "POOLPENDING",
           occurredAt: "2026-07-11T12:00:00.000Z",
           endpoint: "/v1/responses",
@@ -191,7 +191,7 @@ describe("UpstreamAccountAttemptTimeline", () => {
 
   it("opens the exact attempt diagnostics when event navigation focuses it", async () => {
     const focusedAttempt = {
-      id: 3,
+      attemptId: "YG7P25XG",
       invokeId: "POOLFOCUSED",
       occurredAt: "2026-07-11T12:00:00.000Z",
       endpoint: "/v1/responses",
@@ -222,11 +222,11 @@ describe("UpstreamAccountAttemptTimeline", () => {
 
     renderTimeline();
     await flushAsync();
-    renderTimeline(3);
+    renderTimeline("YG7P25XG");
     await flushAsync();
 
     const disclosures = host?.querySelectorAll<HTMLDetailsElement>(
-      '[data-testid="account-attempt-evidence-3"]',
+      '[data-testid="account-attempt-evidence-YG7P25XG"]',
     );
     expect(disclosures).toHaveLength(2);
     expect(Array.from(disclosures ?? []).every((disclosure) => disclosure.open)).toBe(true);

--- a/web/src/features/account-pool/UpstreamAccountAttemptTimeline.tsx
+++ b/web/src/features/account-pool/UpstreamAccountAttemptTimeline.tsx
@@ -218,7 +218,7 @@ function AttemptEvidenceDisclosure({
   return (
     <details
       className="group overflow-hidden rounded-md border border-base-300/70 text-xs"
-      data-testid={`account-attempt-evidence-${attempt.id}`}
+      data-testid={`account-attempt-evidence-${attempt.attemptId}`}
       onToggle={(event) => setIsOpen(event.currentTarget.open)}
       open={isOpen}
     >
@@ -369,7 +369,7 @@ export function UpstreamAccountAttemptTimeline({
   focusedAttemptId,
 }: {
   accountId: number;
-  focusedAttemptId: number | null;
+  focusedAttemptId: string | null;
 }) {
   const { t, locale } = useTranslation();
   const [response, setResponse] = useState<UpstreamAccountAttemptListResponse | null>(null);
@@ -518,13 +518,13 @@ export function UpstreamAccountAttemptTimeline({
             {response.items.map((attempt) => {
               const proxy = formatProxyBinding(attempt, proxyBindingNodesByKey, t);
               return (
-                <Fragment key={attempt.id}>
+                <Fragment key={attempt.attemptId}>
                   <tr
                     className={
-                      attempt.id === focusedAttemptId ? "bg-info/10" : "hover:bg-base-200/35"
+                      attempt.attemptId === focusedAttemptId ? "bg-info/10" : "hover:bg-base-200/35"
                     }
-                    data-attempt-id={attempt.id}
-                    data-testid={`account-attempt-record-${attempt.id}`}
+                    data-attempt-id={attempt.attemptId}
+                    data-testid={`account-attempt-record-${attempt.attemptId}`}
                   >
                     <td className="min-w-24 px-3 py-3 align-top font-mono text-xs tabular-nums text-base-content/70">
                       <AttemptTime
@@ -536,11 +536,14 @@ export function UpstreamAccountAttemptTimeline({
                     <td className="whitespace-nowrap px-3 py-3 align-top font-mono text-xs">
                       <Link
                         className="inline-block whitespace-nowrap text-info underline underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                        title={attempt.invokeId}
-                        to={`/records?requestId=${encodeURIComponent(attempt.invokeId)}&rangePreset=7d`}
+                        title={attempt.attemptId}
+                        to={`/records?attemptId=${encodeURIComponent(attempt.attemptId)}&rangePreset=7d`}
                       >
-                        {attempt.invokeId}
+                        {attempt.attemptId}
                       </Link>
+                      <div className="mt-1 text-[11px] text-base-content/55">
+                        {attempt.invokeId}
+                      </div>
                     </td>
                     <td className="px-3 py-3 align-top">
                       <ModelMapping attempt={attempt} t={t} />
@@ -568,12 +571,12 @@ export function UpstreamAccountAttemptTimeline({
                     </td>
                   </tr>
                   {hasAttemptEvidence(attempt, false) ? (
-                    <tr className={attempt.id === focusedAttemptId ? "bg-info/10" : ""}>
+                    <tr className={attempt.attemptId === focusedAttemptId ? "bg-info/10" : ""}>
                       <td className="px-3 pb-3 pt-0" colSpan={7}>
                         <AttemptEvidenceDisclosure
                           attempt={attempt}
                           includeTimings={false}
-                          isFocused={attempt.id === focusedAttemptId}
+                          isFocused={attempt.attemptId === focusedAttemptId}
                           proxy={proxy}
                           t={t}
                         />
@@ -603,10 +606,10 @@ export function UpstreamAccountAttemptTimeline({
             {response.items.map((attempt) => {
               const proxy = formatProxyBinding(attempt, proxyBindingNodesByKey, t);
               return (
-                <Fragment key={attempt.id}>
+                <Fragment key={attempt.attemptId}>
                   <tr
-                    className={attempt.id === focusedAttemptId ? "bg-info/10" : ""}
-                    data-attempt-id={attempt.id}
+                    className={attempt.attemptId === focusedAttemptId ? "bg-info/10" : ""}
+                    data-attempt-id={attempt.attemptId}
                   >
                     <td className="px-2 py-2 align-top font-mono tabular-nums text-base-content/70">
                       <AttemptTime
@@ -618,11 +621,14 @@ export function UpstreamAccountAttemptTimeline({
                     <td className="px-2 py-2 align-top">
                       <Link
                         className="block whitespace-nowrap font-mono text-info underline underline-offset-4"
-                        title={attempt.invokeId}
-                        to={`/records?requestId=${encodeURIComponent(attempt.invokeId)}&rangePreset=7d`}
+                        title={attempt.attemptId}
+                        to={`/records?attemptId=${encodeURIComponent(attempt.attemptId)}&rangePreset=7d`}
                       >
-                        {attempt.invokeId}
+                        {attempt.attemptId}
                       </Link>
+                      <div className="mt-1 font-mono text-[11px] text-base-content/55">
+                        {attempt.invokeId}
+                      </div>
                       <div className="mt-1">
                         <ModelMapping attempt={attempt} t={t} />
                       </div>
@@ -635,12 +641,12 @@ export function UpstreamAccountAttemptTimeline({
                     </td>
                   </tr>
                   {hasAttemptEvidence(attempt, true) ? (
-                    <tr className={attempt.id === focusedAttemptId ? "bg-info/10" : ""}>
+                    <tr className={attempt.attemptId === focusedAttemptId ? "bg-info/10" : ""}>
                       <td className="px-2 pb-2 pt-0" colSpan={4}>
                         <AttemptEvidenceDisclosure
                           attempt={attempt}
                           includeTimings
-                          isFocused={attempt.id === focusedAttemptId}
+                          isFocused={attempt.attemptId === focusedAttemptId}
                           proxy={proxy}
                           t={t}
                         />

--- a/web/src/features/account-pool/UpstreamAccountsPage.overlays.stories.tsx
+++ b/web/src/features/account-pool/UpstreamAccountsPage.overlays.stories.tsx
@@ -181,7 +181,7 @@ export const DetailDrawerRecordsPopulated: Story = {
     await expect(within(dialog).getByText(/upstream_response_failed/i)).toBeInTheDocument();
     const desktopAttempts = within(dialog).getByTestId("upstream-account-call-records-table");
     await userEvent.click(
-      within(within(desktopAttempts).getByTestId("account-attempt-evidence-9001")).getByText(
+      within(within(desktopAttempts).getByTestId("account-attempt-evidence-4V7MYPJG")).getByText(
         /诊断详情|diagnostics/i,
       ),
     );
@@ -200,11 +200,11 @@ export const DetailDrawerEventLocatesAttempt: Story = {
     await userEvent.click(within(dialog).getByRole("tab", { name: /健康与事件|health & events/i }));
     await userEvent.click(
       within(dialog).getByRole("button", {
-        name: /上游尝试 ID.*9001|upstream attempt id.*9001/i,
+        name: /上游尝试 ID.*4V7MYPJG|upstream attempt id.*4V7MYPJG/i,
       }),
     );
     const recordsTable = await within(dialog).findByTestId("upstream-account-call-records-table");
-    const disclosure = within(recordsTable).getByTestId("account-attempt-evidence-9001");
+    const disclosure = within(recordsTable).getByTestId("account-attempt-evidence-4V7MYPJG");
     await expect(disclosure).toHaveAttribute("open");
     await expect(within(disclosure).getByText("upstream-story-500")).toBeInTheDocument();
   },
@@ -229,7 +229,7 @@ export const DetailDrawerRecordsMobile: Story = {
     await expect(within(dialog).getByText(/上游 HTTP 500|upstream http 500/i)).toBeInTheDocument();
     const mobileAttempts = within(dialog).getByTestId("upstream-account-call-records-mobile-table");
     await userEvent.click(
-      within(within(mobileAttempts).getByTestId("account-attempt-evidence-9001")).getByText(
+      within(within(mobileAttempts).getByTestId("account-attempt-evidence-4V7MYPJG")).getByText(
         /诊断详情|diagnostics/i,
       ),
     );

--- a/web/src/features/account-pool/UpstreamAccountsPage.story-helpers-runtime.tsx
+++ b/web/src/features/account-pool/UpstreamAccountsPage.story-helpers-runtime.tsx
@@ -1022,10 +1022,10 @@ export function StorybookUpstreamAccountsMock({ children }: { children: ReactNod
       );
       if (attemptMatch && method === "GET") {
         const accountId = Number(attemptMatch[1]);
-        const attemptId = Number(parsedUrl.searchParams.get("attemptId") || 9001);
+        const attemptId = parsedUrl.searchParams.get("attemptId")?.trim() || "4V7MYPJG";
         const attempts: ApiPoolUpstreamRequestAttempt[] = [
           {
-            id: 9001,
+            attemptId: "4V7MYPJG",
             invokeId: "storybook-pool-retry-001",
             occurredAt: "2026-07-11T12:00:00.000Z",
             endpoint: "/v1/responses",
@@ -1053,7 +1053,7 @@ export function StorybookUpstreamAccountsMock({ children }: { children: ReactNod
             createdAt: "2026-07-11T12:00:00.000Z",
           },
           {
-            id: 9002,
+            attemptId: "QADKN5Z9",
             invokeId: "storybook-pool-retry-001",
             occurredAt: "2026-07-11T12:00:01.000Z",
             endpoint: "/v1/responses",
@@ -1081,7 +1081,7 @@ export function StorybookUpstreamAccountsMock({ children }: { children: ReactNod
         ];
         if (storyId?.endsWith("--detail-drawer-records-pending-mobile")) {
           attempts.unshift({
-            id: 9003,
+            attemptId: "YG7P25XG",
             invokeId: "storybook-pool-pending-001",
             occurredAt: "2026-07-11T12:00:02.000Z",
             endpoint: "/v1/responses",
@@ -1099,7 +1099,10 @@ export function StorybookUpstreamAccountsMock({ children }: { children: ReactNod
             createdAt: "2026-07-11T12:00:02.000Z",
           });
         }
-        if (path.endsWith("/locate") && !attempts.some((attempt) => attempt.id === attemptId)) {
+        if (
+          path.endsWith("/locate") &&
+          !attempts.some((attempt) => attempt.attemptId === attemptId)
+        ) {
           return jsonResponse({ message: "upstream account attempt was not found" }, 404);
         }
         return jsonResponse({ items: attempts, total: attempts.length, page: 1, pageSize: 50 });

--- a/web/src/features/account-pool/UpstreamAccountsPage.story-runtime-core.ts
+++ b/web/src/features/account-pool/UpstreamAccountsPage.story-runtime-core.ts
@@ -340,7 +340,7 @@ const detailRichRecentActions = [
     httpStatus: 429,
     failureKind: "upstream_http_429_quota_exhausted",
     invokeId: null,
-    attemptId: 9001,
+    attemptId: "4V7MYPJG",
     stickyKey: "019ce3a1-6787-7910-b0fd-c246d6f6a901",
     createdAt: "2026-03-17T12:22:00.000Z",
   },

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.stories.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.stories.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../lib/dashboardWorkingConversations";
 import { AccountDetailDrawerShell } from "../account-pool/AccountDetailDrawerShell";
 import { PromptCacheConversationHistoryDrawer } from "../prompt-cache/PromptCacheConversationTable";
+import { formatStoryAttemptId } from "../records/invocationRecordsStoryFixtures";
 import { DashboardInvocationDetailDrawer } from "./DashboardInvocationDetailDrawer";
 import { DashboardWorkingConversationsSection } from "./DashboardWorkingConversationsSection";
 import { DASHBOARD_WORKSPACE_VIEW_STORAGE_KEY } from "./dashboardActivityRange";
@@ -1748,7 +1749,7 @@ function buildStoryMockData(
     ) {
       poolAttemptsByInvokeId.set(record.invokeId, [
         {
-          id: record.id * 10 + 1,
+          attemptId: formatStoryAttemptId(record.id * 10 + 1),
           invokeId: record.invokeId,
           occurredAt: record.occurredAt,
           endpoint: record.endpoint ?? "/v1/responses",

--- a/web/src/features/invocations/InvocationTable.stories.tsx
+++ b/web/src/features/invocations/InvocationTable.stories.tsx
@@ -18,6 +18,7 @@ import UpstreamAccountsPage, {
 } from "../../pages/account-pool/UpstreamAccounts";
 import {
   createStoryForwardProxyBindingNodes,
+  formatStoryAttemptId,
   STORYBOOK_FIRST_RESPONSE_BYTE_SEMANTICS_RECORDS,
 } from "../records/invocationRecordsStoryFixtures";
 import { InvocationTable } from "./InvocationTable";
@@ -1227,7 +1228,7 @@ function buildPoolAttemptLifecycleAttempts(
   if (phase === "success") {
     return [
       {
-        id: 4101,
+        attemptId: formatStoryAttemptId(4101),
         invokeId: "inv_storybook_pool_attempt_detail_lifecycle",
         occurredAt,
         endpoint: "/v1/responses",
@@ -1256,7 +1257,7 @@ function buildPoolAttemptLifecycleAttempts(
 
   return [
     {
-      id: 4101,
+      attemptId: formatStoryAttemptId(4101),
       invokeId: "inv_storybook_pool_attempt_detail_lifecycle",
       occurredAt,
       endpoint: "/v1/responses",

--- a/web/src/features/invocations/InvocationTable.tsx
+++ b/web/src/features/invocations/InvocationTable.tsx
@@ -49,7 +49,7 @@ interface InvocationTableProps {
   onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
   scrollElement?: HTMLElement | null;
   showInvokeId?: boolean;
-  scrollTarget?: { invokeId: string; version: number } | null;
+  scrollTarget?: { invokeId: string; attemptId?: string | null; version: number } | null;
 }
 
 type StatusMeta = {
@@ -867,6 +867,7 @@ export function InvocationTable({
                       detailNotice={row.detailNotice}
                       size="compact"
                       poolAttemptsState={poolAttemptsState}
+                      focusedAttemptId={isHighlighted ? (scrollTarget?.attemptId ?? null) : null}
                       t={t}
                     />
                   </div>
@@ -1208,6 +1209,9 @@ export function InvocationTable({
                             detailNotice={row.detailNotice}
                             size="default"
                             poolAttemptsState={poolAttemptsState}
+                            focusedAttemptId={
+                              isHighlighted ? (scrollTarget?.attemptId ?? null) : null
+                            }
                             t={t}
                           />
                         </td>

--- a/web/src/features/invocations/invocation-details-shared.tsx
+++ b/web/src/features/invocations/invocation-details-shared.tsx
@@ -117,6 +117,7 @@ interface InvocationExpandedDetailsProps {
   detailNotice: string | null;
   size: DetailPanelSize;
   poolAttemptsState: InvocationPoolAttemptsState;
+  focusedAttemptId?: string | null;
   abnormalResponseBody?: ApiInvocationAbnormalResponseBodyPreview | null;
   abnormalResponseBodyLoading?: boolean;
   abnormalResponseBodyError?: string | null;
@@ -1487,6 +1488,7 @@ function renderPoolAttemptsContent(
   record: ApiInvocation,
   poolAttemptsState: InvocationPoolAttemptsState,
   proxyBindingNodesByKey: Map<string, ForwardProxyBindingNode>,
+  focusedAttemptId: string | null,
   t: Translator,
 ) {
   const invokeId = record.invokeId;
@@ -1575,12 +1577,20 @@ function renderPoolAttemptsContent(
                     attempt,
                     proxyBindingNodesByKey,
                   );
+                  const isFocused =
+                    focusedAttemptId != null && attempt.attemptId === focusedAttemptId;
 
                   return (
                     <div
-                      key={`${attempt.id}-${attempt.attemptIndex}`}
-                      className="rounded-lg border border-base-300/70 bg-base-100/70 p-3"
+                      key={`${attempt.attemptId}-${attempt.attemptIndex}`}
+                      className={cn(
+                        "rounded-lg border bg-base-100/70 p-3",
+                        isFocused
+                          ? "border-primary/45 bg-primary/8 ring-1 ring-inset ring-primary/35"
+                          : "border-base-300/70",
+                      )}
                       data-testid="pool-attempt-item"
+                      data-attempt-id={attempt.attemptId}
                     >
                       <div className="flex flex-wrap items-center gap-2">
                         <Badge variant={statusMeta.variant}>{t(statusMeta.key)}</Badge>
@@ -1592,6 +1602,7 @@ function renderPoolAttemptsContent(
                         <span className="font-mono text-xs text-base-content/70">
                           #{attempt.attemptIndex}
                         </span>
+                        <span className="font-mono text-xs text-info">{attempt.attemptId}</span>
                         <span className="text-sm font-medium">{accountLabel}</span>
                       </div>
                       <div className="mt-2 grid gap-2 text-sm md:grid-cols-2 xl:grid-cols-3">
@@ -1731,9 +1742,10 @@ function renderPoolAttemptsContent(
 
               return (
                 <div
-                  key={`terminal-${attempt.id}-${attempt.attemptIndex}`}
+                  key={`terminal-${attempt.attemptId}-${attempt.attemptIndex}`}
                   className="overflow-hidden rounded-xl border border-warning/40 bg-warning/10 shadow-sm"
                   data-testid="pool-attempt-terminal-record"
+                  data-attempt-id={attempt.attemptId}
                 >
                   <div className="flex flex-col gap-3 border-b border-warning/25 bg-warning/12 px-3 py-3 md:flex-row md:items-start md:justify-between">
                     <div className="flex min-w-0 items-start gap-3">
@@ -2017,6 +2029,7 @@ export function InvocationExpandedDetails({
   detailNotice,
   size,
   poolAttemptsState,
+  focusedAttemptId = null,
   abnormalResponseBody,
   abnormalResponseBodyLoading = false,
   abnormalResponseBodyError,
@@ -2235,7 +2248,13 @@ export function InvocationExpandedDetails({
         </DetailSection>
       ) : null}
 
-      {renderPoolAttemptsContent(record, poolAttemptsState, poolAttemptProxyBindingNodesByKey, t)}
+      {renderPoolAttemptsContent(
+        record,
+        poolAttemptsState,
+        poolAttemptProxyBindingNodesByKey,
+        focusedAttemptId,
+        t,
+      )}
     </div>
   );
 }

--- a/web/src/features/records/InvocationRecordsTable.tsx
+++ b/web/src/features/records/InvocationRecordsTable.tsx
@@ -37,6 +37,7 @@ interface InvocationRecordsTableProps {
   error?: string | null;
   onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
   autoExpandInvokeId?: string | null;
+  focusedAttemptId?: string | null;
 }
 
 type StatusMeta = {
@@ -355,6 +356,7 @@ export function InvocationRecordsTable({
   error,
   onOpenUpstreamAccount,
   autoExpandInvokeId = null,
+  focusedAttemptId = null,
 }: InvocationRecordsTableProps) {
   const { t, locale } = useTranslation();
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -954,6 +956,7 @@ export function InvocationRecordsTable({
                     detailNotice={row.detailNotice}
                     size="compact"
                     poolAttemptsState={poolAttemptsState}
+                    focusedAttemptId={isExpanded ? focusedAttemptId : null}
                     abnormalResponseBody={abnormalResponseBody}
                     abnormalResponseBodyLoading={detailLoading}
                     abnormalResponseBodyError={detailError}
@@ -1066,6 +1069,7 @@ export function InvocationRecordsTable({
                             detailNotice={row.detailNotice}
                             size="default"
                             poolAttemptsState={poolAttemptsState}
+                            focusedAttemptId={isExpanded ? focusedAttemptId : null}
                             abnormalResponseBody={abnormalResponseBody}
                             abnormalResponseBodyLoading={detailLoading}
                             abnormalResponseBodyError={detailError}
@@ -1130,6 +1134,7 @@ export function InvocationRecordsTable({
               detailNotice={drawerRow.detailNotice}
               size="default"
               poolAttemptsState={drawerPoolAttemptsState}
+              focusedAttemptId={focusedAttemptId}
               abnormalResponseBody={
                 drawerResponseBody
                   ? {

--- a/web/src/features/records/invocationRecordsStoryFixtures.ts
+++ b/web/src/features/records/invocationRecordsStoryFixtures.ts
@@ -21,6 +21,12 @@ function formatStoryProxyBindingDisplayName(key: string) {
   return `Story Proxy ${key.slice(-6)}`;
 }
 
+export function formatStoryAttemptId(seed: number) {
+  const compact = Math.abs(Math.trunc(seed)).toString(36).toUpperCase().slice(-8).padStart(8, "0");
+  if (/[A-Z]/.test(compact)) return compact;
+  return `${compact.slice(0, 4)}A${compact.slice(5)}`;
+}
+
 export function createStoryForwardProxyBindingNodes(keys: string[]): ForwardProxyBindingNode[] {
   return Array.from(new Set(keys.map((key) => key.trim()).filter(Boolean)))
     .filter((key) => key !== "__direct__")
@@ -462,7 +468,7 @@ export function createStoryPoolAttemptsByInvokeId(records: ApiInvocation[]) {
         const retryIndex = index < 3 ? index + 1 : index < 6 ? index - 2 : 1;
 
         return {
-          id: record.id * 100 + index + 1,
+          attemptId: formatStoryAttemptId(record.id * 100 + index + 1),
           invokeId: record.invokeId,
           occurredAt: record.occurredAt,
           endpoint: record.endpoint ?? "/v1/responses",
@@ -490,7 +496,7 @@ export function createStoryPoolAttemptsByInvokeId(records: ApiInvocation[]) {
       attemptsByInvokeId[record.invokeId] = [
         ...realAttempts,
         {
-          id: record.id * 100 + 8,
+          attemptId: formatStoryAttemptId(record.id * 100 + 8),
           invokeId: record.invokeId,
           occurredAt: record.occurredAt,
           endpoint: record.endpoint ?? "/v1/responses",
@@ -599,7 +605,7 @@ export function createStoryPoolAttemptsByInvokeId(records: ApiInvocation[]) {
           syntheticOauthBridgeAttempt ?? trueUpstreamHttpAttempt ?? downstreamClosedAttempt;
 
         return {
-          id: record.id * 100 + attemptIndex + 1,
+          attemptId: formatStoryAttemptId(record.id * 100 + attemptIndex + 1),
           invokeId: record.invokeId,
           occurredAt: record.occurredAt,
           endpoint: record.endpoint ?? "/v1/responses",

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -330,11 +330,11 @@ describe("upstream account attempts", () => {
     );
 
     await fetchUpstreamAccountAttempts(42, { page: 3, pageSize: 25 });
-    await locateUpstreamAccountAttempt(42, 9102, { pageSize: 25 });
+    await locateUpstreamAccountAttempt(42, "4V7MYPJG", { pageSize: 25 });
 
     expect(requestedUrls).toEqual([
       "/api/pool/upstream-accounts/42/call-attempts?page=3&pageSize=25",
-      "/api/pool/upstream-accounts/42/call-attempts/locate?attemptId=9102&pageSize=25",
+      "/api/pool/upstream-accounts/42/call-attempts/locate?attemptId=4V7MYPJG&pageSize=25",
     ]);
   });
 });

--- a/web/src/lib/api/core-foundation.ts
+++ b/web/src/lib/api/core-foundation.ts
@@ -403,7 +403,7 @@ export interface ListResponse {
 }
 
 export interface ApiPoolUpstreamRequestAttempt {
-  id: number;
+  attemptId: string;
   invokeId: string;
   occurredAt: string;
   endpoint: string;
@@ -521,13 +521,16 @@ export interface InvocationRecordsResponse extends ListResponse {
 
 export interface InvocationRecordLocationResponse extends InvocationRecordsResponse {
   anchorId: string;
+  requestId?: string;
+  attemptId?: string | null;
   targetIndex: number;
   targetAbsoluteIndex: number;
 }
 
 export interface InvocationRecordLocationQuery {
-  requestId: string;
-  upstreamAccountId: number;
+  requestId?: string;
+  attemptId?: string;
+  upstreamAccountId?: number;
   pageSize?: number;
   signal?: AbortSignal;
 }
@@ -987,10 +990,13 @@ export async function fetchInvocationRecords(query: InvocationRecordsQuery) {
 
 export async function fetchInvocationRecordLocation(query: InvocationRecordLocationQuery) {
   const search = new URLSearchParams({
-    requestId: query.requestId,
-    upstreamAccountId: String(query.upstreamAccountId),
     pageSize: String(query.pageSize ?? 50),
   });
+  if (query.requestId) search.set("requestId", query.requestId);
+  if (query.attemptId) search.set("attemptId", query.attemptId);
+  if (query.upstreamAccountId != null) {
+    search.set("upstreamAccountId", String(query.upstreamAccountId));
+  }
   return fetchJson<InvocationRecordLocationResponse>(
     `/api/invocations/locate?${search.toString()}`,
     { signal: query.signal },
@@ -1044,7 +1050,7 @@ export async function fetchUpstreamAccountAttempts(
 
 export async function locateUpstreamAccountAttempt(
   accountId: number,
-  attemptId: number,
+  attemptId: string,
   options?: { pageSize?: number; signal?: AbortSignal },
 ) {
   const search = new URLSearchParams({

--- a/web/src/lib/api/core-upstream.ts
+++ b/web/src/lib/api/core-upstream.ts
@@ -286,7 +286,7 @@ export interface UpstreamAccountActionEvent {
   httpStatus?: number | null;
   failureKind?: string | null;
   invokeId?: string | null;
-  attemptId?: number | null;
+  attemptId?: string | null;
   stickyKey?: string | null;
   createdAt: string;
 }
@@ -1258,6 +1258,10 @@ function normalizeUpstreamAccountActionEvent(raw: unknown): UpstreamAccountActio
   const action = typeof payload.action === "string" ? payload.action : "";
   const source = typeof payload.source === "string" ? payload.source : "";
   const createdAt = typeof payload.createdAt === "string" ? payload.createdAt : "";
+  const attemptId =
+    typeof payload.attemptId === "string" && payload.attemptId.trim()
+      ? payload.attemptId.trim()
+      : null;
   if (id == null || !occurredAt || !action || !source || !createdAt) {
     return null;
   }
@@ -1283,7 +1287,7 @@ function normalizeUpstreamAccountActionEvent(raw: unknown): UpstreamAccountActio
     httpStatus: normalizeFiniteNumber(payload.httpStatus) ?? null,
     failureKind: typeof payload.failureKind === "string" ? payload.failureKind : null,
     invokeId: typeof payload.invokeId === "string" ? payload.invokeId : null,
-    attemptId: normalizeFiniteNumber(payload.attemptId) ?? null,
+    attemptId,
     stickyKey: typeof payload.stickyKey === "string" ? payload.stickyKey : null,
     createdAt,
   };

--- a/web/src/pages/Records.tsx
+++ b/web/src/pages/Records.tsx
@@ -14,6 +14,7 @@ import { useInvocationRecords } from "../hooks/useInvocationRecords";
 import { useUpstreamAccountDetailRoute } from "../hooks/useUpstreamAccountDetailRoute";
 import { useTranslation } from "../i18n";
 import {
+  fetchInvocationRecordLocation,
   fetchInvocationSuggestions,
   type InvocationFocus,
   type InvocationRangePreset,
@@ -69,8 +70,15 @@ export default function RecordsPage() {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const requestedInvokeId = searchParams.get("requestId")?.trim() || null;
+  const requestedAttemptId = searchParams.get("attemptId")?.trim() || null;
+  const requestedUpstreamAccountIdRaw = searchParams.get("upstreamAccountId")?.trim() || "";
+  const requestedUpstreamAccountId =
+    requestedUpstreamAccountIdRaw && Number.isFinite(Number(requestedUpstreamAccountIdRaw))
+      ? Number(requestedUpstreamAccountIdRaw)
+      : null;
   const requestedRangePreset = searchParams.get("rangePreset") === "7d" ? "7d" : null;
   const appliedRequestIdRef = useRef<string | null>(null);
+  const requestedAttemptLocateKeyRef = useRef<string | null>(null);
   const isCompactViewport = useCompactViewport();
   const { upstreamAccountId, openUpstreamAccount, closeUpstreamAccount } =
     useUpstreamAccountDetailRoute();
@@ -98,6 +106,8 @@ export default function RecordsPage() {
     setPageSize,
     setSort,
   } = useInvocationRecords();
+  const [autoExpandInvokeId, setAutoExpandInvokeId] = useState<string | null>(null);
+  const [focusedAttemptId, setFocusedAttemptId] = useState<string | null>(null);
 
   const appliedSnapshotId = records?.snapshotId ?? summary?.snapshotId;
   const [suggestions, setSuggestions] = useState<InvocationSuggestionsResponse | null>(null);
@@ -120,6 +130,8 @@ export default function RecordsPage() {
     const requestKey = `${requestedInvokeId}:${requestedRangePreset ?? ""}`;
     if (!requestedInvokeId || appliedRequestIdRef.current === requestKey) return;
     appliedRequestIdRef.current = requestKey;
+    setAutoExpandInvokeId(requestedInvokeId);
+    setFocusedAttemptId(null);
     resetDraft();
     updateDraft("requestId", requestedInvokeId);
     if (requestedRangePreset) {
@@ -128,6 +140,61 @@ export default function RecordsPage() {
     const timer = window.setTimeout(() => void search(), 0);
     return () => window.clearTimeout(timer);
   }, [requestedInvokeId, requestedRangePreset, resetDraft, search, updateDraft]);
+
+  useEffect(() => {
+    const requestKey = [
+      requestedAttemptId ?? "",
+      requestedUpstreamAccountId ?? "",
+      requestedRangePreset ?? "",
+    ].join(":");
+    if (!requestedAttemptId || requestedAttemptLocateKeyRef.current === requestKey) return;
+    requestedAttemptLocateKeyRef.current = requestKey;
+    setAutoExpandInvokeId(null);
+    setFocusedAttemptId(requestedAttemptId);
+    let cancelled = false;
+
+    void fetchInvocationRecordLocation({
+      attemptId: requestedAttemptId,
+      upstreamAccountId: requestedUpstreamAccountId ?? undefined,
+      pageSize,
+    })
+      .then(async (response) => {
+        if (cancelled) return;
+        const resolvedInvokeId =
+          response.requestId?.trim() ||
+          response.records[response.targetIndex]?.invokeId?.trim() ||
+          "";
+        if (!resolvedInvokeId) return;
+        resetDraft();
+        updateDraft("requestId", resolvedInvokeId);
+        if (requestedRangePreset) {
+          updateDraft("rangePreset", requestedRangePreset);
+        }
+        setAutoExpandInvokeId(resolvedInvokeId);
+        setFocusedAttemptId(response.attemptId?.trim() || requestedAttemptId);
+        await search();
+        if (!cancelled && response.page > 1) {
+          await setPage(response.page);
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setAutoExpandInvokeId(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    pageSize,
+    requestedAttemptId,
+    requestedRangePreset,
+    requestedUpstreamAccountId,
+    resetDraft,
+    search,
+    setPage,
+    updateDraft,
+  ]);
 
   useEffect(() => {
     suggestionsSeqRef.current += 1;
@@ -845,7 +912,8 @@ export default function RecordsPage() {
             isLoading={tableLoading}
             error={recordsError}
             onOpenUpstreamAccount={(accountId) => openUpstreamAccount(accountId)}
-            autoExpandInvokeId={requestedInvokeId}
+            autoExpandInvokeId={autoExpandInvokeId}
+            focusedAttemptId={focusedAttemptId}
           />
 
           <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-base-300/70 bg-base-100/45 px-4 py-3">

--- a/web/src/pages/account-pool/UpstreamAccounts.page-local-shared.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.page-local-shared.tsx
@@ -243,6 +243,7 @@ type AccountDetailTab = UpstreamAccountDetailRouteTab;
 type AccountRecordsMode = "latest" | "anchored";
 type AccountRecordsLocateError = {
   invokeId: string;
+  attemptId?: string | null;
   kind: "notFound" | "request";
 };
 
@@ -907,7 +908,7 @@ function SharedUpstreamAccountDetailDrawerInner({
     DEFAULT_STICKY_CONVERSATION_SELECTION_VALUE,
   );
   const [expandedStickyKeys, setExpandedStickyKeys] = useState<string[]>([]);
-  const [focusedAttemptId, setFocusedAttemptId] = useState<number | null>(null);
+  const [focusedAttemptId, setFocusedAttemptId] = useState<string | null>(null);
   const [accountRecords, setAccountRecords] = useState<ApiInvocation[]>([]);
   const [accountRecordsMode, setAccountRecordsMode] = useState<AccountRecordsMode>("latest");
   const [accountRecordsFirstPage, setAccountRecordsFirstPage] = useState(0);
@@ -921,6 +922,7 @@ function SharedUpstreamAccountDetailDrawerInner({
     useState<AccountRecordsLocateError | null>(null);
   const [accountRecordsScrollTarget, setAccountRecordsScrollTarget] = useState<{
     invokeId: string;
+    attemptId?: string | null;
     version: number;
   } | null>(null);
   const [detailDrawerBodyElement, setDetailDrawerBodyElement] = useState<HTMLDivElement | null>(
@@ -1974,9 +1976,10 @@ function SharedUpstreamAccountDetailDrawerInner({
     [accountId, openUpstreamAccount],
   );
   const locateAccountAttempt = useCallback(
-    (attemptId: number | null | undefined) => {
-      if (attemptId == null || !Number.isFinite(attemptId)) return;
-      setFocusedAttemptId(attemptId);
+    (attemptId: string | null | undefined) => {
+      const normalizedAttemptId = attemptId?.trim() ?? "";
+      if (!normalizedAttemptId) return;
+      setFocusedAttemptId(normalizedAttemptId);
       handleSelectDetailTab("records");
     },
     [handleSelectDetailTab],

--- a/web/src/pages/account-pool/UpstreamAccounts.test.tsx
+++ b/web/src/pages/account-pool/UpstreamAccounts.test.tsx
@@ -1180,7 +1180,7 @@ function mockAccountsPage(options?: {
         httpStatus: 429,
         failureKind: "upstream_http_429_quota_exhausted",
         invokeId: "invk_action_001",
-        attemptId: 9001,
+        attemptId: "4V7MYPJG",
         stickyKey: "sticky-dup-001",
         createdAt: "2026-03-16T02:06:00.000Z",
       },
@@ -2370,7 +2370,7 @@ describe("UpstreamAccountsPage grouped roster toggle", () => {
 
     await flushAsync();
     expect(document.body.textContent).toMatch(/上游尝试 ID|Upstream attempt ID/);
-    expect(document.body.textContent).toContain("9001");
+    expect(document.body.textContent).toContain("4V7MYPJG");
     expect(document.body.textContent).not.toMatch(/调用 ID: invk_action_001/);
   });
 


### PR DESCRIPTION
## Summary
- persist 8-character attempt public IDs on live and archived pool upstream attempts
- backfill historical attempt IDs at startup and route locate APIs through the attemptId contract
- unify owner-facing account and records surfaces around short attempt IDs and demote invokeId to diagnostics

## Verification
- cargo test invocation_query_filters_and_schema_migrations
- cargo test runtime_overlay_and_group_rule_behaviors
- cd web && bun x tsc --noEmit
- cd web && bun x vitest run --project=unit src/lib/api.test.ts -t "uses distinct pagination and exact-location contracts"
- cd web && bun x vitest run --project=unit src/features/account-pool/UpstreamAccountAttemptTimeline.test.tsx -t "opens the exact attempt diagnostics when event navigation focuses it"
- cd web && bun x vitest run --project=unit src/pages/account-pool/UpstreamAccounts.test.tsx -t "labels a linked health event with its upstream attempt id"

## References
- Specs: docs/specs/z9h7v-invocation-log-observability
- Solutions: -
- Project Docs: -