### PR TITLE
fix(web): prevent hover crash in network recent panel

### DIFF
--- a/docs/specs/v3fum-dashboard-network-speed/HISTORY.md
+++ b/docs/specs/v3fum-dashboard-network-speed/HISTORY.md
@@ -18,3 +18,4 @@
 - 2026-07-20 recent 诊断面板选择独立的全局 300 秒、1 秒粒度读模型，由 `DashboardNetworkSpeedCache` 直接产出，并通过 `GET /api/stats/dashboard-network-recent` 与 `dashboard.network-recent.current` 暴露；不复用分钟桶，也不新增 SQLite 落盘。
 - 2026-07-20 recent 面板前端明确遵守 topic-only SSE 约束：只消费 `dashboard.network-recent.current`，仅在面板打开期间以 1 秒 cadence refresh，同屏不再引入 open-resync 或第二真相源。
 - 2026-07-20 进程启动不足 5 分钟时，recent 面板前导区间统一显示为 `isAvailable=false` 空档并标记 warming；这些空档不再伪装成真实 `0 B/s` 历史。
+- 2026-07-20 线上验证发现：recent 面板首次打开会先经过 loading 分支，再切到真实图表数据；原实现把一个 `useMemo` 放在早退分支之后，导致同一组件实例在 `loading -> data` 间触发 React hook order 崩溃（线上表现为 React 310）。修复改为无条件的普通 tick 派生计算，并补回归测试锁住这个路径。

--- a/docs/specs/v3fum-dashboard-network-speed/IMPLEMENTATION.md
+++ b/docs/specs/v3fum-dashboard-network-speed/IMPLEMENTATION.md
@@ -56,6 +56,7 @@
   - 桌面端复用现有 popover chrome，实现 `hover 打开 + click 固定 + 再次点击/外点/Esc 关闭`。
   - 窄屏端改用 dialog/sheet 承载同一 panel 内容。
   - 图表层将 `isAvailable=false` 样本渲染成空档，并用 warming callout / tooltip 明确“历史积累中”而不是零流量。
+  - `DashboardNetworkRecentPanel` 的秒级图表 tick 计算改成普通派生值，避免组件从 loading 切到有数据时因条件分支后的额外 hook 触发 React hook order 崩溃。
 
 ## 测试与 Storybook
 
@@ -66,6 +67,7 @@
 - 前端新增 recent 面板单测覆盖：
   - `useDashboardRecentNetworkWindow` 的 topic descriptor、打开期间 1 秒 refresh cadence 与关闭停表。
   - `DashboardNetworkRecentPopover` 的桌面 hover/click 固定、`Esc` 关闭、窄屏 dialog 打开与 warming banner 渲染。
+  - `DashboardNetworkRecentPanel` 从 loading 切到真实数据时的 hook order 回归，防止线上打开 recent 面板直接触发 React 310。
 - 后端定向单测覆盖：
   - global/host/account runtime bucket 记账。
   - socket minute rollup 的 direct 写入、cursor seed 与 pool retry host split。

--- a/web/src/features/dashboard/DashboardNetworkRecentPopover.test.tsx
+++ b/web/src/features/dashboard/DashboardNetworkRecentPopover.test.tsx
@@ -295,6 +295,20 @@ describe("DashboardNetworkRecentPopover", () => {
 });
 
 describe("DashboardNetworkRecentPanel", () => {
+  it("does not change hook order when loading resolves into chart data", () => {
+    render(<DashboardNetworkRecentPanel response={null} loading={true} error={null} />);
+
+    expect(() => {
+      act(() => {
+        root?.render(
+          <DashboardNetworkRecentPanel response={createResponse()} loading={false} error={null} />,
+        );
+      });
+    }).not.toThrow();
+
+    expect(host?.querySelector('[data-testid="dashboard-network-recent-chart"]')).not.toBeNull();
+  });
+
   it("shows the warming banner for unavailable leading history", () => {
     render(
       <DashboardNetworkRecentPanel

--- a/web/src/features/dashboard/DashboardNetworkRecentPopover.tsx
+++ b/web/src/features/dashboard/DashboardNetworkRecentPopover.tsx
@@ -98,7 +98,7 @@ function buildRecentTooltipRows(
   for (const seriesKey of ["uploadChartValue", "downloadChartValue"] as const) {
     const entry = payload?.find((candidate) => candidate.dataKey === seriesKey);
     const point = entry?.payload;
-    if (!point || !point.isAvailable) {
+    if (!point?.isAvailable) {
       continue;
     }
     const isUploadSeries = seriesKey === "uploadChartValue";
@@ -214,17 +214,17 @@ export function DashboardNetworkRecentPanel({
     };
   });
   const rangeStartTimestamp = new Date(response.rangeStart).getTime();
-  const chartTickValues = useMemo(() => {
-    const lastPointTimestamp = chartData.at(-1)?.chartTimestamp ?? rangeStartTimestamp;
-    const ticks: number[] = [];
-    for (let offsetSeconds = 0; offsetSeconds < response.windowSeconds; offsetSeconds += 60) {
-      ticks.push(rangeStartTimestamp + offsetSeconds * 1000);
-    }
-    if (ticks.at(-1) !== lastPointTimestamp) {
-      ticks.push(lastPointTimestamp);
-    }
-    return ticks.filter((tick, index, all) => (index === 0 ? true : tick > all[index - 1]!));
-  }, [chartData, rangeStartTimestamp, response.windowSeconds]);
+  const lastPointTimestamp = chartData.at(-1)?.chartTimestamp ?? rangeStartTimestamp;
+  const chartTickValues: number[] = [];
+  for (let offsetSeconds = 0; offsetSeconds < response.windowSeconds; offsetSeconds += 60) {
+    chartTickValues.push(rangeStartTimestamp + offsetSeconds * 1000);
+  }
+  if (chartTickValues.at(-1) !== lastPointTimestamp) {
+    chartTickValues.push(lastPointTimestamp);
+  }
+  const uniqueChartTickValues = chartTickValues.filter(
+    (tick, index, all) => index === 0 || tick > (all[index - 1] ?? Number.NEGATIVE_INFINITY),
+  );
 
   return (
     <div
@@ -307,7 +307,7 @@ export function DashboardNetworkRecentPanel({
                 dataKey="chartTimestamp"
                 scale="time"
                 domain={["dataMin", "dataMax"]}
-                ticks={chartTickValues}
+                ticks={uniqueChartTickValues}
                 axisLine={{ stroke: chartColors.gridLine }}
                 tickLine={{ stroke: chartColors.gridLine }}
                 tick={{ fill: chartColors.axisText, fontSize: 12 }}


### PR DESCRIPTION
Spec: docs/specs/v3fum-dashboard-network-speed/SPEC.md
Spec Disposition: update
Spec Sync: done
Spec Drift: none
Spec Sync Evidence: docs/specs/v3fum-dashboard-network-speed/HISTORY.md@446a966ff4df09320711fee234e8fb5bc55b96a1, docs/specs/v3fum-dashboard-network-speed/IMPLEMENTATION.md@dacf408580814852ccd026223d79b0c02b3e0985
Solutions: -
Solutions Sync: n/a(no reusable solution change)
Project Docs: -
Project Docs Sync: n/a(no human-facing project-doc change)

## Summary
- Fix the dashboard network recent panel crash seen when the popover transitions from loading to chart data.
- Replace the conditional-branch-after-hook `useMemo` tick calculation with plain derived values so hook order stays stable.
- Add a regression test for the loading -> data transition.

## Root Cause
The recent panel rendered early loading/error/empty branches before a later `useMemo`. Opening the popover first rendered loading, then rerendered with data and an extra hook, which triggered the React hook order invariant in production (React 310).

## Verification
- `cd web && bun run test -- DashboardNetworkRecentPopover`
- `cd web && bun run test -- DashboardWorkingConversationsSection DashboardNetworkRecentPopover`
- `cd web && bunx tsc -b`
- `bun run lint:web` (passes with existing repository warnings)
- `cd web && bun run storybook:build`
- `git diff --check`
- `codex review --base origin/main` (no new functional regressions found)
- `/Users/ivan/.codex/skills/spec-sync/scripts/spec_drift_check.sh --base-ref origin/main --spec-path docs/specs/v3fum-dashboard-network-speed/SPEC.md`

## Docs / Spec Sync
- Updated `docs/specs/v3fum-dashboard-network-speed/IMPLEMENTATION.md` and `HISTORY.md`.
- `SPEC.md` unchanged because this is a regression fix with no behavior-contract change.
- `solution_disposition=none`
- `project_doc_disposition=none`

## Visual Evidence

- Spec: docs/specs/v3fum-dashboard-network-speed/SPEC.md
  ![Dashboard recent desktop popover](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/65729d1890f0073e400a7203948209455ce77d7b/docs/specs/v3fum-dashboard-network-speed/assets/dashboard-network-recent-desktop-fixed-open.png?raw=1)

- Spec: docs/specs/v3fum-dashboard-network-speed/SPEC.md
  ![Dashboard recent desktop popover light](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/65729d1890f0073e400a7203948209455ce77d7b/docs/specs/v3fum-dashboard-network-speed/assets/dashboard-network-recent-desktop-fixed-open-light.png?raw=1)

- Spec: docs/specs/v3fum-dashboard-network-speed/SPEC.md
  ![Dashboard recent compact sheet](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/65729d1890f0073e400a7203948209455ce77d7b/docs/specs/v3fum-dashboard-network-speed/assets/dashboard-network-recent-compact-sheet.png?raw=1)
