### PR TITLE
fix(proxy): retry owner-guard sqlite locks

### DIFF
--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -39,6 +39,9 @@ pub(crate) fn notify_pool_no_available_wait_hook(state: &AppState) {
 #[cfg(not(test))]
 pub(crate) fn notify_pool_no_available_wait_hook(_state: &AppState) {}
 
+const POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_ATTEMPTS: usize = 5;
+const POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(10);
+
 pub(crate) fn parse_retry_after_delay(value: &HeaderValue) -> Option<Duration> {
     let text = value.to_str().ok()?.trim();
     if text.is_empty() {
@@ -242,6 +245,7 @@ pub(crate) async fn resolve_pool_account_for_request_with_wait_and_binding_const
     image_intent: crate::ImageIntent,
 ) -> Result<PoolAccountResolutionWithWait> {
     let poll_interval = state.pool_no_available_wait.normalized_poll_interval();
+    let mut sqlite_lock_retries = 0;
 
     loop {
         let now = Instant::now();
@@ -249,7 +253,7 @@ pub(crate) async fn resolve_pool_account_for_request_with_wait_and_binding_const
             return Ok(PoolAccountResolutionWithWait::TotalTimeoutExpired);
         }
         let resolution =
-            resolve_pool_account_for_request_with_route_requirement_and_image_intent_and_override(
+            match resolve_pool_account_for_request_with_route_requirement_and_image_intent_and_override(
                 state,
                 sticky_key,
                 requested_model,
@@ -261,7 +265,32 @@ pub(crate) async fn resolve_pool_account_for_request_with_wait_and_binding_const
                 endpoint,
                 image_intent,
             )
-            .await?;
+            .await
+            {
+                Ok(resolution) => {
+                    sqlite_lock_retries = 0;
+                    resolution
+                }
+                Err(err)
+                    if sqlite_lock_retries < POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_ATTEMPTS
+                        && is_sqlite_lock_error(&err) =>
+                {
+                    sqlite_lock_retries += 1;
+                    let now = Instant::now();
+                    if total_timeout_deadline.is_some_and(|deadline| now >= deadline) {
+                        return Ok(PoolAccountResolutionWithWait::TotalTimeoutExpired);
+                    }
+                    let retry_delay = total_timeout_deadline
+                        .map(|deadline| {
+                            POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_DELAY
+                                .min(deadline.saturating_duration_since(now))
+                        })
+                        .unwrap_or(POOL_ACCOUNT_RESOLUTION_SQLITE_LOCK_RETRY_DELAY);
+                    tokio::time::sleep(retry_delay).await;
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
         if wait_for_no_available
             && matches!(
                 resolution,

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -5,6 +5,9 @@ use super::*;
 type ViaPoolResponseFuture<'a> =
     Pin<Box<dyn Future<Output = Result<Response, ProxyErrorResponse>> + Send + 'a>>;
 
+const PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_ATTEMPTS: usize = 5;
+const PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(10);
+
 fn plain_proxy_error(status: StatusCode, message: impl Into<String>) -> ProxyErrorResponse {
     let message = message.into();
     ProxyErrorResponse {
@@ -218,8 +221,8 @@ pub(crate) async fn load_via_pool_prompt_cache_binding_constraint(
     prompt_cache_key: Option<&str>,
 ) -> Result<Option<PromptCacheConversationBindingConstraint>, (StatusCode, String)> {
     let encrypted_owner_routing_enabled = encrypted_session_owner_routing_enabled(state).await;
-    resolve_prompt_cache_effective_routing_constraint(
-        &state.pool,
+    resolve_prompt_cache_effective_routing_constraint_with_retry(
+        state,
         prompt_cache_key,
         false,
         encrypted_owner_routing_enabled,
@@ -234,14 +237,43 @@ pub(crate) async fn load_via_pool_prompt_cache_binding_constraint(
     })
 }
 
+async fn resolve_prompt_cache_effective_routing_constraint_with_retry(
+    state: &AppState,
+    prompt_cache_key: Option<&str>,
+    request_contains_encrypted_content: bool,
+    encrypted_owner_routing_enabled: bool,
+) -> Result<(Option<PromptCacheConversationBindingConstraint>, bool)> {
+    let mut sqlite_lock_retries = 0;
+    loop {
+        match resolve_prompt_cache_effective_routing_constraint(
+            &state.pool,
+            prompt_cache_key,
+            request_contains_encrypted_content,
+            encrypted_owner_routing_enabled,
+        )
+        .await
+        {
+            Ok(value) => return Ok(value),
+            Err(err)
+                if sqlite_lock_retries < PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_ATTEMPTS
+                    && is_sqlite_lock_error(&err) =>
+            {
+                sqlite_lock_retries += 1;
+                tokio::time::sleep(PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_DELAY).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
 pub(crate) async fn load_via_pool_effective_routing_constraint(
     state: &AppState,
     prompt_cache_key: Option<&str>,
     request_contains_encrypted_content: bool,
 ) -> Result<(Option<PromptCacheConversationBindingConstraint>, bool), (StatusCode, String)> {
     let encrypted_owner_routing_enabled = encrypted_session_owner_routing_enabled(state).await;
-    resolve_prompt_cache_effective_routing_constraint(
-        &state.pool,
+    resolve_prompt_cache_effective_routing_constraint_with_retry(
+        state,
         prompt_cache_key,
         request_contains_encrypted_content,
         encrypted_owner_routing_enabled,
@@ -253,6 +285,26 @@ pub(crate) async fn load_via_pool_effective_routing_constraint(
             format!("failed to resolve prompt cache conversation binding: {err}"),
         )
     })
+}
+
+async fn load_prompt_cache_conversation_routing_override_with_retry(
+    state: &AppState,
+    prompt_cache_key: Option<&str>,
+) -> Result<Option<ConversationRoutingOverride>> {
+    let mut sqlite_lock_retries = 0;
+    loop {
+        match load_prompt_cache_conversation_routing_override(&state.pool, prompt_cache_key).await {
+            Ok(value) => return Ok(value),
+            Err(err)
+                if sqlite_lock_retries < PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_ATTEMPTS
+                    && is_sqlite_lock_error(&err) =>
+            {
+                sqlite_lock_retries += 1;
+                tokio::time::sleep(PROMPT_CACHE_ROUTING_SQLITE_LOCK_RETRY_DELAY).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 pub(crate) async fn load_via_pool_effective_routing(
@@ -274,7 +326,7 @@ pub(crate) async fn load_via_pool_effective_routing(
     )
     .await?;
     let conversation_override =
-        load_prompt_cache_conversation_routing_override(&state.pool, prompt_cache_key)
+        load_prompt_cache_conversation_routing_override_with_retry(state, prompt_cache_key)
             .await
             .map_err(|err| {
                 (

--- a/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
+++ b/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
@@ -1468,6 +1468,134 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_rate_limited_owner_ret
 }
 
 #[tokio::test]
+async fn unwrap_via_pool_initial_account_retries_sqlite_lock_before_rate_limited_owner_returns_owner_unavailable()
+ {
+    let (state, _temp_dir, db_url) = file_backed_test_state_with_busy_timeout(
+        "bodyless-owner-rate-limited-sqlite-lock",
+        Duration::from_millis(20),
+    )
+    .await;
+    enable_encrypted_session_owner_routing_for_test(&state).await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let owner_account_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Encrypted Owner",
+        "upstream-owner",
+        None,
+        None,
+        None,
+    )
+    .await;
+    let _secondary_account_id = insert_test_pool_api_key_account_with_options(
+        &state,
+        "Secondary",
+        "upstream-secondary",
+        None,
+        None,
+        None,
+    )
+    .await;
+    sqlx::query("UPDATE pool_upstream_accounts SET policy_concurrency_limit = 1 WHERE id = ?1")
+        .bind(owner_account_id)
+        .execute(&state.pool)
+        .await
+        .expect("set encrypted owner account concurrency limit");
+    let now_iso = format_utc_iso(Utc::now());
+    insert_test_pool_limit_sample(&state, owner_account_id, Some(20.0), Some(20.0)).await;
+    upsert_sticky_route(
+        &state.pool,
+        "pck-bodyless-header-encrypted-owner-rate-limited-locked-active",
+        owner_account_id,
+        &now_iso,
+    )
+    .await
+    .expect("seed active sticky route for locked rate-limited owner");
+    let prompt_cache_key = "pck-bodyless-header-encrypted-owner-rate-limited-locked";
+    upsert_prompt_cache_encrypted_session_owner(&state.pool, prompt_cache_key, owner_account_id)
+        .await
+        .expect("persist encrypted owner lock");
+
+    let mut lock_conn = SqliteConnection::connect(&db_url)
+        .await
+        .expect("connect sqlite lock holder");
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut lock_conn)
+        .await
+        .expect("acquire sqlite write lock");
+
+    let started = Instant::now();
+    let request_task = tokio::task::spawn_blocking({
+        let state = state.clone();
+        move || {
+            run_future_with_large_stack(async move {
+                let (
+                    prompt_cache_binding_constraint,
+                    owner_auto_guard_active,
+                    conversation_override,
+                ) = load_via_pool_effective_routing(state.as_ref(), Some(prompt_cache_key), false)
+                    .await
+                    .expect("load via-pool effective routing");
+                let mut no_available_wait_deadline = None;
+                let resolution = resolve_pool_account_for_request_with_wait_and_binding_constraint_with_image_intent_and_override(
+                    state.as_ref(),
+                    None,
+                    None,
+                    &[],
+                    &HashSet::new(),
+                    None,
+                    prompt_cache_binding_constraint.as_ref(),
+                    conversation_override.as_ref(),
+                    true,
+                    &mut no_available_wait_deadline,
+                    None,
+                    "/v1/models",
+                    crate::ImageIntent::Unknown,
+                )
+                .await;
+                unwrap_via_pool_initial_account(
+                    state.as_ref(),
+                    Some(&build_via_pool_attempt_trace_context(
+                        5350,
+                        "/v1/models",
+                        None,
+                    )),
+                    resolution,
+                    no_available_wait_deadline,
+                    None,
+                    prompt_cache_binding_constraint.as_ref(),
+                    owner_auto_guard_active,
+                    Some(prompt_cache_key),
+                )
+                .await
+                .expect_err("sqlite lock retries should still end at owner guard")
+            })
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(70)).await;
+    sqlx::query("COMMIT")
+        .execute(&mut lock_conn)
+        .await
+        .expect("release sqlite write lock");
+
+    let response = request_task
+        .await
+        .expect("locked owner-guard request should join");
+    assert!(
+        started.elapsed() >= Duration::from_millis(40),
+        "expected sqlite lock retries before owner guard, elapsed={:?}",
+        started.elapsed()
+    );
+    assert_encrypted_owner_blocked_proxy_error(
+        &response,
+        owner_account_id,
+        format!("#{owner_account_id}"),
+        prompt_cache_key,
+    );
+    assert_eq!(count_pool_upstream_request_attempts(&state.pool).await, 0);
+}
+
+#[tokio::test]
 async fn proxy_openai_v1_bodyless_header_prompt_cache_key_same_account_binding_newer_than_owner_still_returns_owner_unavailable()
  {
     let (upstream_base, attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;


### PR DESCRIPTION
## Summary
- retry account resolution when owner-guard routing hits transient SQLite locks instead of surfacing a spurious `502`
- retry prompt-cache binding and conversation override reads before returning via-pool routing errors
- add a deterministic SQLite-lock regression for the rate-limited encrypted-owner preflight path

## Testing
- `cargo test bodyless_header_prompt_cache_key_rate_limited_owner_returns_owner_unavailable -- --nocapture`
- `cargo test websocket_prepare_rate_limited_owner_returns_owner_unavailable -- --nocapture`
- `cargo test unwrap_via_pool_initial_account_retries_sqlite_lock_before_rate_limited_owner_returns_owner_unavailable -- --nocapture`
- `env RUST_MIN_STACK=33554432 cargo test live_first_and_owner_guard -- --nocapture`
- `env RUST_MIN_STACK=33554432 bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite`

## References
- Specs: `docs/specs/e8n4q-encrypted-session-owner-guard/SPEC.md`, `docs/specs/w5s2x-openai-websocket-proxy/SPEC.md`
- Solutions: `-`
- Project Docs: `-`
