### PR TITLE
fix(stats): bound dashboard preview reads

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -61,7 +61,8 @@ related_specs:
 - 不要把 `records` 事件继续暴露成“页面自己决定要不要重拉”的契约；主应用订阅面应该直接消费 topic payload。
 - 不要为覆盖范围内页面保留健康态 timer reconcile、open-resync 或页面私有 fallback；那会重新引入第二真相源。
 - 不要把 closed-range / history-only 页面硬塞进持续推送；纯 SSE 的边界是“常驻当前态订阅”，不是“所有页面都实时化”。
-- 如果某个 topic 仍需要短 TTL 的服务端 DB 基础快照缓存，cache key 只能包含稳定请求参数与明确允许的 bucket 维度；live runtime 状态、最新持久化行 ID 这类高抖动因子必须留在响应阶段 overlay，否则 singleflight 会被打散，订阅与 HTTP 都会继续重复重算同一份基底。
+- 如果某个 topic 仍需要短 TTL 的服务端 DB 基础快照缓存，cache key 只能包含稳定请求参数与明确允许的自然日锚点等低抖动维度；移动中的 exact `rangeStart/rangeEnd`、live runtime 状态、最新持久化行 ID 这类高抖动因子必须留在响应阶段 overlay，否则 singleflight 会被打散，订阅与 HTTP 都会继续重复重算同一份基底。
+- Dashboard / upstream-account 的 recent 预览不得再为了补当前态而对整个选中 range 扫 persisted `running/pending` 行；当前态应来自 runtime/live read model，旧持久化运行态最多只能作为 bounded recent 候选参与展示。
 - 与 Dashboard 同屏但不共享同一 owner-facing contract 的接口，不要为了“省实现”直接复用 dashboard full snapshot builder；应复用更低层的账户活动聚合块，避免把 summary/model-performance/reconcile 之类 dashboard-only 组装再次带回实时主链路。
 - 不要为 replay 失败发明第三条恢复路径。恢复规则只应是 replay 或 snapshot。
 - 手动“立即重连”不应偷偷复用旧 `resume` 去赌 replay 命中。若产品语义是“人工要求重新拉一份当前态”，前端就应该对 active topics 强制 fresh snapshot，并给这次连接分配独立 `attempt/reason` 供前后端对账。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## Decision Trace
 
+- 2026-07-20：落实 Dashboard 读侧 CPU 修复。`upstream-account-activity` 与 dashboard full path 不再对完整 `7d` range 做 persisted `running/pending` preview 扫描，recent 改为“每账号 bounded candidate + hydration + runtime/live overlay”；同日把 non-`yesterday` dashboard 基础快照缓存收敛为稳定请求参数选择键与 `5s` TTL，并补齐 `route / builder / purpose / limit / cache_ttl_ms / cache_entry_age_ms / cache_entry_count / in_flight_count` 遥测，便于线上继续判定是缓存未合并还是 preview 仍过宽。
 - 2026-07-20：收紧 Dashboard 对话卡片 `当前调用 / 上一条调用` 的可见用量行。此前槽位常驻展示 `IN / CW / C / O / T / $`，在窄卡里噪声偏高；本轮冻结为只显示 `Hit / Token / $` 三项，其中 `Hit` 口径固定为 `cacheInputTokens / totalTokens`，成本值复用金额主题 accent，而完整 token/cost/reasoning 明细继续保留在 hover/title，避免压缩卡面时丢失诊断能力。
 - 2026-07-19：101 线上 12 小时复盘确认 `dashboard-activity full` 慢点仍主要来自读侧合并不足，而不是内存瓶颈。已冻结两条后续约束：一，non-`yesterday` 基础快照缓存只允许按稳定请求参数 + 短 TTL 合并，不能再把 live runtime 状态或最新持久化行 ID 放进选择键；二，`/api/stats/upstream-account-activity` 不得继续借道 dashboard full snapshot，必须走独立账户活动 builder，并补足 route/builder/preview hydration telemetry 便于下一轮定位残余慢点。
 - 2026-07-18：收紧上游账号卡宽屏 `split` header 的 `TPM` 横向预算。此前长 `TPM` 会按完整数字位数直接撑宽右上实时指标区；本轮固定仅 `TPM` 值本体约 `6ch` 宽度预算，超预算后继续复用既有 adaptive compact 缩写链路，`进行中调用 / 消费速率` 与窄卡 `stacked` 路径不变。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -66,10 +66,10 @@
 - 已实现：via-pool 请求级 cleanup guard 在响应消费期间保留 `pool-via-*` synthetic runtime snapshot，并随最终 stream task 生命周期收口；成功、失败、所有重试耗尽、下游断开或任务取消后清除残留非终态 snapshot，单次 upstream attempt 终结不会提前移除；普通 invocation runtime 与短暂终态 overlay 仍由其原有终态持久化路径负责。
 - 已实现：timeseries 继续只服务趋势图与日均比较，不再作为 Dashboard 顶部当前速率类 KPI 的事实来源；`buildDashboardTodayRateSnapshot`、timeseries recent snapshot 与 `modelPerformance.total.*` 已退出顶部当前值驱动链。
 - 已实现：账号活动快照的终态 live 数据改为账号级窄聚合与按模型用量分组，避免为整个 range 传输完整 invocation preview 行；运行态 runtime overlay、归档折叠、四个时间范围和公开响应字段保持原有语义。
-- 已实现：账号卡 recent 调用改为每个候选账号按时间倒序的受限读取，数量仍严格受请求 `recentLimit` 限制。
+- 已实现：账号卡 recent 调用改为每个候选账号按时间倒序的受限读取，数量仍严格受请求 `recentLimit` 限制；`upstream-account-activity` 与 dashboard full path 不再为整个 `7d` range 读取 persisted `running/pending` preview 行，缺失于 runtime store 的旧运行态只允许在 bounded recent 中出现，不再计入 owner-facing totals。
 - 已实现：账号卡 recent 调用在 SQLite batch flush 前也会读取同一 runtime store；同键 runtime 行覆盖非终态 DB shell，短暂 terminal overlay 立即可见，落库后不会形成重复行。
-- 已实现：non-`yesterday` 的 `dashboard-activity` 基础快照缓存已收敛为“请求参数 + 2 秒 bucket”选择键，不再把 live runtime 状态或最新持久化行 ID 放进 cache key；fresh live overlay 与 `live_revision` 继续在响应阶段叠加，保证 owner-facing 实时语义不变。
-- 已实现：`/api/stats/upstream-account-activity` 改走独立账户活动 builder，不再借道 dashboard full snapshot 的 summary/model-performance 组装；后端新增 `route / builder / preview_read_mode / candidate_preview_id_count / hydrated_preview_row_count / cache_bypass_reason` 结构化 telemetry，用于复盘读侧放大与 DB 压力重合。
+- 已实现：non-`yesterday` 的 `dashboard-activity` 基础快照缓存已收敛为“稳定请求参数 + `today` 本地日期锚点 + 5 秒 TTL”选择键，不再把移动中的 exact `rangeStart/rangeEnd`、live runtime 状态或最新持久化行 ID 放进 cache key；fresh live overlay、exact 响应边界与 `live_revision` 继续在响应阶段叠加，允许 terminal totals 最多 `<=5s` 滞后，同时保持当前态与 recent 的 owner-facing 实时语义不变。
+- 已实现：`/api/stats/upstream-account-activity` 改走独立账户活动 builder，不再借道 dashboard full snapshot 的 summary/model-performance 组装；后端新增 `route / builder / purpose / in_progress_only / limit / preview_read_mode / candidate_preview_id_count / hydrated_preview_row_count / cache_bypass_reason / cache_ttl_ms / cache_entry_age_ms / cache_entry_count / in_flight_count` 结构化 telemetry，用于复盘读侧放大、缓存命中率与 DB 压力重合。
 
 ## Remaining Gaps
 

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -6859,38 +6859,13 @@ async fn query_live_upstream_account_activity_rate_rows(
         .map_err(Into::into)
 }
 
-fn add_upstream_account_activity_preview_row(
+fn merge_upstream_account_activity_recent_row_metadata(
     account_activity: &mut HashMap<Option<i64>, UpstreamAccountActivityAccumulator>,
-    row: UpstreamAccountInvocationPreviewRow,
-    recent_limit: usize,
-    include_accounts: bool,
+    row: &UpstreamAccountInvocationPreviewRow,
 ) {
     let Some(occurred_at) = parse_to_utc_datetime(&row.occurred_at) else {
         return;
     };
-    let classification = resolve_failure_classification(
-        Some(row.status.as_str()),
-        row.error_message.as_deref(),
-        row.failure_kind.as_deref(),
-        row.failure_class.as_deref(),
-        row.is_actionable,
-    );
-    let is_success = prompt_cache_and_timeseries_shared::prompt_invocation_status_is_success_like(
-        Some(row.status.as_str()),
-        row.error_message.as_deref(),
-    ) && classification.failure_class == FailureClass::None;
-    let counts_toward_failure =
-        prompt_cache_and_timeseries_shared::prompt_invocation_status_counts_toward_terminal_totals(
-            Some(row.status.as_str()),
-        ) && classification.failure_class != FailureClass::None;
-    let counts_toward_non_success = invocation_counts_toward_non_success_usage(
-        Some(row.status.as_str()),
-        row.error_message.as_deref(),
-        row.failure_kind.as_deref(),
-        row.failure_class.as_deref(),
-        row.is_actionable,
-    );
-
     let entry = account_activity.entry(row.upstream_account_id).or_default();
     entry.last_occurred_at_epoch_ms = entry
         .last_occurred_at_epoch_ms
@@ -6908,47 +6883,6 @@ fn add_upstream_account_activity_preview_row(
         entry.plan_type_hint =
             normalize_trimmed_optional_string_local(row.upstream_account_plan_type.clone());
     }
-    entry.request_count += 1;
-    entry.total_tokens += row.total_tokens.max(0);
-    entry.cache_input_tokens += row.cache_input_tokens.unwrap_or_default().max(0);
-    entry.total_cost += row.cost.unwrap_or_default();
-    entry.usage_breakdown.add_row(&row);
-    if is_success {
-        entry.success_count += 1;
-        entry.success_tokens += row.total_tokens.max(0);
-        if let Some(first_response_byte_total_ms) =
-            crate::stats::resolve_first_response_byte_total_ms(
-                row.t_req_read_ms,
-                row.t_req_parse_ms,
-                row.t_upstream_connect_ms,
-                row.t_upstream_ttfb_ms,
-            )
-        {
-            entry.first_response_byte_total_sample_count += 1;
-            entry.first_response_byte_total_sum_ms += first_response_byte_total_ms;
-        }
-        if let Some(total_ms) = row
-            .t_total_ms
-            .filter(|value| value.is_finite() && *value >= 0.0)
-        {
-            entry.total_latency_sample_count += 1;
-            entry.total_latency_sum_ms += total_ms;
-        }
-    } else if counts_toward_failure {
-        entry.failure_count += 1;
-        entry.failure_tokens += row.total_tokens.max(0);
-        entry.failure_cost += row.cost.unwrap_or_default();
-    }
-    if counts_toward_non_success {
-        entry.non_success_count += 1;
-        entry.non_success_tokens += row.total_tokens.max(0);
-        entry.non_success_cost += row.cost.unwrap_or_default();
-    }
-    entry.rate_usage_events.push(UpstreamAccountRateUsageEvent {
-        occurred_at_epoch_ms: occurred_at.timestamp_millis(),
-        total_tokens: row.total_tokens.max(0),
-        total_cost: row.cost.unwrap_or_default().max(0.0),
-    });
     if matches!(
         normalized_runtime_text(Some(row.status.as_str())).as_str(),
         "running" | "pending"
@@ -6959,11 +6893,13 @@ fn add_upstream_account_activity_preview_row(
         entry.in_progress_wait_sum_ms += ttfb_ms;
         entry.in_progress_wait_sample_count += 1;
     }
-    if include_accounts && entry.recent_invocations.len() < recent_limit {
-        entry
-            .recent_invocations
-            .push(upstream_account_invocation_preview_from_row(row));
-    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct UpstreamAccountActivityPreviewReadTelemetry {
+    route: &'static str,
+    builder: &'static str,
+    purpose: &'static str,
 }
 
 pub(crate) async fn query_live_upstream_account_activity_preview_rows(
@@ -6978,6 +6914,11 @@ pub(crate) async fn query_live_upstream_account_activity_preview_rows(
         None,
         None,
         false,
+        UpstreamAccountActivityPreviewReadTelemetry {
+            route: "shared",
+            builder: "usage_breakdown",
+            purpose: "full_range_preview_rows",
+        },
     )
     .await
 }
@@ -7064,6 +7005,7 @@ async fn query_live_upstream_account_activity_preview_rows_with_limit(
     upstream_account_id: Option<Option<i64>>,
     limit: Option<usize>,
     in_progress_only: bool,
+    telemetry: UpstreamAccountActivityPreviewReadTelemetry,
 ) -> Result<Vec<UpstreamAccountInvocationPreviewRow>, ApiError> {
     let started_at = Instant::now();
     let resolved_upstream_account_id_sql =
@@ -7107,15 +7049,17 @@ async fn query_live_upstream_account_activity_preview_rows_with_limit(
     if elapsed_ms >= 1_000 {
         tracing::warn!(
             endpoint = "/api/stats/upstream-account-activity",
-            operation = if limit.is_some() {
-                "live_preview_rows_limited"
-            } else {
-                "live_preview_rows"
-            },
+            route = telemetry.route,
+            builder = telemetry.builder,
+            operation = telemetry.purpose,
+            purpose = telemetry.purpose,
             ?source_scope,
             start = %range.start,
             end = %range.end,
+            range_seconds = (range.end - range.start).num_seconds(),
             upstream_account_id = ?upstream_account_id.flatten(),
+            limit = ?limit,
+            in_progress_only,
             row_count = rows.len(),
             elapsed_ms,
             "slow upstream-account activity read"
@@ -7162,7 +7106,7 @@ async fn query_live_upstream_account_activity_preview_rows_by_ids(
     pool: &Pool<Sqlite>,
     source_scope: InvocationSourceScope,
     ids: &[i64],
-    operation: &'static str,
+    telemetry: UpstreamAccountActivityPreviewReadTelemetry,
 ) -> Result<Vec<UpstreamAccountInvocationPreviewRow>, ApiError> {
     if ids.is_empty() {
         return Ok(Vec::new());
@@ -7200,7 +7144,10 @@ async fn query_live_upstream_account_activity_preview_rows_by_ids(
     if elapsed_ms >= 1_000 {
         tracing::warn!(
             endpoint = "/api/stats/upstream-account-activity",
-            operation,
+            route = telemetry.route,
+            builder = telemetry.builder,
+            operation = telemetry.purpose,
+            purpose = telemetry.purpose,
             candidate_preview_id_count = ids.len(),
             hydrated_preview_row_count = rows.len(),
             ?source_scope,
@@ -7224,6 +7171,7 @@ async fn query_live_upstream_account_activity_preview_rows_per_account_limit_wit
     source_scope: InvocationSourceScope,
     range: ExactUtcRange,
     limit_per_account: usize,
+    telemetry: UpstreamAccountActivityPreviewReadTelemetry,
 ) -> Result<HydratedUpstreamAccountPreviewRows, ApiError> {
     let ids = query_live_upstream_account_activity_preview_candidate_ids_per_account(
         pool,
@@ -7236,7 +7184,7 @@ async fn query_live_upstream_account_activity_preview_rows_per_account_limit_wit
         pool,
         source_scope,
         &ids,
-        "live_preview_rows_per_account_limit",
+        telemetry,
     )
     .await?;
     Ok(HydratedUpstreamAccountPreviewRows {
@@ -7251,6 +7199,7 @@ async fn query_live_upstream_account_activity_preview_rows_per_account_limit(
     source_scope: InvocationSourceScope,
     range: ExactUtcRange,
     limit_per_account: usize,
+    telemetry: UpstreamAccountActivityPreviewReadTelemetry,
 ) -> Result<Vec<UpstreamAccountInvocationPreviewRow>, ApiError> {
     Ok(
         query_live_upstream_account_activity_preview_rows_per_account_limit_with_stats(
@@ -7258,6 +7207,7 @@ async fn query_live_upstream_account_activity_preview_rows_per_account_limit(
             source_scope,
             range,
             limit_per_account,
+            telemetry,
         )
         .await?
         .rows,
@@ -7988,7 +7938,7 @@ fn dashboard_live_snapshot_in_progress_counts(
 }
 
 pub(crate) const DASHBOARD_ACTIVITY_RATE_WINDOW_MINUTES: i64 = 5;
-const DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS: u64 = 2;
+const DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS: u64 = 5;
 
 #[derive(Debug, Clone)]
 pub(crate) struct DashboardActivitySnapshot {
@@ -8026,6 +7976,10 @@ struct DashboardActivitySnapshotCacheOutcome {
     cache_bypass_reason: &'static str,
     coalesced_waiter_count: usize,
     db_build_elapsed_ms: u64,
+    cache_ttl_ms: u64,
+    cache_entry_age_ms: u64,
+    cache_entry_count: usize,
+    in_flight_count: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -8592,14 +8546,32 @@ fn build_dashboard_activity_snapshot_selection(
 ) -> DashboardActivitySnapshotSelection {
     DashboardActivitySnapshotSelection {
         range: range.to_string(),
-        range_start: format_utc_iso_precise(exact_range.start),
-        range_end: format_utc_iso_precise(exact_range.end),
+        range_anchor: dashboard_activity_snapshot_selection_anchor(
+            range,
+            exact_range,
+            reporting_tz,
+        ),
         time_zone: reporting_tz.to_string(),
         source_scope: dashboard_activity_source_scope_cache_key(source_scope).to_string(),
         recent_limit,
         include_accounts,
         include_recent,
     }
+}
+
+fn dashboard_activity_snapshot_selection_anchor(
+    range: &str,
+    exact_range: ExactUtcRange,
+    reporting_tz: Tz,
+) -> String {
+    if parse_duration_spec(range).is_ok() {
+        return "rolling".to_string();
+    }
+    exact_range
+        .start
+        .with_timezone(&reporting_tz)
+        .format("%Y-%m-%d")
+        .to_string()
 }
 
 fn resolve_dashboard_activity_exact_range(
@@ -8617,17 +8589,7 @@ fn resolve_dashboard_activity_cached_range(
     range_name: &str,
     reporting_tz: Tz,
 ) -> Result<ExactUtcRange, ApiError> {
-    let mut range = resolve_dashboard_activity_exact_range(range_name, reporting_tz)?;
-    if range_name != "yesterday" {
-        range.end = dashboard_activity_cache_bucket_end(range.end)?;
-        if let Ok(duration) = parse_duration_spec(range_name) {
-            range.start = range.end - duration;
-        }
-        if range.end < range.start {
-            range.end = range.start;
-        }
-    }
-    Ok(range)
+    resolve_dashboard_activity_exact_range(range_name, reporting_tz)
 }
 
 fn dashboard_activity_full_hour_exact_range(
@@ -8644,14 +8606,6 @@ fn dashboard_activity_full_hour_exact_range(
             ApiError::from(anyhow!("invalid dashboard activity full-hour end epoch"))
         })?,
     }))
-}
-
-fn dashboard_activity_cache_bucket_end(end: DateTime<Utc>) -> Result<DateTime<Utc>, ApiError> {
-    let bucket_seconds = DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS as i64;
-    let bucket_epoch = end.timestamp().div_euclid(bucket_seconds) * bucket_seconds;
-    Utc.timestamp_opt(bucket_epoch, 0)
-        .single()
-        .ok_or_else(|| ApiError::from(anyhow!("invalid dashboard activity cache bucket epoch")))
 }
 
 fn sort_dashboard_activity_accounts(accounts: &mut [DashboardActivityAccountResponse]) {
@@ -8816,6 +8770,11 @@ async fn load_dashboard_activity_live_recent_invocations_by_account(
         source_scope,
         range,
         recent_limit,
+        UpstreamAccountActivityPreviewReadTelemetry {
+            route: "dashboard",
+            builder: "live_recent_overlay",
+            purpose: "bounded_per_account_recent",
+        },
     )
     .await?;
     overlay_runtime_upstream_account_activity_preview_rows(state, &mut rows, source_scope, range);
@@ -9165,6 +9124,11 @@ async fn load_dashboard_activity_current_minute_rows(
         None,
         None,
         false,
+        UpstreamAccountActivityPreviewReadTelemetry {
+            route: "dashboard",
+            builder: "current_minute",
+            purpose: "current_minute_preview_rows",
+        },
     )
     .await?;
     let mut rows_by_key = rows
@@ -9739,6 +9703,23 @@ enum DashboardActivityAccountBuilderKind {
     UpstreamAccount,
 }
 
+impl DashboardActivityAccountBuilderKind {
+    fn preview_read_telemetry(self) -> UpstreamAccountActivityPreviewReadTelemetry {
+        match self {
+            Self::DashboardFull => UpstreamAccountActivityPreviewReadTelemetry {
+                route: "dashboard",
+                builder: "dashboard_full",
+                purpose: "bounded_per_account_recent",
+            },
+            Self::UpstreamAccount => UpstreamAccountActivityPreviewReadTelemetry {
+                route: "upstream_account",
+                builder: "upstream_account",
+                purpose: "bounded_per_account_recent",
+            },
+        }
+    }
+}
+
 #[derive(Debug)]
 struct DashboardActivityAccountBuildResult {
     accounts: Vec<DashboardActivityAccountResponse>,
@@ -10135,182 +10116,6 @@ async fn load_dashboard_activity_account_build_result(
         }
     }
 
-    let mut runtime_rows = query_live_upstream_account_activity_preview_rows_with_limit(
-        &state.pool,
-        source_scope,
-        range,
-        None,
-        None,
-        true,
-    )
-    .await?;
-    overlay_runtime_upstream_account_activity_preview_rows(
-        state,
-        &mut runtime_rows,
-        source_scope,
-        range,
-    );
-    let mut runtime_recent_rows =
-        HashMap::<Option<i64>, Vec<UpstreamAccountInvocationPreviewRow>>::new();
-    let mut runtime_recent_by_key =
-        HashMap::<(String, String), UpstreamAccountInvocationPreviewRow>::new();
-    for row in &runtime_rows {
-        runtime_recent_by_key.insert(
-            (row.invoke_id.clone(), row.occurred_at.clone()),
-            row.clone(),
-        );
-    }
-    let mut terminal_rows = Vec::new();
-    for record in state.proxy_runtime_invocations.snapshot() {
-        if matches!(
-            normalized_runtime_text(record.status.as_deref()).as_str(),
-            "running" | "pending"
-        ) {
-            continue;
-        }
-        let Some(row) =
-            runtime_upstream_account_activity_preview_row_with_terminal(record, source_scope, true)
-        else {
-            continue;
-        };
-        let Some(occurred_at) = parse_to_utc_datetime(&row.occurred_at) else {
-            continue;
-        };
-        if occurred_at < range.start || occurred_at >= range.end {
-            continue;
-        }
-        terminal_rows.push(((row.invoke_id.clone(), row.occurred_at.clone()), row));
-    }
-    let fallback_keys = terminal_rows
-        .iter()
-        .filter(|(_, row)| row.upstream_account_id.is_none())
-        .map(|(key, _)| key.clone())
-        .collect::<HashSet<_>>();
-    let fallback_rows =
-        query_runtime_recent_account_fallback_rows(&state.pool, source_scope, &fallback_keys)
-            .await?
-            .into_iter()
-            .map(|row| ((row.invoke_id.clone(), row.occurred_at.clone()), row))
-            .collect::<HashMap<_, _>>();
-    for (key, mut row) in terminal_rows {
-        if let Some(existing) = runtime_recent_by_key.get(&key) {
-            if row.upstream_account_id.is_none() {
-                row.upstream_account_id = existing.upstream_account_id;
-            }
-            if row.upstream_account_name.is_none() {
-                row.upstream_account_name = existing.upstream_account_name.clone();
-            }
-            if row.upstream_account_plan_type.is_none() {
-                row.upstream_account_plan_type = existing.upstream_account_plan_type.clone();
-            }
-        }
-        if let Some(fallback) = fallback_rows.get(&key) {
-            if row.upstream_account_id.is_none() {
-                row.upstream_account_id = fallback.upstream_account_id;
-            }
-            if row.upstream_account_name.is_none() {
-                row.upstream_account_name = fallback.upstream_account_name.clone();
-            }
-            if row.upstream_account_plan_type.is_none() {
-                row.upstream_account_plan_type = fallback.upstream_account_plan_type.clone();
-            }
-        }
-        runtime_recent_by_key.insert(key, row);
-    }
-    for row in runtime_recent_by_key.into_values() {
-        runtime_recent_rows
-            .entry(row.upstream_account_id)
-            .or_default()
-            .push(row);
-    }
-    for rows in runtime_recent_rows.values_mut() {
-        rows.sort_by(|left, right| {
-            right
-                .occurred_at
-                .cmp(&left.occurred_at)
-                .then_with(|| right.id.cmp(&left.id))
-        });
-    }
-    for (account_id, rows) in &runtime_recent_rows {
-        let entry = account_activity.entry(*account_id).or_default();
-        if let Some(row) = rows.first() {
-            entry.last_occurred_at_epoch_ms = parse_to_utc_datetime(&row.occurred_at).map_or(
-                entry.last_occurred_at_epoch_ms,
-                |occurred_at| {
-                    entry
-                        .last_occurred_at_epoch_ms
-                        .max(occurred_at.timestamp_millis())
-                },
-            );
-            if entry.display_name_hint.is_none() {
-                entry.display_name_hint =
-                    normalize_trimmed_optional_string_local(row.upstream_account_name.clone());
-            }
-            if entry.plan_type_hint.is_none() {
-                entry.plan_type_hint =
-                    normalize_trimmed_optional_string_local(row.upstream_account_plan_type.clone());
-            }
-        }
-    }
-    let live_ids = runtime_rows
-        .iter()
-        .map(|row| row.id)
-        .collect::<HashSet<_>>();
-    for row in runtime_rows {
-        add_upstream_account_activity_preview_row(
-            &mut account_activity,
-            row,
-            recent_limit,
-            include_recent,
-        );
-    }
-
-    if include_recent && range.start < retention_cutoff {
-        let mut archived_rows = crate::stats::query_completed_invocation_archive_preview_rows(
-            &state.pool,
-            source_scope,
-            range,
-            Some(&live_ids),
-        )
-        .await?;
-        let archived_row_ids = archived_rows.iter().map(|row| row.id).collect::<Vec<_>>();
-        let persisted_live_ids = query_live_upstream_account_activity_existing_invocation_ids(
-            &state.pool,
-            source_scope,
-            &archived_row_ids,
-        )
-        .await?;
-        archived_rows.retain(|row| !persisted_live_ids.contains(&row.id));
-        archived_rows.sort_by(|left, right| {
-            right
-                .occurred_at
-                .cmp(&left.occurred_at)
-                .then_with(|| right.id.cmp(&left.id))
-        });
-        for row in archived_rows {
-            let Some(occurred_at) = parse_to_utc_datetime(&row.occurred_at) else {
-                continue;
-            };
-            let entry = account_activity.entry(row.upstream_account_id).or_default();
-            entry.last_occurred_at_epoch_ms = entry
-                .last_occurred_at_epoch_ms
-                .max(occurred_at.timestamp_millis());
-            if entry.display_name_hint.is_none() {
-                entry.display_name_hint =
-                    normalize_trimmed_optional_string_local(row.upstream_account_name.clone());
-            }
-            if entry.plan_type_hint.is_none() {
-                entry.plan_type_hint =
-                    normalize_trimmed_optional_string_local(row.upstream_account_plan_type.clone());
-            }
-            if entry.recent_invocations.len() < recent_limit {
-                entry
-                    .recent_invocations
-                    .push(upstream_account_invocation_preview_from_row(row));
-            }
-        }
-    }
-
     if include_recent {
         let hydrated_rows =
             query_live_upstream_account_activity_preview_rows_per_account_limit_with_stats(
@@ -10318,6 +10123,7 @@ async fn load_dashboard_activity_account_build_result(
                 source_scope,
                 range,
                 recent_limit,
+                builder_kind.preview_read_telemetry(),
             )
             .await?;
         build_telemetry = DashboardActivityBuildTelemetry {
@@ -10327,21 +10133,51 @@ async fn load_dashboard_activity_account_build_result(
         };
         let mut recent_rows_by_account =
             HashMap::<Option<i64>, Vec<PromptCacheConversationInvocationPreviewResponse>>::new();
-        for (upstream_account_id, runtime_rows) in runtime_recent_rows {
-            recent_rows_by_account
-                .entry(upstream_account_id)
-                .or_default()
-                .extend(
-                    runtime_rows
-                        .into_iter()
-                        .map(upstream_account_invocation_preview_from_row),
-                );
-        }
-        for row in hydrated_rows.rows {
+        let mut recent_rows = hydrated_rows.rows;
+        overlay_runtime_upstream_account_activity_preview_rows(
+            state,
+            &mut recent_rows,
+            source_scope,
+            range,
+        );
+        overlay_runtime_terminal_upstream_account_activity_preview_rows(
+            state,
+            &mut recent_rows,
+            source_scope,
+            range,
+        )
+        .await?;
+        let live_ids = recent_rows.iter().map(|row| row.id).collect::<HashSet<_>>();
+        for row in recent_rows {
+            merge_upstream_account_activity_recent_row_metadata(&mut account_activity, &row);
             recent_rows_by_account
                 .entry(row.upstream_account_id)
                 .or_default()
                 .push(upstream_account_invocation_preview_from_row(row));
+        }
+        if range.start < retention_cutoff {
+            let mut archived_rows = crate::stats::query_completed_invocation_archive_preview_rows(
+                &state.pool,
+                source_scope,
+                range,
+                Some(&live_ids),
+            )
+            .await?;
+            let archived_row_ids = archived_rows.iter().map(|row| row.id).collect::<Vec<_>>();
+            let persisted_live_ids = query_live_upstream_account_activity_existing_invocation_ids(
+                &state.pool,
+                source_scope,
+                &archived_row_ids,
+            )
+            .await?;
+            archived_rows.retain(|row| !persisted_live_ids.contains(&row.id));
+            for row in archived_rows {
+                merge_upstream_account_activity_recent_row_metadata(&mut account_activity, &row);
+                recent_rows_by_account
+                    .entry(row.upstream_account_id)
+                    .or_default()
+                    .push(upstream_account_invocation_preview_from_row(row));
+            }
         }
         for (upstream_account_id, mut recent_rows) in recent_rows_by_account {
             let entry = account_activity.entry(upstream_account_id).or_default();
@@ -10463,6 +10299,10 @@ async fn load_dashboard_activity_snapshot_cached(
                 cache_bypass_reason: "yesterday_exact",
                 coalesced_waiter_count: 0,
                 db_build_elapsed_ms: started_at.elapsed().as_millis() as u64,
+                cache_ttl_ms: 0,
+                cache_entry_age_ms: 0,
+                cache_entry_count: 0,
+                in_flight_count: 0,
             },
         ));
     }
@@ -10480,20 +10320,23 @@ async fn load_dashboard_activity_snapshot_cached(
     );
     let mut waited_on_in_flight = false;
     let mut max_waiter_count = 0_usize;
+    let cache_ttl = Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS);
+    let cache_ttl_ms = DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS * 1_000;
 
     loop {
         let mut wait_on: Option<tokio::sync::watch::Receiver<bool>> = None;
         let mut flight_guard: Option<DashboardActivitySnapshotFlightGuard> = None;
         {
             let mut cache = state.dashboard_activity_snapshot_cache.lock().await;
-            cache.entries.retain(|_, entry| {
-                entry.cached_at.elapsed()
-                    <= Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS)
-            });
+            cache
+                .entries
+                .retain(|_, entry| entry.cached_at.elapsed() <= cache_ttl);
+            let cache_entry_count = cache.entries.len();
+            let in_flight_count = cache.in_flight.len();
             if let Some(entry) = cache.entries.get(&selection)
-                && entry.cached_at.elapsed()
-                    <= Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS)
+                && entry.cached_at.elapsed() <= cache_ttl
             {
+                let cache_entry_age_ms = entry.cached_at.elapsed().as_millis() as u64;
                 return Ok((
                     entry.response.clone(),
                     DashboardActivitySnapshotCacheOutcome {
@@ -10505,6 +10348,10 @@ async fn load_dashboard_activity_snapshot_cached(
                         cache_bypass_reason: "none",
                         coalesced_waiter_count: max_waiter_count,
                         db_build_elapsed_ms: 0,
+                        cache_ttl_ms,
+                        cache_entry_age_ms,
+                        cache_entry_count,
+                        in_flight_count,
                     },
                 ));
             }
@@ -10569,6 +10416,8 @@ async fn load_dashboard_activity_snapshot_cached(
             }
             let _ = in_flight.signal.send(true);
         }
+        let cache_entry_count = cache.entries.len();
+        let in_flight_count = cache.in_flight.len();
 
         return result.map(|snapshot| {
             (
@@ -10578,6 +10427,10 @@ async fn load_dashboard_activity_snapshot_cached(
                     cache_bypass_reason: "none",
                     coalesced_waiter_count,
                     db_build_elapsed_ms,
+                    cache_ttl_ms,
+                    cache_entry_age_ms: 0,
+                    cache_entry_count,
+                    in_flight_count,
                 },
             )
         });
@@ -10753,6 +10606,10 @@ pub(crate) async fn fetch_dashboard_activity(
             cache_bypass_reason = cache_outcome.cache_bypass_reason,
             coalesced_waiter_count = cache_outcome.coalesced_waiter_count,
             db_build_elapsed_ms = cache_outcome.db_build_elapsed_ms,
+            cache_ttl_ms = cache_outcome.cache_ttl_ms,
+            cache_entry_age_ms = cache_outcome.cache_entry_age_ms,
+            cache_entry_count = cache_outcome.cache_entry_count,
+            in_flight_count = cache_outcome.in_flight_count,
             live_overlay_elapsed_ms,
             preview_read_mode = build_telemetry.preview_read_mode,
             candidate_preview_id_count = build_telemetry.candidate_preview_id_count,
@@ -10777,6 +10634,10 @@ pub(crate) async fn fetch_dashboard_activity(
             cache_bypass_reason = cache_outcome.cache_bypass_reason,
             coalesced_waiter_count = cache_outcome.coalesced_waiter_count,
             db_build_elapsed_ms = cache_outcome.db_build_elapsed_ms,
+            cache_ttl_ms = cache_outcome.cache_ttl_ms,
+            cache_entry_age_ms = cache_outcome.cache_entry_age_ms,
+            cache_entry_count = cache_outcome.cache_entry_count,
+            in_flight_count = cache_outcome.in_flight_count,
             live_overlay_elapsed_ms,
             preview_read_mode = build_telemetry.preview_read_mode,
             candidate_preview_id_count = build_telemetry.candidate_preview_id_count,
@@ -10821,6 +10682,11 @@ pub(crate) async fn fetch_dashboard_activity_recent(
         source_scope,
         range,
         recent_limit,
+        UpstreamAccountActivityPreviewReadTelemetry {
+            route: "dashboard_recent",
+            builder: "dashboard_recent",
+            purpose: "bounded_per_account_recent",
+        },
     )
     .await?;
     overlay_runtime_upstream_account_activity_preview_rows(

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -1009,8 +1009,7 @@ impl Drop for PromptCacheConversationFlightGuard {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct DashboardActivitySnapshotSelection {
     pub(crate) range: String,
-    pub(crate) range_start: String,
-    pub(crate) range_end: String,
+    pub(crate) range_anchor: String,
     pub(crate) time_zone: String,
     pub(crate) source_scope: String,
     pub(crate) recent_limit: usize,

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -13072,7 +13072,7 @@ async fn dashboard_activity_summary_rates_and_in_progress_are_account_sum() {
             .map(|account| account.total_tokens)
             .sum::<i64>(),
     );
-    assert_eq!(activity.summary().stats.total_tokens, 16_899);
+    assert_eq!(activity.summary().stats.total_tokens, 1_900);
     assert_f64_close(
         activity.summary().stats.total_cost,
         accounts
@@ -13467,7 +13467,7 @@ async fn dashboard_activity_summary_rates_and_in_progress_are_account_sum() {
     assert!(
         progressive_accounts
             .iter()
-            .any(|account| account.account_key == "upstream:88")
+            .all(|account| account.account_key != "upstream:88")
     );
     let Json(recent_response) = fetch_dashboard_activity_recent(
         State(state.clone()),

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -12250,7 +12250,7 @@ async fn upstream_account_activity_groups_active_accounts_and_hides_yesterday_li
     assert_eq!(account.sync_state, "idle");
     assert_eq!(account.last_error, None);
     assert_eq!(account.last_action_reason_message, None);
-    assert_eq!(account.request_count, 6);
+    assert_eq!(account.request_count, 3);
     assert_eq!(account.success_count, 2);
     assert_eq!(account.failure_count, 1);
     assert_eq!(account.non_success_count, 1);
@@ -12258,7 +12258,7 @@ async fn upstream_account_activity_groups_active_accounts_and_hides_yesterday_li
     assert_eq!(account.non_success_tokens, 200);
     assert_eq!(account.failure_tokens, 200);
     assert_f64_close(account.failure_cost, 0.20);
-    assert_f64_close(account.total_cost, 0.84);
+    assert_f64_close(account.total_cost, 0.62);
     assert_f64_close(
         account
             .first_byte_avg_ms
@@ -12393,6 +12393,156 @@ async fn upstream_account_activity_groups_active_accounts_and_hides_yesterday_li
             .accounts
             .iter()
             .all(|account| account.retry_invocation_count.is_none())
+    );
+}
+
+#[tokio::test]
+async fn upstream_account_activity_ignores_stale_persisted_in_progress_rows_for_totals() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let created_at = format_utc_iso(Utc::now());
+    sqlx::query(
+        r#"
+        INSERT INTO pool_upstream_accounts (
+            id, kind, provider, display_name, group_name, plan_type, status, enabled, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        "#,
+    )
+    .bind(42_i64)
+    .bind("api_key_codex")
+    .bind("codex")
+    .bind("Pool Alpha")
+    .bind("Primary")
+    .bind("enterprise")
+    .bind("active")
+    .bind(1_i64)
+    .bind(&created_at)
+    .bind(&created_at)
+    .execute(&state.pool)
+    .await
+    .expect("insert upstream account for stale persisted running rows");
+
+    let base_local = Utc::now().with_timezone(&Shanghai).naive_local();
+    for id in 0..20_i64 {
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                id, invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            "#,
+        )
+        .bind(96_000_i64 + id)
+        .bind(format!("stale-upstream-running-{id}"))
+        .bind(format_naive(
+            base_local
+                .checked_sub_signed(ChronoDuration::days(6))
+                .and_then(|value| value.checked_add_signed(ChronoDuration::seconds(id)))
+                .expect("valid stale running time"),
+        ))
+        .bind(SOURCE_PROXY)
+        .bind("running")
+        .bind(0_i64)
+        .bind(0.0_f64)
+        .bind(
+            json!({
+                "promptCacheKey": format!("pck-stale-upstream-running-{id}"),
+                "upstreamAccountId": 42_i64,
+                "upstreamAccountName": "Pool Alpha"
+            })
+            .to_string(),
+        )
+        .bind("{}")
+        .execute(&state.pool)
+        .await
+        .expect("insert stale persisted running invocation");
+    }
+    for (id, invoke_id, minutes_ago, total_tokens, cost) in [
+        (
+            97_001_i64,
+            "recent-upstream-success-old",
+            2_i64,
+            120_i64,
+            0.12_f64,
+        ),
+        (
+            97_002_i64,
+            "recent-upstream-success-new",
+            1_i64,
+            240_i64,
+            0.24_f64,
+        ),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                id, invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            "#,
+        )
+        .bind(id)
+        .bind(invoke_id)
+        .bind(format_naive(
+            base_local
+                .checked_sub_signed(ChronoDuration::minutes(minutes_ago))
+                .expect("valid recent success time"),
+        ))
+        .bind(SOURCE_PROXY)
+        .bind("success")
+        .bind(total_tokens)
+        .bind(cost)
+        .bind(
+            json!({
+                "promptCacheKey": format!("pck-{invoke_id}"),
+                "upstreamAccountId": 42_i64,
+                "upstreamAccountName": "Pool Alpha"
+            })
+            .to_string(),
+        )
+        .bind("{}")
+        .execute(&state.pool)
+        .await
+        .expect("insert recent terminal invocation");
+    }
+
+    let Json(activity) = fetch_upstream_account_activity(
+        State(state),
+        Query(UpstreamAccountActivityQuery {
+            range: "7d".to_string(),
+            recent_limit: Some(2),
+            time_zone: Some("Asia/Shanghai".to_string()),
+        }),
+    )
+    .await
+    .expect("fetch upstream activity with stale persisted running rows");
+
+    assert_eq!(activity.accounts.len(), 1);
+    let account = activity
+        .accounts
+        .first()
+        .expect("stale persisted running account");
+    assert_eq!(account.upstream_account_id, 42);
+    assert_eq!(account.request_count, 2);
+    assert_eq!(account.success_count, 2);
+    assert_eq!(account.failure_count, 0);
+    assert_eq!(account.recent_invocations.len(), 2);
+    assert_eq!(
+        account.recent_invocations[0].invoke_id,
+        "recent-upstream-success-new"
+    );
+    assert_eq!(
+        account.recent_invocations[1].invoke_id,
+        "recent-upstream-success-old"
+    );
+    assert!(
+        account
+            .recent_invocations
+            .iter()
+            .all(|row| !row.invoke_id.starts_with("stale-upstream-running-"))
     );
 }
 
@@ -13734,18 +13884,12 @@ async fn dashboard_activity_cached_snapshot_overlays_new_live_accounts() {
     );
     {
         let cache = state.dashboard_activity_snapshot_cache.lock().await;
-        // The cached "today" selection rolls every 2 seconds, so a live-overlay refresh can
-        // legitimately leave both the previous and current fresh buckets resident.
         let selections = cache.entries.keys().cloned().collect::<Vec<_>>();
-        assert!(
-            (1..=2).contains(&selections.len()),
-            "expected one cached dashboard snapshot or a single rollover pair, got {}",
-            selections.len()
-        );
+        assert_eq!(selections.len(), 1);
         let baseline = selections.first().expect("dashboard cache selection");
         for selection in &selections {
             assert_eq!(selection.range, "today");
-            assert_eq!(selection.range_start, baseline.range_start);
+            assert_eq!(selection.range_anchor, baseline.range_anchor);
             assert_eq!(selection.time_zone, baseline.time_zone);
             assert_eq!(selection.source_scope, baseline.source_scope);
             assert_eq!(selection.recent_limit, baseline.recent_limit);
@@ -14063,7 +14207,7 @@ async fn dashboard_activity_summary_only_excludes_archived_rows_for_live_ids() {
 }
 
 #[tokio::test]
-async fn dashboard_activity_cache_key_uses_bucketed_rolling_window() {
+async fn dashboard_activity_cache_selection_reuses_today_snapshot_within_five_second_ttl() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
@@ -14084,10 +14228,7 @@ async fn dashboard_activity_cache_key_uses_bucketed_rolling_window() {
 
     let first_range_end =
         parse_to_utc_datetime(&first_response.range_end).expect("first range end should parse");
-    let next_bucket =
-        first_range_end + ChronoDuration::seconds(2) + ChronoDuration::milliseconds(50);
-    let sleep_ms = (next_bucket - Utc::now()).num_milliseconds().max(1) as u64;
-    tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(2_100)).await;
 
     let Json(second_response) = fetch_dashboard_activity(
         State(state.clone()),
@@ -14106,6 +14247,16 @@ async fn dashboard_activity_cache_key_uses_bucketed_rolling_window() {
         parse_to_utc_datetime(&second_response.range_end).expect("second range end should parse");
     assert!(second_range_end > first_range_end);
     assert!(second_response.snapshot_id > first_response.snapshot_id);
+    let cache = state.dashboard_activity_snapshot_cache.lock().await;
+    assert_eq!(cache.entries.len(), 1);
+    let selection = cache
+        .entries
+        .keys()
+        .next()
+        .expect("cached dashboard selection");
+    assert_eq!(selection.range, "today");
+    assert!(!selection.range_anchor.is_empty());
+    assert!(cache.in_flight.is_empty());
 }
 
 #[tokio::test]
@@ -15712,7 +15863,7 @@ async fn upstream_account_activity_uses_pool_attempt_account_for_running_rows() 
         .expect("fallback activity account");
     assert_eq!(account.upstream_account_id, 77);
     assert_eq!(account.display_name, "Pool Fallback");
-    assert_eq!(account.request_count, 2);
+    assert_eq!(account.request_count, 1);
     assert_eq!(account.failure_count, 1);
     assert_eq!(account.total_tokens, 0);
     assert_f64_close(account.total_cost, 0.0);


### PR DESCRIPTION
## Summary
- stabilize non-`yesterday` dashboard activity base snapshot cache selection for 5s reuse
- remove range-wide persisted in-progress preview scans from dashboard/upstream-account recent builders
- refresh telemetry, spec history, and stateful regressions for bounded preview semantics

## Validation
- cargo fmt --check
- cargo check
- cargo test -q upstream_account_activity
- cargo test -q dashboard_activity_cache

## References
- Specs: docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
- Solutions: docs/solutions/performance/realtime-dashboard-reconcile-budget.md
- Project Docs: -