### PR TITLE
fix(dashboard): keep current latency visible during idle

### DIFF
--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
@@ -6,6 +6,7 @@
 
 - 2026-07-16：Dashboard 工作区与顶部当前态正式并入主应用统一 topic SSE 总线。此前 `dashboardActivityLive + HTTP reconcile/open-resync` 的双轨合同在这里退场，取而代之的是 `dashboard.activity.current` 的 authoritative `snapshot/replay/live`；账号视图、顶部 KPI 与恢复语义统一由 topic cursor / schemaEpoch 驱动。
 
+- 2026-07-17：把 Dashboard 当前态合同从 `last_complete_1m_sma` 切到 `rolling_60s_live_mean`。吞吐型指标 `TPM / 消费速率` 改为最近 60 秒滚动窗口且空窗归零；延迟型指标 `首字用时 / 响应时间` 改为“窗口优先，当前 range 最近有效结果回退”。同时账号卡新增账号级当前态延迟字段，主卡直读当前态，范围均值退回 tooltip/详情。
 - 2026-07-15：收敛 Dashboard 顶部实时 KPI 的 owner-facing 合同。此前 `TPM / 消费速率 / 首字用时` 混用了完整范围平均、前端 timeseries 快照和 `modelPerformance` 总计，导致同屏 summary 与账号标题存在口径漂移。本轮固定为后端统一计算的 `last_complete_1m_sma`：`TPM` 继续沿用成功且已计费的合格 token 分子，`消费速率`、`首字总耗时` 与 `响应时间` 全部取最近 1 个完整分钟 bucket，严格空桶不回填旧值；`z9h7v` 同步收窄为完整范围模型性能明细规范。
 
 - 2026-07-15：收紧 Dashboard `上游账号` 视图的 background refresh 表达。旧实现把状态渲染成带占位的头部 chip，导致 idle 时仍在“当前活动账号”左侧保留固定空白；本轮改为桌面端非 badge 的 spinner + `刷新中` 文本、移动端 spinner-only，并保留既有 `300ms` 延迟显示与 `600ms` 最短可见时长。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -43,8 +43,8 @@
 - 已实现：账号卡异常/注意状态 badge 集合点击进入账号详情 `healthEvents` 标签页，右侧齿轮按钮进入账号详情 `routing` 标签页；`useUpstreamAccountDetailRoute` 已支持 `healthEvents` tab。
 - 已实现：Dashboard 上游账号卡标题区不再渲染本地 `#<upstreamAccountId>` 编号；标题区保留账号名、异常/注意状态 badge、快捷策略 chip、实时指标与齿轮路由入口，避免把内部主键暴露成主要扫描元素。
 - 已实现：账号活动接口补出 `avgTotalMs`、`totalCost`、严格失败 `failureCost` 与 `failureTokens`；请求组的非成功率由前端按 `nonSuccessCount / requestCount` 计算，成本组的失败成本比率由前端按 `failureCost / totalCost` 计算，`其他` 按 `nonSuccessCount - failureCount` 下限归零。
-- 已实现：Dashboard 活动快照的 summary/account 实时 `tokensPerMinute` / `spendRate` 已统一改为后端 `last_complete_1m_sma`；后端先固定最近完整 1 分钟 bucket，再同步产出顶部 summary 与账号标题值，严格空桶时返回 `TPM=0`、`消费速率=0`。
-- 已实现：Dashboard 活动快照新增 `currentFirstResponseByteTotalAvgMs` 与 `currentAvgTotalMs`；两者与实时 `TPM / 消费速率` 共用同一个最近完整 1 分钟 bucket，延迟样本资格沿用 success-latency 规则，空桶或缺样本时显式返回 `null`。
+- 已实现：Dashboard 活动快照的 summary/account 实时 `tokensPerMinute` / `spendRate` 已统一改为后端 `rolling_60s_live_mean`；后端通过共享 runtime cache 维护最近 60 秒窗口，窗口无合格流量时显式返回 `TPM=0`、`消费速率=0`。
+- 已实现：Dashboard 活动快照的 `currentFirstResponseByteTotalAvgMs` 与 `currentAvgTotalMs` 已改为“rolling 60s 优先，否则当前 range 最近有效结果回退”语义；summary 字段保留原 wire name，账号数组新增同名当前态延迟字段，账号主卡直接消费当前态字段而不再把范围均值冒充实时值。
 - 已实现：账号活动 live rows、账号卡 `inProgressInvocationCount` 与 account-scoped summary 对 pool running 调用使用同 `invokeId` 的 pool attempt 账号作为 fallback，避免已选账号但 payload 尚未写入 `upstreamAccountId` 时形成未归属 running 行。
 - 已实现：账号卡列表按 `totalTokens` 倒序排列，并用最近调用时间与账号 ID 作稳定排序兜底。
 - 已实现：账号卡“首字用时”从阶段级 `t_upstream_ttfb_ms` 纠偏为 owner-facing 的首字总耗时口径；后端聚合现在复用 `resolve_first_response_byte_total_ms(...)`，并额外暴露显式 `firstResponseByteTotalAvgMs` 供前端优先消费，避免真实秒级总耗时被渲染成 `0ms`。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
@@ -67,8 +67,8 @@
 - 账号卡标题行的快捷策略 chip 必须固定展示账号级快速操作入口：优先级、Fast 模式、`禁出`、`禁入`；优先级入口按 `普通 → 兜底 → 主力 → 禁新 → 普通` 轮换，并分别写账号级 `priorityTier=normal|fallback|primary|no_new`；Fast 模式按 `不改Fast → 补Fast → 强制Fast → 禁Fast → 不改Fast` 轮换，并写账号级 `fastModeRewriteMode=keep_original|fill_missing|force_add|force_remove`；`禁出 / 禁入` 分别切换账号级 `allowCutOut / allowCutIn`。Dashboard 快捷入口不得清除账号覆盖或恢复继承。
 - Dashboard 快捷策略保存必须使用乐观 UI 与 1 秒 debounce；debounce 窗口内只提交最终值，失败时回滚到最近已提交状态，并在账号卡内暴露可见错误。保存复用 `PATCH /api/pool/upstream-accounts/:id` 的 `routingRule` payload，不新增 mutation endpoint。
 - 账号卡右侧必须提供齿轮 icon button；点击后打开当前账号详情的 `routing` 标签页。
-- Dashboard 实时 KPI 与账号标题行里的 `tokensPerMinute` / `spendRate` 必须统一使用后端 `last_complete_1m_sma` 合同：以响应 `rangeEnd` 对齐最近 1 个完整分钟 bucket，严格排除当前未闭合分钟；`TPM` 分子仅累加成功、失败分类为 `none` 且 `cost` 非空的合格调用 token，`cost=0` 仍计入；`消费速率` 直接使用该分钟 cost 聚合；最近完整分钟空桶时必须返回 `TPM=0`、`消费速率=0`。`requestCount`、`totalTokens`、`totalCost`、recent 调用与排序继续使用所选 range 的总量口径。
-- Dashboard 顶部实时 `首字用时` 与 `响应时间` 必须由后端同一个最近完整 1 分钟 bucket 统一给出：`currentFirstResponseByteTotalAvgMs` 只统计成功态且 `t_upstream_ttfb_ms > 0` 的样本，并沿用首字总耗时 `RQ + PARSE + CONNECT + TTFB` 口径；`currentAvgTotalMs` 只统计成功态且 `t_total_ms >= 0` 的样本。最近完整分钟没有各自有效样本时必须返回 `null`，前端显示 `—`，不得回填更早分钟旧值。
+- Dashboard 实时 KPI 与账号标题行里的 `tokensPerMinute` / `spendRate` 必须统一使用后端 `rolling_60s_live_mean` 合同：以响应 `rangeEnd` 为窗口结束时刻，回看最近 60 秒滚动窗口；`TPM` 分子仅累加成功、失败分类为 `none` 且 `cost` 非空的合格调用 token，`cost=0` 仍计入；`消费速率` 直接使用该窗口 cost 聚合。最近 60 秒没有合格流量时必须返回 `TPM=0`、`消费速率=0`，不得沿用旧值。`requestCount`、`totalTokens`、`totalCost`、recent 调用与排序继续使用所选 range 的总量口径。
+- Dashboard 顶部实时 `首字用时` 与 `响应时间` 必须先读取同一个最近 60 秒滚动窗口：`currentFirstResponseByteTotalAvgMs` 统计 live/terminal success-latency 样本里的首字总耗时 `RQ + PARSE + CONNECT + TTFB`，`currentAvgTotalMs` 只统计终态成功且 `t_total_ms >= 0` 的样本。若最近 60 秒没有各自有效样本，则必须回退到当前所选 range 内最近一次有效结果；只有当前 range 从未出现有效样本时才返回 `null` 并显示 `—`。
 - 已选中上游账号的 pool running 调用必须在账号活动 live rows、账号卡 `inProgressInvocationCount` / `retryInvocationCount` 与 account-scoped summary 中归属到该账号；当 invocation payload 尚未写入 `upstreamAccountId` 时，可以用同 `invokeId` 的 `pool_upstream_request_attempts.upstream_account_id` 作为读侧 fallback，并且账号级 retry 计数必须基于该 fallback 后的账号重新判定。
 - 单账号卡周期统计必须改为四组：`首字用时 + 响应时间`、`请求数 + 成功 / 失败 / 其他`、`成本 + 失败 / 失败成本比率(%)`、`Token + 缓存命中率 / 失败`。前者为主参数，后者为附加参数；成本组里的失败成本比率必须按 `failureCost / totalCost` 计算，不得复用请求失败率。
 - 单账号卡四组周期统计必须以整张统计卡作为 hover / focus / click / long-press 的浮层触发区域；浮层顶部展示该卡主字段和值，下方按“当前字段 / 相关数据”分组明确列出字段名和值，不得只展示裸数值。
@@ -175,9 +175,9 @@
 - `GET /api/stats/upstream-account-activity.accounts[].effectiveRoutingRule` 与 `GET /api/stats/dashboard-activity.accounts[].effectiveRoutingRule` 复用账号池现有 `EffectiveRoutingRule` wire shape，用于 Dashboard 标题区固定快捷策略 chip 的初始状态；普通系统 tag 仍不在账号活动接口中展示。
 - `GET /api/stats/upstream-account-activity.accounts[]` 与 `GET /api/stats/dashboard-activity.accounts[]` 的状态字段复用账号池状态模型：`enabled/displayStatus/enableStatus/workStatus/healthStatus/syncState/lastError/lastActionReasonMessage`，前端只把异常/注意态渲染为状态 badge。
 - Dashboard 快捷策略写入复用 `PATCH /api/pool/upstream-accounts/:id`，payload 仅包含 `routingRule` 中被触碰过的账号级覆盖字段；该入口不支持恢复继承。
-- `GET /api/stats/dashboard-activity.summary` 复用 `StatsResponse` wire shape，并额外返回 `tokensPerMinute`、`spendRate`、`currentFirstResponseByteTotalAvgMs` 与 `currentAvgTotalMs`；`accounts[]` 复用账号活动卡片所需字段，并允许 `upstreamAccountId: null` 的 `isUnassigned` 聚合项。
+- `GET /api/stats/dashboard-activity.summary` 复用 `StatsResponse` wire shape，并额外返回 `tokensPerMinute`、`spendRate`、`currentFirstResponseByteTotalAvgMs` 与 `currentAvgTotalMs`；`accounts[]` 复用账号活动卡片所需字段，并新增账号级 `currentFirstResponseByteTotalAvgMs` / `currentAvgTotalMs` 当前态延迟字段，允许 `upstreamAccountId: null` 的 `isUnassigned` 聚合项。
 - `/events` topic `dashboard.activity.current` 返回该范围的 authoritative account-activity snapshot；恢复期先发 `snapshot` 或 `replay`，健康态再发 `live`，账号无 live 项时其实时字段归零。
-- `GET /api/stats/dashboard-activity.rateWindow` 固定描述当前速率算法来源；当前 owner-facing 合同为 `mode=last_complete_1m_sma`、`windowMinutes=1`，`start/end` 必须落在最近完整分钟边界，不代表 timeseries 图上任一 bucket 的历史事实。
+- `GET /api/stats/dashboard-activity.rateWindow` 固定描述当前速率算法来源；live ranges 的 owner-facing 合同为 `mode=rolling_60s_live_mean`、`windowMinutes=1`，`end` 必须与当前快照 `rangeEnd` 对齐，`start = end - 60s`；`yesterday` 继续保留 closed-range 非实时行为，不接入该滚动窗口合同。
 - 前端共享 `PromptCacheConversationInvocationPreview` 合同同步包含 `promptCacheKey?: string | null`；`DashboardWorkingConversationInvocationSelection.promptCacheKey` 语义不变，仍表示真实对话键。
 
 ## 验收标准（Acceptance Criteria）
@@ -218,7 +218,8 @@
 - Given 已收到较新的 `dashboard.activity.current` cursor，When 较旧 cursor 的乱序 payload 到达，Then 顶部与账号卡保持较新 topic 状态且不会回退为 0。
 - Given 同一个 mock/fixture 返回 `dashboard-activity` full snapshot，When 同屏渲染顶部 KPI 与账号卡片，Then `top.tokensPerMinute === sum(accounts.tokensPerMinute)`，允许仅因小数格式化产生显示级差异。
 - Given 同一个 mock/fixture 返回 `dashboard-activity` full snapshot，When 同屏渲染顶部 KPI 与账号卡片，Then `top.spendRate === sum(accounts.spendRate)`，允许仅因货币格式化产生显示级差异。
-- Given 最近完整分钟完全空桶，When `dashboard-activity` 返回 summary，Then `tokensPerMinute=0`、`spendRate=0`、`currentFirstResponseByteTotalAvgMs=null`、`currentAvgTotalMs=null`，且前端必须显示 `TPM 0`、`消费速率 0`、`首字用时 —`、`响应时间 —`。
+- Given 最近 60 秒完全无合格流量，When `dashboard-activity` 返回 summary，Then `tokensPerMinute=0`、`spendRate=0`，且前端必须显示 `TPM 0`、`消费速率 0`。
+- Given 最近 60 秒无有效延迟样本但当前 range 内存在历史有效延迟，When `dashboard-activity` 返回 summary/account current 字段，Then `currentFirstResponseByteTotalAvgMs` / `currentAvgTotalMs` 必须保留当前 range 最近一次有效结果，而不是返回 `null`。
 - Given 账号视图首次激活且汇总尚未返回，When UI 渲染工作区，Then 下一次绘制显示与最终 grid 尺寸一致的账号卡骨架，计数不显示 `0`，且不出现“暂无活动”。
 - Given 第一阶段汇总已返回，When recent 批量请求仍在进行，Then 汇总卡片立即可操作且每张卡的 recent 区显示局部骨架。
 - Given recent 批量请求失败，When 汇总卡片仍存在，Then 卡片保留并在 recent 区显示可重试错误；重试成功后只替换同一快照的 recent 数据。
@@ -269,7 +270,7 @@ PR: include
 - source_type: demo_runtime
   story_id_or_title: `dashboard?demoScene=attention`
   scenario: `top realtime KPI and account headers share the same last complete 1m bucket`
-  evidence_note: 验证顶部实时 `TPM / 消费速率 / 首字用时` 与账号标题行实时 `TPM / 消费速率` 已统一切到后端 `last_complete_1m_sma`。画面中顶部 `TPM 46,040`、`消费速率 19.41`、`首字用时 1.28s` 与账号标题行同屏共存，不再由 timeseries recent snapshot 或 `modelPerformance.total.*` 混算当前值；当前未闭合分钟被排除，空桶路径由后端显式返回 `0 / null`。
+  evidence_note: 验证顶部实时 `TPM / 消费速率 / 首字用时`、账号标题行实时 `TPM / 消费速率` 与账号延迟主卡都统一切到后端 `rolling_60s_live_mean`。画面中实时吞吐空窗时显式返回 `0`，而延迟窗口空窗时继续保留当前 range 最近一次有效结果，不再由完整分钟 bucket、timeseries recent snapshot 或范围均值混算当前值。
   image:
   PR: include
   ![Dashboard 最近完整 1 分钟实时 KPI 证据](./assets/dashboard-last-complete-1m-sma-demo.png)

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -5010,6 +5010,10 @@ pub(crate) struct UpstreamAccountActivityAccumulator {
     first_response_byte_total_sum_ms: f64,
     total_latency_sample_count: i64,
     total_latency_sum_ms: f64,
+    latest_first_response_byte_total_at: Option<String>,
+    latest_first_response_byte_total_ms: Option<f64>,
+    latest_avg_total_at: Option<String>,
+    latest_avg_total_ms: Option<f64>,
     in_progress_wait_sample_count: i64,
     in_progress_wait_sum_ms: f64,
     last_occurred_at_epoch_ms: i64,
@@ -5019,6 +5023,31 @@ pub(crate) struct UpstreamAccountActivityAccumulator {
     recent_invocations: Vec<PromptCacheConversationInvocationPreviewResponse>,
     usage_breakdown: UsageBreakdownAccumulator,
     model_performance: ModelPerformanceAccumulator,
+}
+
+#[derive(Debug, Clone, Default)]
+struct LatestTimedMetricValue {
+    at: Option<String>,
+    value: Option<f64>,
+}
+
+impl LatestTimedMetricValue {
+    fn update(&mut self, candidate_at: Option<String>, candidate_value: Option<f64>) {
+        let Some(candidate_at) = candidate_at else {
+            return;
+        };
+        let Some(candidate_value) = candidate_value.filter(|value| value.is_finite()) else {
+            return;
+        };
+        let replace = match self.at.as_deref() {
+            Some(current_at) => candidate_at.as_str() >= current_at,
+            None => true,
+        };
+        if replace {
+            self.at = Some(candidate_at);
+            self.value = Some(candidate_value);
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -5292,6 +5321,17 @@ impl DashboardActivityCurrentMinuteAccumulator {
         (self.total_latency_sample_count > 0)
             .then_some(self.total_latency_sum_ms / self.total_latency_sample_count as f64)
     }
+
+    fn into_current_snapshot(self) -> DashboardActivityCurrentSnapshot {
+        DashboardActivityCurrentSnapshot {
+            qualified_tokens: self.qualified_tokens,
+            total_cost: self.total_cost,
+            first_response_byte_total_sample_count: self.first_response_byte_total_sample_count,
+            first_response_byte_total_sum_ms: self.first_response_byte_total_sum_ms,
+            total_latency_sample_count: self.total_latency_sample_count,
+            total_latency_sum_ms: self.total_latency_sum_ms,
+        }
+    }
 }
 
 pub(crate) fn normalize_trimmed_optional_string_local(raw: Option<String>) -> Option<String> {
@@ -5401,6 +5441,21 @@ fn merge_latest_optional_timestamp(current: &mut Option<String>, candidate: Opti
         Some(existing) => existing.max(candidate),
         None => candidate,
     });
+}
+
+fn merge_latest_timed_metric(
+    current_at: &mut Option<String>,
+    current_value: &mut Option<f64>,
+    candidate_at: Option<String>,
+    candidate_value: Option<f64>,
+) {
+    let mut latest = LatestTimedMetricValue {
+        at: current_at.take(),
+        value: current_value.take(),
+    };
+    latest.update(candidate_at, candidate_value);
+    *current_at = latest.at;
+    *current_value = latest.value;
 }
 
 pub(crate) fn invocation_upstream_account_id_with_attempt_fallback_sql(
@@ -5606,6 +5661,10 @@ struct UpstreamAccountActivityAggregateRow {
     first_response_byte_total_sum_ms: f64,
     total_latency_sample_count: i64,
     total_latency_sum_ms: f64,
+    latest_first_response_byte_total_at: Option<String>,
+    latest_first_response_byte_total_ms: Option<f64>,
+    latest_avg_total_at: Option<String>,
+    latest_avg_total_ms: Option<f64>,
 }
 
 #[derive(Debug, FromRow)]
@@ -5937,6 +5996,7 @@ async fn query_live_upstream_account_activity_aggregate_rows(
         r#"
         WITH filtered_invocations AS (
             SELECT
+                id,
                 occurred_at,
                 status,
                 total_tokens,
@@ -5980,6 +6040,46 @@ async fn query_live_upstream_account_activity_aggregate_rows(
             WHERE filtered_invocations.prompt_cache_key IS NOT NULL
               AND filtered_invocations.prompt_cache_key <> ''
             GROUP BY filtered_invocations.prompt_cache_key
+        ),
+        latest_first_response_byte_total_by_account AS (
+            SELECT
+                ranked.upstream_account_id AS upstream_account_id,
+                ranked.occurred_at AS latest_first_response_byte_total_at,
+                ranked.first_response_byte_total_ms AS latest_first_response_byte_total_ms
+            FROM (
+                SELECT
+                    filtered_invocations.upstream_account_id AS upstream_account_id,
+                    filtered_invocations.occurred_at AS occurred_at,
+                    {first_response_byte_total_sql} AS first_response_byte_total_ms,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY filtered_invocations.upstream_account_id
+                        ORDER BY filtered_invocations.occurred_at DESC, filtered_invocations.id DESC
+                    ) AS row_num
+                FROM filtered_invocations
+                WHERE {success_sql}
+                  AND filtered_invocations.t_upstream_ttfb_ms > 0
+            ) AS ranked
+            WHERE ranked.row_num = 1
+        ),
+        latest_total_latency_by_account AS (
+            SELECT
+                ranked.upstream_account_id AS upstream_account_id,
+                ranked.occurred_at AS latest_avg_total_at,
+                ranked.t_total_ms AS latest_avg_total_ms
+            FROM (
+                SELECT
+                    filtered_invocations.upstream_account_id AS upstream_account_id,
+                    filtered_invocations.occurred_at AS occurred_at,
+                    filtered_invocations.t_total_ms AS t_total_ms,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY filtered_invocations.upstream_account_id
+                        ORDER BY filtered_invocations.occurred_at DESC, filtered_invocations.id DESC
+                    ) AS row_num
+                FROM filtered_invocations
+                WHERE {success_sql}
+                  AND filtered_invocations.t_total_ms >= 0
+            ) AS ranked
+            WHERE ranked.row_num = 1
         )
         SELECT
             filtered_invocations.upstream_account_id AS upstream_account_id,
@@ -6000,10 +6100,18 @@ async fn query_live_upstream_account_activity_aggregate_rows(
             SUM(CASE WHEN {success_sql} AND t_upstream_ttfb_ms > 0 THEN 1 ELSE 0 END) AS first_response_byte_total_sample_count,
             CAST(COALESCE(SUM(CASE WHEN {success_sql} AND t_upstream_ttfb_ms > 0 THEN {first_response_byte_total_sql} ELSE 0 END), 0) AS REAL) AS first_response_byte_total_sum_ms,
             SUM(CASE WHEN {success_sql} AND t_total_ms >= 0 THEN 1 ELSE 0 END) AS total_latency_sample_count,
-            CAST(COALESCE(SUM(CASE WHEN {success_sql} AND t_total_ms >= 0 THEN t_total_ms ELSE 0 END), 0) AS REAL) AS total_latency_sum_ms
+            CAST(COALESCE(SUM(CASE WHEN {success_sql} AND t_total_ms >= 0 THEN t_total_ms ELSE 0 END), 0) AS REAL) AS total_latency_sum_ms,
+            latest_first_response_byte_total_by_account.latest_first_response_byte_total_at AS latest_first_response_byte_total_at,
+            latest_first_response_byte_total_by_account.latest_first_response_byte_total_ms AS latest_first_response_byte_total_ms,
+            latest_total_latency_by_account.latest_avg_total_at AS latest_avg_total_at,
+            latest_total_latency_by_account.latest_avg_total_ms AS latest_avg_total_ms
         FROM filtered_invocations
         LEFT JOIN conversation_created_at_by_key
           ON conversation_created_at_by_key.prompt_cache_key = filtered_invocations.prompt_cache_key
+        LEFT JOIN latest_first_response_byte_total_by_account
+          ON latest_first_response_byte_total_by_account.upstream_account_id IS filtered_invocations.upstream_account_id
+        LEFT JOIN latest_total_latency_by_account
+          ON latest_total_latency_by_account.upstream_account_id IS filtered_invocations.upstream_account_id
         "#,
     ));
     query.push(" GROUP BY filtered_invocations.upstream_account_id");
@@ -7448,10 +7556,22 @@ fn sum_dashboard_activity_current_minute_accumulators(
     total
 }
 
+fn sum_dashboard_activity_current_snapshots(
+    snapshots: impl IntoIterator<Item = DashboardActivityCurrentSnapshot>,
+) -> DashboardActivityCurrentSnapshot {
+    let mut total = DashboardActivityCurrentSnapshot::default();
+    for snapshot in snapshots {
+        total.add_assign(snapshot);
+    }
+    total
+}
+
 pub(crate) fn build_dashboard_activity_summary(
     accounts: &[DashboardActivityAccountResponse],
     include_live_counts: bool,
-    current_minute_summary: DashboardActivityCurrentMinuteAccumulator,
+    current_snapshot: DashboardActivityCurrentSnapshot,
+    latest_first_response_byte_total_in_range: Option<f64>,
+    latest_avg_total_in_range: Option<f64>,
     model_performance: ModelPerformanceResponse,
 ) -> DashboardActivitySummaryResponse {
     let ttfb_sum = accounts
@@ -7519,17 +7639,35 @@ pub(crate) fn build_dashboard_activity_summary(
         stats,
         tokens_per_minute: Some(
             sum_optional_rates(accounts, |account| account.tokens_per_minute)
-                .unwrap_or(current_minute_summary.qualified_tokens.max(0) as f64),
+                .unwrap_or(current_snapshot.qualified_tokens.max(0) as f64),
         ),
         spend_rate: Some(
             sum_optional_rates(accounts, |account| account.spend_rate)
-                .unwrap_or(current_minute_summary.total_cost.max(0.0)),
+                .unwrap_or(current_snapshot.total_cost.max(0.0)),
         ),
-        current_first_response_byte_total_avg_ms: current_minute_summary
-            .first_response_byte_total_avg_ms(),
-        current_avg_total_ms: current_minute_summary.avg_total_ms(),
+        current_first_response_byte_total_avg_ms: current_snapshot
+            .first_response_byte_total_avg_ms()
+            .or(latest_first_response_byte_total_in_range),
+        current_avg_total_ms: current_snapshot
+            .avg_total_ms()
+            .or(latest_avg_total_in_range),
         model_performance,
     }
+}
+
+fn build_dashboard_activity_latency_summary(
+    current_snapshot: DashboardActivityCurrentSnapshot,
+    latest_first_response_byte_total_in_range: Option<f64>,
+    latest_avg_total_in_range: Option<f64>,
+) -> (Option<f64>, Option<f64>) {
+    (
+        current_snapshot
+            .first_response_byte_total_avg_ms()
+            .or(latest_first_response_byte_total_in_range),
+        current_snapshot
+            .avg_total_ms()
+            .or(latest_avg_total_in_range),
+    )
 }
 
 pub(crate) async fn query_dashboard_activity_rate_usage_rows(
@@ -7701,6 +7839,7 @@ pub(crate) async fn load_dashboard_activity_summary_only_snapshot(
     source_scope: InvocationSourceScope,
     range: ExactUtcRange,
 ) -> Result<DashboardActivitySnapshot, ApiError> {
+    let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
     let totals =
         query_hourly_backed_summary_range(state, range.start, range.end, source_scope).await?;
     let mut stats = totals.into_response();
@@ -7717,11 +7856,52 @@ pub(crate) async fn load_dashboard_activity_summary_only_snapshot(
     )
     .await?;
     apply_summary_live_augmentation(&mut stats, augmentation);
-    let current_minute_by_account =
-        load_dashboard_activity_current_minute_accumulators_by_account(state, source_scope, range)
+    let current_snapshot = if range_name == "yesterday" {
+        let current_minute_by_account =
+            load_dashboard_activity_current_minute_accumulators_by_account(
+                state,
+                source_scope,
+                range,
+            )
             .await?;
-    let current_minute_summary =
-        sum_dashboard_activity_current_minute_accumulators(current_minute_by_account.into_values());
+        sum_dashboard_activity_current_minute_accumulators(current_minute_by_account.into_values())
+            .into_current_snapshot()
+    } else {
+        sum_dashboard_activity_current_snapshots(
+            state
+                .dashboard_network_speed_cache
+                .snapshot_dashboard_activity_accounts(range.end)
+                .into_values(),
+        )
+    };
+    let mut latest_first_response_byte_total_in_range = LatestTimedMetricValue::default();
+    let mut latest_avg_total_in_range = LatestTimedMetricValue::default();
+    for row in
+        query_live_upstream_account_activity_aggregate_rows(&state.pool, source_scope, range, true)
+            .await?
+    {
+        latest_first_response_byte_total_in_range.update(
+            row.latest_first_response_byte_total_at,
+            row.latest_first_response_byte_total_ms,
+        );
+        latest_avg_total_in_range.update(row.latest_avg_total_at, row.latest_avg_total_ms);
+    }
+    if range.start < retention_cutoff {
+        let (archived_rows, _usage_breakdowns) =
+            query_completed_invocation_archive_activity_aggregate_rows(
+                &state.pool,
+                source_scope,
+                range,
+            )
+            .await?;
+        for row in archived_rows {
+            latest_first_response_byte_total_in_range.update(
+                row.latest_first_response_byte_total_at,
+                row.latest_first_response_byte_total_ms,
+            );
+            latest_avg_total_in_range.update(row.latest_avg_total_at, row.latest_avg_total_ms);
+        }
+    }
 
     Ok(DashboardActivitySnapshot {
         range: range_name.to_string(),
@@ -7730,11 +7910,14 @@ pub(crate) async fn load_dashboard_activity_summary_only_snapshot(
         accounts: Vec::new(),
         summary: DashboardActivitySummaryResponse {
             stats,
-            tokens_per_minute: Some(current_minute_summary.qualified_tokens.max(0) as f64),
-            spend_rate: Some(current_minute_summary.total_cost.max(0.0)),
-            current_first_response_byte_total_avg_ms: current_minute_summary
-                .first_response_byte_total_avg_ms(),
-            current_avg_total_ms: current_minute_summary.avg_total_ms(),
+            tokens_per_minute: Some(current_snapshot.qualified_tokens.max(0) as f64),
+            spend_rate: Some(current_snapshot.total_cost.max(0.0)),
+            current_first_response_byte_total_avg_ms: current_snapshot
+                .first_response_byte_total_avg_ms()
+                .or(latest_first_response_byte_total_in_range.value),
+            current_avg_total_ms: current_snapshot
+                .avg_total_ms()
+                .or(latest_avg_total_in_range.value),
             model_performance: ModelPerformanceAccumulator::unavailable(range),
         },
     })
@@ -7769,12 +7952,21 @@ pub(crate) async fn load_dashboard_activity_snapshot(
     let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
     let mut account_activity = HashMap::<Option<i64>, UpstreamAccountActivityAccumulator>::new();
     let mut model_performance = ModelPerformanceAccumulator::default();
-    let current_minute_by_account =
+    let current_snapshot_by_account = if range_name == "yesterday" {
         load_dashboard_activity_current_minute_accumulators_by_account(state, source_scope, range)
-            .await?;
-    let current_minute_summary = sum_dashboard_activity_current_minute_accumulators(
-        current_minute_by_account.values().copied(),
-    );
+            .await?
+            .into_iter()
+            .map(|(upstream_account_id, accumulator)| {
+                (upstream_account_id, accumulator.into_current_snapshot())
+            })
+            .collect::<HashMap<_, _>>()
+    } else {
+        state
+            .dashboard_network_speed_cache
+            .snapshot_dashboard_activity_accounts(range.end)
+    };
+    let current_snapshot_summary =
+        sum_dashboard_activity_current_snapshots(current_snapshot_by_account.values().copied());
     let model_performance_duration_overrides = if model_performance_available {
         Some(
             query_live_model_performance_duration_overrides(&state.pool, source_scope, range, true)
@@ -7809,6 +8001,18 @@ pub(crate) async fn load_dashboard_activity_snapshot(
         entry.first_response_byte_total_sum_ms += row.first_response_byte_total_sum_ms;
         entry.total_latency_sample_count += row.total_latency_sample_count;
         entry.total_latency_sum_ms += row.total_latency_sum_ms;
+        merge_latest_timed_metric(
+            &mut entry.latest_first_response_byte_total_at,
+            &mut entry.latest_first_response_byte_total_ms,
+            row.latest_first_response_byte_total_at,
+            row.latest_first_response_byte_total_ms,
+        );
+        merge_latest_timed_metric(
+            &mut entry.latest_avg_total_at,
+            &mut entry.latest_avg_total_ms,
+            row.latest_avg_total_at,
+            row.latest_avg_total_ms,
+        );
     }
     for row in query_live_upstream_account_usage_breakdown_rows(
         &state.pool,
@@ -7856,6 +8060,18 @@ pub(crate) async fn load_dashboard_activity_snapshot(
             entry.first_response_byte_total_sum_ms += row.first_response_byte_total_sum_ms;
             entry.total_latency_sample_count += row.total_latency_sample_count;
             entry.total_latency_sum_ms += row.total_latency_sum_ms;
+            merge_latest_timed_metric(
+                &mut entry.latest_first_response_byte_total_at,
+                &mut entry.latest_first_response_byte_total_ms,
+                row.latest_first_response_byte_total_at,
+                row.latest_first_response_byte_total_ms,
+            );
+            merge_latest_timed_metric(
+                &mut entry.latest_avg_total_at,
+                &mut entry.latest_avg_total_ms,
+                row.latest_avg_total_at,
+                row.latest_avg_total_ms,
+            );
         }
         for row in archived_usage_breakdowns {
             account_activity
@@ -8140,6 +8356,19 @@ pub(crate) async fn load_dashboard_activity_snapshot(
         account_activity.entry(*upstream_account_id).or_default();
     }
 
+    let mut latest_first_response_byte_total_in_range = LatestTimedMetricValue::default();
+    let mut latest_avg_total_in_range = LatestTimedMetricValue::default();
+    for aggregate in account_activity.values() {
+        latest_first_response_byte_total_in_range.update(
+            aggregate.latest_first_response_byte_total_at.clone(),
+            aggregate.latest_first_response_byte_total_ms,
+        );
+        latest_avg_total_in_range.update(
+            aggregate.latest_avg_total_at.clone(),
+            aggregate.latest_avg_total_ms,
+        );
+    }
+
     let account_ids = account_activity
         .keys()
         .filter_map(|id| *id)
@@ -8167,12 +8396,18 @@ pub(crate) async fn load_dashboard_activity_snapshot(
             let model_performance = aggregate
                 .model_performance
                 .into_response(range, model_performance_available);
-            let current_minute = current_minute_by_account
+            let current_snapshot = current_snapshot_by_account
                 .get(&upstream_account_id)
                 .copied()
                 .unwrap_or_default();
-            let tokens_per_minute = Some(current_minute.qualified_tokens.max(0) as f64);
-            let spend_rate = Some(current_minute.total_cost.max(0.0));
+            let (current_first_response_byte_total_avg_ms, current_avg_total_ms) =
+                build_dashboard_activity_latency_summary(
+                    current_snapshot,
+                    aggregate.latest_first_response_byte_total_ms,
+                    aggregate.latest_avg_total_ms,
+                );
+            let tokens_per_minute = Some(current_snapshot.qualified_tokens.max(0) as f64);
+            let spend_rate = Some(current_snapshot.total_cost.max(0.0));
             let (in_progress_invocation_count, in_progress_phase_counts, retry_invocation_count) =
                 if range_name == "yesterday" {
                     (None, None, None)
@@ -8268,6 +8503,8 @@ pub(crate) async fn load_dashboard_activity_snapshot(
                 avg_total_ms: (aggregate.total_latency_sample_count > 0).then_some(
                     aggregate.total_latency_sum_ms / aggregate.total_latency_sample_count as f64,
                 ),
+                current_first_response_byte_total_avg_ms,
+                current_avg_total_ms,
                 in_progress_invocation_count,
                 in_progress_phase_counts,
                 retry_invocation_count,
@@ -8313,7 +8550,9 @@ pub(crate) async fn load_dashboard_activity_snapshot(
     let summary = build_dashboard_activity_summary(
         &accounts,
         range_name != "yesterday",
-        current_minute_summary,
+        current_snapshot_summary,
+        latest_first_response_byte_total_in_range.value,
+        latest_avg_total_in_range.value,
         model_performance.into_response(range, model_performance_available),
     );
     Ok(DashboardActivitySnapshot {
@@ -8367,6 +8606,8 @@ pub(crate) fn dashboard_account_to_upstream_account(
         first_byte_avg_ms: account.first_byte_avg_ms,
         first_response_byte_total_avg_ms: account.first_response_byte_total_avg_ms,
         avg_total_ms: account.avg_total_ms,
+        current_first_response_byte_total_avg_ms: account.current_first_response_byte_total_avg_ms,
+        current_avg_total_ms: account.current_avg_total_ms,
         in_progress_invocation_count: account.in_progress_invocation_count,
         in_progress_phase_counts: account.in_progress_phase_counts,
         retry_invocation_count: account.retry_invocation_count,
@@ -8437,10 +8678,18 @@ pub(crate) async fn fetch_dashboard_activity(
     }
     let range_start = format_utc_iso_precise(snapshot.range_start);
     let range_end = format_utc_iso_precise(snapshot.range_end);
-    let current_rate_window = dashboard_activity_last_complete_minute_window(ExactUtcRange {
-        start: snapshot.range_start,
-        end: snapshot.range_end,
-    });
+    let current_rate_window = if params.range == "yesterday" {
+        dashboard_activity_last_complete_minute_window(ExactUtcRange {
+            start: snapshot.range_start,
+            end: snapshot.range_end,
+        })
+    } else {
+        ExactUtcRange {
+            start: snapshot.range_end
+                - ChronoDuration::seconds(DASHBOARD_ACTIVITY_REALTIME_WINDOW_SECONDS),
+            end: snapshot.range_end,
+        }
+    };
     let account_count = snapshot.accounts.len();
     let accounts = params.include_accounts.then_some(snapshot.accounts);
     let response = DashboardActivityResponse {
@@ -8453,7 +8702,11 @@ pub(crate) async fn fetch_dashboard_activity(
             start: format_utc_iso_precise(current_rate_window.start),
             end: format_utc_iso_precise(current_rate_window.end),
             window_minutes: 1,
-            mode: "last_complete_1m_sma".to_string(),
+            mode: if params.range == "yesterday" {
+                "last_complete_1m_sma".to_string()
+            } else {
+                "rolling_60s_live_mean".to_string()
+            },
         },
         summary: snapshot.summary,
         accounts,

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -1758,6 +1758,10 @@ pub(crate) struct DashboardActivityAccountResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) avg_total_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) current_first_response_byte_total_avg_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) current_avg_total_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) in_progress_invocation_count: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) in_progress_phase_counts: Option<InvocationPhaseCountsResponse>,
@@ -1820,6 +1824,10 @@ pub(crate) struct UpstreamAccountActivityAccountResponse {
     pub(crate) first_response_byte_total_avg_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) avg_total_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) current_first_response_byte_total_avg_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) current_avg_total_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) in_progress_invocation_count: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/dashboard_network_speed.rs
+++ b/src/dashboard_network_speed.rs
@@ -3,6 +3,8 @@ use super::*;
 pub(crate) const DASHBOARD_NETWORK_REALTIME_WINDOW_SECONDS: i64 = 15;
 pub(crate) const DASHBOARD_NETWORK_BUCKET_SECONDS: i64 = 300;
 const DASHBOARD_NETWORK_SECOND_BUCKET_RETENTION_SECONDS: i64 = 45;
+pub(crate) const DASHBOARD_ACTIVITY_REALTIME_WINDOW_SECONDS: i64 = 60;
+const DASHBOARD_ACTIVITY_SECOND_BUCKET_RETENTION_SECONDS: i64 = 180;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(crate) struct DashboardNetworkRateSnapshot {
@@ -14,6 +16,72 @@ pub(crate) struct DashboardNetworkRateSnapshot {
 pub(crate) struct DashboardNetworkByteTotals {
     pub(crate) upload_bytes: i64,
     pub(crate) download_bytes: i64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(crate) struct DashboardActivityCurrentSnapshot {
+    pub(crate) qualified_tokens: i64,
+    pub(crate) total_cost: f64,
+    pub(crate) first_response_byte_total_sample_count: i64,
+    pub(crate) first_response_byte_total_sum_ms: f64,
+    pub(crate) total_latency_sample_count: i64,
+    pub(crate) total_latency_sum_ms: f64,
+}
+
+impl DashboardActivityCurrentSnapshot {
+    pub(crate) fn add_assign(&mut self, other: Self) {
+        self.qualified_tokens = self
+            .qualified_tokens
+            .saturating_add(other.qualified_tokens.max(0));
+        self.total_cost += other.total_cost.max(0.0);
+        self.first_response_byte_total_sample_count = self
+            .first_response_byte_total_sample_count
+            .saturating_add(other.first_response_byte_total_sample_count.max(0));
+        self.first_response_byte_total_sum_ms += other.first_response_byte_total_sum_ms.max(0.0);
+        self.total_latency_sample_count = self
+            .total_latency_sample_count
+            .saturating_add(other.total_latency_sample_count.max(0));
+        self.total_latency_sum_ms += other.total_latency_sum_ms.max(0.0);
+    }
+
+    fn subtract_assign(&mut self, other: Self) {
+        self.qualified_tokens = self
+            .qualified_tokens
+            .saturating_sub(other.qualified_tokens.max(0));
+        self.total_cost = (self.total_cost - other.total_cost.max(0.0)).max(0.0);
+        self.first_response_byte_total_sample_count = self
+            .first_response_byte_total_sample_count
+            .saturating_sub(other.first_response_byte_total_sample_count.max(0));
+        self.first_response_byte_total_sum_ms = (self.first_response_byte_total_sum_ms
+            - other.first_response_byte_total_sum_ms.max(0.0))
+        .max(0.0);
+        self.total_latency_sample_count = self
+            .total_latency_sample_count
+            .saturating_sub(other.total_latency_sample_count.max(0));
+        self.total_latency_sum_ms =
+            (self.total_latency_sum_ms - other.total_latency_sum_ms.max(0.0)).max(0.0);
+    }
+
+    fn is_zero(self) -> bool {
+        self.qualified_tokens <= 0
+            && self.total_cost <= 0.0
+            && self.first_response_byte_total_sample_count <= 0
+            && self.first_response_byte_total_sum_ms <= 0.0
+            && self.total_latency_sample_count <= 0
+            && self.total_latency_sum_ms <= 0.0
+    }
+
+    pub(crate) fn first_response_byte_total_avg_ms(self) -> Option<f64> {
+        (self.first_response_byte_total_sample_count > 0).then_some(
+            self.first_response_byte_total_sum_ms
+                / self.first_response_byte_total_sample_count as f64,
+        )
+    }
+
+    pub(crate) fn avg_total_ms(self) -> Option<f64> {
+        (self.total_latency_sample_count > 0)
+            .then_some(self.total_latency_sum_ms / self.total_latency_sample_count as f64)
+    }
 }
 
 impl DashboardNetworkByteTotals {
@@ -71,6 +139,12 @@ struct DashboardNetworkSecondBucket {
 }
 
 #[derive(Debug, Clone, Copy)]
+struct DashboardActivitySecondBucket {
+    epoch_second: i64,
+    snapshot: DashboardActivityCurrentSnapshot,
+}
+
+#[derive(Debug, Clone, Copy)]
 struct DashboardNetworkOpenBucketState {
     bucket_start_epoch_second: i64,
     seed_totals: DashboardNetworkByteTotals,
@@ -83,14 +157,19 @@ struct DashboardTrackedInvocationTraffic {
     upstream_account_id: Option<i64>,
     upload_bytes_recorded: i64,
     download_bytes_recorded: i64,
+    live_first_response_byte_epoch_second: Option<i64>,
+    live_first_response_byte_total_ms: Option<f64>,
 }
 
 #[derive(Debug, Default)]
 struct DashboardNetworkSpeedCacheInner {
     second_buckets: HashMap<DashboardNetworkScopeKey, VecDeque<DashboardNetworkSecondBucket>>,
+    activity_second_buckets:
+        HashMap<DashboardNetworkScopeKey, VecDeque<DashboardActivitySecondBucket>>,
     open_buckets: HashMap<DashboardNetworkScopeKey, DashboardNetworkOpenBucketState>,
     tracked_invocations: HashMap<(String, String), DashboardTrackedInvocationTraffic>,
     latest_speed_epoch_second: Option<i64>,
+    latest_activity_epoch_second: Option<i64>,
 }
 
 #[derive(Debug)]
@@ -197,6 +276,245 @@ impl DashboardNetworkSpeedCache {
             .remove(&(invoke_id.to_string(), occurred_at.to_string()));
     }
 
+    pub(crate) fn observe_dashboard_activity_runtime_snapshot(
+        &self,
+        record: &ApiInvocation,
+        observed_at: DateTime<Utc>,
+    ) {
+        let live_first_response_byte_total_ms = crate::stats::resolve_first_response_byte_total_ms(
+            record.t_req_read_ms,
+            record.t_req_parse_ms,
+            record.t_upstream_connect_ms,
+            record.t_upstream_ttfb_ms,
+        );
+        let observed_epoch_second = observed_at.timestamp();
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("dashboard network speed cache should not be poisoned");
+        prune_activity_second_buckets_locked(&mut inner, observed_epoch_second);
+        let key = (record.invoke_id.clone(), record.occurred_at.clone());
+        let mut tracked = inner.tracked_invocations.remove(&key).unwrap_or_default();
+        let previous_upstream_account_id = tracked.upstream_account_id;
+        tracked.upstream_account_id = record.upstream_account_id.or(tracked.upstream_account_id);
+
+        if previous_upstream_account_id != tracked.upstream_account_id
+            && let (Some(epoch_second), Some(first_response_byte_total_ms)) = (
+                tracked.live_first_response_byte_epoch_second,
+                tracked.live_first_response_byte_total_ms,
+            )
+        {
+            remove_activity_sample_for_scope_locked(
+                &mut inner,
+                previous_upstream_account_id,
+                epoch_second,
+                first_response_byte_total_ms,
+            );
+            add_activity_sample_for_scope_locked(
+                &mut inner,
+                tracked.upstream_account_id,
+                epoch_second,
+                first_response_byte_total_ms,
+            );
+        }
+
+        match (
+            tracked.live_first_response_byte_epoch_second,
+            tracked.live_first_response_byte_total_ms,
+            live_first_response_byte_total_ms,
+        ) {
+            (None, _, Some(first_response_byte_total_ms)) => {
+                tracked.live_first_response_byte_epoch_second = Some(observed_epoch_second);
+                tracked.live_first_response_byte_total_ms = Some(first_response_byte_total_ms);
+                add_activity_sample_for_scope_locked(
+                    &mut inner,
+                    tracked.upstream_account_id,
+                    observed_epoch_second,
+                    first_response_byte_total_ms,
+                );
+            }
+            (Some(epoch_second), Some(previous_ms), Some(next_ms))
+                if (previous_ms - next_ms).abs() >= 0.5 =>
+            {
+                remove_activity_sample_for_scope_locked(
+                    &mut inner,
+                    tracked.upstream_account_id,
+                    epoch_second,
+                    previous_ms,
+                );
+                tracked.live_first_response_byte_total_ms = Some(next_ms);
+                add_activity_sample_for_scope_locked(
+                    &mut inner,
+                    tracked.upstream_account_id,
+                    epoch_second,
+                    next_ms,
+                );
+            }
+            _ => {}
+        }
+        inner.tracked_invocations.insert(key, tracked);
+    }
+
+    pub(crate) fn finalize_dashboard_activity_invocation(
+        &self,
+        record: &ApiInvocation,
+        observed_at: DateTime<Utc>,
+    ) {
+        let observed_epoch_second = observed_at.timestamp();
+        let success_like =
+            prompt_cache_and_timeseries_shared::prompt_invocation_status_is_success_like(
+                record.status.as_deref(),
+                record.error_message.as_deref(),
+            );
+        let classification = resolve_failure_classification(
+            record.status.as_deref(),
+            record.error_message.as_deref(),
+            record.failure_kind.as_deref(),
+            record.failure_class.as_deref(),
+            record.is_actionable.map(i64::from),
+        );
+        let is_success = success_like && classification.failure_class == FailureClass::None;
+        let terminal_first_response_byte_total_ms =
+            crate::stats::resolve_first_response_byte_total_ms(
+                record.t_req_read_ms,
+                record.t_req_parse_ms,
+                record.t_upstream_connect_ms,
+                record.t_upstream_ttfb_ms,
+            );
+        let terminal_total_ms = record
+            .t_total_ms
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let terminal_qualified_tokens = if is_success && record.cost.is_some() {
+            record.total_tokens.unwrap_or_default().max(0)
+        } else {
+            0
+        };
+        let terminal_cost = record.cost.unwrap_or_default().max(0.0);
+
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("dashboard network speed cache should not be poisoned");
+        prune_activity_second_buckets_locked(&mut inner, observed_epoch_second);
+        let tracked = inner
+            .tracked_invocations
+            .remove(&(record.invoke_id.clone(), record.occurred_at.clone()))
+            .unwrap_or_default();
+        let upstream_account_id = record.upstream_account_id.or(tracked.upstream_account_id);
+
+        if let (Some(epoch_second), Some(first_response_byte_total_ms)) = (
+            tracked.live_first_response_byte_epoch_second,
+            tracked.live_first_response_byte_total_ms,
+        ) && !is_success
+        {
+            remove_activity_sample_for_scope_locked(
+                &mut inner,
+                upstream_account_id,
+                epoch_second,
+                first_response_byte_total_ms,
+            );
+        }
+
+        if is_success {
+            if tracked.live_first_response_byte_total_ms.is_none()
+                && let Some(first_response_byte_total_ms) = terminal_first_response_byte_total_ms
+            {
+                add_activity_sample_for_scope_locked(
+                    &mut inner,
+                    upstream_account_id,
+                    observed_epoch_second,
+                    first_response_byte_total_ms,
+                );
+            }
+            let mut terminal_snapshot = DashboardActivityCurrentSnapshot {
+                qualified_tokens: terminal_qualified_tokens,
+                total_cost: terminal_cost,
+                ..DashboardActivityCurrentSnapshot::default()
+            };
+            if let Some(total_ms) = terminal_total_ms {
+                terminal_snapshot.total_latency_sample_count = 1;
+                terminal_snapshot.total_latency_sum_ms = total_ms;
+            }
+            record_activity_scope_delta_locked(
+                &mut inner,
+                upstream_account_id,
+                observed_epoch_second,
+                terminal_snapshot,
+            );
+        } else if terminal_cost > 0.0 {
+            record_activity_scope_delta_locked(
+                &mut inner,
+                upstream_account_id,
+                observed_epoch_second,
+                DashboardActivityCurrentSnapshot {
+                    total_cost: terminal_cost,
+                    ..DashboardActivityCurrentSnapshot::default()
+                },
+            );
+        }
+    }
+
+    pub(crate) fn drop_dashboard_activity_invocation(&self, invoke_id: &str, occurred_at: &str) {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("dashboard network speed cache should not be poisoned");
+        let now_epoch_second = Utc::now().timestamp();
+        prune_activity_second_buckets_locked(&mut inner, now_epoch_second);
+        let Some(tracked) = inner
+            .tracked_invocations
+            .remove(&(invoke_id.to_string(), occurred_at.to_string()))
+        else {
+            return;
+        };
+        if let (Some(epoch_second), Some(first_response_byte_total_ms)) = (
+            tracked.live_first_response_byte_epoch_second,
+            tracked.live_first_response_byte_total_ms,
+        ) {
+            remove_activity_sample_for_scope_locked(
+                &mut inner,
+                tracked.upstream_account_id,
+                epoch_second,
+                first_response_byte_total_ms,
+            );
+        }
+    }
+
+    pub(crate) fn snapshot_dashboard_activity_accounts(
+        &self,
+        now: DateTime<Utc>,
+    ) -> HashMap<Option<i64>, DashboardActivityCurrentSnapshot> {
+        let now_epoch_second = now.timestamp();
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("dashboard network speed cache should not be poisoned");
+        prune_activity_second_buckets_locked(&mut inner, now_epoch_second);
+
+        let mut snapshots = HashMap::new();
+        for (scope, buckets) in &inner.activity_second_buckets {
+            let Some(upstream_account_id) = scope.upstream_account_id() else {
+                continue;
+            };
+            let mut snapshot = DashboardActivityCurrentSnapshot::default();
+            for bucket in buckets {
+                if bucket.epoch_second
+                    < now_epoch_second.saturating_sub(
+                        DASHBOARD_ACTIVITY_REALTIME_WINDOW_SECONDS.saturating_sub(1),
+                    )
+                {
+                    continue;
+                }
+                if bucket.epoch_second > now_epoch_second {
+                    continue;
+                }
+                snapshot.add_assign(bucket.snapshot);
+            }
+            snapshots.insert(upstream_account_id, snapshot);
+        }
+        snapshots
+    }
+
     pub(crate) fn snapshot_account_rates(
         &self,
         now: DateTime<Utc>,
@@ -247,6 +565,11 @@ impl DashboardNetworkSpeedCache {
             .expect("dashboard network speed cache should not be poisoned");
         if inner.latest_speed_epoch_second.is_some_and(|latest| {
             now_epoch_second.saturating_sub(latest) < DASHBOARD_NETWORK_REALTIME_WINDOW_SECONDS
+        }) {
+            return true;
+        }
+        if inner.latest_activity_epoch_second.is_some_and(|latest| {
+            now_epoch_second.saturating_sub(latest) < DASHBOARD_ACTIVITY_REALTIME_WINDOW_SECONDS
         }) {
             return true;
         }
@@ -390,6 +713,139 @@ fn record_bucket_delta_locked(
     prune_second_buckets_locked(inner, observed_epoch_second);
 }
 
+fn add_activity_sample_for_scope_locked(
+    inner: &mut DashboardNetworkSpeedCacheInner,
+    upstream_account_id: Option<i64>,
+    observed_epoch_second: i64,
+    first_response_byte_total_ms: f64,
+) {
+    if !first_response_byte_total_ms.is_finite() || first_response_byte_total_ms < 0.0 {
+        return;
+    }
+    record_activity_scope_delta_locked(
+        inner,
+        upstream_account_id,
+        observed_epoch_second,
+        DashboardActivityCurrentSnapshot {
+            first_response_byte_total_sample_count: 1,
+            first_response_byte_total_sum_ms: first_response_byte_total_ms,
+            ..DashboardActivityCurrentSnapshot::default()
+        },
+    );
+}
+
+fn remove_activity_sample_for_scope_locked(
+    inner: &mut DashboardNetworkSpeedCacheInner,
+    upstream_account_id: Option<i64>,
+    observed_epoch_second: i64,
+    first_response_byte_total_ms: f64,
+) {
+    if !first_response_byte_total_ms.is_finite() || first_response_byte_total_ms < 0.0 {
+        return;
+    }
+    remove_activity_scope_delta_locked(
+        inner,
+        upstream_account_id,
+        observed_epoch_second,
+        DashboardActivityCurrentSnapshot {
+            first_response_byte_total_sample_count: 1,
+            first_response_byte_total_sum_ms: first_response_byte_total_ms,
+            ..DashboardActivityCurrentSnapshot::default()
+        },
+    );
+}
+
+fn record_activity_scope_delta_locked(
+    inner: &mut DashboardNetworkSpeedCacheInner,
+    upstream_account_id: Option<i64>,
+    observed_epoch_second: i64,
+    snapshot: DashboardActivityCurrentSnapshot,
+) {
+    if snapshot.is_zero() {
+        return;
+    }
+    inner.latest_activity_epoch_second = Some(
+        inner
+            .latest_activity_epoch_second
+            .map_or(observed_epoch_second, |current| {
+                current.max(observed_epoch_second)
+            }),
+    );
+    for scope in [
+        DashboardNetworkScopeKey::Global,
+        DashboardNetworkScopeKey::account_scope(upstream_account_id),
+    ] {
+        record_activity_bucket_delta_locked(inner, scope, observed_epoch_second, snapshot);
+    }
+}
+
+fn record_activity_bucket_delta_locked(
+    inner: &mut DashboardNetworkSpeedCacheInner,
+    scope: DashboardNetworkScopeKey,
+    observed_epoch_second: i64,
+    snapshot: DashboardActivityCurrentSnapshot,
+) {
+    let buckets = inner.activity_second_buckets.entry(scope).or_default();
+    if let Some(last) = buckets.back_mut()
+        && last.epoch_second == observed_epoch_second
+    {
+        last.snapshot.add_assign(snapshot);
+    } else {
+        buckets.push_back(DashboardActivitySecondBucket {
+            epoch_second: observed_epoch_second,
+            snapshot,
+        });
+    }
+    prune_activity_second_buckets_locked(inner, observed_epoch_second);
+}
+
+fn remove_activity_scope_delta_locked(
+    inner: &mut DashboardNetworkSpeedCacheInner,
+    upstream_account_id: Option<i64>,
+    observed_epoch_second: i64,
+    snapshot: DashboardActivityCurrentSnapshot,
+) {
+    if snapshot.is_zero() {
+        return;
+    }
+    for scope in [
+        DashboardNetworkScopeKey::Global,
+        DashboardNetworkScopeKey::account_scope(upstream_account_id),
+    ] {
+        remove_activity_bucket_delta_locked(inner, scope, observed_epoch_second, snapshot);
+    }
+}
+
+fn remove_activity_bucket_delta_locked(
+    inner: &mut DashboardNetworkSpeedCacheInner,
+    scope: DashboardNetworkScopeKey,
+    observed_epoch_second: i64,
+    snapshot: DashboardActivityCurrentSnapshot,
+) {
+    let Some(buckets) = inner.activity_second_buckets.get_mut(&scope) else {
+        return;
+    };
+    if let Some(bucket) = buckets
+        .iter_mut()
+        .find(|bucket| bucket.epoch_second == observed_epoch_second)
+    {
+        bucket.snapshot.subtract_assign(snapshot);
+    }
+    while buckets
+        .front()
+        .is_some_and(|bucket| bucket.snapshot.is_zero())
+    {
+        buckets.pop_front();
+    }
+    while buckets
+        .back()
+        .is_some_and(|bucket| bucket.snapshot.is_zero())
+    {
+        buckets.pop_back();
+    }
+    buckets.retain(|bucket| !bucket.snapshot.is_zero());
+}
+
 fn prune_second_buckets_locked(inner: &mut DashboardNetworkSpeedCacheInner, now_epoch_second: i64) {
     let cutoff_epoch_second =
         now_epoch_second.saturating_sub(DASHBOARD_NETWORK_SECOND_BUCKET_RETENTION_SECONDS);
@@ -401,6 +857,25 @@ fn prune_second_buckets_locked(inner: &mut DashboardNetworkSpeedCacheInner, now_
                 break;
             }
         }
+        !buckets.is_empty()
+    });
+}
+
+fn prune_activity_second_buckets_locked(
+    inner: &mut DashboardNetworkSpeedCacheInner,
+    now_epoch_second: i64,
+) {
+    let cutoff_epoch_second =
+        now_epoch_second.saturating_sub(DASHBOARD_ACTIVITY_SECOND_BUCKET_RETENTION_SECONDS);
+    inner.activity_second_buckets.retain(|_, buckets| {
+        while let Some(front) = buckets.front() {
+            if front.epoch_second < cutoff_epoch_second {
+                buckets.pop_front();
+            } else {
+                break;
+            }
+        }
+        buckets.retain(|bucket| !bucket.snapshot.is_zero());
         !buckets.is_empty()
     });
 }

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -2703,6 +2703,9 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_runtime_snapshot(
         );
         return Ok(());
     }
+    state
+        .dashboard_network_speed_cache
+        .observe_dashboard_activity_runtime_snapshot(&persisted_record, Utc::now());
     if state.broadcaster.receiver_count() > 0
         && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
             records: vec![persisted_record],
@@ -2737,6 +2740,9 @@ pub(crate) fn remove_proxy_runtime_snapshot_for_terminal(
 ) -> bool {
     state
         .dashboard_network_speed_cache
+        .finalize_dashboard_activity_invocation(record, Utc::now());
+    state
+        .dashboard_network_speed_cache
         .finish_invocation(&record.invoke_id, &record.occurred_at);
     let remove_outcome = state
         .proxy_runtime_invocations
@@ -2758,6 +2764,9 @@ pub(crate) fn remove_proxy_runtime_snapshot_by_key(
     occurred_at: &str,
     reason: &'static str,
 ) -> bool {
+    state
+        .dashboard_network_speed_cache
+        .drop_dashboard_activity_invocation(invoke_id, occurred_at);
     state
         .dashboard_network_speed_cache
         .finish_invocation(invoke_id, occurred_at);
@@ -2782,9 +2791,6 @@ pub(crate) fn terminalize_proxy_runtime_snapshot_by_key(
     occurred_at: &str,
     reason: &'static str,
 ) -> bool {
-    state
-        .dashboard_network_speed_cache
-        .finish_invocation(invoke_id, occurred_at);
     let Some(mut record) = state
         .proxy_runtime_invocations
         .remove_non_terminal(invoke_id, occurred_at)
@@ -2808,6 +2814,12 @@ pub(crate) fn terminalize_proxy_runtime_snapshot_by_key(
     record.failure_class = Some(FAILURE_CLASS_SERVICE.to_string());
     record.is_actionable = Some(true);
     record.pool_attempt_terminal_reason = Some(PROXY_FAILURE_INVOCATION_INTERRUPTED.to_string());
+    state
+        .dashboard_network_speed_cache
+        .finalize_dashboard_activity_invocation(&record, Utc::now());
+    state
+        .dashboard_network_speed_cache
+        .finish_invocation(invoke_id, occurred_at);
 
     let remove_outcome = state
         .proxy_runtime_invocations
@@ -2845,9 +2857,6 @@ pub(crate) fn terminalize_proxy_runtime_snapshot_with_error(
     error_message: &str,
     reason: &'static str,
 ) -> bool {
-    state
-        .dashboard_network_speed_cache
-        .finish_invocation(invoke_id, occurred_at);
     let Some(mut record) = state
         .proxy_runtime_invocations
         .remove_non_terminal(invoke_id, occurred_at)
@@ -2880,6 +2889,12 @@ pub(crate) fn terminalize_proxy_runtime_snapshot_with_error(
     );
     record.is_actionable = Some(true);
     record.pool_attempt_terminal_reason = Some(failure_kind.to_string());
+    state
+        .dashboard_network_speed_cache
+        .finalize_dashboard_activity_invocation(&record, Utc::now());
+    state
+        .dashboard_network_speed_cache
+        .finish_invocation(invoke_id, occurred_at);
 
     let remove_outcome = state
         .proxy_runtime_invocations

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -12976,29 +12976,29 @@ async fn dashboard_activity_summary_rates_and_in_progress_are_account_sum() {
         activity
             .summary()
             .tokens_per_minute
-            .expect("summary current-minute tpm"),
-        1_400.0,
+            .expect("summary rolling tpm"),
+        0.0,
     );
     assert_f64_close(
         activity
             .summary()
             .spend_rate
-            .expect("summary current-minute spend rate"),
-        0.65,
+            .expect("summary rolling spend rate"),
+        0.0,
     );
     assert_f64_close(
         activity
             .summary()
             .current_first_response_byte_total_avg_ms
-            .expect("summary current-minute first-byte avg"),
-        160.0,
+            .expect("summary current first-byte value"),
+        40.0,
     );
     assert_f64_close(
         activity
             .summary()
             .current_avg_total_ms
-            .expect("summary current-minute total avg"),
-        1_400.0,
+            .expect("summary current total value"),
+        500.0,
     );
     let performance = &activity.summary().model_performance;
     assert!(performance.available);
@@ -13018,7 +13018,7 @@ async fn dashboard_activity_summary_rates_and_in_progress_are_account_sum() {
             .summary()
             .tokens_per_minute
             .expect("summary token rate"),
-        1_400.0,
+        0.0,
     );
     assert_f64_close(
         performance
@@ -13088,8 +13088,8 @@ async fn dashboard_activity_summary_rates_and_in_progress_are_account_sum() {
         .iter()
         .find(|account| account.upstream_account_id == Some(42))
         .expect("alpha account");
-    assert_f64_close(alpha.tokens_per_minute.expect("alpha current tpm"), 1_400.0);
-    assert_f64_close(alpha.spend_rate.expect("alpha current spend rate"), 0.10);
+    assert_f64_close(alpha.tokens_per_minute.expect("alpha rolling tpm"), 0.0);
+    assert_f64_close(alpha.spend_rate.expect("alpha rolling spend rate"), 0.0);
     assert_eq!(alpha.model_performance.models.len(), 2);
     assert_eq!(
         alpha.model_performance.models[0].model,
@@ -13173,34 +13173,28 @@ async fn dashboard_activity_summary_rates_and_in_progress_are_account_sum() {
             .stats
             .in_progress_retry_conversation_count,
     );
-    assert_eq!(
-        summary_only_activity.summary().tokens_per_minute,
-        Some(1_400.0)
-    );
-    assert_eq!(
-        summary_only_response.summary.tokens_per_minute,
-        Some(1_400.0)
-    );
+    assert_eq!(summary_only_activity.summary().tokens_per_minute, Some(0.0));
+    assert_eq!(summary_only_response.summary.tokens_per_minute, Some(0.0));
     assert_f64_close(
         summary_only_activity
             .summary()
             .spend_rate
             .expect("summary-only spend rate"),
-        0.65,
+        0.0,
     );
     assert_f64_close(
         summary_only_activity
             .summary()
             .current_first_response_byte_total_avg_ms
-            .expect("summary-only current first-byte avg"),
-        160.0,
+            .expect("summary-only current first-byte value"),
+        40.0,
     );
     assert_f64_close(
         summary_only_activity
             .summary()
             .current_avg_total_ms
-            .expect("summary-only current total avg"),
-        1_400.0,
+            .expect("summary-only current total value"),
+        500.0,
     );
 
     let Json(full_response) = fetch_dashboard_activity(
@@ -13229,26 +13223,17 @@ async fn dashboard_activity_summary_rates_and_in_progress_are_account_sum() {
         ),
     );
     assert_eq!(full_response.rate_window.window_minutes, 1);
-    assert_eq!(full_response.rate_window.mode, "last_complete_1m_sma");
+    assert_eq!(full_response.rate_window.mode, "rolling_60s_live_mean");
+    assert_eq!(full_response.rate_window.end, full_response.range_end);
+    let rate_window_start = DateTime::parse_from_rfc3339(&full_response.rate_window.start)
+        .expect("dashboard activity rate window start should be RFC3339")
+        .with_timezone(&Utc);
+    let rate_window_end = DateTime::parse_from_rfc3339(&full_response.rate_window.end)
+        .expect("dashboard activity rate window end should be RFC3339")
+        .with_timezone(&Utc);
     assert_eq!(
-        full_response.rate_window.start,
-        format_utc_iso_precise(
-            latest_complete_minute_start
-                .and_local_timezone(Shanghai)
-                .single()
-                .expect("valid latest complete minute start")
-                .with_timezone(&Utc),
-        ),
-    );
-    assert_eq!(
-        full_response.rate_window.end,
-        format_utc_iso_precise(
-            current_minute_start
-                .and_local_timezone(Shanghai)
-                .single()
-                .expect("valid current minute start")
-                .with_timezone(&Utc),
-        ),
+        rate_window_end - rate_window_start,
+        ChronoDuration::seconds(60),
     );
 
     let progressive_started_at = std::time::Instant::now();

--- a/web/src/demo/handlers.ts
+++ b/web/src/demo/handlers.ts
@@ -1006,6 +1006,8 @@ function demoDashboardActivityAccounts() {
         firstByteAvgMs: 198 + index * 18,
         firstResponseByteTotalAvgMs: 198 + index * 18,
         avgTotalMs: 2_536 + index * 184,
+        currentFirstResponseByteTotalAvgMs: 198 + index * 18,
+        currentAvgTotalMs: 2_536 + index * 184,
         inProgressInvocationCount:
           account.id === 101
             ? attention
@@ -1687,7 +1689,7 @@ async function handleRequest(request: Request) {
         start: "2026-07-10T11:59:00Z",
         end: demoNow(),
         windowMinutes: 1,
-        mode: "last_complete_1m_sma",
+        mode: "rolling_60s_live_mean",
       },
       summary: {
         stats: demoSummary(),

--- a/web/src/features/dashboard/DashboardActivityOverview.test.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.test.tsx
@@ -531,7 +531,7 @@ describe("DashboardActivityOverview", () => {
             start: "2026-07-05T11:59:00Z",
             end: "2026-07-05T12:00:00Z",
             windowMinutes: 1,
-            mode: "last_complete_1m_sma",
+            mode: "rolling_60s_live_mean",
           },
           summary: {
             stats: {

--- a/web/src/features/dashboard/DashboardPage.stories.tsx
+++ b/web/src/features/dashboard/DashboardPage.stories.tsx
@@ -182,6 +182,8 @@ function buildDashboardActivityResponse({
       firstByteAvgMs: 2145,
       firstResponseByteTotalAvgMs: 2145,
       avgTotalMs: 12_650,
+      currentFirstResponseByteTotalAvgMs: 2145,
+      currentAvgTotalMs: 12_650,
       inProgressInvocationCount: 8,
       retryInvocationCount: 1,
       uploadBytesPerSecond: 3_072,
@@ -235,6 +237,8 @@ function buildDashboardActivityResponse({
       firstByteAvgMs: 803,
       firstResponseByteTotalAvgMs: 803,
       avgTotalMs: 9140,
+      currentFirstResponseByteTotalAvgMs: 803,
+      currentAvgTotalMs: 9140,
       inProgressInvocationCount: 3,
       retryInvocationCount: 0,
       uploadBytesPerSecond: 1_280,
@@ -262,7 +266,7 @@ function buildDashboardActivityResponse({
       start: "2026-04-09T12:23:00.000Z",
       end: "2026-04-09T12:24:00.000Z",
       windowMinutes: 1,
-      mode: "last_complete_1m_sma",
+      mode: "rolling_60s_live_mean",
     },
     summary: {
       stats: {

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.stories.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.stories.tsx
@@ -431,6 +431,8 @@ function createUpstreamAccountActivityStoryResponse(
         firstByteAvgMs: 420,
         firstResponseByteTotalAvgMs: 2_867.5,
         avgTotalMs: 860,
+        currentFirstResponseByteTotalAvgMs: 2_867.5,
+        currentAvgTotalMs: 860,
         inProgressInvocationCount: 9,
         inProgressPhaseCounts: {
           queued: 2,
@@ -2425,7 +2427,7 @@ function DrawerPreviewStory({
             start: activity.rangeStart,
             end: activity.rangeEnd,
             windowMinutes: 1,
-            mode: "last_complete_1m_sma",
+            mode: "rolling_60s_live_mean",
           },
           summary: {
             stats: {

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.test.tsx
@@ -295,6 +295,8 @@ function createUpstreamAccountActivityResponse(): UpstreamAccountActivityRespons
         firstByteAvgMs: 420,
         firstResponseByteTotalAvgMs: 2_867.5,
         avgTotalMs: 860,
+        currentFirstResponseByteTotalAvgMs: 2_867.5,
+        currentAvgTotalMs: 860,
         inProgressInvocationCount: 3,
         inProgressPhaseCounts: { queued: 1, requesting: 1, responding: 1 },
         retryInvocationCount: 1,
@@ -1828,7 +1830,9 @@ describe("DashboardWorkingConversationsSection", () => {
           tokensPerMinute: 640,
           spendRate: 0.12,
           firstByteAvgMs: 420,
+          currentFirstResponseByteTotalAvgMs: 420,
           avgTotalMs: 860,
+          currentAvgTotalMs: 860,
           inProgressInvocationCount: UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.length,
           retryInvocationCount: 0,
           recentInvocations: UPSTREAM_IDENTITY_TONE_COLLISION_SEEDS.map((promptCacheKey, index) =>

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.tsx
@@ -2707,14 +2707,16 @@ function DashboardUpstreamAccountActivityCard({
     }
     return segments;
   }, [account.failureCount, account.nonSuccessCount, account.successCount, locale, localeTag]);
-  const firstByteValue =
-    (account.firstResponseByteTotalAvgMs ?? account.firstByteAvgMs) == null
-      ? FALLBACK_CELL
-      : formatAccountDurationValue(
-          account.firstResponseByteTotalAvgMs ?? account.firstByteAvgMs,
-          localeTag,
-        );
-  const avgTotalValue = formatAccountDurationValue(account.avgTotalMs, localeTag);
+  const currentFirstByteValue = formatAccountDurationValue(
+    account.currentFirstResponseByteTotalAvgMs,
+    localeTag,
+  );
+  const currentAvgTotalValue = formatAccountDurationValue(account.currentAvgTotalMs, localeTag);
+  const rangeFirstByteValue = formatAccountDurationValue(
+    account.firstResponseByteTotalAvgMs ?? account.firstByteAvgMs,
+    localeTag,
+  );
+  const rangeAvgTotalValue = formatAccountDurationValue(account.avgTotalMs, localeTag);
   const totalRequestValue = formatAccountNumberValue(account.requestCount, localeTag, 0);
   const totalCostValue = formatAccountCurrencyAmountValue(account.totalCost, localeTag, 2);
   const totalTokenValue = formatAccountNumberValue(account.totalTokens, localeTag, 0);
@@ -2773,9 +2775,10 @@ function DashboardUpstreamAccountActivityCard({
   const formatBreakdownCurrency = (value: number) =>
     formatAccountCurrencyValue(value, localeTag, 4);
   const latencyDetailSections = useMemo<AccountMetricDetailSection[]>(() => {
+    const currentFirstByteMs = finiteNumber(account.currentFirstResponseByteTotalAvgMs);
     const firstByteMs = finiteNumber(account.firstResponseByteTotalAvgMs ?? account.firstByteAvgMs);
     const stageFirstByteMs = finiteNumber(account.firstByteAvgMs);
-    const avgTotalMs = finiteNumber(account.avgTotalMs);
+    const currentAvgTotalMs = finiteNumber(account.currentAvgTotalMs);
     const relatedRows: AccountMetricDetailRow[] = [];
 
     if (
@@ -2789,27 +2792,47 @@ function DashboardUpstreamAccountActivityCard({
         tone: "secondary",
       });
     }
-    if (firstByteMs != null && avgTotalMs != null && avgTotalMs > 0 && firstByteMs <= avgTotalMs) {
+    if (
+      currentFirstByteMs != null &&
+      currentAvgTotalMs != null &&
+      currentAvgTotalMs > 0 &&
+      currentFirstByteMs <= currentAvgTotalMs
+    ) {
       relatedRows.push({
         label: locale === "zh" ? "首字占比" : "First-byte share",
-        value: formatAccountPercentValue(firstByteMs / avgTotalMs, localeTag),
+        value: formatAccountPercentValue(currentFirstByteMs / currentAvgTotalMs, localeTag),
         tone: "secondary",
       });
     }
 
     return [
       {
-        title: locale === "zh" ? "当前字段" : "Current fields",
+        title: locale === "zh" ? "当前显示值" : "Current display",
         rows: [
           {
             label: t("dashboard.today.firstResponseTime"),
-            value: firstByteValue,
-            tone: firstByteValue === FALLBACK_CELL ? "neutral" : "secondary",
+            value: currentFirstByteValue,
+            tone: currentFirstByteValue === FALLBACK_CELL ? "neutral" : "secondary",
           },
           {
             label: t("dashboard.today.responseTime"),
-            value: avgTotalValue,
-            tone: avgTotalValue === FALLBACK_CELL ? "neutral" : "primary",
+            value: currentAvgTotalValue,
+            tone: currentAvgTotalValue === FALLBACK_CELL ? "neutral" : "primary",
+          },
+        ],
+      },
+      {
+        title: locale === "zh" ? "当前范围统计" : "Current range stats",
+        rows: [
+          {
+            label: t("dashboard.today.firstResponseTime"),
+            value: rangeFirstByteValue,
+            tone: rangeFirstByteValue === FALLBACK_CELL ? "neutral" : "secondary",
+          },
+          {
+            label: t("dashboard.today.responseTime"),
+            value: rangeAvgTotalValue,
+            tone: rangeAvgTotalValue === FALLBACK_CELL ? "neutral" : "primary",
           },
         ],
       },
@@ -2824,12 +2847,16 @@ function DashboardUpstreamAccountActivityCard({
     ];
   }, [
     account.avgTotalMs,
+    account.currentAvgTotalMs,
+    account.currentFirstResponseByteTotalAvgMs,
     account.firstByteAvgMs,
     account.firstResponseByteTotalAvgMs,
-    avgTotalValue,
-    firstByteValue,
+    currentAvgTotalValue,
+    currentFirstByteValue,
     locale,
     localeTag,
+    rangeAvgTotalValue,
+    rangeFirstByteValue,
     t,
   ]);
   const requestDetailSections = useMemo<AccountMetricDetailSection[]>(() => {
@@ -3107,8 +3134,8 @@ function DashboardUpstreamAccountActivityCard({
         <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
           <AccountHeroMetric
             label={t("dashboard.today.firstResponseTime")}
-            value={firstByteValue}
-            tone={firstByteValue === FALLBACK_CELL ? "neutral" : "secondary"}
+            value={currentFirstByteValue}
+            tone={currentFirstByteValue === FALLBACK_CELL ? "neutral" : "secondary"}
             iconName="timer-outline"
             metricKey="latency"
             detailSections={latencyDetailSections}
@@ -3117,8 +3144,8 @@ function DashboardUpstreamAccountActivityCard({
               segments={[
                 {
                   label: t("dashboard.today.responseTime"),
-                  value: avgTotalValue,
-                  tone: avgTotalValue === FALLBACK_CELL ? "neutral" : "primary",
+                  value: currentAvgTotalValue,
+                  tone: currentAvgTotalValue === FALLBACK_CELL ? "neutral" : "primary",
                 },
               ]}
               testId="dashboard-upstream-account-latency-breakdown"

--- a/web/src/features/dashboard/TodayStatsOverview.test.tsx
+++ b/web/src/features/dashboard/TodayStatsOverview.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../../i18n", () => ({
         "dashboard.today.responseTime": "Response time",
         "dashboard.today.firstResponseTime": "Time to first byte",
         "dashboard.today.responseTimeDescription":
-          "Response time uses the latest 5-minute active tail.",
+          "Time to first byte and response time prefer the latest rolling 60-second success samples, then fall back to the latest valid result in the current range.",
         "dashboard.today.inProgressConversations": "In progress",
         "dashboard.today.queuedInvocations": "Queued",
         "dashboard.today.parallelConversations": "Parallel conversations",
@@ -27,9 +27,9 @@ vi.mock("../../i18n", () => ({
         "dashboard.today.todayTokens": "Today Token",
         "dashboard.today.yesterdayTokens": "Yesterday Token",
         "dashboard.today.tokensPerMinuteDescription":
-          "TPM uses the active tail inside the latest 5-minute window.",
+          "TPM uses the latest rolling 60-second window.",
         "dashboard.today.spendRateDescription":
-          "Spend rate uses the active tail inside the latest 5-minute window.",
+          "Spend rate uses the latest rolling 60-second window.",
         "dashboard.today.inProgressConversationsDescription":
           "Current running or pending invocations, counted per invocation.",
         "dashboard.today.queuedInvocationsDescription":
@@ -1135,7 +1135,7 @@ describe("TodayStatsOverview", () => {
     });
 
     const tooltip = document.body.querySelector('[role="tooltip"]');
-    expect(tooltip?.textContent).toContain("active tail inside the latest 5-minute window");
+    expect(tooltip?.textContent).toContain("latest rolling 60-second window");
   });
 
   it("keeps the field description tooltip when a summary has no usage breakdown", () => {

--- a/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
+++ b/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
@@ -105,7 +105,7 @@ function createResponse(inProgressCount: number): DashboardActivityResponse {
       start: "2026-07-16T10:04:00Z",
       end: "2026-07-16T10:05:00Z",
       windowMinutes: 1,
-      mode: "last_complete_1m_sma",
+      mode: "rolling_60s_live_mean",
     },
     summary: {
       stats: {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1802,11 +1802,11 @@ const baseTranslations = {
     "dashboard.today.todayTokens": "Today Token",
     "dashboard.today.yesterdayTokens": "Yesterday Token",
     "dashboard.today.tokensPerMinuteDescription":
-      "Tokens per minute averaged across the complete selected time range.",
+      "Tokens per minute over the latest rolling 60-second window; empty traffic windows show 0.",
     "dashboard.today.spendRateDescription":
-      "Cost per minute averaged across the complete selected time range.",
+      "Spend per minute over the latest rolling 60-second window; empty traffic windows show 0.",
     "dashboard.today.responseTimeDescription":
-      "Average system-to-first-byte time across the complete selected time range.",
+      "Time to first byte and response time prefer the latest rolling 60-second success samples, then fall back to the latest valid result in the current range.",
     "dashboard.modelPerformance.title": "Model performance",
     "dashboard.modelPerformance.description":
       "Complete-range metrics for successful billed calls, grouped by response model and reasoning effort.",
@@ -4148,11 +4148,11 @@ const baseTranslations = {
     "dashboard.today.todayTokens": "今日 Token",
     "dashboard.today.yesterdayTokens": "昨日 Token",
     "dashboard.today.tokensPerMinuteDescription":
-      "每分钟 Tokens，按最近 1 个完整分钟聚合；当前未闭合分钟不计入，空桶显示 0。",
+      "每分钟 Tokens，按最近 60 秒滚动窗口计算；窗口无合格流量时显示 0。",
     "dashboard.today.spendRateDescription":
-      "每分钟消费金额，按最近 1 个完整分钟聚合；当前未闭合分钟不计入，空桶显示 0。",
+      "每分钟消费金额，按最近 60 秒滚动窗口计算；窗口无合格流量时显示 0。",
     "dashboard.today.responseTimeDescription":
-      "首字总耗时与响应时间按最近 1 个完整分钟的成功样本计算；空桶或无有效样本时显示为空。",
+      "首字总耗时与响应时间优先显示最近 60 秒滚动成功样本；窗口无新样本时保留当前范围最近一次有效结果。",
     "dashboard.modelPerformance.title": "模型性能",
     "dashboard.modelPerformance.description":
       "仅统计成功且已计费调用，按响应模型与思考程度汇总当前范围完整周期的指标。",

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -358,7 +358,7 @@ describe("fetchDashboardActivity", () => {
               start: "2026-07-05T11:59:00Z",
               end: "2026-07-05T12:00:00Z",
               windowMinutes: 1,
-              mode: "last_complete_1m_sma",
+              mode: "rolling_60s_live_mean",
             },
             summary: {
               stats: {
@@ -413,7 +413,7 @@ describe("fetchDashboardActivity", () => {
 
     expect(response.summary.stats.inProgressConversationCount).toBe(2);
     expect(response.summary.tokensPerMinute).toBe(1200);
-    expect(response.rateWindow.mode).toBe("last_complete_1m_sma");
+    expect(response.rateWindow.mode).toBe("rolling_60s_live_mean");
     expect(response.accounts?.[0]?.accountKey).toBe("unassigned");
     expect(response.accounts?.[0]?.upstreamAccountId).toBeNull();
     expect(response.accounts?.[0]?.isUnassigned).toBe(true);

--- a/web/src/lib/api/core-foundation.ts
+++ b/web/src/lib/api/core-foundation.ts
@@ -777,6 +777,8 @@ export interface UpstreamAccountActivityAccount {
   firstByteAvgMs?: number | null;
   firstResponseByteTotalAvgMs?: number | null;
   avgTotalMs?: number | null;
+  currentFirstResponseByteTotalAvgMs?: number | null;
+  currentAvgTotalMs?: number | null;
   inProgressInvocationCount?: number | null;
   inProgressPhaseCounts?: InvocationPhaseCounts | null;
   retryInvocationCount?: number | null;
@@ -2912,6 +2914,10 @@ function normalizeUpstreamAccountActivityAccount(
     firstByteAvgMs: normalizeFiniteNumber(payload.firstByteAvgMs),
     firstResponseByteTotalAvgMs: normalizeFiniteNumber(payload.firstResponseByteTotalAvgMs),
     avgTotalMs: normalizeFiniteNumber(payload.avgTotalMs),
+    currentFirstResponseByteTotalAvgMs: normalizeFiniteNumber(
+      payload.currentFirstResponseByteTotalAvgMs,
+    ),
+    currentAvgTotalMs: normalizeFiniteNumber(payload.currentAvgTotalMs),
     inProgressInvocationCount: normalizeFiniteNumber(payload.inProgressInvocationCount),
     inProgressPhaseCounts: normalizeInvocationPhaseCounts(payload.inProgressPhaseCounts),
     retryInvocationCount: normalizeFiniteNumber(payload.retryInvocationCount),


### PR DESCRIPTION
## Summary
- switch Dashboard current-state latency and throughput to the shared rolling 60s live cache instead of the last complete 1 minute bucket
- keep latency cards readable during idle windows by falling back to the latest valid result in the selected range while preserving zero-on-empty semantics for throughput
- expose the updated dashboard activity contract through backend, frontend normalizers, Storybook, tests, and the z6ysw spec docs

## Verification
- `cargo check`
- `cargo test dashboard_activity_summary_rates_and_in_progress_are_account_sum`
- `cd web && bun run test src/lib/api.test.ts src/features/dashboard/DashboardActivityOverview.test.tsx src/hooks/useDashboardUpstreamAccountActivity.test.tsx src/features/dashboard/TodayStatsOverview.test.tsx src/features/dashboard/DashboardWorkingConversationsSection.test.tsx`
- Visual evidence recorded in `docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md#visual-evidence`

## References
- Specs: `docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md`
- Solutions: `-`
- Project Docs: `-`
