### PR TITLE
fix(dashboard): use realtime network rate

### DIFF
--- a/docs/specs/v3fum-dashboard-network-speed/HISTORY.md
+++ b/docs/specs/v3fum-dashboard-network-speed/HISTORY.md
@@ -3,13 +3,14 @@
 ## 关键决策
 
 - 选择 HTTP 近似真值而不是 network-layer 带宽作为事实源：只记最终可见 header 字段与实际 body 字节，不把 TLS / HTTP/2 framing 等低层开销混入口径。
-- 实时展示继续采用 15 秒滚动均值，图表采用 5 分钟均值，但 runtime cache 从原先的 `global + account` 扩展成 `global + host + account` 三维记账。
+- 活动总览大图继续采用 5 分钟历史桶，但顶部总速率胶囊改成“上一完整 1 秒”的原始速率；runtime cache 继续承载 `global + host + account` 三维记账。
 - pool retry 的上传/下载必须按 attempt 累加；只按 invocation 记账会漏掉跨 host 重试流量，也无法支撑 host 维度分钟 rollup。
 - host minute rollup 选择单独建表 `upstream_host_network_minute`，并复用既有 live replay/materializer；首次只 seed cursor 到当前 live tail，不做历史回填。
 - Dashboard 无 scope 网速改成“系统对所有上游”的全局真值，闭合历史桶从 host minute rollup 汇总，live 末桶继续读 runtime global bucket。
-- 工作区标题区的总速率胶囊保留，但直接读取全局 `networkLiveBucket`；账号卡中的上传/下载速率删除，避免让 owner 把账号卡局部速率误读成系统总量。
+- 工作区标题区的总速率胶囊保留，但改读全局 `networkRealtimeRate`；账号卡中的上传/下载速率删除，避免让 owner 把账号卡局部速率误读成系统总量。
 - 顶部网速图的 steady-state 更新继续保持“首次 hydrate + `dashboardActivityLive` SSE 推送当前桶”，只在桶切换 / SSE 重连时静默回补。
-- 2026-07-18 上线后发现一个 page-shell 漏接线问题：`DashboardWorkingConversationsSection` 已改读 `networkLiveBucket`，但 `Dashboard.tsx` 没把该字段继续下传，导致线上工作区总速率胶囊长期显示 `0 B/s`。修复后补充页面级回归测试与整页 Storybook bootstrap，防止“接口有值、页面为零”的回归再次漏过。
+- 2026-07-18 上线后发现一个 page-shell 漏接线问题：工作区总速率胶囊消费的全局速率字段没有被 `Dashboard.tsx` 继续下传，导致线上胶囊长期显示 `0 B/s`。修复后补充页面级回归测试与整页 Storybook bootstrap，防止“接口有值、页面为零”的回归再次漏过。
 - 2026-07-19 在 Docker 部署诊断中确认：HTTP 近似真值仍会让 OAuth HTTP 与 WebSocket 的 live 网速出现漏记或 `0 B/s` 假零值，因此事实源切换为连接级真实 socket 字节。
 - 真实网速实现保留 host + account 归因，但 Dashboard 展示仍只暴露全局总量与账号 scoped 视图；不新增 host UI。
 - 为避免 timeout / cancel 导致已发生的真实流量被吞掉，HTTP counted transport 与 WebSocket flush task 都补了 drop-time final flush。
+- 2026-07-19 进一步确认：15 秒 SMA 不符合“实时网速”语义，因此顶部胶囊改为读取上一完整 1 秒快照；历史图继续显示 5 分钟桶，并移除左上角误导性说明文案。

--- a/docs/specs/v3fum-dashboard-network-speed/IMPLEMENTATION.md
+++ b/docs/specs/v3fum-dashboard-network-speed/IMPLEMENTATION.md
@@ -3,7 +3,7 @@
 ## 后端
 
 - 新增 `src/dashboard_network_speed.rs`，集中维护：
-  - global、host、account 三维最近 15 秒秒桶滚动窗口。
+  - global、host、account 三维原始秒桶与上一完整秒快照读取路径。
   - 当前开放 5 分钟桶的上传/下载累计。
   - invocation 级连接字节追踪、终态清理与 Dashboard live stream 心跳预算。
 - 代理热路径在以下时机写入缓存：
@@ -14,7 +14,7 @@
 - 新增 `upstream_socket_network_minute`，按 `(bucket_start_epoch, source, upstream_base_url_host, upstream_account_id)` 持久化真实 socket 分钟累计。
 - socket minute materializer 复用现有 live replay 框架，但首次只把 cursor seed 到当前 live table 尾部，不做历史回填。
 - `AppState` 新增 `process_started_at_utc` 与 `dashboard_network_speed_cache`，runtime 初始化时统一挂载。
-- `GET /api/stats/dashboard-activity` / `dashboardActivityLive` 在兼容保留账号级速率字段的同时，新增全局 `networkLiveBucket`。
+- `GET /api/stats/dashboard-activity` / `dashboardActivityLive` 在兼容保留账号级速率字段的同时，新增全局 `networkLiveBucket` 与 `networkRealtimeRate`。
 - 新增 `GET /api/stats/dashboard-network-timeseries`：
   - 只接受 `today | yesterday | 1d`。
   - 固定返回 5 分钟桶。
@@ -35,17 +35,17 @@
   - `today / yesterday` 的 metric toggle 新增 `network`，保留 `trend`。
   - `24 小时` 新增 `network`，选中时用网速面积图替换 heatmap。
   - `7 日 / 历史` 保持原行为不变。
-- `useDashboardUpstreamAccountActivity` 与相关 normalize 逻辑把新的 `networkLiveBucket` 完整透传给上游账号 tab。
-- `Dashboard.tsx` 页面壳层也必须把 `dashboardActivity.networkLiveBucket` 继续下传给 `DashboardWorkingConversationsSection`；否则即使 `/api/stats/dashboard-activity` 已返回非零 live bucket，工作区顶部总速率胶囊仍会退回 `0 B/s`。
+- `useDashboardUpstreamAccountActivity` 与相关 normalize 逻辑把 `networkLiveBucket` 和 `networkRealtimeRate` 一起透传给上游账号 tab。
+- `Dashboard.tsx` 页面壳层也必须把 `dashboardActivity.networkRealtimeRate` 继续下传给 `DashboardWorkingConversationsSection`；否则即使 `/api/stats/dashboard-activity` 已返回非零 realtime 快照，工作区顶部总速率胶囊仍会退回 `0 B/s`。
 - `DashboardWorkingConversationsSection` 同时在两个位置展示网速：
-  - 工作区右上 badge 区展示所有上游请求的全局总上/下行实时速率，直接读取 `networkLiveBucket`。
+  - 工作区右上 badge 区展示所有上游请求的全局总上/下行实时速率，直接读取 `networkRealtimeRate`，口径固定为上一完整 1 秒。
   - 账号卡标题区删除单账号上传/下载速率，只保留活动账号数量、TPM、消费速率、进行中等摘要。
 - 新增 `dashboardNetworkFormatting.ts` 统一处理 `B/s / KiB/s / MiB/s` 与字节单位格式化。
 
 ## 测试与 Storybook
 
 - 前端定向单测覆盖：
-  - live snapshot 合并全局 `networkLiveBucket`。
+  - live snapshot 合并全局 `networkLiveBucket` 与 `networkRealtimeRate`。
   - Dashboard `network` metric 的可见性与 24 小时图切换。
   - 对话工作区右上总网速与账号卡速率删除断言。
 - 后端定向单测覆盖：

--- a/docs/specs/v3fum-dashboard-network-speed/SPEC.md
+++ b/docs/specs/v3fum-dashboard-network-speed/SPEC.md
@@ -13,9 +13,9 @@
 ### Goals
 
 - 把 Dashboard 无 scope 网速统一成“系统对所有上游的真实 socket 带宽”，口径固定为代理与上游之间 TCP 连接的实际读写字节。
-- 在 `今日 / 昨日 / 24 小时` 的活动总览 metric toggle 中继续提供 `网速`，并让闭合历史桶读取按 host 聚合的分钟 rollup，live 末桶读取全局 live bucket。
+- 在 `今日 / 昨日 / 24 小时` 的活动总览 metric toggle 中继续提供 `网速`，并让闭合历史桶读取按 host 聚合的分钟 rollup，live 末桶继续显示当前开放 5 分钟桶。
 - 保留账号 scoped activity overview 的既有语义，不让这次全局真值切源改坏账号详情页。
-- 在工作台上游账号区顶部保留总上传/总下载速率胶囊，但它必须直接显示全局 live 速率，而不是由各账号卡速率求和得到。
+- 在工作台上游账号区顶部保留总上传/总下载速率胶囊，但它必须直接显示“上一完整 1 秒”的全局真实 socket 速率，而不是由各账号卡速率求和得到。
 
 ### Non-goals
 
@@ -31,7 +31,7 @@
 
 - `src/dashboard_network_speed.rs` 及代理热路径：global + host + account 三维实时秒桶与开放 5 分钟桶、连接级读写字节写入点与终态清理。
 - `pool_upstream_request_attempts.upstream_base_url_host` 与新的 `upstream_socket_network_minute` 分钟表。
-- `GET /api/stats/dashboard-activity` 与 `dashboardActivityLive`：追加全局 `networkLiveBucket`，保留账号级实时字段兼容对外合同。
+- `GET /api/stats/dashboard-activity` 与 `dashboardActivityLive`：追加全局 `networkLiveBucket` 与 `networkRealtimeRate`，并把账号级实时字段统一成上一完整 1 秒语义。
 - `GET /api/stats/dashboard-network-timeseries`：无 scope 时切到 host minute rollup + 全局 live bucket；账号 scoped 时保留既有路径。
 - `web/src/features/dashboard/DashboardActivityOverview.tsx`、`DashboardNetworkActivityChart.tsx`、`DashboardWorkingConversationsSection.tsx`、相关 hook、测试与视觉证据。
 
@@ -46,15 +46,15 @@
 ### MUST
 
 - 无 `upstreamAccountId` 的 Dashboard 网速必须展示“系统对所有上游的真实 socket 带宽”，不能再依赖账号级求和。
-- 实时速率必须包含进行中的流式请求，并以 15 秒滚动均值每秒更新一次。
+- 顶部实时速率必须包含进行中的流式请求，并固定显示上一完整 1 秒的原始速率；不得对当前秒 partial bytes 做外推，也不得再做 15 秒滚动均值。
 - `今日 / 昨日 / 24 小时` 的 metric toggle 必须出现 `网速`；`7 日 / 历史` 不得出现。
 - `网速` 图必须使用固定 5 分钟桶，同图展示上传/下载两条平滑半透明面积，保留 tooltip、图例与单位格式化。
 - `今日 / 24 小时` 必须显示当前未收口 5 分钟桶，且末桶由内存 current-bucket cache 驱动；`昨日` 只展示闭合历史桶。
 - pool invocation 跨 host 重试时，每个 attempt 的上传/下载都必须累计到全局与对应 host；不能按 invocation 去重。
 - HTTP 与 WebSocket 都必须走同一套连接级字节计数；OAuth 路径不能退回 reqwest body 近似值。
 - host 归一化固定为 lowercase；缺失 host 写入 `__unknown__`，仍参与全局汇总。
-- 工作台顶部总速率胶囊必须直接读取 `networkLiveBucket`；账号卡不得继续显示上传/下载速率。
-- 当前 5 分钟桶与实时 15 秒窗口必须以内存缓存为主；socket minute rollup 不做历史回填，初次 materialize 时只从当前 live table 尾部开始累计。
+- 工作台顶部总速率胶囊必须直接读取 `networkRealtimeRate`；`networkLiveBucket` 继续表示当前开放 5 分钟桶；账号卡不得继续显示上传/下载速率。
+- 当前 5 分钟桶与上一完整 1 秒实时快照必须以内存缓存为主；socket minute rollup 不做历史回填，初次 materialize 时只从当前 live table 尾部开始累计。
 - 连接在握手前失败、等待首包超时或流式途中提前 drop 时，已实际发生的 socket 字节仍必须冲刷到 live bucket 与 minute rollup，不能因为 future 被取消而丢样本。
 
 ### SHOULD
@@ -88,9 +88,10 @@
 | 接口（Name）                                       | 类型（Kind）        | 范围（Scope） | 变更（Change） | 负责人（Owner） | 使用方（Consumers）         | 备注（Notes）                               |
 | -------------------------------------------------- | ------------------- | ------------- | -------------- | --------------- | --------------------------- | ------------------------------------------- |
 | `GET /api/stats/dashboard-network-timeseries`      | http-endpoint       | external      | Add            | backend/stats   | Dashboard activity overview | dashboard-only；无 scope 时读 host minute   |
-| `DashboardActivityAccountResponse.*BytesPerSecond` | http-response-field | external      | Add            | backend/stats   | Dashboard upstream cards    | 账号级 15 秒滚动均值                        |
-| `DashboardActivityLiveAccount.*BytesPerSecond`     | sse/http-live-field | external      | Add            | backend/stats   | Dashboard live merge        | 与 in-progress live snapshot 同步更新       |
-| `DashboardActivityResponse.networkLiveBucket`      | http-response-field | external      | Add            | backend/stats   | Dashboard upstream summary  | 全局实时总速率                              |
+| `DashboardActivityAccountResponse.*BytesPerSecond` | http-response-field | external      | Add            | backend/stats   | Dashboard upstream cards    | 账号级上一完整 1 秒原始速率                 |
+| `DashboardActivityLiveAccount.*BytesPerSecond`     | sse/http-live-field | external      | Add            | backend/stats   | Dashboard live merge        | 与账号级上一完整 1 秒快照保持同语义         |
+| `DashboardActivityResponse.networkLiveBucket`      | http-response-field | external      | Add            | backend/stats   | Dashboard network chart     | 当前开放 5 分钟桶，用于历史图末桶           |
+| `DashboardActivityResponse.networkRealtimeRate`    | http-response-field | external      | Add            | backend/stats   | Dashboard upstream summary  | 全局上一完整 1 秒实时总速率                 |
 | `DashboardNetworkSpeedCache`                       | runtime-cache       | internal      | Update         | backend/proxy   | proxy dispatch / stats read | 维护 global + host + account 秒桶与开放桶   |
 | `upstream_socket_network_minute`                   | sqlite-table        | internal      | Add            | backend/stats   | Dashboard network history   | host + account 维度分钟累计，不存 global 行 |
 | `useDashboardNetworkTimeseries`                    | ui-hook             | internal      | Update         | web/dashboard   | Dashboard activity overview | 初次 hydrate + SSE 合并当前开放桶           |
@@ -99,7 +100,7 @@
 
 - Given 任意一个 Dashboard 无 scope 总览，When `网速` tab 激活，Then 图表展示的是系统对所有上游的真实 socket 带宽，而不是账号卡求和或单 invocation 近似值。
 - Given 任意一张上游账号卡，When 页面渲染，Then 顶部仍保留总速率胶囊，但账号卡自身不显示上传/下载速率行。
-- Given 流式响应仍在进行中，When 观察顶部总速率胶囊，Then 下载速率会每秒更新，而不是等调用结束后才变化。
+- Given 流式响应仍在进行中，When 观察顶部总速率胶囊，Then 下载速率按上一完整秒逐秒更新，而不是等调用结束后才变化，也不会把当前秒 partial bytes 外推成虚高峰值。
 - Given 活动总览处于 `今日 / 昨日 / 24 小时`，When 打开 metric toggle，Then 可以看到 `网速`；切到 `7 日 / 历史` 时看不到它。
 - Given `今日` 或 `24 小时` 选择 `网速`，When 当前开放 5 分钟桶仍在接收流量，Then 图表末桶会持续更新。
 - Given `昨日` 选择 `网速`，When 图表渲染完成，Then 不包含实时开放桶，只显示闭合历史 5 分钟桶。

--- a/src/api/slices/error_distribution_and_sse.rs
+++ b/src/api/slices/error_distribution_and_sse.rs
@@ -1845,6 +1845,37 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_activity_live_snapshot_serializes_network_realtime_rate() {
+        let snapshot = DashboardActivityLiveSnapshot {
+            revision: 11,
+            generated_at: "2026-07-19T18:04:00.000Z".to_string(),
+            in_progress_invocation_count: 0,
+            in_progress_phase_counts: InvocationPhaseCountsResponse::default(),
+            retry_invocation_count: 0,
+            network_live_bucket: None,
+            network_realtime_rate: Some(DashboardNetworkRealtimeRateResponse {
+                sample_start: "2026-07-19T18:03:59.000Z".to_string(),
+                sample_end: "2026-07-19T18:04:00.000Z".to_string(),
+                sample_seconds: 1,
+                upload_bytes_per_second: 2048.0,
+                download_bytes_per_second: 4096.0,
+                upload_bytes: 2048,
+                download_bytes: 4096,
+            }),
+            accounts: Vec::new(),
+        };
+
+        let payload = serde_json::to_value(&snapshot).expect("serialize dashboard activity live");
+
+        assert_eq!(payload["networkRealtimeRate"]["sampleSeconds"], 1);
+        assert_eq!(payload["networkRealtimeRate"]["uploadBytes"], 2048);
+        assert_eq!(
+            payload["networkRealtimeRate"]["downloadBytesPerSecond"],
+            4096.0
+        );
+    }
+
+    #[test]
     fn build_invocation_filters_normalizes_request_id() {
         let params = ListQuery {
             request_id: Some(" invoke-123 ".to_string()),
@@ -2061,6 +2092,8 @@ pub(crate) struct DashboardActivityLiveSnapshot {
     pub(crate) retry_invocation_count: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) network_live_bucket: Option<DashboardNetworkTimeseriesPointResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) network_realtime_rate: Option<DashboardNetworkRealtimeRateResponse>,
     pub(crate) accounts: Vec<DashboardActivityLiveAccount>,
 }
 
@@ -2157,6 +2190,7 @@ pub(crate) fn build_dashboard_activity_live_snapshot(
         in_progress_phase_counts: phase_counts,
         retry_invocation_count,
         network_live_bucket: None,
+        network_realtime_rate: None,
         accounts,
     }
 }

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7864,6 +7864,10 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_from_runtime(
     )
     .await?;
     let account_rates = dashboard_network_speed_cache.snapshot_account_rates(now);
+    let global_realtime_rate = build_dashboard_network_realtime_rate_response(
+        dashboard_network_speed_cache
+            .snapshot_scope_realtime_bytes(DashboardNetworkScopeKey::Global, now),
+    );
     let mut live_bucket_account_ids = counts.keys().copied().collect::<Vec<_>>();
     for upstream_account_id in account_rates.keys() {
         if !live_bucket_account_ids.contains(upstream_account_id) {
@@ -7959,6 +7963,7 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_from_runtime(
             )
             .await?,
         ),
+        network_realtime_rate: Some(global_realtime_rate),
         accounts,
     })
 }
@@ -10654,6 +10659,9 @@ pub(crate) async fn fetch_dashboard_activity(
     let network_live_bucket = live
         .as_ref()
         .and_then(|snapshot| snapshot.network_live_bucket.clone());
+    let network_realtime_rate = live
+        .as_ref()
+        .and_then(|snapshot| snapshot.network_realtime_rate.clone());
     let include_recent = params.include_recent.unwrap_or(true);
     let request_range =
         resolve_dashboard_activity_exact_range(params.range.as_str(), reporting_tz)?;
@@ -10720,6 +10728,7 @@ pub(crate) async fn fetch_dashboard_activity(
         },
         summary: snapshot.summary,
         network_live_bucket,
+        network_realtime_rate,
         accounts,
     };
     let elapsed_ms = started_at.elapsed().as_millis() as u64;
@@ -11135,6 +11144,30 @@ fn dashboard_network_bucket_rate(
         .num_milliseconds()
         .max(1);
     total_bytes.max(0) as f64 / (effective_millis as f64 / 1000.0)
+}
+
+fn build_dashboard_network_realtime_rate_response(
+    snapshot: DashboardNetworkRealtimeByteSnapshot,
+) -> DashboardNetworkRealtimeRateResponse {
+    DashboardNetworkRealtimeRateResponse {
+        sample_start: format_utc_iso_precise(
+            Utc.timestamp_opt(snapshot.sample_start_epoch_second, 0)
+                .single()
+                .expect("valid realtime sample start"),
+        ),
+        sample_end: format_utc_iso_precise(
+            Utc.timestamp_opt(snapshot.sample_end_epoch_second, 0)
+                .single()
+                .expect("valid realtime sample end"),
+        ),
+        sample_seconds: snapshot.sample_seconds,
+        upload_bytes_per_second: snapshot.totals.upload_bytes.max(0) as f64
+            / snapshot.sample_seconds.max(1) as f64,
+        download_bytes_per_second: snapshot.totals.download_bytes.max(0) as f64
+            / snapshot.sample_seconds.max(1) as f64,
+        upload_bytes: snapshot.totals.upload_bytes.max(0),
+        download_bytes: snapshot.totals.download_bytes.max(0),
+    }
 }
 
 fn build_dashboard_network_timeseries_point_response(
@@ -11557,6 +11590,7 @@ mod upstream_account_activity_rate_tests {
 #[cfg(test)]
 mod dashboard_network_timeseries_tests {
     use super::*;
+    use serde_json::json;
     use sqlx::sqlite::SqlitePoolOptions;
 
     async fn network_pool() -> Pool<Sqlite> {
@@ -11753,6 +11787,49 @@ mod dashboard_network_timeseries_tests {
         assert_eq!(rows[0].bucket_start_epoch_second, bucket_start_epoch);
         assert_eq!(rows[0].upload_bytes, 140);
         assert_eq!(rows[0].download_bytes, 280);
+    }
+
+    #[test]
+    fn dashboard_network_realtime_rate_response_serializes_complete_second_snapshot() {
+        let response =
+            build_dashboard_network_realtime_rate_response(DashboardNetworkRealtimeByteSnapshot {
+                sample_start_epoch_second: Utc
+                    .with_ymd_and_hms(2026, 7, 19, 18, 3, 59)
+                    .single()
+                    .expect("valid sample start")
+                    .timestamp(),
+                sample_end_epoch_second: Utc
+                    .with_ymd_and_hms(2026, 7, 19, 18, 4, 0)
+                    .single()
+                    .expect("valid sample end")
+                    .timestamp(),
+                sample_seconds: 1,
+                totals: DashboardNetworkByteTotals {
+                    upload_bytes: 2048,
+                    download_bytes: 4096,
+                },
+            });
+
+        assert_eq!(response.sample_start, "2026-07-19T18:03:59Z");
+        assert_eq!(response.sample_end, "2026-07-19T18:04:00Z");
+        assert_eq!(response.sample_seconds, 1);
+        assert_eq!(response.upload_bytes_per_second, 2048.0);
+        assert_eq!(response.download_bytes_per_second, 4096.0);
+
+        let payload =
+            serde_json::to_value(&response).expect("serialize dashboard network realtime rate");
+        assert_eq!(
+            payload,
+            json!({
+                "sampleStart": "2026-07-19T18:03:59Z",
+                "sampleEnd": "2026-07-19T18:04:00Z",
+                "sampleSeconds": 1,
+                "uploadBytesPerSecond": 2048.0,
+                "downloadBytesPerSecond": 4096.0,
+                "uploadBytes": 2048,
+                "downloadBytes": 4096
+            })
+        );
     }
 }
 

--- a/src/api/slices/mod.rs
+++ b/src/api/slices/mod.rs
@@ -2,7 +2,6 @@ use super::*;
 
 #[expect(
     clippy::too_many_arguments,
-    clippy::large_enum_variant,
     reason = "Existing internal response adapters preserve established call-site and payload contracts."
 )]
 mod error_distribution_and_sse;

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -1828,6 +1828,8 @@ pub(crate) struct DashboardActivityResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) network_live_bucket: Option<DashboardNetworkTimeseriesPointResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) network_realtime_rate: Option<DashboardNetworkRealtimeRateResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) accounts: Option<Vec<DashboardActivityAccountResponse>>,
 }
 
@@ -1857,6 +1859,18 @@ pub(crate) struct DashboardNetworkTimeseriesPointResponse {
     pub(crate) upload_bytes: i64,
     pub(crate) download_bytes: i64,
     pub(crate) is_live_bucket: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardNetworkRealtimeRateResponse {
+    pub(crate) sample_start: String,
+    pub(crate) sample_end: String,
+    pub(crate) sample_seconds: i64,
+    pub(crate) upload_bytes_per_second: f64,
+    pub(crate) download_bytes_per_second: f64,
+    pub(crate) upload_bytes: i64,
+    pub(crate) download_bytes: i64,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/dashboard_network_speed.rs
+++ b/src/dashboard_network_speed.rs
@@ -1,11 +1,12 @@
 use super::*;
 
-pub(crate) const DASHBOARD_NETWORK_REALTIME_WINDOW_SECONDS: i64 = 15;
 pub(crate) const DASHBOARD_NETWORK_BUCKET_SECONDS: i64 = 300;
 const DASHBOARD_NETWORK_SECOND_BUCKET_RETENTION_SECONDS: i64 = 45;
 pub(crate) const DASHBOARD_ACTIVITY_REALTIME_WINDOW_SECONDS: i64 = 60;
 const DASHBOARD_ACTIVITY_SECOND_BUCKET_RETENTION_SECONDS: i64 = 180;
 pub(crate) const DASHBOARD_NETWORK_UNKNOWN_UPSTREAM_HOST: &str = "__unknown__";
+pub(crate) const DASHBOARD_NETWORK_REALTIME_SAMPLE_SECONDS: i64 = 1;
+const DASHBOARD_NETWORK_LIVE_STREAM_KEEPALIVE_SECONDS: i64 = 15;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(crate) struct DashboardNetworkRateSnapshot {
@@ -13,10 +14,28 @@ pub(crate) struct DashboardNetworkRateSnapshot {
     pub(crate) download_bytes_per_second: f64,
 }
 
+impl DashboardNetworkRateSnapshot {
+    fn from_totals(totals: DashboardNetworkByteTotals, sample_seconds: i64) -> Self {
+        let divisor = sample_seconds.max(1) as f64;
+        Self {
+            upload_bytes_per_second: totals.upload_bytes.max(0) as f64 / divisor,
+            download_bytes_per_second: totals.download_bytes.max(0) as f64 / divisor,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct DashboardNetworkByteTotals {
     pub(crate) upload_bytes: i64,
     pub(crate) download_bytes: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DashboardNetworkRealtimeByteSnapshot {
+    pub(crate) sample_start_epoch_second: i64,
+    pub(crate) sample_end_epoch_second: i64,
+    pub(crate) sample_seconds: i64,
+    pub(crate) totals: DashboardNetworkByteTotals,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -604,30 +623,28 @@ impl DashboardNetworkSpeedCache {
             let Some(upstream_account_id) = scope.upstream_account_id() else {
                 continue;
             };
-            let mut totals = DashboardNetworkByteTotals::default();
-            for bucket in buckets {
-                if bucket.epoch_second
-                    < now_epoch_second
-                        .saturating_sub(DASHBOARD_NETWORK_REALTIME_WINDOW_SECONDS.saturating_sub(1))
-                {
-                    continue;
-                }
-                if bucket.epoch_second > now_epoch_second {
-                    continue;
-                }
-                totals.add_assign(bucket.totals);
-            }
+            let snapshot = snapshot_complete_second_rate_from_buckets(buckets, now_epoch_second);
             rates.insert(
                 upstream_account_id,
-                DashboardNetworkRateSnapshot {
-                    upload_bytes_per_second: totals.upload_bytes.max(0) as f64
-                        / DASHBOARD_NETWORK_REALTIME_WINDOW_SECONDS as f64,
-                    download_bytes_per_second: totals.download_bytes.max(0) as f64
-                        / DASHBOARD_NETWORK_REALTIME_WINDOW_SECONDS as f64,
-                },
+                DashboardNetworkRateSnapshot::from_totals(snapshot.totals, snapshot.sample_seconds),
             );
         }
         rates
+    }
+
+    pub(crate) fn snapshot_scope_realtime_bytes(
+        &self,
+        scope: DashboardNetworkScopeKey,
+        now: DateTime<Utc>,
+    ) -> DashboardNetworkRealtimeByteSnapshot {
+        let now_epoch_second = now.timestamp();
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("dashboard network speed cache should not be poisoned");
+        prune_second_buckets_locked(&mut inner, now_epoch_second);
+        let buckets = inner.second_buckets.get(&scope);
+        snapshot_complete_second_rate_from_optional_buckets(buckets, now_epoch_second)
     }
 
     pub(crate) fn should_keep_dashboard_activity_live_stream(&self, now: DateTime<Utc>) -> bool {
@@ -637,7 +654,8 @@ impl DashboardNetworkSpeedCache {
             .lock()
             .expect("dashboard network speed cache should not be poisoned");
         if inner.latest_speed_epoch_second.is_some_and(|latest| {
-            now_epoch_second.saturating_sub(latest) < DASHBOARD_NETWORK_REALTIME_WINDOW_SECONDS
+            now_epoch_second.saturating_sub(latest)
+                < DASHBOARD_NETWORK_LIVE_STREAM_KEEPALIVE_SECONDS
         }) {
             return true;
         }
@@ -994,6 +1012,36 @@ fn record_activity_scope_delta_locked(
     }
 }
 
+fn snapshot_complete_second_rate_from_buckets(
+    buckets: &VecDeque<DashboardNetworkSecondBucket>,
+    now_epoch_second: i64,
+) -> DashboardNetworkRealtimeByteSnapshot {
+    snapshot_complete_second_rate_from_optional_buckets(Some(buckets), now_epoch_second)
+}
+
+fn snapshot_complete_second_rate_from_optional_buckets(
+    buckets: Option<&VecDeque<DashboardNetworkSecondBucket>>,
+    now_epoch_second: i64,
+) -> DashboardNetworkRealtimeByteSnapshot {
+    let sample_end_epoch_second = now_epoch_second;
+    let sample_start_epoch_second =
+        sample_end_epoch_second.saturating_sub(DASHBOARD_NETWORK_REALTIME_SAMPLE_SECONDS);
+    let target_epoch_second = sample_start_epoch_second;
+    let totals = buckets
+        .and_then(|rows| {
+            rows.iter()
+                .find(|bucket| bucket.epoch_second == target_epoch_second)
+                .map(|bucket| bucket.totals)
+        })
+        .unwrap_or_default();
+    DashboardNetworkRealtimeByteSnapshot {
+        sample_start_epoch_second,
+        sample_end_epoch_second,
+        sample_seconds: DASHBOARD_NETWORK_REALTIME_SAMPLE_SECONDS,
+        totals,
+    }
+}
+
 fn record_activity_bucket_delta_locked(
     inner: &mut DashboardNetworkSpeedCacheInner,
     scope: DashboardNetworkScopeKey,
@@ -1272,7 +1320,7 @@ mod tests {
     }
 
     #[test]
-    fn realtime_rates_use_last_fifteen_seconds_only() {
+    fn realtime_rates_use_previous_complete_second_only() {
         let cache = DashboardNetworkSpeedCache::new(fixed_utc(0));
         cache.record_request_bytes(
             "invoke-1",
@@ -1299,10 +1347,10 @@ mod tests {
             fixed_utc(24),
         );
 
-        let rates = cache.snapshot_account_rates(fixed_utc(24));
+        let rates = cache.snapshot_account_rates(fixed_utc(25));
         let account = rates.get(&Some(7)).copied().unwrap_or_default();
-        assert!((account.upload_bytes_per_second - 5.0).abs() < f64::EPSILON);
-        assert!((account.download_bytes_per_second - 4.0).abs() < f64::EPSILON);
+        assert!((account.upload_bytes_per_second - 45.0).abs() < f64::EPSILON);
+        assert!((account.download_bytes_per_second - 60.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -1334,9 +1382,66 @@ mod tests {
         );
         cache.finish_invocation("invoke-1", "2026-07-15 12:00:00");
 
-        let rates = cache.snapshot_account_rates(fixed_utc(100));
+        let rates = cache.snapshot_account_rates(fixed_utc(101));
         let account = rates.get(&None).copied().unwrap_or_default();
-        assert!((account.upload_bytes_per_second - 26.0).abs() < f64::EPSILON);
+        assert!((account.upload_bytes_per_second - 390.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn realtime_rates_ignore_current_second_partial_bytes() {
+        let cache = DashboardNetworkSpeedCache::new(fixed_utc(0));
+        cache.record_request_bytes(
+            "invoke-1",
+            "2026-07-15 12:00:00",
+            Some(7),
+            Some("api.openai.com"),
+            90,
+            fixed_utc(200),
+        );
+        cache.record_request_bytes(
+            "invoke-1",
+            "2026-07-15 12:00:00",
+            Some(7),
+            Some("api.openai.com"),
+            120,
+            fixed_utc(201),
+        );
+
+        let rates = cache.snapshot_account_rates(fixed_utc(201));
+        let account = rates.get(&Some(7)).copied().unwrap_or_default();
+        assert!((account.upload_bytes_per_second - 90.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn global_realtime_rate_reads_previous_complete_second() {
+        let cache = DashboardNetworkSpeedCache::new(fixed_utc(0));
+        cache.record_request_bytes(
+            "invoke-1",
+            "2026-07-15 12:00:00",
+            Some(7),
+            Some("api.openai.com"),
+            8240,
+            fixed_utc(320),
+        );
+        cache.record_response_chunk_bytes(
+            "invoke-2",
+            "2026-07-15 12:00:01",
+            Some(8),
+            Some("api.openai.com"),
+            4096,
+            fixed_utc(320),
+        );
+
+        let snapshot =
+            cache.snapshot_scope_realtime_bytes(DashboardNetworkScopeKey::Global, fixed_utc(321));
+        let rate =
+            DashboardNetworkRateSnapshot::from_totals(snapshot.totals, snapshot.sample_seconds);
+        assert_eq!(snapshot.sample_start_epoch_second, 320);
+        assert_eq!(snapshot.sample_end_epoch_second, 321);
+        assert_eq!(snapshot.totals.upload_bytes, 8240);
+        assert_eq!(snapshot.totals.download_bytes, 4096);
+        assert!((rate.upload_bytes_per_second - 8240.0).abs() < f64::EPSILON);
+        assert!((rate.download_bytes_per_second - 4096.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/web/src/features/dashboard/DashboardActivityOverview.test.tsx
+++ b/web/src/features/dashboard/DashboardActivityOverview.test.tsx
@@ -66,7 +66,6 @@ vi.mock("../../i18n", () => ({
         "dashboard.activityOverview.network": "Network",
         "dashboard.activityOverview.networkUpload": "Upload",
         "dashboard.activityOverview.networkDownload": "Download",
-        "dashboard.activityOverview.networkLiveNote": "Live bucket",
         "dashboard.activityOverview.networkRefreshing": "Refreshing",
         "dashboard.activityOverview.snapshotBannerTitle": "Offline snapshot",
         "dashboard.activityOverview.snapshotBannerDescription":

--- a/web/src/features/dashboard/DashboardNetworkActivityChart.test.tsx
+++ b/web/src/features/dashboard/DashboardNetworkActivityChart.test.tsx
@@ -50,7 +50,6 @@ vi.mock("../../i18n", () => ({
         "chart.noDataRange": "No data",
         "dashboard.activityOverview.networkUpload": "Upload",
         "dashboard.activityOverview.networkDownload": "Download",
-        "dashboard.activityOverview.networkLiveNote": "5-minute average",
         "dashboard.activityOverview.networkRefreshing": "Refreshing",
       };
       return map[key] ?? key;
@@ -169,6 +168,7 @@ describe("DashboardNetworkActivityChart", () => {
         ?.querySelector('[data-testid="dashboard-network-activity-chart"]')
         ?.getAttribute("data-theme"),
     ).toBe("vibe-dark");
+    expect(host?.textContent).not.toContain("5-minute average");
     expect(html).toContain('data-theme="vibe-dark"');
     expect(html).toContain("Upload");
     expect(html).toContain("Download");

--- a/web/src/features/dashboard/DashboardNetworkActivityChart.tsx
+++ b/web/src/features/dashboard/DashboardNetworkActivityChart.tsx
@@ -164,17 +164,14 @@ export function DashboardNetworkActivityChart({
       style={panelStyle}
       className="overflow-hidden rounded-2xl border border-base-300/60 px-2 py-3 sm:px-4"
     >
-      <div className="mb-3 flex items-center justify-between gap-3 px-1">
-        <div className="text-sm font-medium text-base-content/74">
-          {t("dashboard.activityOverview.networkLiveNote")}
-        </div>
-        {loading ? (
-          <div className="flex items-center gap-2 text-xs text-base-content/55">
+      {loading ? (
+        <div className="mb-3 flex items-center justify-end px-1 text-xs text-base-content/55">
+          <div className="flex items-center gap-2">
             <Spinner size="sm" aria-label={t("chart.loadingDetailed")} />
             <span>{t("dashboard.activityOverview.networkRefreshing")}</span>
           </div>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
       <div className="h-[22rem] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData} margin={{ top: 12, right: 20, left: 0, bottom: 4 }}>

--- a/web/src/features/dashboard/DashboardPage.stories.tsx
+++ b/web/src/features/dashboard/DashboardPage.stories.tsx
@@ -276,6 +276,15 @@ function buildDashboardActivityResponse({
       downloadBytes: 12_582_912 * 300,
       isLiveBucket: true,
     },
+    networkRealtimeRate: {
+      sampleStart: "2026-04-09T12:23:59.000Z",
+      sampleEnd: "2026-04-09T12:24:00.000Z",
+      sampleSeconds: 1,
+      uploadBytesPerSecond: 4_352,
+      downloadBytesPerSecond: 12_582_912,
+      uploadBytes: 4_352,
+      downloadBytes: 12_582_912,
+    },
     rateWindow: {
       start: "2026-04-09T12:23:00.000Z",
       end: "2026-04-09T12:24:00.000Z",
@@ -1721,6 +1730,15 @@ export const LiveRefreshDiagnostics: Story = {
           uploadBytes: 3_072 * 300,
           downloadBytes: 9_437_184 * 300,
           isLiveBucket: true,
+        },
+        networkRealtimeRate: {
+          sampleStart: "2026-04-06T12:00:20.000Z",
+          sampleEnd: "2026-04-06T12:00:21.000Z",
+          sampleSeconds: 1,
+          uploadBytesPerSecond: 3_072,
+          downloadBytesPerSecond: 9_437_184,
+          uploadBytes: 3_072,
+          downloadBytes: 9_437_184,
         },
         accounts: [
           {

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.test.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.test.tsx
@@ -241,6 +241,15 @@ function createUpstreamAccountActivityResponse(): UpstreamAccountActivityRespons
       downloadBytes: 5 * 1024 * 1024 * 300,
       isLiveBucket: true,
     },
+    networkRealtimeRate: {
+      sampleStart: "2026-04-04T10:04:59Z",
+      sampleEnd: "2026-04-04T10:05:00Z",
+      sampleSeconds: 1,
+      uploadBytesPerSecond: 1_536,
+      downloadBytesPerSecond: 5 * 1024 * 1024,
+      uploadBytes: 1_536,
+      downloadBytes: 5 * 1024 * 1024,
+    },
     accounts: [
       {
         upstreamAccountId: 42,
@@ -1382,14 +1391,14 @@ describe("DashboardWorkingConversationsSection", () => {
       downloadBytesPerSecond: 1024 * 1024,
       recentInvocations: [],
     });
-    upstreamActivity.networkLiveBucket = {
-      bucketStart: "2026-04-04T10:00:00Z",
-      bucketEnd: "2026-04-04T10:05:00Z",
+    upstreamActivity.networkRealtimeRate = {
+      sampleStart: "2026-04-04T10:04:59Z",
+      sampleEnd: "2026-04-04T10:05:00Z",
+      sampleSeconds: 1,
       uploadBytesPerSecond: 2_048,
       downloadBytesPerSecond: 6 * 1024 * 1024,
-      uploadBytes: 2_048 * 300,
-      downloadBytes: 6 * 1024 * 1024 * 300,
-      isLiveBucket: true,
+      uploadBytes: 2_048,
+      downloadBytes: 6 * 1024 * 1024,
     };
 
     renderSection(

--- a/web/src/features/dashboard/DashboardWorkingConversationsSection.tsx
+++ b/web/src/features/dashboard/DashboardWorkingConversationsSection.tsx
@@ -4112,14 +4112,14 @@ export function DashboardWorkingConversationsSection({
     () => ({
       uploadBytesPerSecond: Math.max(
         0,
-        upstreamAccountActivity?.networkLiveBucket?.uploadBytesPerSecond ?? 0,
+        upstreamAccountActivity?.networkRealtimeRate?.uploadBytesPerSecond ?? 0,
       ),
       downloadBytesPerSecond: Math.max(
         0,
-        upstreamAccountActivity?.networkLiveBucket?.downloadBytesPerSecond ?? 0,
+        upstreamAccountActivity?.networkRealtimeRate?.downloadBytesPerSecond ?? 0,
       ),
     }),
-    [upstreamAccountActivity?.networkLiveBucket],
+    [upstreamAccountActivity?.networkRealtimeRate],
   );
   useEffect(() => {
     persistDashboardWorkspaceView(DASHBOARD_WORKSPACE_VIEW_STORAGE_KEY, preferredView);

--- a/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
+++ b/web/src/hooks/useDashboardUpstreamAccountActivity.test.tsx
@@ -127,6 +127,15 @@ function createResponse(inProgressCount: number): DashboardActivityResponse {
       downloadBytes: 38_400,
       isLiveBucket: true,
     },
+    networkRealtimeRate: {
+      sampleStart: "2026-07-16T10:04:59Z",
+      sampleEnd: "2026-07-16T10:05:00Z",
+      sampleSeconds: 1,
+      uploadBytesPerSecond: 64,
+      downloadBytesPerSecond: 128,
+      uploadBytes: 64,
+      downloadBytes: 128,
+    },
     accounts: [
       {
         accountKey: "upstream:7",
@@ -234,6 +243,15 @@ describe("mergeDashboardActivityLiveSnapshot", () => {
         downloadBytes: 307_200,
         isLiveBucket: true,
       },
+      networkRealtimeRate: {
+        sampleStart: "2026-07-16T10:05:29Z",
+        sampleEnd: "2026-07-16T10:05:30Z",
+        sampleSeconds: 1,
+        uploadBytesPerSecond: 77,
+        downloadBytesPerSecond: 155,
+        uploadBytes: 77,
+        downloadBytes: 155,
+      },
       accounts: [
         {
           accountKey: "upstream:7",
@@ -256,6 +274,8 @@ describe("mergeDashboardActivityLiveSnapshot", () => {
     expect(merged.summary.stats.inProgressConversationCount).toBe(3);
     expect(merged.networkLiveBucket?.uploadBytesPerSecond).toBe(512);
     expect(merged.networkLiveBucket?.downloadBytesPerSecond).toBe(1024);
+    expect(merged.networkRealtimeRate?.uploadBytesPerSecond).toBe(77);
+    expect(merged.networkRealtimeRate?.downloadBytesPerSecond).toBe(155);
     expect(merged.accounts?.[0]).toEqual(
       expect.objectContaining({
         inProgressInvocationCount: 3,

--- a/web/src/hooks/useDashboardUpstreamAccountActivity.ts
+++ b/web/src/hooks/useDashboardUpstreamAccountActivity.ts
@@ -102,6 +102,7 @@ export function mergeDashboardActivityLiveSnapshot(
     ...response,
     liveRevision: live.revision,
     networkLiveBucket: live.networkLiveBucket ?? response.networkLiveBucket,
+    networkRealtimeRate: live.networkRealtimeRate ?? response.networkRealtimeRate,
     summary: {
       ...response.summary,
       stats: {
@@ -256,6 +257,7 @@ export function useDashboardUpstreamAccountActivity(
         rangeStart: snapshot.data.rangeStart,
         rangeEnd: snapshot.data.rangeEnd,
         networkLiveBucket: snapshot.data.networkLiveBucket,
+        networkRealtimeRate: snapshot.data.networkRealtimeRate,
         accounts: snapshot.data.accounts ?? [],
       }
     : null;

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1814,8 +1814,6 @@ const baseTranslations = {
     "dashboard.activityOverview.network": "Network",
     "dashboard.activityOverview.networkUpload": "Upload",
     "dashboard.activityOverview.networkDownload": "Download",
-    "dashboard.activityOverview.networkLiveNote":
-      "5-minute mean speed · current bucket updates live",
     "dashboard.activityOverview.networkRefreshing": "Refreshing",
     "dashboard.activityOverview.rangeToggleAria": "Switch activity range",
     "dashboard.activityOverview.snapshotBannerTitle": "Offline snapshot",
@@ -4308,7 +4306,6 @@ const baseTranslations = {
     "dashboard.activityOverview.network": "网速",
     "dashboard.activityOverview.networkUpload": "上行",
     "dashboard.activityOverview.networkDownload": "下行",
-    "dashboard.activityOverview.networkLiveNote": "5 分钟均值网速，当前桶实时更新",
     "dashboard.activityOverview.networkRefreshing": "刷新中",
     "dashboard.activityOverview.rangeToggleAria": "时间范围切换",
     "dashboard.activityOverview.snapshotBannerTitle": "离线快照",

--- a/web/src/lib/api/core-foundation.ts
+++ b/web/src/lib/api/core-foundation.ts
@@ -799,6 +799,7 @@ export interface UpstreamAccountActivityResponse {
   rangeStart: string;
   rangeEnd: string;
   networkLiveBucket?: DashboardNetworkTimeseriesPoint | null;
+  networkRealtimeRate?: DashboardNetworkRealtimeRate | null;
   accounts: UpstreamAccountActivityAccount[];
 }
 
@@ -836,6 +837,7 @@ export interface DashboardActivityLiveSnapshot {
   inProgressPhaseCounts: InvocationPhaseCounts;
   retryInvocationCount: number;
   networkLiveBucket?: DashboardNetworkTimeseriesPoint | null;
+  networkRealtimeRate?: DashboardNetworkRealtimeRate | null;
   accounts: DashboardActivityLiveAccount[];
 }
 
@@ -848,6 +850,7 @@ export interface DashboardActivityResponse {
   rateWindow: DashboardActivityRateWindow;
   summary: DashboardActivitySummary;
   networkLiveBucket?: DashboardNetworkTimeseriesPoint | null;
+  networkRealtimeRate?: DashboardNetworkRealtimeRate | null;
   accounts?: UpstreamAccountActivityAccount[];
 }
 
@@ -869,6 +872,16 @@ export interface DashboardNetworkTimeseriesPoint {
   uploadBytes: number;
   downloadBytes: number;
   isLiveBucket: boolean;
+}
+
+export interface DashboardNetworkRealtimeRate {
+  sampleStart: string;
+  sampleEnd: string;
+  sampleSeconds: number;
+  uploadBytesPerSecond: number;
+  downloadBytesPerSecond: number;
+  uploadBytes: number;
+  downloadBytes: number;
 }
 
 export interface DashboardNetworkTimeseriesResponse {
@@ -3260,6 +3273,7 @@ function normalizeUpstreamAccountActivityResponse(raw: unknown): UpstreamAccount
     rangeStart: typeof payload.rangeStart === "string" ? payload.rangeStart : "",
     rangeEnd: typeof payload.rangeEnd === "string" ? payload.rangeEnd : "",
     networkLiveBucket: normalizeDashboardNetworkTimeseriesPoint(payload.networkLiveBucket),
+    networkRealtimeRate: normalizeDashboardNetworkRealtimeRate(payload.networkRealtimeRate),
     accounts: Array.isArray(payload.accounts)
       ? payload.accounts
           .map(normalizeUpstreamAccountActivityAccount)
@@ -3295,6 +3309,7 @@ function normalizeDashboardActivityResponse(raw: unknown): DashboardActivityResp
       modelPerformance: normalizeModelPerformance(summaryPayload.modelPerformance),
     },
     networkLiveBucket: normalizeDashboardNetworkTimeseriesPoint(payload.networkLiveBucket),
+    networkRealtimeRate: normalizeDashboardNetworkRealtimeRate(payload.networkRealtimeRate),
     accounts: Array.isArray(payload.accounts)
       ? payload.accounts
           .map(normalizeUpstreamAccountActivityAccount)
@@ -3340,6 +3355,27 @@ function normalizeDashboardNetworkTimeseriesPoint(
     uploadBytes: normalizeFiniteNumber(point.uploadBytes) ?? 0,
     downloadBytes: normalizeFiniteNumber(point.downloadBytes) ?? 0,
     isLiveBucket: point.isLiveBucket === true,
+  };
+}
+
+function normalizeDashboardNetworkRealtimeRate(raw: unknown): DashboardNetworkRealtimeRate | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const point = raw as Record<string, unknown>;
+  const sampleStart = typeof point.sampleStart === "string" ? point.sampleStart : null;
+  const sampleEnd = typeof point.sampleEnd === "string" ? point.sampleEnd : null;
+  if (sampleStart == null || sampleEnd == null) {
+    return null;
+  }
+  return {
+    sampleStart,
+    sampleEnd,
+    sampleSeconds: normalizeFiniteNumber(point.sampleSeconds) ?? 1,
+    uploadBytesPerSecond: normalizeFiniteNumber(point.uploadBytesPerSecond) ?? 0,
+    downloadBytesPerSecond: normalizeFiniteNumber(point.downloadBytesPerSecond) ?? 0,
+    uploadBytes: normalizeFiniteNumber(point.uploadBytes) ?? 0,
+    downloadBytes: normalizeFiniteNumber(point.downloadBytes) ?? 0,
   };
 }
 

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -158,7 +158,7 @@ vi.mock("../features/dashboard/DashboardWorkingConversationsSection", () => ({
       invocation: { record: { invokeId: string } };
     }) => void;
     upstreamAccountActivity?: {
-      networkLiveBucket?: {
+      networkRealtimeRate?: {
         uploadBytesPerSecond?: number;
         downloadBytesPerSecond?: number;
       } | null;
@@ -170,8 +170,8 @@ vi.mock("../features/dashboard/DashboardWorkingConversationsSection", () => ({
         {cards.map((card) => card.currentInvocation.preview.endpoint ?? "").join(",")}
       </span>
       <span data-testid="dashboard-working-conversations-network-live-bucket">
-        {upstreamAccountActivity?.networkLiveBucket
-          ? `${upstreamAccountActivity.networkLiveBucket.uploadBytesPerSecond ?? 0}/${upstreamAccountActivity.networkLiveBucket.downloadBytesPerSecond ?? 0}`
+        {upstreamAccountActivity?.networkRealtimeRate
+          ? `${upstreamAccountActivity.networkRealtimeRate.uploadBytesPerSecond ?? 0}/${upstreamAccountActivity.networkRealtimeRate.downloadBytesPerSecond ?? 0}`
           : "missing"}
       </span>
       {cards[0] ? (
@@ -485,14 +485,14 @@ function installSummaryMocks() {
           models: [],
         },
       },
-      networkLiveBucket: {
-        bucketStart: "2026-04-08T00:00:00.000Z",
-        bucketEnd: "2026-04-08T00:05:00.000Z",
+      networkRealtimeRate: {
+        sampleStart: "2026-04-08T00:04:59.000Z",
+        sampleEnd: "2026-04-08T00:05:00.000Z",
+        sampleSeconds: 1,
         uploadBytesPerSecond: 2048,
         downloadBytesPerSecond: 4096,
-        uploadBytes: 2048 * 300,
-        downloadBytes: 4096 * 300,
-        isLiveBucket: true,
+        uploadBytes: 2048,
+        downloadBytes: 4096,
       },
       accounts: [
         {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -243,6 +243,7 @@ export default function DashboardPage() {
                 rangeStart: dashboardActivity.rangeStart,
                 rangeEnd: dashboardActivity.rangeEnd,
                 networkLiveBucket: dashboardActivity.networkLiveBucket,
+                networkRealtimeRate: dashboardActivity.networkRealtimeRate,
                 accounts: dashboardActivity.accounts,
               }
             : null


### PR DESCRIPTION
## Summary\n- Switch dashboard top network pill to previous complete 1-second realtime rate.\n- Remove the misleading chart note and keep the 5-minute history chart.\n- Thread  through backend API, web normalize, and stories/tests.\n\n## Verification\n- cargo check -q\n- cargo test -q dashboard_network_speed::tests::\n- cargo test -q dashboard_network_timeseries_tests::\n- cargo test -q dashboard_activity_live_snapshot_serializes_network_realtime_rate\n- cd web && bun run test DashboardActivityOverview.test.tsx DashboardNetworkActivityChart.test.tsx useDashboardUpstreamAccountActivity.test.tsx DashboardWorkingConversationsSection.test.tsx Dashboard.test.tsx\n- cd web && bun run storybook:build\n\n## References\n- Specs: docs/specs/v3fum-dashboard-network-speed/SPEC.md\n- Solutions: docs/solutions/performance/realtime-dashboard-reconcile-budget.md, docs/solutions/workflow/mock-only-web-demo-runtime.md\n- Project Docs: -