### PR TITLE
feat(worktree): auto-restore dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@
 - `cargo run` — start the backend (reads `.env.local`, listens on `127.0.0.1:8080`).
 - `bun install` — install repo-level tooling for hooks, worktree bootstrap, and docs checks.
 - `bun run hooks:install` — install shared Git hooks for every linked worktree in this repository.
-- `bun run worktree:bootstrap` — manually rerun the copy-missing-only local config sync for the current worktree.
-- `bun run worktree:setup` — explicitly install root, `web/`, and `docs-site/` Bun dependencies for the current worktree.
+- `bun run worktree:bootstrap` — manually rerun local resource sync and dependency recovery for the current worktree.
+- `bun run worktree:setup` — install root, `web/`, `docs-site/`, and Rust dependencies with locked dependency metadata.
 - `cd web && bun install` — install SPA dependencies once per setup.
 - `cd web && bun run dev -- --host 127.0.0.1 --port 60080` — run the front-end dev server with proxy to the backend.
 - `cd web && bun run build` — produce production assets for `web/dist`.
@@ -75,6 +75,6 @@ Use non-blocking runtime management for long-lived services, but do not require 
 ## Security & Configuration Tips
 
 - Store authentication cookies and secrets in `.env.local`; the file is ignored—never commit credentials.
-- Worktree bootstrap only copies missing resources declared in `scripts/worktree-sync.paths`; the current contract syncs `.env.local` from the primary worktree into new linked worktrees, never overwrites existing local files, and never copies dependency or runtime directories. Dependency installation is explicit via `bun run worktree:setup`, not automatic from `post-checkout`.
+- Worktree bootstrap copies missing resources declared in `scripts/worktree-sync.paths` and recovers dependencies in linked worktrees. It syncs `.env.local` from the primary worktree without overwriting existing local files, never copies dependency or runtime directories, and uses `bun install --frozen-lockfile` plus `cargo fetch --locked`. Automatic dependency failures warn and do not block checkout; manual `bun run worktree:bootstrap` returns non-zero when any recovery step fails.
 - SQLite files default to `codex_vibe_monitor.db` in the repo root; add alternate paths via `DATABASE_PATH` if running in containers.
 - SSE and HTTP clients depend on stable polling; monitor logs (`RUST_LOG=info cargo run`) when adjusting concurrency or timeouts.

--- a/README.md
+++ b/README.md
@@ -230,21 +230,19 @@ bun install
 bun run hooks:install
 ```
 
-之后新建 linked worktree 时，shared Git `post-checkout` hook 会自动补齐缺失的 `.env.local`。如果需要手动重跑轻量 bootstrap，可执行：
+之后新建或切换 linked worktree 时，shared Git `post-checkout` hook 会自动补齐缺失的 `.env.local`，并尝试恢复当前 checkout 所需的依赖。主 worktree 的普通 checkout 不会触发依赖安装。如果需要手动重跑完整 bootstrap，可执行：
 
 ```bash
 bun run worktree:bootstrap
 ```
 
-该 bootstrap 只会复制 `scripts/worktree-sync.paths` 中声明的缺失本地资源；当前首版仅同步 `.env.local`，不会覆盖已有本地文件，也不会复制或安装 `node_modules`、数据库文件或 `.codex/xray-forward` 一类运行态目录。
+该 bootstrap 会复制 `scripts/worktree-sync.paths` 中声明的缺失本地资源，并使用锁定文件恢复 repo root、`web/`、`docs-site/` 的 Bun 依赖以及 Rust crate 缓存。它不会覆盖已有本地文件，也不会复制 `node_modules`、数据库文件或 `.codex/xray-forward` 一类运行态目录。
 
-如果需要把当前 worktree 初始化成完整开发环境，显式执行：
+安装分为 repo root、`web`、`docs-site` 三项 `bun install --frozen-lockfile` 和一项 `cargo fetch --locked`，每项失败后仍会继续执行其余项。自动 `post-checkout` 会告警但不阻断 checkout；手动 bootstrap 会在存在失败时返回非零，便于脚本或 CI 发现问题。若需只执行依赖安装，可使用：
 
 ```bash
 bun run worktree:setup
 ```
-
-`worktree:setup` 会依次安装 repo root、`web/` 与 `docs-site/` 的 Bun 依赖。依赖安装不会由 `post-checkout` 自动触发，避免 checkout 依赖网络或长时间阻塞。
 
 ## 第一次部署最该先确认的配置
 

--- a/docs/specs/v7se4-worktree-bootstrap/HISTORY.md
+++ b/docs/specs/v7se4-worktree-bootstrap/HISTORY.md
@@ -6,11 +6,13 @@
 
 - 2026-03-14: archived spec 固定 shared hooks、`post-checkout`、`.env.local` copy-missing-only 与真实 linked worktree smoke。
 - 2026-05-15: 重新建立 canonical `docs/specs/` 主题 spec，并将依赖安装明确拆到显式 `worktree:setup`，避免 checkout hook 变成联网/重型动作。
+- 2026-07-24: 将依赖恢复扩展到 linked `post-checkout`；三项 Bun 安装和 `cargo fetch --locked` 逐项执行，自动路径告警后继续 checkout，手动 bootstrap 返回聚合失败码。
 
 ## Key Reasons / Replacements
 
-- 自动 bootstrap 适合补缺失本地配置，不适合安装依赖；依赖安装失败不应阻断普通 Git checkout。
-- `worktree:setup` 是完整开发环境初始化入口，职责与 `worktree:bootstrap` 分离。
+- linked worktree 的自动 bootstrap 需要同时恢复依赖，但主 worktree 的普通 checkout 不应承担这类网络动作。
+- 依赖任务必须逐项隔离；自动 hook 不能阻断 Git checkout，手动入口则必须暴露失败。
+- `worktree:setup` 继续作为共享的依赖恢复实现，`worktree:bootstrap` 负责在资源同步后调用它。
 - 本 spec 继承并取代 archived `docs/archive/specs/v7se4-worktree-bootstrap/SPEC.md` 作为当前有效规范。
 
 ## References

--- a/docs/specs/v7se4-worktree-bootstrap/IMPLEMENTATION.md
+++ b/docs/specs/v7se4-worktree-bootstrap/IMPLEMENTATION.md
@@ -6,14 +6,15 @@
 
 - Implementation: 已实现
 - Lifecycle: active
-- Catalog note: `post-checkout` bootstrap 保持轻量；依赖安装由 `worktree:setup` 显式触发。
+- Catalog note: linked `post-checkout` 自动恢复依赖，主 worktree 跳过；手动 bootstrap 保留失败码。
 
 ## Coverage / rollout summary
 
-- `scripts/worktree-bootstrap.sh` 继续只安装 shared hooks 并同步缺失本地资源。
-- `scripts/worktree-setup.sh` 安装 repo root、`web/`、`docs-site/` Bun 依赖。
-- `scripts/test-worktree-bootstrap.sh` 使用真实 linked worktree smoke 和 fake `bun` 验证 no-deps bootstrap 与 setup 调用链。
-- README 与 AGENTS 已说明 bootstrap/setup 的职责差异。
+- `scripts/worktree-bootstrap.sh` 安装 shared hooks、同步缺失本地资源并调用依赖 setup。
+- `scripts/worktree-setup.sh` 逐项执行三项 `bun install --frozen-lockfile` 与 `cargo fetch --locked`，汇总失败。
+- `scripts/run-lefthook-hook.sh` 仅在 linked worktree 的 `post-checkout` 调用依赖 setup，并吞掉失败码。
+- `scripts/test-worktree-bootstrap.sh` 使用真实 linked worktree smoke 和 fake `bun`/`cargo` 验证自动/手动入口、主 worktree 跳过与失败隔离。
+- README 与 AGENTS 已说明自动恢复、手动失败码和 locked 参数。
 
 ## Remaining Gaps
 
@@ -21,8 +22,9 @@
 
 ## Related Changes
 
-- 新增 `bun run worktree:setup`。
-- 扩展 worktree bootstrap smoke test。
+- 扩展 `bun run worktree:setup` 覆盖 Rust 与 locked install。
+- 将依赖恢复接入 linked `post-checkout` 和手动 `worktree:bootstrap`。
+- 扩展 worktree bootstrap smoke test 的失败隔离与退出码覆盖。
 
 ## References
 

--- a/docs/specs/v7se4-worktree-bootstrap/SPEC.md
+++ b/docs/specs/v7se4-worktree-bootstrap/SPEC.md
@@ -4,23 +4,23 @@
 
 ## 背景 / 问题陈述
 
-- linked worktree 需要稳定继承本地配置，但 checkout hook 不应承担联网安装依赖等重型动作。
-- 当前仓库已经有 shared Git hooks、copy-missing-only `.env.local` 同步与真实 linked worktree smoke；本规范将“轻量 bootstrap”和“显式依赖 setup”作为长期边界固定下来。
+- linked worktree 需要在首次进入和后续 checkout 后稳定继承本地配置与依赖，但依赖恢复失败不应破坏 Git checkout。
+- 当前仓库已经有 shared Git hooks、copy-missing-only `.env.local` 同步与真实 linked worktree smoke；本规范将“自动依赖恢复”和“手动完整 bootstrap”作为同一套可复用实现固定下来。
 - archived `docs/archive/specs/v7se4-worktree-bootstrap/SPEC.md` 是历史来源；本文是当前 canonical spec。
 
 ## 目标 / 非目标
 
 ### Goals
 
-- 保持 `post-checkout` bootstrap 轻量、安全、幂等，只补缺失本地资源。
-- 提供显式 `bun run worktree:setup`，一次安装 repo root、`web/` 与 `docs-site/` 的 Bun 依赖。
-- 用 smoke test 锁住默认 bootstrap 不安装依赖、setup 才调用依赖安装的行为。
+- 保持 `post-checkout` bootstrap 安全、可重复执行，并只在 linked worktree 中恢复依赖。
+- 提供统一的依赖恢复实现，覆盖 repo root、`web`、`docs-site` 的 Bun 依赖和 Rust crate 缓存。
+- 用 smoke test 锁住自动/手动入口、主/linked worktree 区分、锁定参数与失败隔离行为。
 
 ### Non-goals
 
-- 不在 `post-checkout` 中默认执行 `bun install`。
 - 不复制 `node_modules`、SQLite DB、`.codex/xray-forward` 或其他运行态目录。
 - 不修改 HTTP API、SSE、数据库 schema 或前端业务逻辑。
+- 不自动安装 Bun、Cargo、系统库或 Playwright 浏览器等外部前置条件。
 
 ## 范围（Scope）
 
@@ -39,15 +39,16 @@
 
 ### MUST
 
-- `post-checkout` 自动路径不得安装依赖、不得创建或复制 `node_modules`。
+- linked worktree 的 `post-checkout` 自动路径必须尝试执行三项 `bun install --frozen-lockfile` 和一项 `cargo fetch --locked`；主 worktree 的 `post-checkout` 不得安装依赖。
 - `worktree:bootstrap` 必须继续遵守 copy-missing-only；目标文件已存在时不得覆盖。
-- `worktree:setup` 必须由开发者显式执行，并按 repo root、`web/`、`docs-site/` 覆盖 Bun 依赖安装。
-- smoke test 必须验证默认 bootstrap 的 no-deps 边界和 setup 的安装调用链，且不得真实联网安装依赖。
+- `worktree:setup` 必须按四项依赖任务执行，使用 locked 参数；单项失败后必须继续其余任务并汇总失败。
+- 自动 hook 必须返回成功并告警；手动 `worktree:bootstrap` 在存在失败时必须返回非零。
+- smoke test 必须使用 fake Bun/Cargo 验证上述调用链，且不得真实联网安装依赖。
 
 ### SHOULD
 
-- setup 脚本保持薄封装，优先复用 Bun 与现有 package manifests。
-- 文档应明确 bootstrap 与 setup 的职责差异，避免维护者误以为 checkout 会自动安装依赖。
+- setup 脚本保持薄封装，优先复用 Bun、Cargo 与现有 lockfiles。
+- 文档应明确主 worktree 与 linked worktree 的触发差异，以及自动/手动失败码语义。
 
 ### COULD
 
@@ -57,24 +58,26 @@
 
 ### Core flows
 
-- 新 linked worktree checkout 时，shared `post-checkout` hook 调用当前 checkout 的 bootstrap runner；runner 只安装/维护 hook 链并同步 manifest 中缺失的本地资源。
-- 开发者需要完整依赖环境时，在目标 worktree 执行 `bun run worktree:setup`；脚本依次在 repo root、`web/`、`docs-site/` 运行 `bun install`。
+- 新建或切换 linked worktree 时，shared `post-checkout` hook 调用当前 checkout 的 bootstrap runner；runner 同步 manifest 中缺失的本地资源，并调用依赖 setup。
+- 依赖 setup 在 repo root、`web`、`docs-site` 运行 `bun install --frozen-lockfile`，随后在 repo root 运行 `cargo fetch --locked`。
+- 主 worktree 的 `post-checkout` 只同步本地资源，不运行依赖 setup。
+- 自动 hook 忽略依赖 setup 的最终失败码并打印补救提示；手动 `bun run worktree:bootstrap` 保留失败码。
 
 ### Edge cases / errors
 
 - 当前 worktree 已存在 `.env.local` 时，bootstrap 必须跳过且不覆盖。
-- 目标依赖目录不存在时，bootstrap 不负责创建；setup 的 Bun install 负责正常依赖安装。
+- 目标依赖目录不存在或依赖状态需要更新时，由对应 locked install 命令负责恢复。
 - 若当前 revision 缺少 bootstrap 脚本，shared hook wrapper 继续安全 no-op。
 
 ## 接口契约（Interfaces & Contracts）
 
 ### 接口清单（Inventory）
 
-| 接口（Name）                 | 类型（Kind） | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner） | 使用方（Consumers） | 备注（Notes）               |
-| ---------------------------- | ------------ | ------------- | -------------- | ------------------------ | --------------- | ------------------- | --------------------------- |
-| `bun run worktree:setup`     | CLI          | internal      | New            | None                     | repo tooling    | contributors        | 显式安装 root/web/docs 依赖 |
-| `bun run worktree:bootstrap` | CLI          | internal      | Modify         | None                     | repo tooling    | contributors        | 明确保持 no-deps 轻量边界   |
-| `post-checkout` bootstrap    | Git hook     | internal      | Modify         | None                     | repo tooling    | linked worktrees    | 自动路径不得安装依赖        |
+| 接口（Name）                 | 类型（Kind） | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner） | 使用方（Consumers） | 备注（Notes）                     |
+| ---------------------------- | ------------ | ------------- | -------------- | ------------------------ | --------------- | ------------------- | --------------------------------- |
+| `bun run worktree:setup`     | CLI          | internal      | Modify         | None                     | repo tooling    | contributors        | 执行三项 Bun + 一项 Rust 依赖恢复 |
+| `bun run worktree:bootstrap` | CLI          | internal      | Modify         | None                     | repo tooling    | contributors        | 同步资源并聚合依赖恢复失败        |
+| `post-checkout` bootstrap    | Git hook     | internal      | Modify         | None                     | repo tooling    | linked worktrees    | 自动恢复依赖但不阻断 checkout     |
 
 ### 契约文档（按 Kind 拆分）
 
@@ -82,22 +85,26 @@
 
 ## 验收标准（Acceptance Criteria）
 
-- Given 新 linked worktree 缺失 `.env.local`
+- Given 新 linked worktree 缺失 `.env.local` 和依赖目录
   When shared `post-checkout` hook 触发
-  Then worktree 获得缺失 `.env.local`，且不会创建 root、`web/`、`docs-site/` 的 `node_modules`。
+  Then worktree 获得缺失 `.env.local`，并执行三项 frozen Bun install 与一次 locked Cargo fetch。
 
-- Given 开发者执行 `bun run worktree:setup`
+- Given 主 worktree 触发 `post-checkout`
   When setup 脚本运行
-  Then repo root、`web/`、`docs-site/` 均执行一次 `bun install`。
+  Then 不执行任何 Bun 或 Cargo 依赖命令。
+
+- Given 任一 Bun/Cargo 依赖任务失败
+  When 自动 hook 继续执行
+  Then 其余任务仍执行、输出失败摘要且 hook 返回 0；手动 bootstrap 返回非零。
 
 - Given CI 运行 `scripts/test-worktree-bootstrap.sh`
-  When fake `bun` 捕获 setup 调用链
-  Then 测试不联网且能证明 setup 覆盖三个依赖安装位置。
+  When fake `bun` 和 fake `cargo` 捕获 setup 调用链
+  Then 测试不联网且能证明命令参数、执行顺序和失败隔离。
 
 ## 验收清单（Acceptance checklist）
 
-- [x] bootstrap no-deps 边界已由 smoke test 覆盖。
-- [x] setup 显式安装路径已由 fake `bun` 覆盖。
+- [x] linked 自动依赖恢复与主 worktree 跳过已由 smoke test 覆盖。
+- [x] locked Bun/Cargo 安装路径与失败隔离已由 fake `bun`/`cargo` 覆盖。
 - [x] README / AGENTS 已区分 bootstrap 与 setup。
 - [x] archived spec 的历史语义已迁移到 canonical spec。
 
@@ -128,7 +135,7 @@ None
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 
-- 风险：把依赖安装放进 checkout hook 会让 Git 操作依赖网络和耗时命令；本规范固定为显式 setup。
+- 风险：把依赖安装放进 linked checkout hook 会增加网络和耗时；本规范固定为逐项 best-effort，失败不阻断 checkout。
 - 假设：Bun 是仓库唯一 JS package manager，且 root、`web/`、`docs-site/` 都由 Bun 管理。
 
 ## 参考（References）

--- a/scripts/run-lefthook-hook.sh
+++ b/scripts/run-lefthook-hook.sh
@@ -8,14 +8,38 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [ -z "$repo_root" ]; then
   exit 0
 fi
+repo_root="$(cd "$repo_root" && pwd)"
 cd "$repo_root"
 
 sync_script="$repo_root/scripts/sync-worktree-resources.sh"
+setup_script="$repo_root/scripts/worktree-setup.sh"
+
+is_linked_worktree() {
+  common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -z "$common_dir" ]; then
+    return 1
+  fi
+
+  case "$common_dir" in
+    /*) ;;
+    *) common_dir="$repo_root/$common_dir" ;;
+  esac
+
+  source_root="$(cd "$(dirname "$common_dir")" 2>/dev/null && pwd || true)"
+  [ -n "$source_root" ] && [ "$repo_root" != "$source_root" ]
+}
 
 if [ "$hook_name" = "post-checkout" ]; then
   if [ -x "$sync_script" ]; then
     "$sync_script" "$@"
   fi
+
+  if is_linked_worktree && [ -x "$setup_script" ]; then
+    if ! "$setup_script"; then
+      printf '[worktree-bootstrap] dependency setup failed; checkout continues. Run `bun run worktree:bootstrap` to retry.\n' >&2
+    fi
+  fi
+
   exit 0
 fi
 

--- a/scripts/test-worktree-bootstrap.sh
+++ b/scripts/test-worktree-bootstrap.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-vibe-monitor-worktree-bootstrap.XXXXXX")"
 tmp_dir="$(cd "$tmp_dir" && pwd)"
-trap 'rm -rf "$tmp_dir"' EXIT
+
+cleanup() {
+  if [ -n "${fixture_repo:-}" ] && [ -n "${worktree_dir:-}" ] && [ -d "$fixture_repo" ]; then
+    git -C "$fixture_repo" worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
 
 copy_repo() {
   src="$1"
@@ -72,8 +79,29 @@ write_fake_bun() {
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\t%s\n' "$(pwd)" "$*" >> "${BUN_INSTALL_LOG:?}"
+surface=repo
+case "$(basename "$(pwd)")" in
+  web|docs-site) surface="$(basename "$(pwd)")" ;;
+esac
+if [ "${FAKE_BUN_FAIL_SURFACE:-}" = "$surface" ]; then
+  exit 11
+fi
 EOF_FAKE
   chmod +x "$bin_dir/bun"
+}
+
+write_fake_cargo() {
+  bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/cargo" <<'EOF_FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\t%s\n' "$(pwd)" "$*" >> "${CARGO_FETCH_LOG:?}"
+if [ "${FAKE_CARGO_FAIL:-0}" = '1' ]; then
+  exit 12
+fi
+EOF_FAKE
+  chmod +x "$bin_dir/cargo"
 }
 
 fixture_repo="$tmp_dir/fixture"
@@ -82,6 +110,17 @@ init_repo "$fixture_repo"
 
 printf 'PRIMARY_SECRET=from-primary\n' > "$fixture_repo/.env.local"
 write_fake_lefthook "$fixture_repo"
+
+fake_bin="$tmp_dir/fake-bin"
+bun_install_log="$tmp_dir/bun-install.log"
+cargo_fetch_log="$tmp_dir/cargo-fetch.log"
+write_fake_bun "$fake_bin"
+write_fake_cargo "$fake_bin"
+export PATH="$fake_bin:$PATH"
+export BUN_INSTALL_LOG="$bun_install_log"
+export CARGO_FETCH_LOG="$cargo_fetch_log"
+: > "$bun_install_log"
+: > "$cargo_fetch_log"
 
 install_output="$(bash "$fixture_repo/scripts/install-hooks.sh" 2>&1)"
 assert_file_contains <(printf '%s' "$install_output") 'installed shared hooks'
@@ -95,10 +134,25 @@ assert_file_contains "$hooks_dir/post-checkout" '# managed by codex-vibe-monitor
 worktree_dir="$tmp_dir/linked"
 git -C "$fixture_repo" worktree add --detach "$worktree_dir" HEAD >/dev/null
 assert_equal_file "$fixture_repo/.env.local" "$worktree_dir/.env.local"
+assert_file_contains "$bun_install_log" "$worktree_dir"$'\t''install --frozen-lockfile'
+assert_file_contains "$bun_install_log" "$worktree_dir/web"$'\t''install --frozen-lockfile'
+assert_file_contains "$bun_install_log" "$worktree_dir/docs-site"$'\t''install --frozen-lockfile'
+assert_file_contains "$cargo_fetch_log" "$worktree_dir"$'\t''fetch --locked'
 
 printf 'TARGET_SECRET=keep-me\n' > "$worktree_dir/.env.local"
 git -C "$worktree_dir" checkout --detach HEAD >/dev/null 2>&1
 assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+
+: > "$bun_install_log"
+: > "$cargo_fetch_log"
+(
+  cd "$fixture_repo"
+  "$hooks_dir/post-checkout" HEAD HEAD 1 >/dev/null 2>&1
+)
+if [ -s "$bun_install_log" ] || [ -s "$cargo_fetch_log" ]; then
+  printf 'primary worktree post-checkout must not install dependencies\n' >&2
+  exit 1
+fi
 
 rm -rf "$worktree_dir/node_modules"
 (
@@ -118,23 +172,41 @@ mkdir -p "$(dirname "$commit_editmsg_path")"
 assert_file_contains "$worktree_dir/.lefthook-run.log" 'run commit-msg'
 assert_file_contains "$worktree_dir/.lefthook-run.log" "$commit_editmsg_path"
 
-bash "$worktree_dir/scripts/worktree-bootstrap.sh" >/dev/null
-assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
-if [ -e "$worktree_dir/node_modules" ] || [ -e "$worktree_dir/web/node_modules" ] || [ -e "$worktree_dir/docs-site/node_modules" ]; then
-  printf 'worktree bootstrap must not install dependency directories\n' >&2
-  exit 1
-fi
-
-fake_bun_dir="$tmp_dir/fake-bun"
-bun_install_log="$tmp_dir/bun-install.log"
-write_fake_bun "$fake_bun_dir"
 (
   cd "$worktree_dir"
-  PATH="$fake_bun_dir:$PATH" BUN_INSTALL_LOG="$bun_install_log" bash scripts/worktree-setup.sh >/dev/null
+  bash scripts/worktree-bootstrap.sh >/dev/null
 )
-assert_file_contains "$bun_install_log" "$worktree_dir"$'\t''install'
-assert_file_contains "$bun_install_log" "$worktree_dir/web"$'\t''install'
-assert_file_contains "$bun_install_log" "$worktree_dir/docs-site"$'\t''install'
+assert_file_contains "$worktree_dir/.env.local" 'TARGET_SECRET=keep-me'
+
+: > "$bun_install_log"
+: > "$cargo_fetch_log"
+failure_output="$tmp_dir/failure-output.log"
+if (
+  cd "$worktree_dir"
+  FAKE_BUN_FAIL_SURFACE=web FAKE_CARGO_FAIL=1 \
+    "$hooks_dir/post-checkout" HEAD HEAD 1 > "$failure_output" 2>&1
+); then
+  assert_file_contains "$failure_output" 'dependency setup failed'
+else
+  printf 'post-checkout dependency failures must not fail the hook\n' >&2
+  exit 1
+fi
+assert_file_contains "$bun_install_log" "$worktree_dir"$'\t''install --frozen-lockfile'
+assert_file_contains "$bun_install_log" "$worktree_dir/web"$'\t''install --frozen-lockfile'
+assert_file_contains "$bun_install_log" "$worktree_dir/docs-site"$'\t''install --frozen-lockfile'
+assert_file_contains "$cargo_fetch_log" "$worktree_dir"$'\t''fetch --locked'
+assert_file_contains "$failure_output" 'web Bun dependencies'
+assert_file_contains "$failure_output" 'Rust dependencies'
+
+if (
+  cd "$worktree_dir"
+  FAKE_BUN_FAIL_SURFACE=web FAKE_CARGO_FAIL=1 \
+    bash scripts/worktree-bootstrap.sh > "$failure_output" 2>&1
+); then
+  printf 'manual worktree bootstrap must report dependency failures\n' >&2
+  exit 1
+fi
+assert_file_contains "$failure_output" 'dependency setup failed'
 
 rm -f "$fixture_repo/scripts/run-lefthook-hook.sh" \
   "$fixture_repo/scripts/sync-worktree-resources.sh" \

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -6,3 +6,4 @@ repo_root="$(cd "$script_dir/.." && pwd)"
 
 bash "$repo_root/scripts/install-hooks.sh"
 bash "$repo_root/scripts/sync-worktree-resources.sh"
+bash "$repo_root/scripts/worktree-setup.sh"

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 
-run_install() {
+failed_labels=()
+
+run_step() {
   label="$1"
   dir="$2"
+  shift 2
 
-  printf '[worktree-setup] installing %s dependencies\n' "$label"
-  (
-    cd "$dir"
-    bun install
-  )
+  printf '[worktree-setup] installing %s\n' "$label"
+  if (
+    cd "$dir" &&
+    "$@"
+  ); then
+    printf '[worktree-setup] installed %s\n' "$label"
+  else
+    printf '[worktree-setup] failed %s\n' "$label" >&2
+    failed_labels+=("$label")
+  fi
 }
 
-run_install "repo" "$repo_root"
-run_install "web" "$repo_root/web"
-run_install "docs-site" "$repo_root/docs-site"
+run_step "repo Bun dependencies" "$repo_root" bun install --frozen-lockfile
+run_step "web Bun dependencies" "$repo_root/web" bun install --frozen-lockfile
+run_step "docs-site Bun dependencies" "$repo_root/docs-site" bun install --frozen-lockfile
+run_step "Rust dependencies" "$repo_root" cargo fetch --locked
+
+if [ "${#failed_labels[@]}" -gt 0 ]; then
+  printf '[worktree-setup] dependency setup failed: %s\n' "${failed_labels[*]}" >&2
+  exit 1
+fi
 
 printf '[worktree-setup] dependencies installed\n'


### PR DESCRIPTION
## Summary
- Restore root, `web`, `docs-site`, and Rust dependencies for linked worktrees after `post-checkout`.
- Run four locked dependency tasks independently; automatic hook failures warn and do not block checkout, while manual bootstrap returns non-zero.
- Keep primary worktrees dependency-free on `post-checkout` and preserve copy-missing-only local configuration sync.

## Verification
- `bash -n scripts/worktree-setup.sh scripts/worktree-bootstrap.sh scripts/run-lefthook-hook.sh scripts/test-worktree-bootstrap.sh`
- `bash scripts/test-worktree-bootstrap.sh`
- `cargo check --locked` and `cargo fetch --locked`
- root/web/docs-site `bun install --frozen-lockfile`
- `cd web && bun run test`
- `bun run lint:web && bun run lint:docs`

## References
- Spec: `docs/specs/v7se4-worktree-bootstrap/SPEC.md`
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions: -
- Solutions Sync: n/a(no related solution)
- Project Docs: `README.md`, `AGENTS.md`
- Project Docs Sync: done
- Visual evidence: not applicable; no UI changes

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->