### PR TITLE
fix(stats): coalesce dashboard read-side snapshots

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -61,6 +61,8 @@ related_specs:
 - 不要把 `records` 事件继续暴露成“页面自己决定要不要重拉”的契约；主应用订阅面应该直接消费 topic payload。
 - 不要为覆盖范围内页面保留健康态 timer reconcile、open-resync 或页面私有 fallback；那会重新引入第二真相源。
 - 不要把 closed-range / history-only 页面硬塞进持续推送；纯 SSE 的边界是“常驻当前态订阅”，不是“所有页面都实时化”。
+- 如果某个 topic 仍需要短 TTL 的服务端 DB 基础快照缓存，cache key 只能包含稳定请求参数与明确允许的 bucket 维度；live runtime 状态、最新持久化行 ID 这类高抖动因子必须留在响应阶段 overlay，否则 singleflight 会被打散，订阅与 HTTP 都会继续重复重算同一份基底。
+- 与 Dashboard 同屏但不共享同一 owner-facing contract 的接口，不要为了“省实现”直接复用 dashboard full snapshot builder；应复用更低层的账户活动聚合块，避免把 summary/model-performance/reconcile 之类 dashboard-only 组装再次带回实时主链路。
 - 不要为 replay 失败发明第三条恢复路径。恢复规则只应是 replay 或 snapshot。
 - 手动“立即重连”不应偷偷复用旧 `resume` 去赌 replay 命中。若产品语义是“人工要求重新拉一份当前态”，前端就应该对 active topics 强制 fresh snapshot，并给这次连接分配独立 `attempt/reason` 供前后端对账。
 - topic 参数必须 canonicalize；否则 resume cursor 与 cache key 会漂移。

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -14,6 +14,7 @@
 - `proxy capture follow-up` 也必须遵守这个分级：没有 SSE 订阅者时，不得再消耗 summary/quota 或 hourly rollup refresh 预算。
 - 即使存在 active SSE 订阅者，terminal follow-up 也不应强制 `flush_now` 式 SQLite barrier；terminal overlay 是 UI 的立即收敛来源，summary/quota 可以在 write controller 后续 flush 后最终一致。
 - 对请求收尾里的同一实体写入，要优先消除“重复唯一键探测 + 紧跟二次更新”“先重算 rollup 再补 timing 再重算一次”这类单请求内自我放大；SQLite 压力常常不是来自单条大 SQL，而是来自几条语义重复的写语句连发。
+- 对 owner-facing 聚合读路径，同样要先消除“整窗扫明细再丢弃大部分结果”和“同参请求因 cache key 掺入 runtime 抖动而无法合并”这两类读放大；它们会和写侧单写者争用同一 SQLite 预算，并以 `database is locked` 的形式回灌到前台。
 - 当并发不能降低且业务成功率高于观测记录完整性时，用进程内短窗口 write controller 承接所有观测记录写：terminal invocation 进入 P1 best-effort 队列，attempt 中间进度、rollup/live progress、account touch、system task finish 等可延迟项进入 P2 并按 key coalesce。记录入队/flush 失败必须报警和计数，但不得让已经完成的业务响应失败。
 - 高频 runtime snapshot 不应默认等同于主事实写。`running` / first-byte / response-ready 这类 UI 新鲜度事件可以先走进程内共享 runtime store + SSE/HTTP overlay；如果服务选择业务优先于记录，terminal success/failure 也可以先进入 P1 write controller，并用 SSE terminal payload + runtime tombstone 支撑短暂最终一致窗口。
 - 路由公平性字段如果不是路由正确性的硬状态，可以拆成“进程内立即生效 + batch 落库”。例如 `last_selected_at` 可先写内存锚点并叠加候选排序，账号 status/cooldown/failure 则继续同步写。
@@ -62,6 +63,7 @@
 - write controller 必须有有界队列、flush 触发（时间窗口 / row count / 最大等待）、coalesced row count、oldest age、flush elapsed、queue depth、enqueue failed 与 dropped count 证据；否则只是把 SQLite 锁问题藏到内存里。
 - buffered progress 不能立刻广播“已持久化”的 DB snapshot；要么广播内存态，要么等后续 reconcile/terminal 更新。否则会把 stale DB state 伪装成实时状态。
 - 如果选择内存态广播，就必须让所有相关读方共享同一个 runtime store，包括 SSE、records open-resync、current summary、current timeseries、账号活动 in-flight 统计与 prompt-cache working conversations；否则去掉 DB running 写后会产生多套不一致实时视图。
+- Dashboard / account activity 这类短 TTL 聚合快照，如果允许 `<=2s` 的服务端合并刷新预算，就不应再把 live runtime 状态或最新持久化行 ID 放进 cache key；否则表面上有 singleflight，实测仍会长期 `wait_on_in_flight=0`，既保不住实时性，也保不住 SQLite。
 - `INSERT OR IGNORE` 会静默吞掉 `NOT NULL` 约束错误；用于占位写时必须绑定所有 NOT NULL 默认列，或者检查 `rows_affected` 并记录结构化证据，否则会误以为 batch flush 成功。
 - 为每个后台入口单独做局部退避，容易遗漏同一压力窗口内的其他维护任务；进程级 gate 更容易统一行为。
 - `SELECT MAX(id) ... WHERE <稀疏条件>`、`NOT EXISTS` + 低选择性 phase 过滤这类查询，即使最终只返回 1 行，也可能在 SQLite 上吃掉秒级读锁预算；若它们会与前台 HTTP 共享同一数据库，必须先压成 cursor 读取或用 partial index 固定扫描面。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## Decision Trace
 
+- 2026-07-19：101 线上 12 小时复盘确认 `dashboard-activity full` 慢点仍主要来自读侧合并不足，而不是内存瓶颈。已冻结两条后续约束：一，non-`yesterday` 基础快照缓存只允许按稳定请求参数 + 短 TTL 合并，不能再把 live runtime 状态或最新持久化行 ID 放进选择键；二，`/api/stats/upstream-account-activity` 不得继续借道 dashboard full snapshot，必须走独立账户活动 builder，并补足 route/builder/preview hydration telemetry 便于下一轮定位残余慢点。
 - 2026-07-18：收紧上游账号卡宽屏 `split` header 的 `TPM` 横向预算。此前长 `TPM` 会按完整数字位数直接撑宽右上实时指标区；本轮固定仅 `TPM` 值本体约 `6ch` 宽度预算，超预算后继续复用既有 adaptive compact 缩写链路，`进行中调用 / 消费速率` 与窄卡 `stacked` 路径不变。
 - 2026-07-16：Dashboard 工作区与顶部当前态正式并入主应用统一 topic SSE 总线。此前 `dashboardActivityLive + HTTP reconcile/open-resync` 的双轨合同在这里退场，取而代之的是 `dashboard.activity.current` 的 authoritative `snapshot/replay/live`；账号视图、顶部 KPI 与恢复语义统一由 topic cursor / schemaEpoch 驱动。
 

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -67,6 +67,8 @@
 - 已实现：账号活动快照的终态 live 数据改为账号级窄聚合与按模型用量分组，避免为整个 range 传输完整 invocation preview 行；运行态 runtime overlay、归档折叠、四个时间范围和公开响应字段保持原有语义。
 - 已实现：账号卡 recent 调用改为每个候选账号按时间倒序的受限读取，数量仍严格受请求 `recentLimit` 限制。
 - 已实现：账号卡 recent 调用在 SQLite batch flush 前也会读取同一 runtime store；同键 runtime 行覆盖非终态 DB shell，短暂 terminal overlay 立即可见，落库后不会形成重复行。
+- 已实现：non-`yesterday` 的 `dashboard-activity` 基础快照缓存已收敛为“请求参数 + 2 秒 bucket”选择键，不再把 live runtime 状态或最新持久化行 ID 放进 cache key；fresh live overlay 与 `live_revision` 继续在响应阶段叠加，保证 owner-facing 实时语义不变。
+- 已实现：`/api/stats/upstream-account-activity` 改走独立账户活动 builder，不再借道 dashboard full snapshot 的 summary/model-performance 组装；后端新增 `route / builder / preview_read_mode / candidate_preview_id_count / hydrated_preview_row_count / cache_bypass_reason` 结构化 telemetry，用于复盘读侧放大与 DB 压力重合。
 
 ## Remaining Gaps
 

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -9899,7 +9899,7 @@ async fn load_dashboard_activity_account_build_result(
     let source_scope = resolve_default_source_scope(&state.pool).await?;
     let mut account_activity = HashMap::<Option<i64>, UpstreamAccountActivityAccumulator>::new();
     let mut model_performance = ModelPerformanceAccumulator::default();
-    let mut materialized_archive_fallback_totals = StatsTotals::default();
+    let materialized_archive_fallback_totals = StatsTotals::default();
     let mut materialized_archive_details_limited = false;
     let current_snapshot_by_account = if range_name == "yesterday" {
         load_dashboard_activity_current_minute_accumulators_by_account(state, source_scope, range)
@@ -10043,47 +10043,45 @@ async fn load_dashboard_activity_account_build_result(
                 .add_aggregate_row(&row);
         }
         if !skipped_materialized_ranges.is_empty() {
-            let mut account_fallback_totals =
-                dashboard_activity_materialized_archive_account_fallback_totals(
-                    state,
-                    source_scope,
-                    &skipped_materialized_ranges,
-                )
-                .await?;
-            if builder_kind == DashboardActivityAccountBuilderKind::DashboardFull {
-                let global_fallback_totals =
-                    dashboard_activity_materialized_archive_fallback_totals(
+            let global_fallback_totals = dashboard_activity_materialized_archive_fallback_totals(
+                state,
+                source_scope,
+                skipped_materialized_ranges.clone(),
+            )
+            .await?;
+            if dashboard_activity_stats_totals_has_values(global_fallback_totals) {
+                if builder_kind == DashboardActivityAccountBuilderKind::DashboardFull {
+                    materialized_archive_details_limited = true;
+                }
+                let mut account_fallback_totals =
+                    dashboard_activity_materialized_archive_account_fallback_totals(
                         state,
                         source_scope,
-                        skipped_materialized_ranges.clone(),
+                        &skipped_materialized_ranges,
                     )
                     .await?;
-                if dashboard_activity_stats_totals_has_values(global_fallback_totals) {
-                    materialized_archive_fallback_totals = global_fallback_totals;
-                    materialized_archive_details_limited = true;
-                    let account_fallback_sum = account_fallback_totals
-                        .values()
-                        .fold(StatsTotals::default(), |total, account_totals| {
-                            total.add(account_totals.stats_totals())
-                        });
-                    let residual_fallback_totals = dashboard_activity_stats_totals_subtract(
-                        global_fallback_totals,
-                        account_fallback_sum,
-                    );
-                    if dashboard_activity_stats_totals_has_values(residual_fallback_totals) {
-                        account_fallback_totals.entry(None).or_default().add_assign(
-                            DashboardActivityAccountFallbackTotals::from_stats_totals(
-                                residual_fallback_totals,
-                            ),
-                        );
-                    }
-                }
-            }
-            for (upstream_account_id, totals) in account_fallback_totals {
-                dashboard_activity_merge_account_fallback_totals(
-                    account_activity.entry(upstream_account_id).or_default(),
-                    totals,
+                let account_fallback_sum = account_fallback_totals
+                    .values()
+                    .fold(StatsTotals::default(), |total, account_totals| {
+                        total.add(account_totals.stats_totals())
+                    });
+                let residual_fallback_totals = dashboard_activity_stats_totals_subtract(
+                    global_fallback_totals,
+                    account_fallback_sum,
                 );
+                if dashboard_activity_stats_totals_has_values(residual_fallback_totals) {
+                    account_fallback_totals.entry(None).or_default().add_assign(
+                        DashboardActivityAccountFallbackTotals::from_stats_totals(
+                            residual_fallback_totals,
+                        ),
+                    );
+                }
+                for (upstream_account_id, totals) in account_fallback_totals {
+                    dashboard_activity_merge_account_fallback_totals(
+                        account_activity.entry(upstream_account_id).or_default(),
+                        totals,
+                    );
+                }
             }
         }
     }

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7201,6 +7201,8 @@ async fn query_live_upstream_account_activity_preview_rows_by_ids(
         tracing::warn!(
             endpoint = "/api/stats/upstream-account-activity",
             operation,
+            candidate_preview_id_count = ids.len(),
+            hydrated_preview_row_count = rows.len(),
             ?source_scope,
             selected_preview_row_count = ids.len(),
             row_count = rows.len(),
@@ -7211,12 +7213,18 @@ async fn query_live_upstream_account_activity_preview_rows_by_ids(
     Ok(rows)
 }
 
-async fn query_live_upstream_account_activity_preview_rows_per_account_limit(
+struct HydratedUpstreamAccountPreviewRows {
+    rows: Vec<UpstreamAccountInvocationPreviewRow>,
+    candidate_preview_id_count: usize,
+    hydrated_preview_row_count: usize,
+}
+
+async fn query_live_upstream_account_activity_preview_rows_per_account_limit_with_stats(
     pool: &Pool<Sqlite>,
     source_scope: InvocationSourceScope,
     range: ExactUtcRange,
     limit_per_account: usize,
-) -> Result<Vec<UpstreamAccountInvocationPreviewRow>, ApiError> {
+) -> Result<HydratedUpstreamAccountPreviewRows, ApiError> {
     let ids = query_live_upstream_account_activity_preview_candidate_ids_per_account(
         pool,
         source_scope,
@@ -7224,13 +7232,36 @@ async fn query_live_upstream_account_activity_preview_rows_per_account_limit(
         limit_per_account,
     )
     .await?;
-    query_live_upstream_account_activity_preview_rows_by_ids(
+    let rows = query_live_upstream_account_activity_preview_rows_by_ids(
         pool,
         source_scope,
         &ids,
         "live_preview_rows_per_account_limit",
     )
-    .await
+    .await?;
+    Ok(HydratedUpstreamAccountPreviewRows {
+        candidate_preview_id_count: ids.len(),
+        hydrated_preview_row_count: rows.len(),
+        rows,
+    })
+}
+
+async fn query_live_upstream_account_activity_preview_rows_per_account_limit(
+    pool: &Pool<Sqlite>,
+    source_scope: InvocationSourceScope,
+    range: ExactUtcRange,
+    limit_per_account: usize,
+) -> Result<Vec<UpstreamAccountInvocationPreviewRow>, ApiError> {
+    Ok(
+        query_live_upstream_account_activity_preview_rows_per_account_limit_with_stats(
+            pool,
+            source_scope,
+            range,
+            limit_per_account,
+        )
+        .await?
+        .rows,
+    )
 }
 
 async fn query_live_upstream_account_activity_existing_invocation_ids(
@@ -7963,6 +7994,7 @@ pub(crate) struct DashboardActivitySnapshot {
     summary: DashboardActivitySummaryResponse,
     materialized_archive_fallback_totals: StatsTotals,
     materialized_archive_details_limited: bool,
+    build_telemetry: DashboardActivityBuildTelemetry,
 }
 
 #[cfg(test)]
@@ -7986,8 +8018,26 @@ impl DashboardActivitySnapshot {
 #[derive(Debug, Clone, Copy)]
 struct DashboardActivitySnapshotCacheOutcome {
     cache_hit_or_miss: &'static str,
+    cache_bypass_reason: &'static str,
     coalesced_waiter_count: usize,
     db_build_elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DashboardActivityBuildTelemetry {
+    preview_read_mode: &'static str,
+    candidate_preview_id_count: usize,
+    hydrated_preview_row_count: usize,
+}
+
+impl Default for DashboardActivityBuildTelemetry {
+    fn default() -> Self {
+        Self {
+            preview_read_mode: "none",
+            candidate_preview_id_count: 0,
+            hydrated_preview_row_count: 0,
+        }
+    }
 }
 
 fn dashboard_activity_build_scope(include_accounts: bool, _include_recent: bool) -> &'static str {
@@ -8526,49 +8576,11 @@ fn dashboard_activity_source_scope_cache_key(source_scope: InvocationSourceScope
     }
 }
 
-fn dashboard_activity_live_snapshot_cache_key(
-    live: Option<&DashboardActivityLiveSnapshot>,
-) -> String {
-    let Some(live) = live else {
-        return "idle".to_string();
-    };
-    if live.in_progress_invocation_count <= 0 {
-        return "idle".to_string();
-    }
-
-    let mut parts = Vec::with_capacity(live.accounts.len() + 1);
-    parts.push(format!(
-        "total:{}:{}:{}:{}:{}",
-        live.in_progress_invocation_count,
-        live.retry_invocation_count,
-        live.in_progress_phase_counts.queued,
-        live.in_progress_phase_counts.requesting,
-        live.in_progress_phase_counts.responding
-    ));
-    for account in &live.accounts {
-        if account.in_progress_invocation_count <= 0 && account.retry_invocation_count <= 0 {
-            continue;
-        }
-        parts.push(format!(
-            "{}:{}:{}:{}:{}:{}",
-            account.account_key,
-            account.in_progress_invocation_count,
-            account.retry_invocation_count,
-            account.in_progress_phase_counts.queued,
-            account.in_progress_phase_counts.requesting,
-            account.in_progress_phase_counts.responding
-        ));
-    }
-    parts.join("|")
-}
-
 fn build_dashboard_activity_snapshot_selection(
     range: &str,
     exact_range: ExactUtcRange,
     reporting_tz: Tz,
     source_scope: InvocationSourceScope,
-    invocation_snapshot_id: i64,
-    live_activity_key: &str,
     recent_limit: usize,
     include_accounts: bool,
     include_recent: bool,
@@ -8579,8 +8591,6 @@ fn build_dashboard_activity_snapshot_selection(
         range_end: format_utc_iso_precise(exact_range.end),
         time_zone: reporting_tz.to_string(),
         source_scope: dashboard_activity_source_scope_cache_key(source_scope).to_string(),
-        invocation_snapshot_id,
-        live_activity_key: live_activity_key.to_string(),
         recent_limit,
         include_accounts,
         include_recent,
@@ -9634,6 +9644,7 @@ pub(crate) async fn load_dashboard_activity_summary_only_snapshot(
         },
         materialized_archive_fallback_totals: StatsTotals::default(),
         materialized_archive_details_limited: false,
+        build_telemetry: DashboardActivityBuildTelemetry::default(),
     })
 }
 
@@ -9680,12 +9691,215 @@ async fn load_dashboard_activity_snapshot_for_range(
         )
         .await;
     }
+    let build = load_dashboard_activity_account_build_result(
+        state,
+        range_name,
+        range,
+        recent_limit,
+        include_recent,
+        in_progress_counts_override,
+        DashboardActivityAccountBuilderKind::DashboardFull,
+    )
+    .await?;
+    let mut summary = build_dashboard_activity_summary(
+        &build.accounts,
+        range_name != "yesterday",
+        build.current_snapshot_summary,
+        build.latest_first_response_byte_total_in_range,
+        build.latest_avg_total_in_range,
+        build.summary_model_performance,
+    );
+    dashboard_activity_apply_materialized_archive_fallback_to_stats(
+        &mut summary.stats,
+        build.materialized_archive_fallback_totals,
+    );
+    if build.materialized_archive_details_limited {
+        dashboard_activity_clear_materialized_archive_detail_fields(&mut summary.stats);
+    }
+    Ok(DashboardActivitySnapshot {
+        range: range_name.to_string(),
+        range_start: range.start,
+        range_end: range.end,
+        accounts: build.accounts,
+        summary,
+        materialized_archive_fallback_totals: build.materialized_archive_fallback_totals,
+        materialized_archive_details_limited: build.materialized_archive_details_limited,
+        build_telemetry: build.build_telemetry,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DashboardActivityAccountBuilderKind {
+    DashboardFull,
+    UpstreamAccount,
+}
+
+#[derive(Debug)]
+struct DashboardActivityAccountBuildResult {
+    accounts: Vec<DashboardActivityAccountResponse>,
+    current_snapshot_summary: DashboardActivityCurrentSnapshot,
+    latest_first_response_byte_total_in_range: Option<f64>,
+    latest_avg_total_in_range: Option<f64>,
+    summary_model_performance: ModelPerformanceResponse,
+    materialized_archive_fallback_totals: StatsTotals,
+    materialized_archive_details_limited: bool,
+    build_telemetry: DashboardActivityBuildTelemetry,
+}
+
+fn build_dashboard_activity_account_response(
+    range_name: &str,
+    range: ExactUtcRange,
+    model_performance_available: bool,
+    current_snapshot_by_account: &HashMap<Option<i64>, DashboardActivityCurrentSnapshot>,
+    account_meta: &HashMap<i64, UpstreamAccountActivityMetaRow>,
+    effective_routing_rules: &HashMap<i64, crate::upstream_accounts::EffectiveRoutingRule>,
+    in_progress_counts: &HashMap<Option<i64>, UpstreamAccountInProgressSummary>,
+    upstream_account_id: Option<i64>,
+    aggregate: UpstreamAccountActivityAccumulator,
+) -> DashboardActivityAccountResponse {
+    let meta = upstream_account_id.and_then(|id| account_meta.get(&id));
+    let status_fields =
+        meta.map(|row| build_upstream_account_activity_status_fields(row, Utc::now()));
+    let model_performance = aggregate
+        .model_performance
+        .into_response(range, model_performance_available);
+    let current_snapshot = current_snapshot_by_account
+        .get(&upstream_account_id)
+        .copied()
+        .unwrap_or_default();
+    let (current_first_response_byte_total_avg_ms, current_avg_total_ms) =
+        build_dashboard_activity_latency_summary(
+            current_snapshot,
+            aggregate.latest_first_response_byte_total_ms,
+            aggregate.latest_avg_total_ms,
+        );
+    let tokens_per_minute = Some(current_snapshot.qualified_tokens.max(0) as f64);
+    let spend_rate = Some(current_snapshot.total_cost.max(0.0));
+    let (in_progress_invocation_count, in_progress_phase_counts, retry_invocation_count) =
+        if range_name == "yesterday" {
+            (None, None, None)
+        } else {
+            let summary = in_progress_counts
+                .get(&upstream_account_id)
+                .copied()
+                .unwrap_or_default();
+            (
+                Some(summary.in_progress_count),
+                Some(summary.phase_counts),
+                Some(summary.retry_count),
+            )
+        };
+    let account_key = upstream_account_id
+        .map(|id| format!("upstream:{id}"))
+        .unwrap_or_else(|| "unassigned".to_string());
+
+    DashboardActivityAccountResponse {
+        account_key,
+        upstream_account_id,
+        display_name: upstream_account_id
+            .map(|id| {
+                resolve_upstream_account_activity_display_name(
+                    id,
+                    meta,
+                    aggregate.display_name_hint.as_deref(),
+                )
+            })
+            .unwrap_or_else(|| "未分配上游账号".to_string()),
+        is_unassigned: upstream_account_id.is_none(),
+        latest_conversation_created_at: aggregate.latest_conversation_created_at,
+        last_invocation_at: aggregate.last_invocation_at,
+        group_name: normalize_trimmed_optional_string_local(
+            meta.and_then(|row| row.group_name.clone()),
+        ),
+        plan_type: normalize_trimmed_optional_string_local(
+            meta.and_then(|row| row.plan_type.clone())
+                .or(aggregate.plan_type_hint),
+        ),
+        enabled: status_fields.as_ref().map(|fields| fields.enabled),
+        display_status: status_fields
+            .as_ref()
+            .map(|fields| fields.display_status.clone()),
+        enable_status: status_fields
+            .as_ref()
+            .map(|fields| fields.enable_status.clone()),
+        work_status: status_fields
+            .as_ref()
+            .map(|fields| fields.work_status.clone()),
+        health_status: status_fields
+            .as_ref()
+            .map(|fields| fields.health_status.clone()),
+        sync_state: status_fields
+            .as_ref()
+            .map(|fields| fields.sync_state.clone()),
+        last_error: status_fields
+            .as_ref()
+            .and_then(|fields| fields.last_error.clone()),
+        last_action_reason_message: status_fields
+            .as_ref()
+            .and_then(|fields| fields.last_action_reason_message.clone()),
+        request_count: aggregate.request_count,
+        success_count: aggregate.success_count,
+        failure_count: aggregate.failure_count,
+        non_success_count: aggregate.non_success_count,
+        total_tokens: aggregate.total_tokens,
+        success_tokens: aggregate.success_tokens,
+        non_success_tokens: aggregate.non_success_tokens,
+        failure_tokens: aggregate.failure_tokens,
+        failure_cost: aggregate.failure_cost,
+        non_success_cost: aggregate.non_success_cost,
+        total_cost: aggregate.total_cost,
+        usage_breakdown: aggregate.usage_breakdown.clone().into_response(),
+        model_performance,
+        cache_hit_rate: (aggregate.total_tokens > 0)
+            .then_some(aggregate.cache_input_tokens as f64 / aggregate.total_tokens as f64),
+        tokens_per_minute,
+        spend_rate,
+        first_byte_avg_ms: (aggregate.first_response_byte_total_sample_count > 0).then_some(
+            aggregate.first_response_byte_total_sum_ms
+                / aggregate.first_response_byte_total_sample_count as f64,
+        ),
+        first_response_byte_total_avg_ms: (aggregate.first_response_byte_total_sample_count > 0)
+            .then_some(
+                aggregate.first_response_byte_total_sum_ms
+                    / aggregate.first_response_byte_total_sample_count as f64,
+            ),
+        avg_total_ms: (aggregate.total_latency_sample_count > 0).then_some(
+            aggregate.total_latency_sum_ms / aggregate.total_latency_sample_count as f64,
+        ),
+        current_first_response_byte_total_avg_ms,
+        current_avg_total_ms,
+        in_progress_invocation_count,
+        in_progress_phase_counts,
+        retry_invocation_count,
+        upload_bytes_per_second: 0.0,
+        download_bytes_per_second: 0.0,
+        in_progress_wait_sum_ms: aggregate.in_progress_wait_sum_ms,
+        in_progress_wait_sample_count: aggregate.in_progress_wait_sample_count,
+        effective_routing_rule: upstream_account_id.map(|id| {
+            effective_routing_rules
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(crate::upstream_accounts::default_effective_routing_rule)
+        }),
+        recent_invocations: aggregate.recent_invocations,
+    }
+}
+
+async fn load_dashboard_activity_account_build_result(
+    state: &AppState,
+    range_name: &str,
+    range: ExactUtcRange,
+    recent_limit: usize,
+    include_recent: bool,
+    in_progress_counts_override: Option<HashMap<Option<i64>, UpstreamAccountInProgressSummary>>,
+    builder_kind: DashboardActivityAccountBuilderKind,
+) -> Result<DashboardActivityAccountBuildResult, ApiError> {
     let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
     let model_performance_available = range.start >= retention_cutoff;
-    let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
+    let source_scope = resolve_default_source_scope(&state.pool).await?;
     let mut account_activity = HashMap::<Option<i64>, UpstreamAccountActivityAccumulator>::new();
     let mut model_performance = ModelPerformanceAccumulator::default();
-    let materialized_archive_fallback_totals = StatsTotals::default();
+    let mut materialized_archive_fallback_totals = StatsTotals::default();
     let mut materialized_archive_details_limited = false;
     let current_snapshot_by_account = if range_name == "yesterday" {
         load_dashboard_activity_current_minute_accumulators_by_account(state, source_scope, range)
@@ -9702,7 +9916,10 @@ async fn load_dashboard_activity_snapshot_for_range(
     };
     let current_snapshot_summary =
         sum_dashboard_activity_current_snapshots(current_snapshot_by_account.values().copied());
-    let model_performance_duration_overrides = if model_performance_available {
+    let model_performance_duration_overrides = if builder_kind
+        == DashboardActivityAccountBuilderKind::DashboardFull
+        && model_performance_available
+    {
         Some(
             query_live_model_performance_duration_overrides(&state.pool, source_scope, range, true)
                 .await?,
@@ -9825,14 +10042,7 @@ async fn load_dashboard_activity_snapshot_for_range(
                 .usage_breakdown
                 .add_aggregate_row(&row);
         }
-        let global_fallback_totals = dashboard_activity_materialized_archive_fallback_totals(
-            state,
-            source_scope,
-            skipped_materialized_ranges.clone(),
-        )
-        .await?;
-        if dashboard_activity_stats_totals_has_values(global_fallback_totals) {
-            materialized_archive_details_limited = true;
+        if !skipped_materialized_ranges.is_empty() {
             let mut account_fallback_totals =
                 dashboard_activity_materialized_archive_account_fallback_totals(
                     state,
@@ -9840,21 +10050,34 @@ async fn load_dashboard_activity_snapshot_for_range(
                     &skipped_materialized_ranges,
                 )
                 .await?;
-            let account_fallback_sum = account_fallback_totals
-                .values()
-                .fold(StatsTotals::default(), |total, account_totals| {
-                    total.add(account_totals.stats_totals())
-                });
-            let residual_fallback_totals = dashboard_activity_stats_totals_subtract(
-                global_fallback_totals,
-                account_fallback_sum,
-            );
-            if dashboard_activity_stats_totals_has_values(residual_fallback_totals) {
-                account_fallback_totals.entry(None).or_default().add_assign(
-                    DashboardActivityAccountFallbackTotals::from_stats_totals(
-                        residual_fallback_totals,
-                    ),
-                );
+            if builder_kind == DashboardActivityAccountBuilderKind::DashboardFull {
+                let global_fallback_totals =
+                    dashboard_activity_materialized_archive_fallback_totals(
+                        state,
+                        source_scope,
+                        skipped_materialized_ranges.clone(),
+                    )
+                    .await?;
+                if dashboard_activity_stats_totals_has_values(global_fallback_totals) {
+                    materialized_archive_fallback_totals = global_fallback_totals;
+                    materialized_archive_details_limited = true;
+                    let account_fallback_sum = account_fallback_totals
+                        .values()
+                        .fold(StatsTotals::default(), |total, account_totals| {
+                            total.add(account_totals.stats_totals())
+                        });
+                    let residual_fallback_totals = dashboard_activity_stats_totals_subtract(
+                        global_fallback_totals,
+                        account_fallback_sum,
+                    );
+                    if dashboard_activity_stats_totals_has_values(residual_fallback_totals) {
+                        account_fallback_totals.entry(None).or_default().add_assign(
+                            DashboardActivityAccountFallbackTotals::from_stats_totals(
+                                residual_fallback_totals,
+                            ),
+                        );
+                    }
+                }
             }
             for (upstream_account_id, totals) in account_fallback_totals {
                 dashboard_activity_merge_account_fallback_totals(
@@ -9892,6 +10115,7 @@ async fn load_dashboard_activity_snapshot_for_range(
             }
         }
     }
+    let mut build_telemetry = DashboardActivityBuildTelemetry::default();
     for row in
         query_live_upstream_account_activity_rate_rows(&state.pool, source_scope, range).await?
     {
@@ -9925,108 +10149,103 @@ async fn load_dashboard_activity_snapshot_for_range(
     );
     let mut runtime_recent_rows =
         HashMap::<Option<i64>, Vec<UpstreamAccountInvocationPreviewRow>>::new();
-    if include_accounts {
-        let mut runtime_recent_by_key =
-            HashMap::<(String, String), UpstreamAccountInvocationPreviewRow>::new();
-        for row in &runtime_rows {
-            runtime_recent_by_key.insert(
-                (row.invoke_id.clone(), row.occurred_at.clone()),
-                row.clone(),
+    let mut runtime_recent_by_key =
+        HashMap::<(String, String), UpstreamAccountInvocationPreviewRow>::new();
+    for row in &runtime_rows {
+        runtime_recent_by_key.insert(
+            (row.invoke_id.clone(), row.occurred_at.clone()),
+            row.clone(),
+        );
+    }
+    let mut terminal_rows = Vec::new();
+    for record in state.proxy_runtime_invocations.snapshot() {
+        if matches!(
+            normalized_runtime_text(record.status.as_deref()).as_str(),
+            "running" | "pending"
+        ) {
+            continue;
+        }
+        let Some(row) =
+            runtime_upstream_account_activity_preview_row_with_terminal(record, source_scope, true)
+        else {
+            continue;
+        };
+        let Some(occurred_at) = parse_to_utc_datetime(&row.occurred_at) else {
+            continue;
+        };
+        if occurred_at < range.start || occurred_at >= range.end {
+            continue;
+        }
+        terminal_rows.push(((row.invoke_id.clone(), row.occurred_at.clone()), row));
+    }
+    let fallback_keys = terminal_rows
+        .iter()
+        .filter(|(_, row)| row.upstream_account_id.is_none())
+        .map(|(key, _)| key.clone())
+        .collect::<HashSet<_>>();
+    let fallback_rows =
+        query_runtime_recent_account_fallback_rows(&state.pool, source_scope, &fallback_keys)
+            .await?
+            .into_iter()
+            .map(|row| ((row.invoke_id.clone(), row.occurred_at.clone()), row))
+            .collect::<HashMap<_, _>>();
+    for (key, mut row) in terminal_rows {
+        if let Some(existing) = runtime_recent_by_key.get(&key) {
+            if row.upstream_account_id.is_none() {
+                row.upstream_account_id = existing.upstream_account_id;
+            }
+            if row.upstream_account_name.is_none() {
+                row.upstream_account_name = existing.upstream_account_name.clone();
+            }
+            if row.upstream_account_plan_type.is_none() {
+                row.upstream_account_plan_type = existing.upstream_account_plan_type.clone();
+            }
+        }
+        if let Some(fallback) = fallback_rows.get(&key) {
+            if row.upstream_account_id.is_none() {
+                row.upstream_account_id = fallback.upstream_account_id;
+            }
+            if row.upstream_account_name.is_none() {
+                row.upstream_account_name = fallback.upstream_account_name.clone();
+            }
+            if row.upstream_account_plan_type.is_none() {
+                row.upstream_account_plan_type = fallback.upstream_account_plan_type.clone();
+            }
+        }
+        runtime_recent_by_key.insert(key, row);
+    }
+    for row in runtime_recent_by_key.into_values() {
+        runtime_recent_rows
+            .entry(row.upstream_account_id)
+            .or_default()
+            .push(row);
+    }
+    for rows in runtime_recent_rows.values_mut() {
+        rows.sort_by(|left, right| {
+            right
+                .occurred_at
+                .cmp(&left.occurred_at)
+                .then_with(|| right.id.cmp(&left.id))
+        });
+    }
+    for (account_id, rows) in &runtime_recent_rows {
+        let entry = account_activity.entry(*account_id).or_default();
+        if let Some(row) = rows.first() {
+            entry.last_occurred_at_epoch_ms = parse_to_utc_datetime(&row.occurred_at).map_or(
+                entry.last_occurred_at_epoch_ms,
+                |occurred_at| {
+                    entry
+                        .last_occurred_at_epoch_ms
+                        .max(occurred_at.timestamp_millis())
+                },
             );
-        }
-        let mut terminal_rows = Vec::new();
-        for record in state.proxy_runtime_invocations.snapshot() {
-            if matches!(
-                normalized_runtime_text(record.status.as_deref()).as_str(),
-                "running" | "pending"
-            ) {
-                continue;
+            if entry.display_name_hint.is_none() {
+                entry.display_name_hint =
+                    normalize_trimmed_optional_string_local(row.upstream_account_name.clone());
             }
-            let Some(row) = runtime_upstream_account_activity_preview_row_with_terminal(
-                record,
-                source_scope,
-                true,
-            ) else {
-                continue;
-            };
-            let Some(occurred_at) = parse_to_utc_datetime(&row.occurred_at) else {
-                continue;
-            };
-            if occurred_at < range.start || occurred_at >= range.end {
-                continue;
-            }
-            terminal_rows.push(((row.invoke_id.clone(), row.occurred_at.clone()), row));
-        }
-        let fallback_keys = terminal_rows
-            .iter()
-            .filter(|(_, row)| row.upstream_account_id.is_none())
-            .map(|(key, _)| key.clone())
-            .collect::<HashSet<_>>();
-        let fallback_rows =
-            query_runtime_recent_account_fallback_rows(&state.pool, source_scope, &fallback_keys)
-                .await?
-                .into_iter()
-                .map(|row| ((row.invoke_id.clone(), row.occurred_at.clone()), row))
-                .collect::<HashMap<_, _>>();
-        for (key, mut row) in terminal_rows {
-            if let Some(existing) = runtime_recent_by_key.get(&key) {
-                if row.upstream_account_id.is_none() {
-                    row.upstream_account_id = existing.upstream_account_id;
-                }
-                if row.upstream_account_name.is_none() {
-                    row.upstream_account_name = existing.upstream_account_name.clone();
-                }
-                if row.upstream_account_plan_type.is_none() {
-                    row.upstream_account_plan_type = existing.upstream_account_plan_type.clone();
-                }
-            }
-            if let Some(fallback) = fallback_rows.get(&key) {
-                if row.upstream_account_id.is_none() {
-                    row.upstream_account_id = fallback.upstream_account_id;
-                }
-                if row.upstream_account_name.is_none() {
-                    row.upstream_account_name = fallback.upstream_account_name.clone();
-                }
-                if row.upstream_account_plan_type.is_none() {
-                    row.upstream_account_plan_type = fallback.upstream_account_plan_type.clone();
-                }
-            }
-            runtime_recent_by_key.insert(key, row);
-        }
-        for row in runtime_recent_by_key.into_values() {
-            runtime_recent_rows
-                .entry(row.upstream_account_id)
-                .or_default()
-                .push(row);
-        }
-        for rows in runtime_recent_rows.values_mut() {
-            rows.sort_by(|left, right| {
-                right
-                    .occurred_at
-                    .cmp(&left.occurred_at)
-                    .then_with(|| right.id.cmp(&left.id))
-            });
-        }
-        for (account_id, rows) in &runtime_recent_rows {
-            let entry = account_activity.entry(*account_id).or_default();
-            if let Some(row) = rows.first() {
-                entry.last_occurred_at_epoch_ms = parse_to_utc_datetime(&row.occurred_at).map_or(
-                    entry.last_occurred_at_epoch_ms,
-                    |occurred_at| {
-                        entry
-                            .last_occurred_at_epoch_ms
-                            .max(occurred_at.timestamp_millis())
-                    },
-                );
-                if entry.display_name_hint.is_none() {
-                    entry.display_name_hint =
-                        normalize_trimmed_optional_string_local(row.upstream_account_name.clone());
-                }
-                if entry.plan_type_hint.is_none() {
-                    entry.plan_type_hint = normalize_trimmed_optional_string_local(
-                        row.upstream_account_plan_type.clone(),
-                    );
-                }
+            if entry.plan_type_hint.is_none() {
+                entry.plan_type_hint =
+                    normalize_trimmed_optional_string_local(row.upstream_account_plan_type.clone());
             }
         }
     }
@@ -10039,7 +10258,7 @@ async fn load_dashboard_activity_snapshot_for_range(
             &mut account_activity,
             row,
             recent_limit,
-            include_accounts && include_recent,
+            include_recent,
         );
     }
 
@@ -10089,14 +10308,20 @@ async fn load_dashboard_activity_snapshot_for_range(
         }
     }
 
-    if include_accounts && include_recent {
-        let rows = query_live_upstream_account_activity_preview_rows_per_account_limit(
-            &state.pool,
-            source_scope,
-            range,
-            recent_limit,
-        )
-        .await?;
+    if include_recent {
+        let hydrated_rows =
+            query_live_upstream_account_activity_preview_rows_per_account_limit_with_stats(
+                &state.pool,
+                source_scope,
+                range,
+                recent_limit,
+            )
+            .await?;
+        build_telemetry = DashboardActivityBuildTelemetry {
+            preview_read_mode: "bounded_per_account",
+            candidate_preview_id_count: hydrated_rows.candidate_preview_id_count,
+            hydrated_preview_row_count: hydrated_rows.hydrated_preview_row_count,
+        };
         let mut recent_rows_by_account =
             HashMap::<Option<i64>, Vec<PromptCacheConversationInvocationPreviewResponse>>::new();
         for (upstream_account_id, runtime_rows) in runtime_recent_rows {
@@ -10109,7 +10334,7 @@ async fn load_dashboard_activity_snapshot_for_range(
                         .map(upstream_account_invocation_preview_from_row),
                 );
         }
-        for row in rows {
+        for row in hydrated_rows.rows {
             recent_rows_by_account
                 .entry(row.upstream_account_id)
                 .or_default()
@@ -10162,203 +10387,40 @@ async fn load_dashboard_activity_snapshot_for_range(
         .keys()
         .filter_map(|id| *id)
         .collect::<Vec<_>>();
-    let account_meta = if include_accounts {
-        query_upstream_account_activity_meta(&state.pool, &account_ids).await?
-    } else {
-        HashMap::new()
-    };
-    let effective_routing_rules = if include_accounts {
+    let account_meta = query_upstream_account_activity_meta(&state.pool, &account_ids).await?;
+    let effective_routing_rules =
         crate::upstream_accounts::load_effective_routing_rules_for_accounts(
             &state.pool,
             &account_ids,
         )
-        .await?
-    } else {
-        HashMap::new()
-    };
+        .await?;
     let mut accounts = account_activity
         .into_iter()
         .map(|(upstream_account_id, aggregate)| {
-            let meta = upstream_account_id.and_then(|id| account_meta.get(&id));
-            let status_fields =
-                meta.map(|row| build_upstream_account_activity_status_fields(row, Utc::now()));
-            let model_performance = aggregate
-                .model_performance
-                .into_response(range, model_performance_available);
-            let current_snapshot = current_snapshot_by_account
-                .get(&upstream_account_id)
-                .copied()
-                .unwrap_or_default();
-            let (current_first_response_byte_total_avg_ms, current_avg_total_ms) =
-                build_dashboard_activity_latency_summary(
-                    current_snapshot,
-                    aggregate.latest_first_response_byte_total_ms,
-                    aggregate.latest_avg_total_ms,
-                );
-            let tokens_per_minute = Some(current_snapshot.qualified_tokens.max(0) as f64);
-            let spend_rate = Some(current_snapshot.total_cost.max(0.0));
-            let (in_progress_invocation_count, in_progress_phase_counts, retry_invocation_count) =
-                if range_name == "yesterday" {
-                    (None, None, None)
-                } else {
-                    let summary = in_progress_counts
-                        .get(&upstream_account_id)
-                        .copied()
-                        .unwrap_or_default();
-                    (
-                        Some(summary.in_progress_count),
-                        Some(summary.phase_counts),
-                        Some(summary.retry_count),
-                    )
-                };
-            let account_key = upstream_account_id
-                .map(|id| format!("upstream:{id}"))
-                .unwrap_or_else(|| "unassigned".to_string());
-            let is_unassigned = upstream_account_id.is_none();
-
-            DashboardActivityAccountResponse {
-                account_key,
+            build_dashboard_activity_account_response(
+                range_name,
+                range,
+                model_performance_available,
+                &current_snapshot_by_account,
+                &account_meta,
+                &effective_routing_rules,
+                &in_progress_counts,
                 upstream_account_id,
-                display_name: upstream_account_id
-                    .map(|id| {
-                        resolve_upstream_account_activity_display_name(
-                            id,
-                            meta,
-                            aggregate.display_name_hint.as_deref(),
-                        )
-                    })
-                    .unwrap_or_else(|| "未分配上游账号".to_string()),
-                is_unassigned,
-                latest_conversation_created_at: aggregate.latest_conversation_created_at,
-                last_invocation_at: aggregate.last_invocation_at,
-                group_name: normalize_trimmed_optional_string_local(
-                    meta.and_then(|row| row.group_name.clone()),
-                ),
-                plan_type: normalize_trimmed_optional_string_local(
-                    meta.and_then(|row| row.plan_type.clone())
-                        .or(aggregate.plan_type_hint),
-                ),
-                enabled: status_fields.as_ref().map(|fields| fields.enabled),
-                display_status: status_fields
-                    .as_ref()
-                    .map(|fields| fields.display_status.clone()),
-                enable_status: status_fields
-                    .as_ref()
-                    .map(|fields| fields.enable_status.clone()),
-                work_status: status_fields
-                    .as_ref()
-                    .map(|fields| fields.work_status.clone()),
-                health_status: status_fields
-                    .as_ref()
-                    .map(|fields| fields.health_status.clone()),
-                sync_state: status_fields
-                    .as_ref()
-                    .map(|fields| fields.sync_state.clone()),
-                last_error: status_fields
-                    .as_ref()
-                    .and_then(|fields| fields.last_error.clone()),
-                last_action_reason_message: status_fields
-                    .as_ref()
-                    .and_then(|fields| fields.last_action_reason_message.clone()),
-                request_count: aggregate.request_count,
-                success_count: aggregate.success_count,
-                failure_count: aggregate.failure_count,
-                non_success_count: aggregate.non_success_count,
-                total_tokens: aggregate.total_tokens,
-                success_tokens: aggregate.success_tokens,
-                non_success_tokens: aggregate.non_success_tokens,
-                failure_tokens: aggregate.failure_tokens,
-                failure_cost: aggregate.failure_cost,
-                non_success_cost: aggregate.non_success_cost,
-                total_cost: aggregate.total_cost,
-                usage_breakdown: aggregate.usage_breakdown.clone().into_response(),
-                model_performance,
-                cache_hit_rate: (aggregate.total_tokens > 0)
-                    .then_some(aggregate.cache_input_tokens as f64 / aggregate.total_tokens as f64),
-                tokens_per_minute,
-                spend_rate,
-                first_byte_avg_ms: (aggregate.first_response_byte_total_sample_count > 0)
-                    .then_some(
-                        aggregate.first_response_byte_total_sum_ms
-                            / aggregate.first_response_byte_total_sample_count as f64,
-                    ),
-                first_response_byte_total_avg_ms: (aggregate
-                    .first_response_byte_total_sample_count
-                    > 0)
-                .then_some(
-                    aggregate.first_response_byte_total_sum_ms
-                        / aggregate.first_response_byte_total_sample_count as f64,
-                ),
-                avg_total_ms: (aggregate.total_latency_sample_count > 0).then_some(
-                    aggregate.total_latency_sum_ms / aggregate.total_latency_sample_count as f64,
-                ),
-                current_first_response_byte_total_avg_ms,
-                current_avg_total_ms,
-                in_progress_invocation_count,
-                in_progress_phase_counts,
-                retry_invocation_count,
-                upload_bytes_per_second: 0.0,
-                download_bytes_per_second: 0.0,
-                in_progress_wait_sum_ms: aggregate.in_progress_wait_sum_ms,
-                in_progress_wait_sample_count: aggregate.in_progress_wait_sample_count,
-                effective_routing_rule: upstream_account_id.map(|id| {
-                    effective_routing_rules
-                        .get(&id)
-                        .cloned()
-                        .unwrap_or_else(crate::upstream_accounts::default_effective_routing_rule)
-                }),
-                recent_invocations: aggregate.recent_invocations,
-            }
+                aggregate,
+            )
         })
         .collect::<Vec<_>>();
-
-    accounts.sort_by(|left, right| {
-        right
-            .total_tokens
-            .cmp(&left.total_tokens)
-            .then_with(|| {
-                right
-                    .recent_invocations
-                    .first()
-                    .map(|row| row.occurred_at.as_str())
-                    .cmp(
-                        &left
-                            .recent_invocations
-                            .first()
-                            .map(|row| row.occurred_at.as_str()),
-                    )
-            })
-            .then_with(|| {
-                right
-                    .upstream_account_id
-                    .unwrap_or(i64::MIN)
-                    .cmp(&left.upstream_account_id.unwrap_or(i64::MIN))
-            })
-    });
-
-    let mut summary = build_dashboard_activity_summary(
-        &accounts,
-        range_name != "yesterday",
-        current_snapshot_summary,
-        latest_first_response_byte_total_in_range.value,
-        latest_avg_total_in_range.value,
-        model_performance.into_response(range, model_performance_available),
-    );
-    dashboard_activity_apply_materialized_archive_fallback_to_stats(
-        &mut summary.stats,
-        materialized_archive_fallback_totals,
-    );
-    if materialized_archive_details_limited {
-        dashboard_activity_clear_materialized_archive_detail_fields(&mut summary.stats);
-    }
-    Ok(DashboardActivitySnapshot {
-        range: range_name.to_string(),
-        range_start: range.start,
-        range_end: range.end,
+    sort_dashboard_activity_accounts(&mut accounts);
+    Ok(DashboardActivityAccountBuildResult {
         accounts,
-        summary,
+        current_snapshot_summary,
+        latest_first_response_byte_total_in_range: latest_first_response_byte_total_in_range.value,
+        latest_avg_total_in_range: latest_avg_total_in_range.value,
+        summary_model_performance: model_performance
+            .into_response(range, model_performance_available),
         materialized_archive_fallback_totals,
         materialized_archive_details_limited,
+        build_telemetry,
     })
 }
 
@@ -10366,7 +10428,6 @@ async fn load_dashboard_activity_snapshot_cached(
     state: &AppState,
     range_name: &str,
     reporting_tz: Tz,
-    live_activity_key: &str,
     recent_limit: usize,
     include_accounts: bool,
     include_recent: bool,
@@ -10396,6 +10457,7 @@ async fn load_dashboard_activity_snapshot_cached(
             snapshot,
             DashboardActivitySnapshotCacheOutcome {
                 cache_hit_or_miss: "uncached",
+                cache_bypass_reason: "yesterday_exact",
                 coalesced_waiter_count: 0,
                 db_build_elapsed_ms: started_at.elapsed().as_millis() as u64,
             },
@@ -10403,15 +10465,12 @@ async fn load_dashboard_activity_snapshot_cached(
     }
 
     let source_scope = resolve_default_source_scope(&state.pool).await?;
-    let invocation_snapshot_id = resolve_invocation_snapshot_id(&state.pool, source_scope).await?;
     let range = resolve_dashboard_activity_cached_range(range_name, reporting_tz)?;
     let selection = build_dashboard_activity_snapshot_selection(
         range_name,
         range,
         reporting_tz,
         source_scope,
-        invocation_snapshot_id,
-        live_activity_key,
         recent_limit,
         include_accounts,
         include_recent,
@@ -10440,6 +10499,7 @@ async fn load_dashboard_activity_snapshot_cached(
                         } else {
                             "cache_hit"
                         },
+                        cache_bypass_reason: "none",
                         coalesced_waiter_count: max_waiter_count,
                         db_build_elapsed_ms: 0,
                     },
@@ -10512,6 +10572,7 @@ async fn load_dashboard_activity_snapshot_cached(
                 snapshot,
                 DashboardActivitySnapshotCacheOutcome {
                     cache_hit_or_miss: "cache_miss_build",
+                    cache_bypass_reason: "none",
                     coalesced_waiter_count,
                     db_build_elapsed_ms,
                 },
@@ -10596,14 +10657,12 @@ pub(crate) async fn fetch_dashboard_activity(
         .as_ref()
         .and_then(|snapshot| snapshot.network_live_bucket.clone());
     let include_recent = params.include_recent.unwrap_or(true);
-    let live_activity_key = dashboard_activity_live_snapshot_cache_key(live.as_ref());
     let request_range =
         resolve_dashboard_activity_exact_range(params.range.as_str(), reporting_tz)?;
     let (mut snapshot, cache_outcome) = load_dashboard_activity_snapshot_cached(
         state.as_ref(),
         params.range.as_str(),
         reporting_tz,
-        live_activity_key.as_str(),
         recent_limit,
         params.include_accounts,
         include_recent,
@@ -10627,6 +10686,7 @@ pub(crate) async fn fetch_dashboard_activity(
         )
         .await?;
     }
+    let build_telemetry = snapshot.build_telemetry;
     let live_overlay_elapsed_ms = live_overlay_started_at.elapsed().as_millis() as u64;
     let range_start = format_utc_iso_precise(snapshot.range_start);
     let range_end = format_utc_iso_precise(snapshot.range_end);
@@ -10665,8 +10725,15 @@ pub(crate) async fn fetch_dashboard_activity(
         accounts,
     };
     let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    let builder = if params.include_accounts {
+        "dashboard_full"
+    } else {
+        "summary_only"
+    };
     if elapsed_ms >= 250 {
         tracing::warn!(
+            route = "dashboard",
+            builder,
             endpoint = "/api/stats/dashboard-activity",
             range = %params.range,
             include_accounts = params.include_accounts,
@@ -10676,15 +10743,21 @@ pub(crate) async fn fetch_dashboard_activity(
             account_count,
             build_scope = dashboard_activity_build_scope(params.include_accounts, include_recent),
             cache_hit_or_miss = cache_outcome.cache_hit_or_miss,
+            cache_bypass_reason = cache_outcome.cache_bypass_reason,
             coalesced_waiter_count = cache_outcome.coalesced_waiter_count,
             db_build_elapsed_ms = cache_outcome.db_build_elapsed_ms,
             live_overlay_elapsed_ms,
+            preview_read_mode = build_telemetry.preview_read_mode,
+            candidate_preview_id_count = build_telemetry.candidate_preview_id_count,
+            hydrated_preview_row_count = build_telemetry.hydrated_preview_row_count,
             model_performance_available = response.summary.model_performance.available,
             elapsed_ms,
             "dashboard activity snapshot exceeded slow-path threshold"
         );
     } else {
         tracing::debug!(
+            route = "dashboard",
+            builder,
             endpoint = "/api/stats/dashboard-activity",
             range = %params.range,
             include_accounts = params.include_accounts,
@@ -10694,9 +10767,13 @@ pub(crate) async fn fetch_dashboard_activity(
             account_count,
             build_scope = dashboard_activity_build_scope(params.include_accounts, include_recent),
             cache_hit_or_miss = cache_outcome.cache_hit_or_miss,
+            cache_bypass_reason = cache_outcome.cache_bypass_reason,
             coalesced_waiter_count = cache_outcome.coalesced_waiter_count,
             db_build_elapsed_ms = cache_outcome.db_build_elapsed_ms,
             live_overlay_elapsed_ms,
+            preview_read_mode = build_telemetry.preview_read_mode,
+            candidate_preview_id_count = build_telemetry.candidate_preview_id_count,
+            hydrated_preview_row_count = build_telemetry.hydrated_preview_row_count,
             model_performance_available = response.summary.model_performance.available,
             elapsed_ms,
             "dashboard activity snapshot completed"
@@ -11272,32 +11349,64 @@ pub(crate) async fn fetch_upstream_account_activity(
     State(state): State<Arc<AppState>>,
     Query(params): Query<UpstreamAccountActivityQuery>,
 ) -> Result<Json<UpstreamAccountActivityResponse>, ApiError> {
+    let started_at = Instant::now();
     let recent_limit = validate_dashboard_activity_params(
         "upstream-account-activity",
         params.range.as_str(),
         params.recent_limit,
     )?;
     let reporting_tz = parse_reporting_tz(params.time_zone.as_deref())?;
-    let snapshot = load_dashboard_activity_snapshot(
+    let range = resolve_dashboard_activity_exact_range(params.range.as_str(), reporting_tz)?;
+    let build = load_dashboard_activity_account_build_result(
         state.as_ref(),
         params.range.as_str(),
-        reporting_tz,
+        range,
         recent_limit,
         true,
-        true,
         None,
+        DashboardActivityAccountBuilderKind::UpstreamAccount,
     )
     .await?;
-    let accounts = snapshot
+    let accounts = build
         .accounts
         .into_iter()
         .filter_map(dashboard_account_to_upstream_account)
-        .collect();
+        .collect::<Vec<_>>();
+    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    if elapsed_ms >= 250 {
+        tracing::warn!(
+            route = "upstream_account",
+            builder = "upstream_account",
+            endpoint = "/api/stats/upstream-account-activity",
+            range = %params.range,
+            recent_limit,
+            account_count = accounts.len(),
+            preview_read_mode = build.build_telemetry.preview_read_mode,
+            candidate_preview_id_count = build.build_telemetry.candidate_preview_id_count,
+            hydrated_preview_row_count = build.build_telemetry.hydrated_preview_row_count,
+            elapsed_ms,
+            "upstream account activity exceeded slow-path threshold"
+        );
+    } else {
+        tracing::debug!(
+            route = "upstream_account",
+            builder = "upstream_account",
+            endpoint = "/api/stats/upstream-account-activity",
+            range = %params.range,
+            recent_limit,
+            account_count = accounts.len(),
+            preview_read_mode = build.build_telemetry.preview_read_mode,
+            candidate_preview_id_count = build.build_telemetry.candidate_preview_id_count,
+            hydrated_preview_row_count = build.build_telemetry.hydrated_preview_row_count,
+            elapsed_ms,
+            "upstream account activity completed"
+        );
+    }
 
     Ok(Json(UpstreamAccountActivityResponse {
-        range: snapshot.range,
-        range_start: format_utc_iso(snapshot.range_start),
-        range_end: format_utc_iso(snapshot.range_end),
+        range: params.range,
+        range_start: format_utc_iso(range.start),
+        range_end: format_utc_iso(range.end),
         accounts,
     }))
 }

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -1013,8 +1013,6 @@ pub(crate) struct DashboardActivitySnapshotSelection {
     pub(crate) range_end: String,
     pub(crate) time_zone: String,
     pub(crate) source_scope: String,
-    pub(crate) invocation_snapshot_id: i64,
-    pub(crate) live_activity_key: String,
     pub(crate) recent_limit: usize,
     pub(crate) include_accounts: bool,
     pub(crate) include_recent: bool,

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -13501,6 +13501,10 @@ async fn dashboard_activity_cached_snapshot_overlays_new_live_accounts() {
             .iter()
             .all(|account| account.account_key != "upstream:99")
     );
+    {
+        let cache = state.dashboard_activity_snapshot_cache.lock().await;
+        assert_eq!(cache.entries.len(), 1);
+    }
 
     let cached_existing_recent_at = format_naive(Utc::now().with_timezone(&Shanghai).naive_local());
     sqlx::query(
@@ -13728,6 +13732,10 @@ async fn dashboard_activity_cached_snapshot_overlays_new_live_accounts() {
             .expect("cached summary spend rate"),
         0.32,
     );
+    {
+        let cache = state.dashboard_activity_snapshot_cache.lock().await;
+        assert_eq!(cache.entries.len(), 1);
+    }
 }
 
 #[tokio::test]
@@ -15034,6 +15042,89 @@ async fn dashboard_activity_progressive_summary_keeps_archived_account_aggregate
     assert_eq!(compatible_account.request_count, 2);
     assert_eq!(compatible_account.total_tokens, 30);
     assert_eq!(compatible_account.recent_invocations.len(), 2);
+}
+
+#[tokio::test]
+async fn upstream_account_activity_does_not_populate_dashboard_snapshot_cache() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let created_at = format_utc_iso(Utc::now());
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_accounts (
+            id, kind, provider, display_name, group_name, plan_type, status, enabled, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        "#,
+    )
+    .bind(42_i64)
+    .bind("api_key_codex")
+    .bind("codex")
+    .bind("Cache Isolation")
+    .bind("Primary")
+    .bind("enterprise")
+    .bind("active")
+    .bind(1_i64)
+    .bind(&created_at)
+    .bind(&created_at)
+    .execute(&state.pool)
+    .await
+    .expect("insert cache isolation account");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            id, invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        "#,
+    )
+    .bind(97_001_i64)
+    .bind("upstream-cache-isolation")
+    .bind(format_naive(
+        Utc::now().with_timezone(&Shanghai).naive_local(),
+    ))
+    .bind(SOURCE_PROXY)
+    .bind("success")
+    .bind(123_i64)
+    .bind(0.12_f64)
+    .bind(
+        json!({
+            "promptCacheKey": "pck-upstream-cache-isolation",
+            "upstreamAccountId": 42_i64,
+        })
+        .to_string(),
+    )
+    .bind("{}")
+    .execute(&state.pool)
+    .await
+    .expect("insert cache isolation invocation");
+
+    {
+        let cache = state.dashboard_activity_snapshot_cache.lock().await;
+        assert!(cache.entries.is_empty());
+        assert!(cache.in_flight.is_empty());
+    }
+
+    let Json(response) = fetch_upstream_account_activity(
+        State(state.clone()),
+        Query(UpstreamAccountActivityQuery {
+            range: "today".to_string(),
+            recent_limit: Some(2),
+            time_zone: Some("Asia/Shanghai".to_string()),
+        }),
+    )
+    .await
+    .expect("fetch upstream account activity without dashboard cache coupling");
+    assert_eq!(response.accounts.len(), 1);
+    assert_eq!(response.accounts[0].upstream_account_id, 42_i64);
+
+    {
+        let cache = state.dashboard_activity_snapshot_cache.lock().await;
+        assert!(cache.entries.is_empty());
+        assert!(cache.in_flight.is_empty());
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- remove dashboard full-path preview read amplification by switching account activity recent selection to bounded per-account candidates plus batched hydration
- split \/api\/stats\/upstream-account-activity onto a dedicated account snapshot builder so it no longer pays the dashboard full snapshot assembly cost
- stabilize non-yesterday dashboard base snapshot caching, add cache bypass telemetry, and refresh the linked spec and solution docs

## Verification
- `cargo check -q`
- `cargo test -q dashboard_activity_cache_key_uses_bucketed_rolling_window`
- `cargo test -q upstream_account_activity_does_not_populate_dashboard_snapshot_cache`
- `cargo test -q dashboard_activity_cached_snapshot_overlays_new_live_accounts`
- `cargo test -q dashboard_activity_progressive_summary_keeps_archived_account_aggregates`

## References
- Specs: `docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md`
- Solutions: `docs/solutions/performance/sqlite-write-pressure-backpressure.md`, `docs/solutions/performance/realtime-dashboard-reconcile-budget.md`
- Project Docs: `-`