### PR TITLE
fix(web): refresh persisted dashboard invocation detail

### DIFF
--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/HISTORY.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/HISTORY.md
@@ -21,3 +21,4 @@
 - 2026-07-18: 历史 pre-dispatch pseudo-attempt 采用聚合层渲染纠偏，不做数据库回写迁移；workflow detail 会把稳定特征命中的旧行折叠成 `路由决定 + 系统裁定`。
 - 2026-07-18: 路由块详情 contract 固定为 `请求 / 请求头 / 请求体` 三分区，其中 `请求体` 继续回放调用级原始 request body，而不是复制 attempt-level raw body。
 - 2026-07-18: 本地终态错误响应改为复用共享 envelope；HTTP 下游返回与 `ProxyCaptureRecord` 持久化使用同一份 status/headers/body，`systemFinalFailure.responseBody` 因而回放真实裁定 body，不再依赖 `"{}"` / `missing_body` 占位。
+- 2026-07-18: Dashboard 调用详情抽屉在首轮只命中瞬态 `id <= 0` 记录时，会继续按 `invokeId` 重查持久化行，避免异步落盘期间长期停在“调用未落盘”。

--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/IMPLEMENTATION.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/IMPLEMENTATION.md
@@ -4,13 +4,14 @@
 
 - Canonical spec: `docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md`
 - Implementation summary: 调用详情继续使用统一工作流视图；当前真相已收紧为 `attempt = 真实开始向上游 dispatch`，pre-dispatch pool 终态统一表现为 `路由决定 + 系统裁定`，本地裁定返回体回放真实下游 body。
-- Branch: `detached HEAD`
-- Base: `origin/main@87061c330ff3879c389ddf8a5d0658c927c7cd93`
+- Branch: `th/fix-dashboard-invocation-persisted-refresh`
+- Base: `main@60f036ff163d14a44d179101b8ebf4539a1473ee`
 
 ## Implemented Coverage
 
 - Dashboard 新增 `/dashboard/invocations/:invokeId` nested route；打开、刷新、直达和关闭均由 route 驱动，卡片 selection 只保留临时上下文。
 - `DashboardInvocationDetailDrawer` 可只凭 `invokeId` 通过既有 records API 补取完整记录，未知记录继续呈现可关闭的 empty/error 状态。
+- `DashboardInvocationDetailDrawer` 在首轮 lookup 只拿到瞬态 `id <= 0` 记录时，会继续按 `invokeId` 轻量重查，直到异步 SQLite 落盘后的持久化记录可见，避免终态 `HTTP 400` / `failed` 调用长期卡在“调用未落盘”。
 - 新增 `GET /api/invocations/:id/workflow-detail` 聚合接口，输出 hero、timeline、partial/reconstructed 状态，以及尝试级 request/response 结构化摘要。
 - `codex_invocations` 新增 `timeline_json` 字段；`pool_upstream_request_attempts` 新增 `request_summary_json` / `response_summary_json` 字段，用于承载工作流时间线和尝试级结构化快照。
 - 工作流详情接口在没有 attempt 行时可合成 synthetic attempt，并在缺失 `timeline_json` 时根据调用级记录和尝试表进行 best-effort reconstruction。
@@ -36,7 +37,7 @@
 - `cargo test capture_target_pool_route_timeout_surfaces_blocked_policy_terminal -- --nocapture`: passed。
 - `cargo test websocket_prepare_rate_limited_owner_returns_owner_unavailable -- --nocapture`: passed。
 - `cd web && bun run test src/features/invocations/InvocationWorkflowDetailPanel.test.tsx`: 1 file passed，3 tests passed。
-- `cd web && bun run test src/features/dashboard/DashboardInvocationDetailDrawer.test.tsx`: 1 file passed，8 tests passed。
+- `cd web && bun run test src/features/dashboard/DashboardInvocationDetailDrawer.test.tsx`: 1 file passed，9 tests passed。
 - `cd web && bun run build-storybook`: passed。
 - 本地 Playwright 截图验证了 Storybook `BlockedPoolWorkflow` 的概览态、路由 `请求体` 详情态和裁定 `返回体` 详情态，并已把证据写入 spec `## Visual Evidence`。
 

--- a/web/src/features/dashboard/DashboardInvocationDetailDrawer.test.tsx
+++ b/web/src/features/dashboard/DashboardInvocationDetailDrawer.test.tsx
@@ -88,12 +88,27 @@ function render(ui: React.ReactNode) {
   });
 }
 
+async function flushMicrotasks(rounds = 4) {
+  await act(async () => {
+    for (let index = 0; index < rounds; index += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
 async function flushAsyncWork(rounds = 4) {
   await act(async () => {
     for (let index = 0; index < rounds; index += 1) {
       await Promise.resolve();
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function advanceTime(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
   });
 }
 
@@ -643,5 +658,49 @@ describe("DashboardInvocationDetailDrawer", () => {
 
     expect(apiMocks.fetchInvocationWorkflowDetail).not.toHaveBeenCalled();
     expect(apiMocks.fetchInvocationResponseBody).not.toHaveBeenCalled();
+  });
+
+  it("retries the lookup after opening on a transient record until the persisted row arrives", async () => {
+    vi.useFakeTimers();
+    const transientRecord = createRecord({
+      id: 0,
+      status: "failed",
+      failureClass: "service_failure",
+      errorMessage: "upstream exploded before placeholder flush",
+    });
+    const persistedRecord = createRecord({
+      id: 501,
+      status: "failed",
+      failureClass: "service_failure",
+      errorMessage: "upstream exploded after sqlite flush",
+    });
+    apiMocks.fetchInvocationRecords
+      .mockResolvedValueOnce(createRecordsResponse([transientRecord]))
+      .mockResolvedValueOnce(createRecordsResponse([persistedRecord]));
+    apiMocks.fetchInvocationWorkflowDetail.mockResolvedValue(
+      createWorkflowDetailFixture(persistedRecord),
+    );
+
+    try {
+      render(
+        <DashboardInvocationDetailDrawer
+          open
+          selection={createSelection(transientRecord)}
+          onClose={() => undefined}
+        />,
+      );
+
+      await flushMicrotasks();
+      expect(document.body.textContent ?? "").toContain("调用未落盘");
+      await advanceTime(1_500);
+      await flushMicrotasks();
+
+      expect(document.body.textContent ?? "").toContain("工作流时间线");
+
+      expect(apiMocks.fetchInvocationRecords).toHaveBeenCalledTimes(2);
+      expect(apiMocks.fetchInvocationWorkflowDetail).toHaveBeenCalledWith(501);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/features/dashboard/DashboardInvocationDetailDrawer.tsx
+++ b/web/src/features/dashboard/DashboardInvocationDetailDrawer.tsx
@@ -23,6 +23,8 @@ interface DashboardInvocationDetailDrawerProps {
   onOpenUpstreamAccount?: (accountId: number, accountLabel: string) => void;
 }
 
+const TRANSIENT_RECORD_LOOKUP_RETRY_MS = 1_500;
+
 type StatusMeta = {
   variant: "default" | "secondary" | "success" | "warning" | "error";
   labelKey?: string;
@@ -94,6 +96,7 @@ export function DashboardInvocationDetailDrawer({
   const localeTag = locale === "zh" ? "zh-CN" : "en-US";
   const titleId = useId();
   const requestSeqRef = useRef(0);
+  const [retryRevision, setRetryRevision] = useState(0);
   const [fullRecord, setFullRecord] = useState<ApiInvocation | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -114,16 +117,26 @@ export function DashboardInvocationDetailDrawer({
   useEffect(() => {
     if (!open || !effectiveInvocationId) {
       requestSeqRef.current += 1;
+      setRetryRevision(0);
       setFullRecord(null);
       setIsLoading(false);
       setLoadError(null);
       return;
     }
 
+    const selectedRecord =
+      selection?.invocation.record.invokeId === effectiveInvocationId
+        ? selection.invocation.record
+        : null;
+    const transientRecord =
+      fullRecord?.invokeId === effectiveInvocationId ? fullRecord : selectedRecord;
+    const isRetryLookup = retryRevision > 0 && transientRecord != null && !(transientRecord.id > 0);
     const requestSeq = requestSeqRef.current + 1;
     requestSeqRef.current = requestSeq;
-    setFullRecord(null);
-    setIsLoading(true);
+    if (!isRetryLookup) {
+      setFullRecord(null);
+      setIsLoading(true);
+    }
     setLoadError(null);
 
     void fetchInvocationRecords({
@@ -143,16 +156,52 @@ export function DashboardInvocationDetailDrawer({
         setLoadError(error instanceof Error ? error.message : String(error));
       })
       .finally(() => {
-        if (requestSeq === requestSeqRef.current) {
+        if (requestSeq === requestSeqRef.current && !isRetryLookup) {
           setIsLoading(false);
         }
       });
-  }, [effectiveInvocationId, open]);
+  }, [effectiveInvocationId, open, retryRevision]);
 
   const selectionRecord =
     selection?.invocation.record.invokeId === effectiveInvocationId
       ? selection.invocation.record
       : null;
+  const effectiveTransientRecord =
+    fullRecord?.invokeId === effectiveInvocationId ? fullRecord : selectionRecord;
+
+  useEffect(() => {
+    if (
+      selectionRecord != null &&
+      selectionRecord.id > 0 &&
+      fullRecord != null &&
+      !(fullRecord.id > 0) &&
+      selectionRecord.invokeId === effectiveInvocationId
+    ) {
+      setFullRecord(selectionRecord);
+      setIsLoading(false);
+      setLoadError(null);
+    }
+  }, [effectiveInvocationId, fullRecord?.id, selectionRecord]);
+
+  useEffect(() => {
+    if (
+      !open ||
+      effectiveInvocationId == null ||
+      effectiveTransientRecord == null ||
+      effectiveTransientRecord.invokeId !== effectiveInvocationId ||
+      effectiveTransientRecord.id > 0 ||
+      isLoading ||
+      loadError != null
+    ) {
+      return;
+    }
+
+    const retryTimer = window.setTimeout(() => {
+      setRetryRevision((current) => current + 1);
+    }, TRANSIENT_RECORD_LOOKUP_RETRY_MS);
+    return () => window.clearTimeout(retryTimer);
+  }, [effectiveInvocationId, effectiveTransientRecord, isLoading, loadError, open]);
+
   const recordForHeader = fullRecord ?? selectionRecord;
   const statusMeta = resolveStatusMeta(
     recordForHeader != null


### PR DESCRIPTION
## Summary
- retry dashboard invocation detail lookups when the first request only sees a transient `id <= 0` row
- keep the drawer on the persisted workflow detail once async SQLite flush finishes instead of leaving it stuck on "Invocation not persisted"
- sync the invocation-detail routing spec history and implementation notes for the transient-to-persisted refresh path

## Verification
- `cd web && bun run test -- src/features/dashboard/DashboardInvocationDetailDrawer.test.tsx`
- `cd web && bun x tsc -p tsconfig.json --noEmit`
- local Storybook review: `Dashboard/WorkingConversationsSection / InvocationDrawerOpen`

## References
- Specs: `docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md`
- Solutions: `-`
- Project Docs: `-`

## Notes
- Visual evidence was reviewed locally from Storybook and returned in chat; no screenshot files are included in this PR.