### PR TITLE
fix(summary): remove open-range raw scan slow path

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -64,6 +64,7 @@ related_specs:
 - 如果某个 topic 仍需要短 TTL 的服务端 DB 基础快照缓存，cache key 只能包含稳定请求参数与明确允许的自然日锚点等低抖动维度；移动中的 exact `rangeStart/rangeEnd`、live runtime 状态、最新持久化行 ID 这类高抖动因子必须留在响应阶段 overlay，否则 singleflight 会被打散，订阅与 HTTP 都会继续重复重算同一份基底。对应的 invalidate 粒度也必须与同一 selection 对齐；单个 terminal 事件只能清掉匹配 selection，不能把整张 dashboard snapshot cache 一起 flush。
 - 对 `dashboard.activity.current` 这类 open-range topic，`live` 广播不应该再反向触发完整 DB snapshot builder。更稳妥的模式是：topic cache 内存 snapshot 直接覆写当前态字段并立即 fanout；terminal `records` 只负责安排一次 `<=TTL` 的节流 refresh，且 refresh 前必须失效对应的 dashboard snapshot cache，否则 deferred refresh 仍可能命中旧 TTL 快照，owner-facing totals 会比预算再多滞后一个窗口。
 - Dashboard / upstream-account 的 recent 预览不得再为了补当前态而对整个选中 range 扫 persisted `running/pending` 行；当前态应来自 runtime/live read model，旧持久化运行态最多只能作为 bounded recent 候选参与展示。
+- `stats.summary.current` 与 `/api/stats/summary` 的 open-range `usage_breakdown / non_success_tokens` 也不能再借道 raw preview rows 或 live invocation id overlap scan。若 summary 仍需要 `7d` / `today` / 长 duration 的模型分组或非成功 token，优先复用 live aggregate + archive aggregate merge；只有在 materialized archive 无法提供所需明细时，才允许显式 fallback/置空，而不是悄悄扫整窗 raw rows。
 - 与 Dashboard 同屏但不共享同一 owner-facing contract 的接口，不要为了“省实现”直接复用 dashboard full snapshot builder；应复用更低层的账户活动聚合块，避免把 summary/model-performance/reconcile 之类 dashboard-only 组装再次带回实时主链路。
 - 不要为 replay 失败发明第三条恢复路径。恢复规则只应是 replay 或 snapshot。
 - 手动“立即重连”不应偷偷复用旧 `resume` 去赌 replay 命中。若产品语义是“人工要求重新拉一份当前态”，前端就应该对 active topics 强制 fresh snapshot，并给这次连接分配独立 `attempt/reason` 供前后端对账。

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -15,6 +15,7 @@
 - 即使存在 active SSE 订阅者，terminal follow-up 也不应强制 `flush_now` 式 SQLite barrier；terminal overlay 是 UI 的立即收敛来源，summary/quota 可以在 write controller 后续 flush 后最终一致。
 - 对请求收尾里的同一实体写入，要优先消除“重复唯一键探测 + 紧跟二次更新”“先重算 rollup 再补 timing 再重算一次”这类单请求内自我放大；SQLite 压力常常不是来自单条大 SQL，而是来自几条语义重复的写语句连发。
 - 对 owner-facing 聚合读路径，同样要先消除“整窗扫明细再丢弃大部分结果”和“同参请求因 cache key 掺入 runtime 抖动而无法合并”这两类读放大；它们会和写侧单写者争用同一 SQLite 预算，并以 `database is locked` 的形式回灌到前台。
+- 对 summary open-range 这类总览接口，`usage_breakdown` 与 `non_success_tokens` 不能再为了 account/model 维度或 archive overlap 去扫整窗 raw preview rows、也不能先枚举整段 live invocation id 再和 archive 去重；这类明细必须优先落到 live aggregate + archive aggregate merge，否则 7d overview 会在看似“只读总览”时重新制造数据库压力。
 - 当并发不能降低且业务成功率高于观测记录完整性时，用进程内短窗口 write controller 承接所有观测记录写：terminal invocation 进入 P1 best-effort 队列，attempt 中间进度、rollup/live progress、account touch、system task finish 等可延迟项进入 P2 并按 key coalesce。记录入队/flush 失败必须报警和计数，但不得让已经完成的业务响应失败。
 - 高频 runtime snapshot 不应默认等同于主事实写。`running` / first-byte / response-ready 这类 UI 新鲜度事件可以先走进程内共享 runtime store + SSE/HTTP overlay；如果服务选择业务优先于记录，terminal success/failure 也可以先进入 P1 write controller，并用 SSE terminal payload + runtime tombstone 支撑短暂最终一致窗口。
 - 路由公平性字段如果不是路由正确性的硬状态，可以拆成“进程内立即生效 + batch 落库”。例如 `last_selected_at` 可先写内存锚点并叠加候选排序，账号 status/cooldown/failure 则继续同步写。
@@ -64,6 +65,7 @@
 - buffered progress 不能立刻广播“已持久化”的 DB snapshot；要么广播内存态，要么等后续 reconcile/terminal 更新。否则会把 stale DB state 伪装成实时状态。
 - 如果选择内存态广播，就必须让所有相关读方共享同一个 runtime store，包括 SSE、records open-resync、current summary、current timeseries、账号活动 in-flight 统计与 prompt-cache working conversations；否则去掉 DB running 写后会产生多套不一致实时视图。
 - Dashboard / account activity 这类短 TTL 聚合快照，如果允许 `<=2s` 的服务端合并刷新预算，就不应再把 live runtime 状态或最新持久化行 ID 放进 cache key；否则表面上有 singleflight，实测仍会长期 `wait_on_in_flight=0`，既保不住实时性，也保不住 SQLite。
+- 如果 `stats.summary.current` 与 `/api/stats/summary` 共享同一 owner-facing contract，就必须共享同一内部 summary builder 与相同的 aggregate/fallback 语义；不要让 topic 侧通过 route wrapper 间接复用旧慢链，否则线上会出现“HTTP 已修、SSE 仍慢读”的假收敛。
 - `INSERT OR IGNORE` 会静默吞掉 `NOT NULL` 约束错误；用于占位写时必须绑定所有 NOT NULL 默认列，或者检查 `rows_affected` 并记录结构化证据，否则会误以为 batch flush 成功。
 - 为每个后台入口单独做局部退避，容易遗漏同一压力窗口内的其他维护任务；进程级 gate 更容易统一行为。
 - `SELECT MAX(id) ... WHERE <稀疏条件>`、`NOT EXISTS` + 低选择性 phase 过滤这类查询，即使最终只返回 1 行，也可能在 SQLite 上吃掉秒级读锁预算；若它们会与前台 HTTP 共享同一数据库，必须先压成 cursor 读取或用 partial index 固定扫描面。

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Key Decisions
 
+- 2026-07-20：`stats.summary.current` 的 open-range 残留慢链从旧 HTTP summary 构建器完全收口到共享内部 builder；同轮把 `usage_breakdown` 和 `non_success_tokens` 改成 live/archive aggregate merge，去掉 `full_range_preview_rows(limit=None)` 与 live invocation id overlap 全窗扫描，避免 topic SSE 与 Dashboard 7d overview 再次把 summary 读压打回 SQLite。
 - 2026-07-17：手动“立即重连”被收紧为同页 fresh snapshot 恢复，而不是“复用旧 resume 的软重连”或整页刷新。前端现在为每次连接分配 `attempt` 和 `reason`，手动重连会对当前 active topics 全量 forced snapshot，并把同一轮证据同时暴露到黄条诊断文本与后端 `/events` 初始化日志。
 - 2026-07-17：浏览器 drill 暴露出一个更底层的缺口：等价 topic descriptor 在 React 重渲时会反复退订/重订，叠加 `eventsource-error` 的立即重连，能把 `attempt` 冲到数千次。现已把订阅稳定性下沉到 `useSubscriptionTopic` 的语义 key，并把失败恢复重新收紧为指数退避。
 - 2026-07-16：主应用常驻订阅从“`records` SSE + HTTP bootstrap/open-resync/reconcile + 页面私有 fallback”一次性切到单 `/events` 的 topic SSE 合同。覆盖范围内连接只消费 `snapshot/replay/live` envelope；恢复只走 replay 或新 snapshot，不再偷偷打 HTTP。

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -23,6 +23,7 @@
 - 已实现：开发环境把当前页使用中的 SSE 单例以 `window.__CVM_SSE__` 暴露出来，仅用于浏览器 drill 与诊断，不进入生产路径。
 - 已实现：`AppLayout` 版本信息切到 `app.version` topic，主应用 shell 不再额外打 `/api/version` 作为首屏 bootstrap。
 - 已实现：订阅 envelope 统一以 camelCase `topicKey/schemaEpoch` 对外发送；前端消费层同时兼容历史 `topic_key/schema_epoch`，避免灰度期间把 authoritative snapshot 吞掉。
+- 已实现：`stats.summary.current` 与 `/api/stats/summary` 现共享同一套内部 summary range builder；open-range `usage_breakdown` 与 `non_success_tokens` 已改为 live/archive aggregate merge，不再经 `full_range_preview_rows(limit=None)` 或 live-id overlap 全窗扫描构建。
 
 ## Migrated consumers
 

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## Decision Trace
 
+- 2026-07-20：Dashboard 7d 总览残留慢点确认不只来自 account activity；同轮把 `/api/stats/summary` 与 `stats.summary.current` 的 open-range `usage_breakdown / non_success_tokens` 改成 aggregate-only builder，移除 raw preview 全窗扫描与 live-id overlap 扫描，避免 overview bundle 在 `fetchDashboardActivity("7d") + fetchSummary("7d")` 下继续把 SQLite 压力打回读侧。
 - 2026-07-20：落实 Dashboard 读侧 CPU 修复。`upstream-account-activity` 与 dashboard full path 不再对完整 `7d` range 做 persisted `running/pending` preview 扫描，recent 改为“每账号 bounded candidate + hydration + runtime/live overlay”；同日把 non-`yesterday` dashboard 基础快照缓存收敛为稳定请求参数选择键与 `5s` TTL，并补齐 `route / builder / purpose / limit / cache_ttl_ms / cache_entry_age_ms / cache_entry_count / in_flight_count` 遥测，便于线上继续判定是缓存未合并还是 preview 仍过宽。
 - 2026-07-20：收紧 Dashboard 对话卡片 `当前调用 / 上一条调用` 的可见用量行。此前槽位常驻展示 `IN / CW / C / O / T / $`，在窄卡里噪声偏高；本轮冻结为只显示 `Hit / Token / $` 三项，其中 `Hit` 口径固定为 `cacheInputTokens / totalTokens`，成本值复用金额主题 accent，而完整 token/cost/reasoning 明细继续保留在 hover/title，避免压缩卡面时丢失诊断能力。
 - 2026-07-19：101 线上 12 小时复盘确认 `dashboard-activity full` 慢点仍主要来自读侧合并不足，而不是内存瓶颈。已冻结两条后续约束：一，non-`yesterday` 基础快照缓存只允许按稳定请求参数 + 短 TTL 合并，不能再把 live runtime 状态或最新持久化行 ID 放进选择键；二，`/api/stats/upstream-account-activity` 不得继续借道 dashboard full snapshot，必须走独立账户活动 builder，并补足 route/builder/preview hydration telemetry 便于下一轮定位残余慢点。

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -4799,6 +4799,7 @@ pub(crate) async fn fetch_stats(
             include_in_progress: true,
             include_non_success_tokens: false,
         },
+        None,
     )
     .await?;
     apply_summary_live_augmentation(&mut response, augmentation);
@@ -4816,6 +4817,121 @@ pub(crate) async fn load_in_progress_conversation_count(
             .await?
             .in_progress_count,
     )
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SummaryBuildRoute {
+    Http,
+    Topic,
+}
+
+impl SummaryBuildRoute {
+    fn telemetry_route(self) -> &'static str {
+        match self {
+            Self::Http => "summary_http",
+            Self::Topic => "summary_topic",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SummaryRangeBuildTelemetry {
+    route: SummaryBuildRoute,
+    window_kind: &'static str,
+    window_name: &'static str,
+}
+
+impl SummaryRangeBuildTelemetry {
+    fn new(
+        route: SummaryBuildRoute,
+        window: &SummaryWindow,
+        requested_window: Option<&str>,
+    ) -> Self {
+        let window_kind = match window {
+            SummaryWindow::Duration(_) => "duration",
+            SummaryWindow::Calendar(_) => "calendar",
+            SummaryWindow::PreviousFullDays(_) => "previous_full_days",
+            SummaryWindow::All => "all",
+            SummaryWindow::Current(_) => "current",
+        };
+        let window_name = match window {
+            SummaryWindow::Duration(_) => match requested_window {
+                Some("7d") => "7d",
+                Some("1d") | None => "1d",
+                _ => "range",
+            },
+            SummaryWindow::Calendar(spec) => match spec.as_str() {
+                "today" => "today",
+                "yesterday" => "yesterday",
+                _ => "range",
+            },
+            SummaryWindow::PreviousFullDays(7) => "previous7d",
+            _ => "range",
+        };
+        Self {
+            route,
+            window_kind,
+            window_name,
+        }
+    }
+
+    fn route_label(self) -> &'static str {
+        self.route.telemetry_route()
+    }
+}
+
+fn emit_summary_range_builder_telemetry(
+    telemetry: SummaryRangeBuildTelemetry,
+    builder: &'static str,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+    aggregation_mode: &'static str,
+    archive_overlap_strategy: &'static str,
+    live_group_row_count: usize,
+    archive_group_row_count: usize,
+    live_row_scan_mode: &'static str,
+    live_id_overlap_scan_mode: &'static str,
+    elapsed_ms: u64,
+) {
+    let route = telemetry.route_label();
+    let group_row_count = live_group_row_count + archive_group_row_count;
+    if elapsed_ms >= 250 {
+        tracing::warn!(
+            route,
+            builder,
+            ?source_scope,
+            upstream_account_id,
+            window_kind = telemetry.window_kind,
+            window_name = telemetry.window_name,
+            aggregation_mode,
+            archive_overlap_strategy,
+            live_group_row_count,
+            archive_group_row_count,
+            group_row_count,
+            live_row_scan_mode,
+            live_id_overlap_scan_mode,
+            elapsed_ms,
+            "summary range builder exceeded slow-path threshold"
+        );
+    } else {
+        tracing::debug!(
+            route,
+            builder,
+            ?source_scope,
+            upstream_account_id,
+            window_kind = telemetry.window_kind,
+            window_name = telemetry.window_name,
+            aggregation_mode,
+            archive_overlap_strategy,
+            live_group_row_count,
+            archive_group_row_count,
+            group_row_count,
+            live_row_scan_mode,
+            live_id_overlap_scan_mode,
+            elapsed_ms,
+            "summary range builder completed"
+        );
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -4862,6 +4978,7 @@ pub(crate) async fn load_summary_live_augmentation(
     upstream_account_id: Option<i64>,
     range: Option<(DateTime<Utc>, DateTime<Utc>)>,
     policy: SummaryLiveAugmentationPolicy,
+    range_telemetry: Option<SummaryRangeBuildTelemetry>,
 ) -> Result<SummaryLiveAugmentation, ApiError> {
     let in_progress = if policy.include_in_progress {
         let snapshot =
@@ -4877,8 +4994,19 @@ pub(crate) async fn load_summary_live_augmentation(
     };
     let non_success_tokens = if policy.include_non_success_tokens {
         if let Some((start, end)) = range {
-            load_non_success_tokens_snapshot(state, source_scope, upstream_account_id, start, end)
-                .await?
+            let telemetry = range_telemetry.ok_or_else(|| {
+                ApiError::from(anyhow!(
+                    "summary range telemetry is required for non-success token augmentation"
+                ))
+            })?;
+            load_non_success_tokens_snapshot(
+                state,
+                source_scope,
+                upstream_account_id,
+                ExactUtcRange { start, end },
+                telemetry,
+            )
+            .await?
         } else {
             None
         }
@@ -5203,194 +5331,144 @@ pub(crate) async fn load_non_success_tokens_snapshot(
     state: &AppState,
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
-    start: DateTime<Utc>,
-    end: DateTime<Utc>,
+    range: ExactUtcRange,
+    telemetry: SummaryRangeBuildTelemetry,
 ) -> Result<Option<i64>, ApiError> {
     let started_at = Instant::now();
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT \
-            COALESCE(SUM(COALESCE(total_tokens, 0)), 0) AS non_success_tokens \
-         FROM codex_invocations \
-         WHERE occurred_at >= ",
-    );
-    query
-        .push_bind(db_occurred_at_lower_bound(start))
-        .push(" AND occurred_at < ")
-        .push_bind(db_occurred_at_upper_bound(end))
-        .push(" AND LOWER(TRIM(")
-        .push(invocation_display_status_sql())
-        .push(")) IN ('failed', 'interrupted')");
-
-    if source_scope == InvocationSourceScope::ProxyOnly {
-        query.push(" AND source = ").push_bind(SOURCE_PROXY);
-    }
-    if let Some(upstream_account_id) = upstream_account_id {
-        query
-            .push(" AND ")
-            .push(crate::api::INVOCATION_UPSTREAM_ACCOUNT_ID_SQL)
-            .push(" = ")
-            .push_bind(upstream_account_id);
-    }
-
-    let live_tokens = match query
-        .build_query_scalar::<i64>()
-        .fetch_one(&state.pool)
-        .await
-    {
-        Ok(tokens) => tokens,
-        Err(err) => {
-            let err = anyhow!(err);
-            if crate::is_sqlite_lock_error(&err) {
-                tracing::warn!(
-                    endpoint = "/api/stats/summary",
-                    window = "range",
-                    ?source_scope,
-                    upstream_account_id,
-                    start = %start,
-                    end = %end,
-                    "summary live non-success token snapshot skipped because sqlite is locked"
-                );
-                return Ok(None);
-            }
-            return Err(ApiError::from(err));
-        }
-    };
-
-    let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
-    if start >= retention_cutoff {
-        let elapsed_ms = started_at.elapsed().as_millis() as u64;
-        if elapsed_ms >= 250 {
-            tracing::warn!(
-                endpoint = "/api/stats/summary",
-                window = "range",
-                ?source_scope,
-                upstream_account_id,
-                cache_hit_or_miss = "live_only",
-                elapsed_ms,
-                row_count = 0_i64,
-                start = %start,
-                end = %end,
-                "summary non-success token snapshot exceeded slow-path threshold"
-            );
-        } else {
-            tracing::debug!(
-                endpoint = "/api/stats/summary",
-                window = "range",
-                ?source_scope,
-                upstream_account_id,
-                cache_hit_or_miss = "live_only",
-                elapsed_ms,
-                row_count = 0_i64,
-                start = %start,
-                end = %end,
-                "summary non-success token snapshot completed"
-            );
-        }
-        return Ok(Some(live_tokens));
-    }
-
-    let live_invocation_ids = match load_live_invocation_ids_in_range(
+    let live_rows = match query_live_upstream_account_activity_aggregate_rows(
         &state.pool,
         source_scope,
-        upstream_account_id,
-        start,
-        end,
+        range,
+        false,
+        DashboardActivityExcludedInvocationIdsFilter::None,
     )
     .await
     {
-        Ok(ids) => ids,
+        Ok(rows) => rows,
+        Err(err) => {
+            if let ApiError::Internal(ref internal) = err
+                && crate::is_sqlite_lock_error(internal)
+            {
+                tracing::warn!(
+                    route = telemetry.route_label(),
+                    builder = "summary_non_success_tokens",
+                    ?source_scope,
+                    upstream_account_id,
+                    window_kind = telemetry.window_kind,
+                    window_name = telemetry.window_name,
+                    aggregation_mode = "fallback",
+                    archive_overlap_strategy = "fallback",
+                    live_group_row_count = 0_usize,
+                    archive_group_row_count = 0_usize,
+                    live_row_scan_mode = "none",
+                    live_id_overlap_scan_mode = "fallback",
+                    start = %range.start,
+                    end = %range.end,
+                    "summary non-success token aggregate skipped because sqlite is locked"
+                );
+                return Ok(None);
+            }
+            return Err(err);
+        }
+    };
+    let live_group_row_count = live_rows.len();
+    let live_tokens = live_rows
+        .into_iter()
+        .filter(|row| {
+            upstream_account_id.is_none_or(|account_id| row.upstream_account_id == Some(account_id))
+        })
+        .map(|row| row.non_success_tokens)
+        .sum::<i64>();
+
+    let retention_cutoff = shanghai_retention_cutoff(state.config.invocation_max_days);
+    if range.start >= retention_cutoff {
+        let elapsed_ms = started_at.elapsed().as_millis() as u64;
+        emit_summary_range_builder_telemetry(
+            telemetry,
+            "summary_non_success_tokens",
+            source_scope,
+            upstream_account_id,
+            "aggregate_only",
+            "aggregate_merge",
+            live_group_row_count,
+            0,
+            "none",
+            "none",
+            elapsed_ms,
+        );
+        return Ok(Some(live_tokens));
+    }
+
+    let archive_rows = match query_completed_invocation_archive_activity_aggregate_rows(
+        &state.pool,
+        source_scope,
+        range,
+    )
+    .await
+    {
+        Ok(rows) => rows,
         Err(ApiError::Internal(err)) if crate::is_sqlite_lock_error(&err) => {
             tracing::warn!(
-                endpoint = "/api/stats/summary",
-                window = "range",
+                route = telemetry.route_label(),
+                builder = "summary_non_success_tokens",
                 ?source_scope,
                 upstream_account_id,
-                start = %start,
-                end = %end,
-                "summary archive overlap scan skipped because sqlite is locked"
+                window_kind = telemetry.window_kind,
+                window_name = telemetry.window_name,
+                aggregation_mode = "fallback",
+                archive_overlap_strategy = "fallback",
+                live_group_row_count,
+                archive_group_row_count = 0_usize,
+                live_row_scan_mode = "none",
+                live_id_overlap_scan_mode = "fallback",
+                start = %range.start,
+                end = %range.end,
+                "summary archive aggregate overlap merge skipped because sqlite is locked"
             );
             return Ok(None);
         }
         Err(err) => return Err(err),
     };
-    let archived_tokens = if let Some(upstream_account_id) = upstream_account_id {
-        match crate::stats::query_completed_upstream_account_archive_non_success_usage(
-            &state.pool,
+    let archive_group_row_count = archive_rows.aggregates.len();
+    if !archive_rows.skipped_materialized_ranges.is_empty() {
+        let elapsed_ms = started_at.elapsed().as_millis() as u64;
+        emit_summary_range_builder_telemetry(
+            telemetry,
+            "summary_non_success_tokens",
             source_scope,
-            Some((start, end)),
-            Some(&live_invocation_ids),
             upstream_account_id,
-        )
-        .await
-        {
-            Ok((_, tokens)) => tokens,
-            Err(err) if crate::is_sqlite_lock_error(&err) => {
-                tracing::warn!(
-                    endpoint = "/api/stats/summary",
-                    window = "range",
-                    ?source_scope,
-                    upstream_account_id,
-                    start = %start,
-                    end = %end,
-                    "summary archived non-success token lookup skipped because sqlite is locked"
-                );
-                return Ok(None);
-            }
-            Err(err) => return Err(ApiError::from(err)),
-        }
-    } else {
-        match crate::stats::query_completed_invocation_archive_non_success_usage(
-            &state.pool,
-            source_scope,
-            Some((start, end)),
-            Some(&live_invocation_ids),
-        )
-        .await
-        {
-            Ok((_, tokens)) => tokens,
-            Err(err) if crate::is_sqlite_lock_error(&err) => {
-                tracing::warn!(
-                    endpoint = "/api/stats/summary",
-                    window = "range",
-                    ?source_scope,
-                    start = %start,
-                    end = %end,
-                    "summary archived non-success token lookup skipped because sqlite is locked"
-                );
-                return Ok(None);
-            }
-            Err(err) => return Err(ApiError::from(err)),
-        }
-    };
-    let elapsed_ms = started_at.elapsed().as_millis() as u64;
-    let row_count = live_invocation_ids.len() as i64;
-    if elapsed_ms >= 250 {
-        tracing::warn!(
-            endpoint = "/api/stats/summary",
-            window = "range",
-            ?source_scope,
-            upstream_account_id,
-            cache_hit_or_miss = "live_plus_archive",
+            "fallback",
+            "fallback",
+            live_group_row_count,
+            archive_group_row_count,
+            "none",
+            "fallback",
             elapsed_ms,
-            row_count,
-            start = %start,
-            end = %end,
-            "summary non-success token snapshot exceeded slow-path threshold"
         );
-    } else {
-        tracing::debug!(
-            endpoint = "/api/stats/summary",
-            window = "range",
-            ?source_scope,
-            upstream_account_id,
-            cache_hit_or_miss = "live_plus_archive",
-            elapsed_ms,
-            row_count,
-            start = %start,
-            end = %end,
-            "summary non-success token snapshot completed"
-        );
+        return Ok(None);
     }
+    let archived_tokens = archive_rows
+        .aggregates
+        .into_iter()
+        .filter(|row| {
+            upstream_account_id.is_none_or(|account_id| row.upstream_account_id == Some(account_id))
+        })
+        .map(|row| row.non_success_tokens)
+        .sum::<i64>();
+    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    emit_summary_range_builder_telemetry(
+        telemetry,
+        "summary_non_success_tokens",
+        source_scope,
+        upstream_account_id,
+        "aggregate_only",
+        "aggregate_merge",
+        live_group_row_count,
+        archive_group_row_count,
+        "none",
+        "none",
+        elapsed_ms,
+    );
     Ok(Some(live_tokens + archived_tokens))
 }
 
@@ -5423,6 +5501,7 @@ pub(crate) async fn build_empty_summary_response(
             include_in_progress: true,
             include_non_success_tokens: false,
         },
+        None,
     )
     .await?;
     apply_summary_live_augmentation(&mut response, augmentation);
@@ -6814,7 +6893,7 @@ async fn query_live_upstream_account_usage_breakdown_rows(
         "COALESCE(NULLIF(TRIM({}), ''), NULLIF(TRIM(model), ''), 'unknown')",
         INVOCATION_RESPONSE_MODEL_SQL
     );
-    let reasoning_effort_sql = INVOCATION_REASONING_EFFORT_SQL;
+    let reasoning_effort_sql = format!("NULLIF(TRIM({}), '')", INVOCATION_REASONING_EFFORT_SQL);
     let cost_complete_sql = if has_cost_breakdown_columns {
         "cost_input IS NOT NULL AND cost_cache_write IS NOT NULL AND cost_cache_read IS NOT NULL AND cost_output IS NOT NULL AND cost_reasoning IS NOT NULL"
     } else {
@@ -6926,7 +7005,7 @@ async fn query_live_model_performance_duration_overrides(
         "COALESCE(NULLIF(TRIM({}), ''), NULLIF(TRIM(model), ''), 'unknown')",
         INVOCATION_RESPONSE_MODEL_SQL
     );
-    let reasoning_effort_sql = INVOCATION_REASONING_EFFORT_SQL;
+    let reasoning_effort_sql = format!("NULLIF(TRIM({}), '')", INVOCATION_REASONING_EFFORT_SQL);
     let occurred_at_epoch_ms_sql = "(CAST(CASE WHEN instr(occurred_at, 'T') > 0 THEN strftime('%s', occurred_at) ELSE strftime('%s', occurred_at || '+08:00') END AS REAL) * 1000.0)";
     let failure_class_sql = INVOCATION_RESOLVED_FAILURE_CLASS_SQL;
     let success_billed_sql = format!(
@@ -6940,7 +7019,7 @@ async fn query_live_model_performance_duration_overrides(
         .push(" AS upstream_account_id, ")
         .push(model_sql.as_str())
         .push(" AS model, ")
-        .push(reasoning_effort_sql)
+        .push(reasoning_effort_sql.as_str())
         .push(" AS reasoning_effort, ")
         .push(occurred_at_epoch_ms_sql)
         .push(" AS start_epoch_ms, MIN(")
@@ -7882,47 +7961,92 @@ pub(crate) async fn load_usage_breakdown_for_range(
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
     range: ExactUtcRange,
-) -> Result<UsageBreakdownResponse, ApiError> {
-    let account_metadata_table_count = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM sqlite_master \
-         WHERE type = 'table' \
-           AND name IN ('pool_upstream_accounts', 'pool_upstream_account_limit_samples')",
-    )
-    .fetch_one(&state.pool)
-    .await?;
-    let mut live_rows = if account_metadata_table_count == 2 {
-        query_live_upstream_account_activity_preview_rows(&state.pool, source_scope, range).await?
-    } else {
-        Vec::new()
-    };
-    overlay_runtime_upstream_account_activity_preview_rows(
-        state,
-        &mut live_rows,
+    telemetry: SummaryRangeBuildTelemetry,
+) -> Result<Option<UsageBreakdownResponse>, ApiError> {
+    let started_at = Instant::now();
+    let has_cost_breakdown_columns =
+        crate::stats::sqlite_table_has_column(&state.pool, "codex_invocations", "cost_input")
+            .await?;
+    let mut usage_breakdown = UsageBreakdownAccumulator::default();
+    let live_rows = query_live_upstream_account_usage_breakdown_rows(
+        &state.pool,
         source_scope,
         range,
-    );
-    let live_ids = live_rows.iter().map(|row| row.id).collect::<HashSet<_>>();
-    let mut rows = live_rows;
-    if range.start < shanghai_retention_cutoff(state.config.invocation_max_days) {
-        rows.extend(
-            crate::stats::query_completed_invocation_archive_preview_rows(
-                &state.pool,
-                source_scope,
-                range,
-                Some(&live_ids),
-            )
-            .await?,
-        );
-    }
-
-    let mut usage_breakdown = UsageBreakdownAccumulator::default();
-    for row in rows {
+        has_cost_breakdown_columns,
+        true,
+        DashboardActivityExcludedInvocationIdsFilter::None,
+    )
+    .await?;
+    let live_group_row_count = live_rows.len();
+    for row in live_rows {
         if upstream_account_id.is_none_or(|account_id| row.upstream_account_id == Some(account_id))
         {
-            usage_breakdown.add_row(&row);
+            usage_breakdown.add_aggregate_row(&row);
         }
     }
-    Ok(usage_breakdown.into_response())
+    if range.start < shanghai_retention_cutoff(state.config.invocation_max_days) {
+        let archive_rows = query_completed_invocation_archive_activity_aggregate_rows(
+            &state.pool,
+            source_scope,
+            range,
+        )
+        .await?;
+        let archive_group_row_count = archive_rows.usage_breakdowns.len();
+        if !archive_rows.skipped_materialized_ranges.is_empty() {
+            let elapsed_ms = started_at.elapsed().as_millis() as u64;
+            emit_summary_range_builder_telemetry(
+                telemetry,
+                "summary_usage_breakdown",
+                source_scope,
+                upstream_account_id,
+                "fallback",
+                "fallback",
+                live_group_row_count,
+                archive_group_row_count,
+                "none",
+                "none",
+                elapsed_ms,
+            );
+            return Ok(None);
+        }
+        for row in archive_rows.usage_breakdowns {
+            if upstream_account_id
+                .is_none_or(|account_id| row.upstream_account_id == Some(account_id))
+            {
+                usage_breakdown.add_aggregate_row(&row);
+            }
+        }
+        let elapsed_ms = started_at.elapsed().as_millis() as u64;
+        emit_summary_range_builder_telemetry(
+            telemetry,
+            "summary_usage_breakdown",
+            source_scope,
+            upstream_account_id,
+            "aggregate_only",
+            "aggregate_merge",
+            live_group_row_count,
+            archive_group_row_count,
+            "none",
+            "none",
+            elapsed_ms,
+        );
+        return Ok(Some(usage_breakdown.into_response()));
+    }
+    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    emit_summary_range_builder_telemetry(
+        telemetry,
+        "summary_usage_breakdown",
+        source_scope,
+        upstream_account_id,
+        "aggregate_only",
+        "aggregate_merge",
+        live_group_row_count,
+        0,
+        "none",
+        "none",
+        elapsed_ms,
+    );
+    Ok(Some(usage_breakdown.into_response()))
 }
 
 pub(crate) async fn query_upstream_account_activity_meta(
@@ -9912,6 +10036,7 @@ pub(crate) async fn load_dashboard_activity_summary_only_snapshot(
             // scan here would defeat the summary-only fast path.
             include_non_success_tokens: false,
         },
+        None,
     )
     .await?;
     apply_summary_live_augmentation(&mut stats, augmentation);
@@ -12233,12 +12358,13 @@ mod model_performance_duration_override_tests {
     }
 }
 
-pub(crate) async fn fetch_summary(
-    State(state): State<Arc<AppState>>,
-    Query(params): Query<SummaryQuery>,
-) -> Result<Json<StatsResponse>, ApiError> {
+pub(crate) async fn load_summary_response_from_query(
+    state: &AppState,
+    params: &SummaryQuery,
+    route: SummaryBuildRoute,
+) -> Result<StatsResponse, ApiError> {
     let default_limit = state.config.list_limit_max as i64;
-    let window = parse_summary_window(&params, default_limit)?;
+    let window = parse_summary_window(params, default_limit)?;
     let reporting_tz = parse_reporting_tz(params.time_zone.as_deref())?;
     let source_scope = resolve_default_source_scope(&state.pool).await?;
     let upstream_account_id = params.upstream_account_id;
@@ -12251,7 +12377,7 @@ pub(crate) async fn fetch_summary(
                     ApiError::from(anyhow!("invalid account all-time summary start"))
                 })?;
                 query_hourly_backed_summary_range_for_account(
-                    state.as_ref(),
+                    state,
                     start,
                     Utc::now(),
                     source_scope,
@@ -12282,7 +12408,7 @@ pub(crate) async fn fetch_summary(
             let start = now - duration;
             if let Some(upstream_account_id) = upstream_account_id {
                 query_hourly_backed_summary_range_for_account(
-                    state.as_ref(),
+                    state,
                     start,
                     now,
                     source_scope,
@@ -12290,21 +12416,19 @@ pub(crate) async fn fetch_summary(
                 )
                 .await?
             } else {
-                query_hourly_backed_summary_since(state.as_ref(), start, source_scope).await?
+                query_hourly_backed_summary_since(state, start, source_scope).await?
             }
         }
         SummaryWindow::Calendar(ref spec) => {
             let range_window =
                 resolve_range_window(spec.as_str(), reporting_tz).map_err(ApiError::from)?;
             if range_window.start >= range_window.end {
-                return Ok(Json(
-                    build_empty_summary_response(state.as_ref(), source_scope, upstream_account_id)
-                        .await?,
-                ));
+                return build_empty_summary_response(state, source_scope, upstream_account_id)
+                    .await;
             }
             if let Some(upstream_account_id) = upstream_account_id {
                 query_hourly_backed_summary_range_for_account(
-                    state.as_ref(),
+                    state,
                     range_window.start,
                     range_window.end,
                     source_scope,
@@ -12313,7 +12437,7 @@ pub(crate) async fn fetch_summary(
                 .await?
             } else {
                 query_hourly_backed_summary_range(
-                    state.as_ref(),
+                    state,
                     range_window.start,
                     range_window.end,
                     source_scope,
@@ -12328,7 +12452,7 @@ pub(crate) async fn fetch_summary(
                 })?;
             if let Some(upstream_account_id) = upstream_account_id {
                 query_hourly_backed_summary_range_for_account(
-                    state.as_ref(),
+                    state,
                     start,
                     end,
                     source_scope,
@@ -12336,7 +12460,7 @@ pub(crate) async fn fetch_summary(
                 )
                 .await?
             } else {
-                query_hourly_backed_summary_range(state.as_ref(), start, end, source_scope).await?
+                query_hourly_backed_summary_range(state, start, end, source_scope).await?
             }
         }
     };
@@ -12344,29 +12468,41 @@ pub(crate) async fn fetch_summary(
     let mut response = totals.into_response();
     response.non_success_cost = Some(totals.non_success_cost);
     let range = summary_window_range(&window, reporting_tz, now)?;
+    let range_telemetry =
+        range.map(|_| SummaryRangeBuildTelemetry::new(route, &window, params.window.as_deref()));
     if let Some((start, end)) = range {
-        response.usage_breakdown = Some(
-            load_usage_breakdown_for_range(
-                state.as_ref(),
-                source_scope,
-                upstream_account_id,
-                ExactUtcRange { start, end },
-            )
-            .await?,
-        );
+        let telemetry = range_telemetry.expect("summary range telemetry should exist");
+        response.usage_breakdown = load_usage_breakdown_for_range(
+            state,
+            source_scope,
+            upstream_account_id,
+            ExactUtcRange { start, end },
+            telemetry,
+        )
+        .await?;
     }
     let policy = summary_live_augmentation_policy(&window, range, now);
     let augmentation = load_summary_live_augmentation(
-        state.as_ref(),
+        state,
         source_scope,
         upstream_account_id,
         range,
         policy,
+        range_telemetry,
     )
     .await?;
     apply_summary_live_augmentation(&mut response, augmentation);
-    response.maintenance = Some(load_stats_maintenance_response(state.as_ref()).await?);
-    Ok(Json(response))
+    response.maintenance = Some(load_stats_maintenance_response(state).await?);
+    Ok(response)
+}
+
+pub(crate) async fn fetch_summary(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<SummaryQuery>,
+) -> Result<Json<StatsResponse>, ApiError> {
+    Ok(Json(
+        load_summary_response_from_query(state.as_ref(), &params, SummaryBuildRoute::Http).await?,
+    ))
 }
 
 pub(crate) async fn load_stats_maintenance_response(

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -1694,14 +1694,15 @@ impl SubscriptionTopic {
                 limit,
                 upstream_account_id,
             } => {
-                let Json(response) = fetch_summary(
-                    State(state),
-                    Query(SummaryQuery {
+                let response = load_summary_response_from_query(
+                    state.as_ref(),
+                    &SummaryQuery {
                         window: Some(window.clone()),
                         limit: *limit,
                         time_zone: Some(time_zone.clone()),
                         upstream_account_id: *upstream_account_id,
-                    }),
+                    },
+                    SummaryBuildRoute::Topic,
                 )
                 .await?;
                 Ok(serde_json::to_value(response)?)

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -2325,6 +2325,21 @@ async fn archived_range_reads_include_unmaterialized_batches_without_inline_repa
         0.20,
     );
     assert_eq!(summary.non_success_tokens, Some(20));
+    let usage_breakdown = summary
+        .usage_breakdown
+        .expect("historical summary should include usage breakdown");
+    assert_eq!(usage_breakdown.cache_write_tokens, 0);
+    assert_eq!(usage_breakdown.cache_read_tokens, 0);
+    assert_eq!(usage_breakdown.output_tokens, 0);
+    let usage_costs = usage_breakdown
+        .costs
+        .expect("historical usage breakdown should preserve known total cost");
+    assert_f64_close(usage_costs.input, 0.0);
+    assert_f64_close(usage_costs.cache_write, 0.0);
+    assert_f64_close(usage_costs.cache_read, 0.0);
+    assert_f64_close(usage_costs.output, 0.0);
+    assert_f64_close(usage_costs.reasoning, 0.0);
+    assert_f64_close(usage_costs.unknown, 0.30);
 
     let Json(failure_summary) = fetch_failure_summary(
         State(state.clone()),
@@ -2550,6 +2565,17 @@ async fn archived_range_reads_skip_archive_fallback_rows_already_counted_in_live
     assert_eq!(summary.failure_count, 1);
     assert_eq!(summary.total_tokens, 30);
     assert!((summary.total_cost - 0.30).abs() < 1e-9);
+    assert_eq!(summary.non_success_tokens, Some(20));
+    let usage_breakdown = summary
+        .usage_breakdown
+        .expect("overlapping archive/live summary should include usage breakdown");
+    assert_eq!(usage_breakdown.cache_write_tokens, 0);
+    assert_eq!(usage_breakdown.cache_read_tokens, 0);
+    assert_eq!(usage_breakdown.output_tokens, 0);
+    let usage_costs = usage_breakdown
+        .costs
+        .expect("overlapping archive/live summary should preserve known total cost");
+    assert_f64_close(usage_costs.unknown, 0.30);
 
     let Json(failure_summary) = fetch_failure_summary(
         State(state.clone()),
@@ -11491,6 +11517,127 @@ async fn ranged_summary_keeps_exact_costs_when_historical_cost_is_mixed_in() {
 }
 
 #[tokio::test]
+async fn summary_topic_builder_matches_http_for_open_range() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let occurred_at = format_naive(Utc::now().with_timezone(&Shanghai).naive_local());
+
+    for (
+        id,
+        invoke_id,
+        status,
+        total_tokens,
+        cost,
+        cost_input,
+        cost_cache_write,
+        cost_cache_read,
+        cost_output,
+        cost_reasoning,
+        error_message,
+        failure_kind,
+        failure_class,
+    ) in [
+        (
+            470_i64,
+            "summary-topic-success",
+            "success",
+            120_i64,
+            Some(0.50_f64),
+            Some(0.06_f64),
+            Some(0.14_f64),
+            Some(0.04_f64),
+            Some(0.21_f64),
+            Some(0.05_f64),
+            None,
+            None,
+            Some("none"),
+        ),
+        (
+            471_i64,
+            "summary-topic-failed",
+            "failed",
+            80_i64,
+            Some(0.20_f64),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("HTTP 429 too many requests"),
+            Some("upstream_response_failed"),
+            Some("service_failure"),
+        ),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO codex_invocations (
+                id, invoke_id, occurred_at, source, model, status,
+                input_tokens, cache_input_tokens, output_tokens, reasoning_tokens, total_tokens,
+                cost, cost_input, cost_cache_write, cost_cache_read, cost_output, cost_reasoning,
+                error_message, failure_kind, failure_class, raw_response
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)
+            "#,
+        )
+        .bind(id)
+        .bind(invoke_id)
+        .bind(&occurred_at)
+        .bind(SOURCE_PROXY)
+        .bind("gpt-5.6")
+        .bind(status)
+        .bind(100_i64)
+        .bind(40_i64)
+        .bind(25_i64)
+        .bind(5_i64)
+        .bind(total_tokens)
+        .bind(cost)
+        .bind(cost_input)
+        .bind(cost_cache_write)
+        .bind(cost_cache_read)
+        .bind(cost_output)
+        .bind(cost_reasoning)
+        .bind(error_message)
+        .bind(failure_kind)
+        .bind(failure_class)
+        .bind("{}")
+        .execute(&state.pool)
+        .await
+        .expect("insert summary topic builder row");
+    }
+
+    let Json(http_summary) = fetch_summary(
+        State(state.clone()),
+        Query(SummaryQuery {
+            window: Some("7d".to_string()),
+            limit: None,
+            time_zone: Some("Asia/Shanghai".to_string()),
+            upstream_account_id: None,
+        }),
+    )
+    .await
+    .expect("fetch summary over http");
+    let topic_summary = load_summary_response_from_query(
+        state.as_ref(),
+        &SummaryQuery {
+            window: Some("7d".to_string()),
+            limit: None,
+            time_zone: Some("Asia/Shanghai".to_string()),
+            upstream_account_id: None,
+        },
+        SummaryBuildRoute::Topic,
+    )
+    .await
+    .expect("build summary for topic");
+
+    assert_eq!(
+        serde_json::to_value(http_summary).expect("serialize http summary"),
+        serde_json::to_value(topic_summary).expect("serialize topic summary"),
+    );
+}
+
+#[tokio::test]
 async fn empty_summary_response_keeps_live_in_progress_conversation_count() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
@@ -16739,6 +16886,16 @@ async fn account_scoped_historical_stats_include_unmaterialized_archived_hours()
         0.20,
     );
     assert_eq!(summary.non_success_tokens, Some(20));
+    let usage_breakdown = summary
+        .usage_breakdown
+        .expect("account historical summary should include usage breakdown");
+    assert_eq!(usage_breakdown.cache_write_tokens, 0);
+    assert_eq!(usage_breakdown.cache_read_tokens, 0);
+    assert_eq!(usage_breakdown.output_tokens, 0);
+    let usage_costs = usage_breakdown
+        .costs
+        .expect("account historical usage breakdown should preserve known total cost");
+    assert_f64_close(usage_costs.unknown, 0.30);
 
     let Json(timeseries) = fetch_timeseries(
         State(state.clone()),


### PR DESCRIPTION
## Summary
- replace open-range summary `usage_breakdown` with live/archive aggregate merges instead of full-range preview scans
- replace open-range summary `non_success_tokens` overlap handling with aggregate merges instead of live invocation id scans
- share the same summary range builder between `/api/stats/summary` and `stats.summary.current`, and refresh spec/solution history for the new telemetry and fallback boundaries

## Testing
- cargo fmt --check
- cargo check
- cargo test -q summary_
- cargo test -q summary_topic_builder_matches_http_for_open_range
- cargo test -q archived_range_reads_
- cargo test -q account_scoped_historical_stats_include_unmaterialized_archived_hours
- cargo test -q ranged_summary_

## References
- Specs
  - docs/specs/5932d-sse-proxy-live-sync/SPEC.md
  - docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
- Solutions
  - docs/solutions/performance/realtime-dashboard-reconcile-budget.md
  - docs/solutions/performance/sqlite-write-pressure-backpressure.md
- Project Docs
  - -
