### PR TITLE
fix(proxy): stabilize encrypted owner guard routing

### DIFF
--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -39,6 +39,8 @@ pub(crate) fn notify_pool_no_available_wait_hook(state: &AppState) {
 #[cfg(not(test))]
 pub(crate) fn notify_pool_no_available_wait_hook(_state: &AppState) {}
 
+const POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_ATTEMPTS: usize = 5;
+
 pub(crate) fn parse_retry_after_delay(value: &HeaderValue) -> Option<Duration> {
     let text = value.to_str().ok()?.trim();
     if text.is_empty() {
@@ -242,14 +244,14 @@ pub(crate) async fn resolve_pool_account_for_request_with_wait_and_binding_const
     image_intent: crate::ImageIntent,
 ) -> Result<PoolAccountResolutionWithWait> {
     let poll_interval = state.pool_no_available_wait.normalized_poll_interval();
+    let mut sqlite_lock_retries = 0;
 
     loop {
         let now = Instant::now();
         if total_timeout_deadline.is_some_and(|deadline| now >= deadline) {
             return Ok(PoolAccountResolutionWithWait::TotalTimeoutExpired);
         }
-        let resolution =
-            resolve_pool_account_for_request_with_route_requirement_and_image_intent_and_override(
+        let resolution = match resolve_pool_account_for_request_with_route_requirement_and_image_intent_and_override(
                 state,
                 sticky_key,
                 requested_model,
@@ -261,7 +263,31 @@ pub(crate) async fn resolve_pool_account_for_request_with_wait_and_binding_const
                 endpoint,
                 image_intent,
             )
-            .await?;
+            .await
+        {
+            Ok(resolution) => {
+                sqlite_lock_retries = 0;
+                resolution
+            }
+            Err(err)
+                if sqlite_lock_retries < POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_ATTEMPTS
+                    && is_sqlite_lock_error(&err) =>
+            {
+                sqlite_lock_retries += 1;
+                let now = Instant::now();
+                if total_timeout_deadline.is_some_and(|deadline| now >= deadline) {
+                    return Ok(PoolAccountResolutionWithWait::TotalTimeoutExpired);
+                }
+                let retry_delay = total_timeout_deadline
+                    .map(|deadline| {
+                        poll_interval.min(deadline.saturating_duration_since(now))
+                    })
+                    .unwrap_or(poll_interval);
+                tokio::time::sleep(retry_delay).await;
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
         if wait_for_no_available
             && matches!(
                 resolution,

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -40,6 +40,7 @@ pub(crate) fn notify_pool_no_available_wait_hook(state: &AppState) {
 pub(crate) fn notify_pool_no_available_wait_hook(_state: &AppState) {}
 
 const POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_ATTEMPTS: usize = 5;
+const POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 pub(crate) fn parse_retry_after_delay(value: &HeaderValue) -> Option<Duration> {
     let text = value.to_str().ok()?.trim();
@@ -280,9 +281,10 @@ pub(crate) async fn resolve_pool_account_for_request_with_wait_and_binding_const
                 }
                 let retry_delay = total_timeout_deadline
                     .map(|deadline| {
-                        poll_interval.min(deadline.saturating_duration_since(now))
+                        POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_DELAY
+                            .min(deadline.saturating_duration_since(now))
                     })
-                    .unwrap_or(poll_interval);
+                    .unwrap_or(POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_DELAY);
                 tokio::time::sleep(retry_delay).await;
                 continue;
             }

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -221,8 +221,8 @@ pub(crate) async fn load_via_pool_prompt_cache_binding_constraint(
     prompt_cache_key: Option<&str>,
 ) -> Result<Option<PromptCacheConversationBindingConstraint>, (StatusCode, String)> {
     let encrypted_owner_routing_enabled = encrypted_session_owner_routing_enabled(state).await;
-    resolve_prompt_cache_effective_routing_constraint(
-        &state.pool,
+    resolve_prompt_cache_effective_routing_constraint_with_retry(
+        state,
         prompt_cache_key,
         false,
         encrypted_owner_routing_enabled,
@@ -237,12 +237,12 @@ pub(crate) async fn load_via_pool_prompt_cache_binding_constraint(
     })
 }
 
-pub(crate) async fn load_via_pool_effective_routing_constraint(
+async fn resolve_prompt_cache_effective_routing_constraint_with_retry(
     state: &AppState,
     prompt_cache_key: Option<&str>,
     request_contains_encrypted_content: bool,
-) -> Result<(Option<PromptCacheConversationBindingConstraint>, bool), (StatusCode, String)> {
-    let encrypted_owner_routing_enabled = encrypted_session_owner_routing_enabled(state).await;
+    encrypted_owner_routing_enabled: bool,
+) -> Result<(Option<PromptCacheConversationBindingConstraint>, bool)> {
     let mut sqlite_lock_retries = 0;
     loop {
         match resolve_prompt_cache_effective_routing_constraint(
@@ -261,12 +261,48 @@ pub(crate) async fn load_via_pool_effective_routing_constraint(
                 sqlite_lock_retries += 1;
                 tokio::time::sleep(PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_DELAY).await;
             }
-            Err(err) => {
-                return Err((
-                    StatusCode::BAD_GATEWAY,
-                    format!("failed to resolve prompt cache conversation binding: {err}"),
-                ));
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+pub(crate) async fn load_via_pool_effective_routing_constraint(
+    state: &AppState,
+    prompt_cache_key: Option<&str>,
+    request_contains_encrypted_content: bool,
+) -> Result<(Option<PromptCacheConversationBindingConstraint>, bool), (StatusCode, String)> {
+    let encrypted_owner_routing_enabled = encrypted_session_owner_routing_enabled(state).await;
+    resolve_prompt_cache_effective_routing_constraint_with_retry(
+        state,
+        prompt_cache_key,
+        request_contains_encrypted_content,
+        encrypted_owner_routing_enabled,
+    )
+    .await
+    .map_err(|err| {
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("failed to resolve prompt cache conversation binding: {err}"),
+        )
+    })
+}
+
+async fn load_prompt_cache_conversation_routing_override_with_retry(
+    state: &AppState,
+    prompt_cache_key: Option<&str>,
+) -> Result<Option<ConversationRoutingOverride>> {
+    let mut sqlite_lock_retries = 0;
+    loop {
+        match load_prompt_cache_conversation_routing_override(&state.pool, prompt_cache_key).await {
+            Ok(value) => return Ok(value),
+            Err(err)
+                if sqlite_lock_retries < PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_ATTEMPTS
+                    && is_sqlite_lock_error(&err) =>
+            {
+                sqlite_lock_retries += 1;
+                tokio::time::sleep(PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_DELAY).await;
             }
+            Err(err) => return Err(err),
         }
     }
 }
@@ -290,7 +326,7 @@ pub(crate) async fn load_via_pool_effective_routing(
     )
     .await?;
     let conversation_override =
-        load_prompt_cache_conversation_routing_override(&state.pool, prompt_cache_key)
+        load_prompt_cache_conversation_routing_override_with_retry(state, prompt_cache_key)
             .await
             .map_err(|err| {
                 (

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -5,6 +5,9 @@ use super::*;
 type ViaPoolResponseFuture<'a> =
     Pin<Box<dyn Future<Output = Result<Response, ProxyErrorResponse>> + Send + 'a>>;
 
+const PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_ATTEMPTS: usize = 5;
+const PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(10);
+
 fn plain_proxy_error(status: StatusCode, message: impl Into<String>) -> ProxyErrorResponse {
     let message = message.into();
     ProxyErrorResponse {
@@ -240,19 +243,32 @@ pub(crate) async fn load_via_pool_effective_routing_constraint(
     request_contains_encrypted_content: bool,
 ) -> Result<(Option<PromptCacheConversationBindingConstraint>, bool), (StatusCode, String)> {
     let encrypted_owner_routing_enabled = encrypted_session_owner_routing_enabled(state).await;
-    resolve_prompt_cache_effective_routing_constraint(
-        &state.pool,
-        prompt_cache_key,
-        request_contains_encrypted_content,
-        encrypted_owner_routing_enabled,
-    )
-    .await
-    .map_err(|err| {
-        (
-            StatusCode::BAD_GATEWAY,
-            format!("failed to resolve prompt cache conversation binding: {err}"),
+    let mut sqlite_lock_retries = 0;
+    loop {
+        match resolve_prompt_cache_effective_routing_constraint(
+            &state.pool,
+            prompt_cache_key,
+            request_contains_encrypted_content,
+            encrypted_owner_routing_enabled,
         )
-    })
+        .await
+        {
+            Ok(value) => return Ok(value),
+            Err(err)
+                if sqlite_lock_retries < PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_ATTEMPTS
+                    && is_sqlite_lock_error(&err) =>
+            {
+                sqlite_lock_retries += 1;
+                tokio::time::sleep(PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_DELAY).await;
+            }
+            Err(err) => {
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    format!("failed to resolve prompt cache conversation binding: {err}"),
+                ));
+            }
+        }
+    }
 }
 
 pub(crate) async fn load_via_pool_effective_routing(

--- a/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
+++ b/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
@@ -8,16 +8,22 @@ fn assert_encrypted_owner_blocked_proxy_error(
     prompt_cache_key: &str,
 ) {
     let owner_label = owner_label.into();
-    assert_eq!(response.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "unexpected encrypted owner guard proxy response: {response:?}"
+    );
     assert_eq!(
         response.message,
         format!(
             "encrypted session owner routing is constrained to upstream account {owner_label} but that account is currently unavailable"
-        )
+        ),
+        "unexpected encrypted owner guard proxy response: {response:?}"
     );
     assert_eq!(
         response.code.as_deref(),
-        Some(PROXY_FAILURE_POOL_ASSIGNED_ACCOUNT_BLOCKED)
+        Some(PROXY_FAILURE_POOL_ASSIGNED_ACCOUNT_BLOCKED),
+        "unexpected encrypted owner guard proxy response: {response:?}"
     );
     assert_eq!(
         response.blocked_binding,
@@ -27,8 +33,33 @@ fn assert_encrypted_owner_blocked_proxy_error(
             upstream_account_label: owner_label,
             prompt_cache_key: Some(prompt_cache_key.to_string()),
             recovery_action: BlockedBindingRecoveryAction::ClearAndResetAffinity,
-        })
+        }),
+        "unexpected encrypted owner guard proxy response: {response:?}"
     );
+}
+
+async fn assert_encrypted_owner_constraint_active(
+    state: &AppState,
+    prompt_cache_key: &str,
+    owner_account_id: i64,
+) -> (Option<PromptCacheConversationBindingConstraint>, bool) {
+    let (binding_constraint, owner_auto_guard_active) =
+        load_via_pool_effective_routing_constraint(state, Some(prompt_cache_key), false)
+            .await
+            .expect("load encrypted owner effective routing constraint");
+    assert!(
+        owner_auto_guard_active,
+        "encrypted owner auto guard should be active for {prompt_cache_key}: {binding_constraint:?}"
+    );
+    assert!(
+        matches!(
+            binding_constraint.as_ref(),
+            Some(PromptCacheConversationBindingConstraint::UpstreamAccount(account_id))
+                if *account_id == owner_account_id
+        ),
+        "unexpected encrypted owner routing constraint for {prompt_cache_key}: {binding_constraint:?}"
+    );
+    (binding_constraint, owner_auto_guard_active)
 }
 
 fn run_future_with_large_stack<T, Fut>(future: Fut) -> T
@@ -1370,6 +1401,77 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_preserves_encrypted_ow
 }
 
 #[tokio::test]
+async fn resolver_blocks_encrypted_owner_when_active_sticky_route_fills_owner_capacity() {
+    let state = test_state_with_openai_base_and_pool_no_available_wait(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+        Duration::from_millis(80),
+        Duration::from_millis(10),
+    )
+    .await;
+    enable_encrypted_session_owner_routing_for_test(&state).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let owner_account_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Encrypted Owner",
+        "upstream-owner",
+        None,
+        None,
+        None,
+    )
+    .await;
+    let _secondary_account_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Secondary",
+        "upstream-secondary",
+        None,
+        None,
+        None,
+    )
+    .await;
+    sqlx::query("UPDATE pool_upstream_accounts SET policy_concurrency_limit = 1 WHERE id = ?1")
+        .bind(owner_account_id)
+        .execute(&state.pool)
+        .await
+        .expect("set encrypted owner account concurrency limit");
+    let now_iso = format_utc_iso(Utc::now());
+    upsert_sticky_route(
+        &state.pool,
+        "pck-resolver-encrypted-owner-rate-limited-active",
+        owner_account_id,
+        &now_iso,
+    )
+    .await
+    .expect("seed active sticky route for resolver owner");
+    let prompt_cache_key = "pck-resolver-encrypted-owner-rate-limited";
+    upsert_prompt_cache_encrypted_session_owner(&state.pool, prompt_cache_key, owner_account_id)
+        .await
+        .expect("persist encrypted owner lock");
+    let (binding_constraint, _owner_auto_guard_active) = assert_encrypted_owner_constraint_active(
+        state.as_ref(),
+        prompt_cache_key,
+        owner_account_id,
+    )
+    .await;
+
+    let resolution = resolve_pool_account_for_request_with_route_requirement(
+        state.as_ref(),
+        None,
+        None,
+        &[],
+        &HashSet::new(),
+        None,
+        binding_constraint.as_ref(),
+    )
+    .await
+    .expect("resolve encrypted owner-constrained pool account");
+
+    assert!(
+        matches!(resolution, PoolAccountResolution::Unavailable),
+        "rate-limited encrypted owner should block fresh assignment, got {resolution:?}"
+    );
+}
+
+#[tokio::test]
 async fn proxy_openai_v1_bodyless_header_prompt_cache_key_rate_limited_owner_returns_owner_unavailable()
  {
     let (upstream_base, attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;
@@ -1418,6 +1520,12 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_rate_limited_owner_ret
     upsert_prompt_cache_encrypted_session_owner(&state.pool, prompt_cache_key, owner_account_id)
         .await
         .expect("persist encrypted owner lock");
+    let _ = assert_encrypted_owner_constraint_active(
+        state.as_ref(),
+        prompt_cache_key,
+        owner_account_id,
+    )
+    .await;
 
     let runtime_timeouts = resolve_proxy_request_timeouts(state.as_ref(), true)
         .await
@@ -1539,6 +1647,12 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_same_account_binding_n
     .execute(&state.pool)
     .await
     .expect("persist same-account binding newer than owner");
+    let _ = assert_encrypted_owner_constraint_active(
+        state.as_ref(),
+        prompt_cache_key,
+        owner_account_id,
+    )
+    .await;
 
     let runtime_timeouts = resolve_proxy_request_timeouts(state.as_ref(), true)
         .await
@@ -1740,15 +1854,26 @@ async fn websocket_prepare_rate_limited_owner_returns_owner_unavailable() {
         .execute(&state.pool)
         .await
         .expect("set websocket encrypted owner account concurrency limit");
+    let now_iso = format_utc_iso(Utc::now());
     insert_test_pool_limit_sample(&state, owner_account_id, Some(20.0), Some(20.0)).await;
+    upsert_sticky_route(
+        &state.pool,
+        "pck-websocket-encrypted-owner-rate-limited-active",
+        owner_account_id,
+        &now_iso,
+    )
+    .await
+    .expect("seed active sticky route for websocket rate-limited owner");
     let prompt_cache_key = "pck-websocket-encrypted-owner-rate-limited";
     upsert_prompt_cache_encrypted_session_owner(&state.pool, prompt_cache_key, owner_account_id)
         .await
         .expect("persist encrypted owner lock");
-    let (binding_constraint, owner_auto_guard_active) =
-        load_via_pool_effective_routing_constraint(state.as_ref(), Some(prompt_cache_key), false)
-            .await
-            .expect("load websocket effective routing constraint");
+    let (binding_constraint, owner_auto_guard_active) = assert_encrypted_owner_constraint_active(
+        state.as_ref(),
+        prompt_cache_key,
+        owner_account_id,
+    )
+    .await;
 
     let err = prepare_upstream_websocket(
         state.clone(),


### PR DESCRIPTION
## Summary
- retry transient SQLite lock errors while loading prompt-cache routing constraints
- retry transient SQLite lock errors during pool account resolution before returning routing errors
- strengthen encrypted-owner guard tests for HTTP and WS capacity-blocked owner scenarios

## Tests
- RUST_MIN_STACK=8388608 cargo nextest run -E 'test(resolver_blocks_encrypted_owner_when_active_sticky_route_fills_owner_capacity) | test(proxy_openai_v1_bodyless_header_prompt_cache_key_rate_limited_owner_returns_owner_unavailable) | test(proxy_openai_v1_bodyless_header_prompt_cache_key_same_account_binding_newer_than_owner_still_returns_owner_unavailable) | test(websocket_prepare_rate_limited_owner_returns_owner_unavailable)' --no-fail-fast
- RUST_MIN_STACK=8388608 cargo nextest run live_first_and_owner_guard --no-fail-fast
- bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
- cargo fmt -- --check
- cargo clippy --locked --all-features --all-targets -- -D warnings