### PR TITLE
fix(invocations): isolate retry response details

### DIFF
--- a/docs/solutions/performance/proxy-capture-body-replay-safety.md
+++ b/docs/solutions/performance/proxy-capture-body-replay-safety.md
@@ -50,6 +50,7 @@ The capture path historically used one full in-memory request body as both routi
 - Do not infer “no encrypted content” from a prefix scan; absence is only safe after full parse or an equivalent explicit contract.
 - Do not drop or truncate raw payload as a performance optimization. If raw writer fails, log and classify it, but keep business response semantics separate.
 - Keep fallback reason values stable enough for production log comparison.
+- Treat invocation-level raw response capture as final-attempt evidence only. When reconstructing a retry timeline, compute the final real attempt first; non-final attempts must retain their own status, headers, and byte metrics, while an uncaptured attempt response stays explicitly unavailable instead of inheriting the final response body.
 - Treat `snapshot_kind="memory"` on multi-MiB requests as a regression unless the same log window shows a temp-file create/write/flush warning explaining the fail-soft fallback.
 - Do not convert a terminal direct-image timeout into a generic no-account result; return a traceable gateway timeout and release the account reservation without replaying the body.
 

--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/HISTORY.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/HISTORY.md
@@ -26,3 +26,4 @@
 - 2026-07-20: unavailable payload reason 统一映射为人类可读文案；UI 不再直接暴露 `missing_body`、`raw_file_missing` 等内部 reason code。
 - 2026-07-20: mock-only Web Demo 为 `demo-invocation-9002` 补齐 Dashboard 路由级 workflow detail / request-body / response-body 夹具，页面级最终证据切回真实 `#/dashboard/invocations/:invokeId` 抽屉，而不是只依赖 Storybook 组件画布。
 - 2026-07-25: workflow detail 的响应 fallback 按最终真实出站 attempt 隔离；非最终重试只展示自身状态、响应头摘要与响应体字节指标，调用级 raw response 仅允许绑定最终尝试，避免 502 重试卡片伪装成后续成功响应。
+- 2026-07-25: 本修复的视觉证据仅用于聊天中的 Storybook 验收；preferred evidence section 使用 `PR: none`，避免在没有截图提交授权时向 PR 发布图片链接。

--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/HISTORY.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/HISTORY.md
@@ -25,3 +25,4 @@
 - 2026-07-20: 修正调用详情 payload lazy loader 的 effect 竞态；请求体/响应体 fetch 完成后改用 sequence guard 判定最新请求，避免成功返回后仍永远停在 `加载请求体…` / `加载响应体…`。
 - 2026-07-20: unavailable payload reason 统一映射为人类可读文案；UI 不再直接暴露 `missing_body`、`raw_file_missing` 等内部 reason code。
 - 2026-07-20: mock-only Web Demo 为 `demo-invocation-9002` 补齐 Dashboard 路由级 workflow detail / request-body / response-body 夹具，页面级最终证据切回真实 `#/dashboard/invocations/:invokeId` 抽屉，而不是只依赖 Storybook 组件画布。
+- 2026-07-25: workflow detail 的响应 fallback 按最终真实出站 attempt 隔离；非最终重试只展示自身状态、响应头摘要与响应体字节指标，调用级 raw response 仅允许绑定最终尝试，避免 502 重试卡片伪装成后续成功响应。

--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/IMPLEMENTATION.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/IMPLEMENTATION.md
@@ -4,8 +4,8 @@
 
 - Canonical spec: `docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md`
 - Implementation summary: 调用详情继续使用统一工作流视图；当前真相已收紧为 `attempt = 真实开始向上游 dispatch`，pre-dispatch pool 终态统一表现为 `路由决定 + 系统裁定`，本地裁定返回体回放真实下游 body。
-- Branch: `th/fix-invocation-payload-loading`
-- Base: `main@1bd0ae7d63ce9123a8c8311c934c842ae99dcffa`
+- Branch: `th/fix-attempt-response-detail-isolation`
+- Base: `origin/main@5cc11b2c`
 
 ## Implemented Coverage
 
@@ -23,6 +23,7 @@
 - 尝试块进一步改成显式子页面目录：默认展开首个尝试块，并直接展示 `概览 + 7 个尝试子详情页` 的入口矩阵，避免请求 / 响应细节继续藏在两级按钮后面。
 - 路由块详情固定为 `请求 / 请求头 / 请求体` 三个分区；其中 `请求体` 直接复用调用级 request-body 读取路径，不在 attempt 表复制 raw body。
 - 调用详情的 lazy payload loader 现在统一使用 request/response sequence guard：点击 `请求体` / `响应体` 后，异步完成必须以最近一次请求为准收口到 `ready` 或 `error`，不能再因 effect 自清理把已成功返回的结果永久丢成 `loading`。
+- workflow detail 聚合层现在按真实出站 attempt 的最大 `attempt_index` 判定最终尝试；非最终尝试的响应头、错误上下文、延迟 fallback 与响应体 capture 均保持 attempt 级边界，不再回退到调用级最终响应。
 - mock-only Web Demo 现在为 `demo-invocation-9002` 补齐 `/api/invocations/:id/workflow-detail`、`/request-body` 和 `/response-body` 路由级夹具；Dashboard 可直接从分享路由回放真实 attempt 卡片，并稳定复现“请求体未存档但不再卡 loading”的 owner-facing 证据面。
 - 本地生成的终态错误响应改为复用共享 envelope，同时驱动 HTTP 下游返回与 `ProxyCaptureRecord` 持久化；`systemFinalFailure.responseBody` 对 503/429/同类本地裁定现在回放真实 JSON body，不再落 `"{}"` / `missing_body` 假空体。
 - pre-dispatch pool 失败、budget terminal、websocket pre-upstream owner-guard 等本地终态不再前向写入 `pool_upstream_request_attempts`；真实出站调用的 attempt 主路径保持不变。
@@ -43,6 +44,10 @@
 - `cd web && bun run test src/features/dashboard/DashboardInvocationDetailDrawer.test.tsx`: 1 file passed，9 tests passed。
 - `cd web && bun run demo:build`: passed。
 - `cd web && bun run build-storybook`: passed。
+- `cargo test invocation_cost_audit_tests -- --nocapture`: 5 tests passed，覆盖非最终尝试的响应头/响应体隔离及最终尝试映射。
+- `cd web && bun run test -- src/features/invocations/InvocationWorkflowDetailPanel.test.tsx`: 1 file passed，8 tests passed，覆盖非最终尝试不会 lazy-fetch 调用级响应体。
+- `cd web && bun run build`: passed。
+- Chrome + Storybook `RetriedAttemptResponseBodyUnavailable` 验证：H3HxTB12 显示 `HTTP 502`、`98 B`、`attempt_metrics`，W1scc2SS 显示 `HTTP 200`、`181,382 B`，控制台无 error/warn。
 - Chrome + Storybook `BlockedPoolWorkflowMissingArchivedRequestBody` 验证：`请求体` lazy fetch 最终显示 `该记录没有保留可展示的载荷。`，且页面文本不再包含内部 `missing_body` reason。
 - Chrome + mock-only Web Demo Dashboard 路由验证：`#/dashboard/invocations/demo-invocation-9002?demoScene=operational&demoTheme=dark` 内的 attempt `qPvNNAK8` 展开 `请求体` 后，界面显示 `请求体不可用：该记录没有保留可展示的载荷。`，且保留请求/响应指标、压缩信息与 `归档 未存档`。
 - 本地截图验证已补充 `workflow-detail-dashboard-attempt-request-body-unavailable.png`，并写回 spec `## Visual Evidence` 作为页面级最终证据；Storybook 截图继续只承担组件级回归证据。

--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/IMPLEMENTATION.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/IMPLEMENTATION.md
@@ -48,6 +48,7 @@
 - `cd web && bun run test -- src/features/invocations/InvocationWorkflowDetailPanel.test.tsx`: 1 file passed，8 tests passed，覆盖非最终尝试不会 lazy-fetch 调用级响应体。
 - `cd web && bun run build`: passed。
 - Chrome + Storybook `RetriedAttemptResponseBodyUnavailable` 验证：H3HxTB12 显示 `HTTP 502`、`98 B`、`attempt_metrics`，W1scc2SS 显示 `HTTP 200`、`181,382 B`，控制台无 error/warn。
+- Stateful SQLite owner-guard 回归测试改为通过 `spawn_blocking` 等待大栈 worker，避免在 Tokio 测试 runtime 内同步 join 导致 mock upstream 饿死并误报 502；覆盖模块 70 tests 及目标三例的 20 轮循环均通过。
 - Chrome + Storybook `BlockedPoolWorkflowMissingArchivedRequestBody` 验证：`请求体` lazy fetch 最终显示 `该记录没有保留可展示的载荷。`，且页面文本不再包含内部 `missing_body` reason。
 - Chrome + mock-only Web Demo Dashboard 路由验证：`#/dashboard/invocations/demo-invocation-9002?demoScene=operational&demoTheme=dark` 内的 attempt `qPvNNAK8` 展开 `请求体` 后，界面显示 `请求体不可用：该记录没有保留可展示的载荷。`，且保留请求/响应指标、压缩信息与 `归档 未存档`。
 - 本地截图验证已补充 `workflow-detail-dashboard-attempt-request-body-unavailable.png`，并写回 spec `## Visual Evidence` 作为页面级最终证据；Storybook 截图继续只承担组件级回归证据。

--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md
@@ -123,47 +123,7 @@ Dashboard / Live / Records 三处调用详情曾经以“摘要字段 + 局部�
   - 裁定返回体态：系统裁定块展开后切换到 `返回体`，证明详情页显示的是实际下发给调用方的 JSON body，而非 `missing_body` 或空占位。
   - unavailable 回放态：`请求体` lazy fetch 完成后，界面必须从 loading 收口到人类可读提示 `该记录没有保留可展示的载荷。`，而不是无限 loading 或直接暴露内部 `missing_body` reason。
 
-PR: include
-![Dashboard 调用详情 attempt 请求体 unavailable 路由证据](./assets/workflow-detail-dashboard-attempt-request-body-unavailable.png)
-
-PR: include
-![Pre-dispatch blocked workflow 概览态](./assets/workflow-detail-blocked-overview.png)
-
-PR: include
-![Pre-dispatch blocked workflow 请求体详情态](./assets/workflow-detail-blocked-request-body.png)
-
-PR: include
-![Pre-dispatch blocked workflow 请求体 unavailable 回放态](./assets/workflow-detail-blocked-request-body-unavailable.png)
-
-PR: include
-![Pre-dispatch blocked workflow 裁定返回体态](./assets/workflow-detail-blocked-final-body.png)
-
-PR: include
-![调用详情概览时间线](./assets/workflow-detail-overview.png)
-
-PR: include
-![调用详情暗色概览时间线](./assets/workflow-detail-dark-theme-overview.png)
-
-PR: include
-![调用详情亮色概览时间线](./assets/workflow-detail-light-theme-overview.png)
-
-PR: include
-![调用详情尝试子详情目录](./assets/workflow-detail-attempt-subpages-overview.png)
-
-PR: include
-![调用详情请求头视图](./assets/workflow-detail-request-headers.png)
-
-PR: include
-![调用详情请求体视图](./assets/workflow-detail-attempt-request.png)
-
-PR: include
-![调用详情响应头视图](./assets/workflow-detail-response-headers.png)
-
-PR: include
-![调用详情响应体视图](./assets/workflow-detail-response-body.png)
-
-PR: include
-![调用详情响应体子页](./assets/workflow-detail-attempt-subpages-response-body.png)
+PR: none
 
 ## References
 

--- a/docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md
+++ b/docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md
@@ -69,6 +69,8 @@ Dashboard / Live / Records 三处调用详情曾经以“摘要字段 + 局部�
 - 尝试级结构化详情允许通过 `request_summary_json` / `response_summary_json` 保存，必要时可回退为运行时重建。
 - 除尝试外的时间线动作允许以 `timeline_json` 保存在 `codex_invocations` 上；缺失时，工作流详情接口必须基于调用级记录与尝试记录进行 best-effort reconstruction，并显式标记是否为 partial / reconstructed。
 - 当前契约下，请求体完整原文只保证在调用级记录存在；尝试级接口默认暴露结构化摘要，而不是再次复制完整 request body。
+- 响应体完整原文同样只保证在调用级记录存在，且只允许绑定到最终真实尝试或系统最终裁定；非最终尝试必须显示自己的状态、响应头摘要与上游响应体字节指标，响应体回放明确为 unavailable，不得把调用级最终响应体或最终响应头 fallback 到该尝试。
+- 运行时重建尝试响应摘要时，只能使用该尝试的列和明确持久化的 `response_summary_json`；调用级 `response_raw_*`、`responseContentEncoding`、最终 `upstreamRequestId` 与 delivery snapshot 仅可用于最终尝试/系统最终裁定。
 - 本地生成的终态裁定响应必须复用单一共享 envelope，同时驱动实际 HTTP 下游返回与调用级持久化；`systemFinalFailure.responseBody` 必须回放真实下发 body，不得再落 `"{}"`、`missing_body` 等占位假空体，除非历史记录从未持久化真实 body。
 
 ### Payload 识别与渲染
@@ -95,6 +97,7 @@ Dashboard / Live / Records 三处调用详情曾经以“摘要字段 + 局部�
 - 新的 pre-dispatch pool 失败时间线只展示 `路由决定 + 系统裁定`，`hero.timelineAttemptCount = 0`。
 - 真实出站调用仍按顺序展示辅助块、尝试块和失败场景下的系统裁定块；同一时刻仅展开一个块，展开区保持紧凑。
 - 点击尝试块后，默认展示概览，并可通过次级操作进入请求 / 响应；点击路由块后，默认展示概览，并可通过次级操作进入 `请求 / 请求头 / 请求体`；点击失败裁定块后，默认展示概览，并可通过次级操作进入 `裁定 / 返回体`。
+- 对包含重试的调用，非最终 Attempt 的响应详情不得显示最终 Attempt 的响应体大小、响应头或 lazy response-body 内容；如果没有尝试级原文，应明确显示 `non_final_attempt_response_body_not_captured` 对应的 unavailable 状态。
 - 历史 pseudo-attempt 在纠偏后不得再显示为 Attempt；若旧记录从未持久化真实 body，允许继续显示 unavailable。
 - JSON、NDJSON、SSE JSON data 均显示可折叠、高亮、键盘可操作的结构化视图。
 - 纯文本、解析失败内容和超长无空格文本保持可读并自动换行。

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -3491,17 +3491,40 @@ fn build_request_client_snapshot(payload: Option<&Value>) -> Value {
     })
 }
 
-fn build_response_header_snapshot(record: &ApiInvocation, payload: Option<&Value>) -> Value {
+fn build_response_header_snapshot(
+    record: &ApiInvocation,
+    attempt: Option<&InvocationWorkflowAttemptRow>,
+    payload: Option<&Value>,
+    allow_invocation_level_fields: bool,
+) -> Value {
+    let content_encoding = allow_invocation_level_fields
+        .then(|| {
+            record
+                .response_content_encoding
+                .clone()
+                .or_else(|| payload_string(payload, &["responseContentEncoding"]))
+        })
+        .flatten();
+    let content_encoding_chain = allow_invocation_level_fields
+        .then(|| payload_string(payload, &["contentEncodingChain"]))
+        .flatten();
+    let upstream_request_id = attempt
+        .and_then(|attempt| attempt.upstream_request_id.clone())
+        .or_else(|| {
+            allow_invocation_level_fields
+                .then(|| {
+                    record
+                        .upstream_request_id
+                        .clone()
+                        .or_else(|| payload_string(payload, &["upstreamRequestId"]))
+                })
+                .flatten()
+        });
+
     json!({
-        "contentEncoding": record
-            .response_content_encoding
-            .clone()
-            .or_else(|| payload_string(payload, &["responseContentEncoding"])),
-        "contentEncodingChain": payload_string(payload, &["contentEncodingChain"]),
-        "upstreamRequestId": record
-            .upstream_request_id
-            .clone()
-            .or_else(|| payload_string(payload, &["upstreamRequestId"])),
+        "contentEncoding": content_encoding,
+        "contentEncodingChain": content_encoding_chain,
+        "upstreamRequestId": upstream_request_id,
         "cvmInvokeId": Some(record.invoke_id.clone()),
     })
 }
@@ -3888,48 +3911,88 @@ fn build_attempt_response_summary(
     attempt: &InvocationWorkflowAttemptRow,
     payload: Option<&Value>,
     usage_cost_audit: Option<&InvocationCostAudit>,
+    is_final_attempt: bool,
 ) -> Value {
+    let invocation_failure_kind = is_final_attempt
+        .then_some(record.failure_kind.as_ref())
+        .flatten();
+    let invocation_error_message = is_final_attempt
+        .then_some(record.error_message.as_ref())
+        .flatten();
+    let invocation_downstream_error_message = is_final_attempt
+        .then_some(record.downstream_error_message.as_ref())
+        .flatten();
+    let invocation_upstream_request_id = is_final_attempt
+        .then_some(record.upstream_request_id.as_ref())
+        .flatten();
+    let invocation_response_content_encoding = is_final_attempt
+        .then(|| record.response_content_encoding.clone())
+        .flatten();
+    let invocation_response_payload = is_final_attempt.then_some(payload).flatten();
+    let response_body_capture_size = if is_final_attempt {
+        record.response_raw_size
+    } else {
+        attempt.upstream_response_body_bytes
+    };
+    let response_body_capture_truncated = if is_final_attempt {
+        record.response_raw_truncated.unwrap_or_default() != 0
+    } else {
+        false
+    };
+    let response_body_capture_truncated_reason = if is_final_attempt {
+        record.response_raw_truncated_reason.clone()
+    } else {
+        None
+    };
+    let response_body_capture_detail_level = if is_final_attempt {
+        Some(record.detail_level.clone())
+    } else {
+        Some("attempt_metrics".to_string())
+    };
+
     json!({
         "status": attempt.status.clone(),
         "phase": attempt.phase.clone(),
         "httpStatus": attempt.http_status,
-        "compactionResponseKind": record.compaction_response_kind.clone(),
-        "failureKind": attempt.failure_kind.as_ref().or(record.failure_kind.as_ref()),
-        "errorMessage": attempt.error_message.as_ref().or(record.error_message.as_ref()),
+        "compactionResponseKind": is_final_attempt.then(|| record.compaction_response_kind.clone()).flatten(),
+        "failureKind": attempt.failure_kind.as_ref().or(invocation_failure_kind),
+        "errorMessage": attempt.error_message.as_ref().or(invocation_error_message),
         "downstreamErrorMessage": attempt
             .downstream_error_message
             .as_ref()
-            .or(record.downstream_error_message.as_ref()),
-        "upstreamRequestId": attempt.upstream_request_id.as_ref().or(record.upstream_request_id.as_ref()),
-        "upstreamErrorCode": record.upstream_error_code.clone(),
-        "upstreamErrorMessage": record.upstream_error_message.clone(),
-        "streamTerminalEvent": record.stream_terminal_event.clone(),
-        "responseContentEncoding": record.response_content_encoding.clone(),
-        "serviceTier": record.service_tier.clone(),
-        "billingServiceTier": record.billing_service_tier.clone(),
-        "headers": build_response_header_snapshot(record, payload),
-        "delivery": build_response_delivery_snapshot(payload),
+            .or(invocation_downstream_error_message),
+        "upstreamRequestId": attempt.upstream_request_id.as_ref().or(invocation_upstream_request_id),
+        "upstreamErrorCode": is_final_attempt.then(|| record.upstream_error_code.clone()).flatten(),
+        "upstreamErrorMessage": is_final_attempt.then(|| record.upstream_error_message.clone()).flatten(),
+        "streamTerminalEvent": is_final_attempt.then(|| record.stream_terminal_event.clone()).flatten(),
+        "responseContentEncoding": invocation_response_content_encoding,
+        "serviceTier": is_final_attempt.then(|| record.service_tier.clone()).flatten(),
+        "billingServiceTier": is_final_attempt.then(|| record.billing_service_tier.clone()).flatten(),
+        "headers": build_response_header_snapshot(record, Some(attempt), payload, is_final_attempt),
+        "delivery": build_response_delivery_snapshot(invocation_response_payload),
         "compactSupport": {
             "status": attempt.compact_support_status.clone(),
             "reason": attempt.compact_support_reason.clone(),
         },
         "latencyMs": {
-            "connect": attempt.connect_latency_ms.or(record.t_upstream_connect_ms),
-            "firstByte": attempt.first_byte_latency_ms.or(record.t_upstream_ttfb_ms),
-            "stream": attempt.stream_latency_ms.or(record.t_upstream_stream_ms),
-            "requestRead": record.t_req_read_ms,
-            "requestParse": record.t_req_parse_ms,
-            "responseParse": record.t_resp_parse_ms,
-            "persist": record.t_persist_ms,
-            "total": record.t_total_ms,
+            "connect": attempt.connect_latency_ms.or_else(|| is_final_attempt.then_some(record.t_upstream_connect_ms).flatten()),
+            "firstByte": attempt.first_byte_latency_ms.or_else(|| is_final_attempt.then_some(record.t_upstream_ttfb_ms).flatten()),
+            "stream": attempt.stream_latency_ms.or_else(|| is_final_attempt.then_some(record.t_upstream_stream_ms).flatten()),
+            "requestRead": is_final_attempt.then_some(record.t_req_read_ms).flatten(),
+            "requestParse": is_final_attempt.then_some(record.t_req_parse_ms).flatten(),
+            "responseParse": is_final_attempt.then_some(record.t_resp_parse_ms).flatten(),
+            "persist": is_final_attempt.then_some(record.t_persist_ms).flatten(),
+            "total": is_final_attempt.then_some(record.t_total_ms).flatten(),
         },
         "responseBodyCapture": {
-            "availableAtInvocationLevel": record.response_raw_path.is_some(),
-            "size": record.response_raw_size,
-            "truncated": record.response_raw_truncated.unwrap_or_default() != 0,
-            "truncatedReason": record.response_raw_truncated_reason.clone(),
-            "detailLevel": record.detail_level.clone(),
-            "detailPruneReason": record.detail_prune_reason.clone(),
+            "availableAtInvocationLevel": is_final_attempt && record.response_raw_path.is_some(),
+            "size": response_body_capture_size,
+            "truncated": response_body_capture_truncated,
+            "truncatedReason": response_body_capture_truncated_reason,
+            "detailLevel": response_body_capture_detail_level,
+            "detailPruneReason": is_final_attempt.then(|| record.detail_prune_reason.clone()).flatten(),
+            "unavailableReason": (!is_final_attempt)
+                .then_some("non_final_attempt_response_body_not_captured"),
         },
         "usage": usage_cost_audit.map(|audit| build_invocation_usage_summary(record, audit)),
     })
@@ -3940,7 +4003,21 @@ fn build_workflow_attempt_from_row(
     attempt: &InvocationWorkflowAttemptRow,
     payload: Option<&Value>,
     usage_cost_audit: Option<&InvocationCostAudit>,
+    is_final_attempt: bool,
 ) -> InvocationWorkflowAttempt {
+    let invocation_failure_kind = is_final_attempt
+        .then(|| record.failure_kind.clone())
+        .flatten();
+    let invocation_error_message = is_final_attempt
+        .then(|| record.error_message.clone())
+        .flatten();
+    let invocation_downstream_error_message = is_final_attempt
+        .then(|| record.downstream_error_message.clone())
+        .flatten();
+    let invocation_upstream_request_id = is_final_attempt
+        .then(|| record.upstream_request_id.clone())
+        .flatten();
+
     InvocationWorkflowAttempt {
         synthetic: false,
         attempt_id: attempt.attempt_id.clone(),
@@ -3970,32 +4047,46 @@ fn build_workflow_attempt_from_row(
         phase: attempt.phase.clone(),
         http_status: attempt.http_status,
         downstream_http_status: attempt.downstream_http_status,
-        failure_kind: attempt
-            .failure_kind
-            .clone()
-            .or_else(|| record.failure_kind.clone()),
-        error_message: attempt
-            .error_message
-            .clone()
-            .or_else(|| record.error_message.clone()),
+        failure_kind: attempt.failure_kind.clone().or(invocation_failure_kind),
+        error_message: attempt.error_message.clone().or(invocation_error_message),
         downstream_error_message: attempt
             .downstream_error_message
             .clone()
-            .or_else(|| record.downstream_error_message.clone()),
-        connect_latency_ms: attempt.connect_latency_ms.or(record.t_upstream_connect_ms),
-        first_byte_latency_ms: attempt.first_byte_latency_ms.or(record.t_upstream_ttfb_ms),
-        stream_latency_ms: attempt.stream_latency_ms.or(record.t_upstream_stream_ms),
+            .or(invocation_downstream_error_message),
+        connect_latency_ms: attempt.connect_latency_ms.or_else(|| {
+            is_final_attempt
+                .then_some(record.t_upstream_connect_ms)
+                .flatten()
+        }),
+        first_byte_latency_ms: attempt.first_byte_latency_ms.or_else(|| {
+            is_final_attempt
+                .then_some(record.t_upstream_ttfb_ms)
+                .flatten()
+        }),
+        stream_latency_ms: attempt.stream_latency_ms.or_else(|| {
+            is_final_attempt
+                .then_some(record.t_upstream_stream_ms)
+                .flatten()
+        }),
         upstream_request_id: attempt
             .upstream_request_id
             .clone()
-            .or_else(|| record.upstream_request_id.clone()),
+            .or(invocation_upstream_request_id),
         request_summary: parse_summary_json_or_fallback(
             attempt.request_summary_json.as_deref(),
             || build_attempt_request_summary(record, attempt, payload),
         ),
         response_summary: parse_summary_json_or_fallback(
             attempt.response_summary_json.as_deref(),
-            || build_attempt_response_summary(record, attempt, payload, usage_cost_audit),
+            || {
+                build_attempt_response_summary(
+                    record,
+                    attempt,
+                    payload,
+                    usage_cost_audit,
+                    is_final_attempt,
+                )
+            },
         ),
     }
 }
@@ -4060,7 +4151,7 @@ fn build_synthetic_workflow_attempt(
         "responseContentEncoding": record.response_content_encoding.clone(),
         "serviceTier": record.service_tier.clone(),
         "billingServiceTier": record.billing_service_tier.clone(),
-        "headers": build_response_header_snapshot(record, payload),
+        "headers": build_response_header_snapshot(record, None, payload, true),
         "delivery": build_response_delivery_snapshot(payload),
         "latencyMs": {
             "connect": record.t_upstream_connect_ms,
@@ -4391,27 +4482,6 @@ fn build_workflow_attempt_timeline_entry(
     }
 }
 
-fn suppress_invocation_level_response_body_for_account_retry(
-    attempt: &mut InvocationWorkflowAttempt,
-    attempt_row: &InvocationWorkflowAttemptRow,
-) {
-    let Some(Value::Object(response_summary)) = attempt.response_summary.as_mut() else {
-        return;
-    };
-
-    let mut capture = serde_json::Map::new();
-    capture.insert("availableAtInvocationLevel".to_string(), Value::Bool(false));
-    if let Some(size) = attempt_row.upstream_response_body_bytes {
-        capture.insert("size".to_string(), json!(size));
-    }
-    capture.insert("detailLevel".to_string(), json!("attempt_metrics"));
-    capture.insert(
-        "unavailableReason".to_string(),
-        json!("non_final_attempt_response_body_not_captured"),
-    );
-    response_summary.insert("responseBodyCapture".to_string(), Value::Object(capture));
-}
-
 pub(crate) async fn hydrate_upstream_account_attempt_workflow_entries(
     state: &AppState,
     records: &mut [ApiPoolUpstreamRequestAttempt],
@@ -4475,26 +4545,15 @@ pub(crate) async fn hydrate_upstream_account_attempt_workflow_entries(
         let workflow_entries = real_attempt_rows
             .into_iter()
             .filter_map(|attempt_row| {
-                let mut attempt = build_workflow_attempt_from_row(
+                let attempt = build_workflow_attempt_from_row(
                     &record,
                     attempt_row,
                     payload_value.as_ref(),
                     (last_success_attempt_index == Some(attempt_row.attempt_index))
                         .then_some(usage_cost_audit.as_ref())
                         .flatten(),
+                    final_attempt_index == Some(attempt_row.attempt_index),
                 );
-                if final_attempt_index != Some(attempt_row.attempt_index)
-                    && attempt_row
-                        .response_summary_json
-                        .as_deref()
-                        .map(str::trim)
-                        .is_none_or(str::is_empty)
-                {
-                    suppress_invocation_level_response_body_for_account_retry(
-                        &mut attempt,
-                        attempt_row,
-                    );
-                }
                 let attempt_id = attempt.attempt_id.clone()?;
                 Some((attempt_id, build_workflow_attempt_timeline_entry(attempt)))
             })
@@ -4711,7 +4770,13 @@ pub(crate) async fn fetch_invocation_workflow_detail(
         pseudo_attempt_rows
             .last()
             .map(|attempt| {
-                build_workflow_attempt_from_row(&record, attempt, payload_value.as_ref(), None)
+                build_workflow_attempt_from_row(
+                    &record,
+                    attempt,
+                    payload_value.as_ref(),
+                    None,
+                    false,
+                )
             })
             .unwrap_or_else(|| {
                 build_synthetic_workflow_attempt(&record, payload_value.as_ref(), None)
@@ -4728,6 +4793,10 @@ pub(crate) async fn fetch_invocation_workflow_detail(
             )]
         }
     } else {
+        let final_attempt_index = real_attempt_rows
+            .iter()
+            .map(|attempt| attempt.attempt_index)
+            .max();
         real_attempt_rows
             .iter()
             .map(|attempt| {
@@ -4738,6 +4807,7 @@ pub(crate) async fn fetch_invocation_workflow_detail(
                     (last_success_attempt_index == Some(attempt.attempt_index))
                         .then_some(usage_cost_audit.as_ref())
                         .flatten(),
+                    final_attempt_index == Some(attempt.attempt_index),
                 )
             })
             .collect::<Vec<_>>()
@@ -15182,6 +15252,7 @@ mod invocation_cost_audit_tests {
                     None,
                     (last_success_attempt_index == Some(attempt.attempt_index))
                         .then_some(&usage_cost_audit),
+                    attempt.attempt_index == 3,
                 )
             })
             .collect::<Vec<_>>();
@@ -15205,6 +15276,91 @@ mod invocation_cost_audit_tests {
         assert_eq!(
             final_response_summary["usage"]["audit"]["reason"].as_str(),
             Some(INVOCATION_COST_AUDIT_REASON_PRICE_VERSION_CHANGED)
+        );
+    }
+
+    #[test]
+    fn non_final_attempt_response_summary_does_not_reuse_invocation_level_response_details() {
+        let mut record = sample_invocation(Some(0));
+        record.response_raw_path = Some("response-body.json".to_string());
+        record.response_raw_size = Some(181_382);
+        record.response_content_encoding = Some("identity".to_string());
+        record.upstream_request_id = Some("W1scc2SS".to_string());
+
+        let mut attempt = sample_attempt_row(1, "failed");
+        attempt.upstream_request_id = Some("H3HxTB12".to_string());
+        attempt.upstream_response_body_bytes = Some(98);
+
+        let response_summary = build_attempt_response_summary(&record, &attempt, None, None, false);
+
+        assert_eq!(
+            response_summary["responseBodyCapture"]["availableAtInvocationLevel"],
+            Value::Bool(false)
+        );
+        assert_eq!(response_summary["responseBodyCapture"]["size"], json!(98));
+        assert_eq!(
+            response_summary["responseBodyCapture"]["detailLevel"],
+            json!("attempt_metrics")
+        );
+        assert_eq!(
+            response_summary["responseBodyCapture"]["unavailableReason"],
+            json!("non_final_attempt_response_body_not_captured")
+        );
+        assert_eq!(
+            response_summary["headers"]["upstreamRequestId"],
+            json!("H3HxTB12")
+        );
+        assert!(response_summary["headers"]["contentEncoding"].is_null());
+        assert!(response_summary["responseContentEncoding"].is_null());
+    }
+
+    #[test]
+    fn workflow_attempt_mapping_scopes_invocation_response_capture_to_final_attempt() {
+        let mut record = sample_invocation(Some(0));
+        record.response_raw_path = Some("response-body.json".to_string());
+        record.response_raw_size = Some(181_382);
+        record.response_content_encoding = Some("identity".to_string());
+        record.upstream_request_id = Some("W1scc2SS".to_string());
+
+        let mut first_attempt = sample_attempt_row(1, "failed");
+        first_attempt.upstream_request_id = Some("H3HxTB12".to_string());
+        first_attempt.upstream_response_body_bytes = Some(98);
+        let mut final_attempt = sample_attempt_row(2, "success");
+        final_attempt.upstream_request_id = Some("W1scc2SS".to_string());
+        final_attempt.upstream_response_body_bytes = Some(181_382);
+
+        let first = build_workflow_attempt_from_row(&record, &first_attempt, None, None, false);
+        let final_attempt =
+            build_workflow_attempt_from_row(&record, &final_attempt, None, None, true);
+
+        assert_eq!(
+            first.response_summary.as_ref().expect("first summary")["headers"]["upstreamRequestId"],
+            json!("H3HxTB12")
+        );
+        assert_eq!(
+            first.response_summary.as_ref().expect("first summary")["responseBodyCapture"]["size"],
+            json!(98)
+        );
+        assert_eq!(
+            final_attempt
+                .response_summary
+                .as_ref()
+                .expect("final summary")["headers"]["upstreamRequestId"],
+            json!("W1scc2SS")
+        );
+        assert_eq!(
+            final_attempt
+                .response_summary
+                .as_ref()
+                .expect("final summary")["responseBodyCapture"]["size"],
+            json!(181_382)
+        );
+        assert_eq!(
+            final_attempt
+                .response_summary
+                .as_ref()
+                .expect("final summary")["responseBodyCapture"]["availableAtInvocationLevel"],
+            Value::Bool(true)
         );
     }
 }

--- a/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
+++ b/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
@@ -51,6 +51,16 @@ where
         .expect("join large-stack test worker")
 }
 
+async fn run_future_with_large_stack_async<T, Fut>(future: Fut) -> T
+where
+    T: Send + 'static,
+    Fut: std::future::Future<Output = T> + Send + 'static,
+{
+    tokio::task::spawn_blocking(move || run_future_with_large_stack(future))
+        .await
+        .expect("join large-stack test worker")
+}
+
 #[tokio::test]
 async fn proxy_openai_v1_via_pool_waits_for_initial_account_resolution_before_sending() {
     let (upstream_base, attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;
@@ -1324,7 +1334,7 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_preserves_encrypted_ow
     let runtime_timeouts = resolve_proxy_request_timeouts(state.as_ref(), true)
         .await
         .expect("resolve pool runtime timeouts");
-    let response = run_future_with_large_stack({
+    let response = run_future_with_large_stack_async({
         let state = state.clone();
         async move {
             proxy_openai_v1_via_pool(
@@ -1349,7 +1359,8 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_preserves_encrypted_ow
             .await
             .expect_err("bodyless encrypted owner lock should not reroute to another account")
         }
-    });
+    })
+    .await;
 
     assert_encrypted_owner_blocked_proxy_error(
         &response,
@@ -1419,10 +1430,21 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_rate_limited_owner_ret
         .await
         .expect("persist encrypted owner lock");
 
+    let (binding_constraint, owner_auto_guard_active) =
+        load_via_pool_effective_routing_constraint(state.as_ref(), Some(prompt_cache_key), false)
+            .await
+            .expect("load rate-limited encrypted owner routing constraint");
+    assert!(matches!(
+        binding_constraint,
+        Some(PromptCacheConversationBindingConstraint::UpstreamAccount(account_id))
+            if account_id == owner_account_id
+    ));
+    assert!(owner_auto_guard_active);
+
     let runtime_timeouts = resolve_proxy_request_timeouts(state.as_ref(), true)
         .await
         .expect("resolve pool runtime timeouts");
-    let response = run_future_with_large_stack({
+    let response = run_future_with_large_stack_async({
         let state = state.clone();
         async move {
             proxy_openai_v1_via_pool(
@@ -1447,7 +1469,8 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_rate_limited_owner_ret
             .await
             .expect_err("rate-limited encrypted owner lock should not reroute to another account")
         }
-    });
+    })
+    .await;
 
     assert_encrypted_owner_blocked_proxy_error(
         &response,
@@ -1540,10 +1563,21 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_same_account_binding_n
     .await
     .expect("persist same-account binding newer than owner");
 
+    let (binding_constraint, owner_auto_guard_active) =
+        load_via_pool_effective_routing_constraint(state.as_ref(), Some(prompt_cache_key), false)
+            .await
+            .expect("load same-account encrypted owner routing constraint");
+    assert!(matches!(
+        binding_constraint,
+        Some(PromptCacheConversationBindingConstraint::UpstreamAccount(account_id))
+            if account_id == owner_account_id
+    ));
+    assert!(owner_auto_guard_active);
+
     let runtime_timeouts = resolve_proxy_request_timeouts(state.as_ref(), true)
         .await
         .expect("resolve pool runtime timeouts");
-    let response = run_future_with_large_stack({
+    let response = run_future_with_large_stack_async({
         let state = state.clone();
         async move {
             proxy_openai_v1_via_pool(
@@ -1568,7 +1602,8 @@ async fn proxy_openai_v1_bodyless_header_prompt_cache_key_same_account_binding_n
             .await
             .expect_err("same-account newer binding should still keep encrypted owner guard")
         }
-    });
+    })
+    .await;
 
     assert_encrypted_owner_blocked_proxy_error(
         &response,

--- a/web/src/features/invocations/InvocationWorkflowDetailPanel.stories.tsx
+++ b/web/src/features/invocations/InvocationWorkflowDetailPanel.stories.tsx
@@ -2,7 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ReactNode, useEffect } from "react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 import { I18nProvider } from "../../i18n";
-import type { ApiInvocation, ApiInvocationWorkflowDetailResponse } from "../../lib/api";
+import type {
+  ApiInvocation,
+  ApiInvocationWorkflowDetailResponse,
+  ApiInvocationWorkflowTimelineEntry,
+} from "../../lib/api";
 import { FullPageStorySurface } from "../../storybook/storybookPageHelpers";
 import { InvocationWorkflowDetailPanel } from "./InvocationWorkflowDetailPanel";
 import {
@@ -381,6 +385,114 @@ const failedWorkflowResponse: ApiInvocationWorkflowDetailResponse = {
   partial: false,
   partialReason: null,
 };
+
+function createRetriedWorkflowResponse(): ApiInvocationWorkflowDetailResponse {
+  const firstAttemptEntry = failedWorkflowResponse.timeline.find(
+    (entry) => entry.kind === "attempt",
+  );
+  const finalFailureEntry = failedWorkflowResponse.timeline.find(
+    (entry) => entry.kind === "systemFinalFailure",
+  );
+  if (!firstAttemptEntry?.attempt || !finalFailureEntry) {
+    throw new Error("retry workflow fixture must contain an attempt and final failure");
+  }
+
+  const firstAttempt: ApiInvocationWorkflowTimelineEntry = {
+    ...firstAttemptEntry,
+    blockId: "attempt-h3hxtb12",
+    title: "Attempt 1",
+    subtitle: "pool-alpha@example.com",
+    status: "http_failure",
+    attempt: {
+      ...firstAttemptEntry.attempt,
+      attemptId: "H3HxTB12",
+      status: "http_failure",
+      phase: "failed",
+      httpStatus: 502,
+      failureKind: "upstream_http_5xx",
+      errorMessage: "pool upstream responded with 502",
+      downstreamErrorMessage: "pool upstream responded with 502",
+      upstreamRequestId: "H3HxTB12",
+      responseSummary: {
+        ...(firstAttemptEntry.attempt.responseSummary ?? {}),
+        status: "http_failure",
+        phase: "failed",
+        httpStatus: 502,
+        failureKind: "upstream_http_5xx",
+        errorMessage: "pool upstream responded with 502",
+        downstreamErrorMessage: "pool upstream responded with 502",
+        responseContentEncoding: null,
+        headers: {
+          contentEncoding: null,
+          upstreamRequestId: "H3HxTB12",
+        },
+        responseBodyCapture: {
+          availableAtInvocationLevel: false,
+          size: 98,
+          detailLevel: "attempt_metrics",
+          unavailableReason: "non_final_attempt_response_body_not_captured",
+        },
+      },
+    },
+  };
+
+  const finalAttempt: ApiInvocationWorkflowTimelineEntry = {
+    ...firstAttemptEntry,
+    blockId: "attempt-w1scc2ss",
+    occurredAt: "2026-07-15T13:56:08Z",
+    title: "Attempt 2",
+    subtitle: "pool-beta@example.com",
+    status: "success",
+    attempt: {
+      ...firstAttemptEntry.attempt,
+      attemptId: "W1scc2SS",
+      occurredAt: "2026-07-15T13:56:08Z",
+      attemptIndex: 2,
+      upstreamAccountId: 43,
+      upstreamAccountName: "pool-beta@example.com",
+      status: "success",
+      phase: "completed",
+      httpStatus: 200,
+      failureKind: null,
+      errorMessage: null,
+      downstreamErrorMessage: null,
+      upstreamRequestId: "W1scc2SS",
+      responseSummary: {
+        ...(firstAttemptEntry.attempt.responseSummary ?? {}),
+        status: "success",
+        phase: "completed",
+        httpStatus: 200,
+        failureKind: null,
+        errorMessage: null,
+        downstreamErrorMessage: null,
+        responseContentEncoding: "identity",
+        headers: {
+          contentEncoding: "identity",
+          upstreamRequestId: "W1scc2SS",
+        },
+        responseBodyCapture: {
+          availableAtInvocationLevel: true,
+          size: 181_382,
+          detailLevel: "full",
+        },
+      },
+    },
+  };
+
+  return {
+    ...failedWorkflowResponse,
+    hero: {
+      ...failedWorkflowResponse.hero,
+      timelineAttemptCount: 2,
+      poolAttemptCount: 2,
+      upstreamAccountId: 43,
+      upstreamAccountName: "pool-beta@example.com",
+    },
+    timeline: [failedWorkflowResponse.timeline[0], firstAttempt, finalAttempt, finalFailureEntry],
+  };
+}
+
+const retriedWorkflowResponse = createRetriedWorkflowResponse();
 
 const blockedWorkflowRecord: ApiInvocation = {
   ...failedWorkflowRecord,
@@ -991,6 +1103,49 @@ export const FailedPoolWorkflow: Story = {
       </>
     ),
   ],
+};
+
+export const RetriedAttemptResponseBodyUnavailable: Story = {
+  args: {
+    record: failedWorkflowRecord,
+    size: "default",
+  },
+  decorators: [
+    (Story) => (
+      <>
+        <WorkflowFetchMock recordId={77} response={retriedWorkflowResponse} />
+        <Story />
+      </>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A retried workflow keeps the first 502 attempt bound to its own response headers and metrics. The final response body is only available on the W1scc2SS attempt.",
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvasElement.textContent ?? "").toContain("H3HxTB12");
+      expect(canvasElement.textContent ?? "").toContain("98 B");
+    });
+    const nonFinalResponseBodyButton = (
+      await canvas.findAllByRole("button", {
+        name: /响应体/i,
+      })
+    ).find((button) => button.textContent?.includes("98 B"));
+    if (!nonFinalResponseBodyButton) {
+      throw new Error("non-final response body action not found");
+    }
+    await userEvent.click(nonFinalResponseBodyButton);
+    await waitFor(() => {
+      expect(canvasElement.textContent ?? "").toContain("该重试不是最终响应，未绑定调用级响应体。");
+    });
+    expect(nonFinalResponseBodyButton.textContent ?? "").not.toContain("181,382 B");
+  },
 };
 
 export const FailedPoolWorkflowPage: Story = {

--- a/web/src/features/invocations/InvocationWorkflowDetailPanel.test.tsx
+++ b/web/src/features/invocations/InvocationWorkflowDetailPanel.test.tsx
@@ -803,6 +803,110 @@ describe("InvocationWorkflowDetailPanel", () => {
     expect(host?.textContent ?? "").not.toContain("最终响应体：调用级存档。");
   });
 
+  it("does not lazy-fetch invocation response body for a non-final attempt", async () => {
+    const response = createWorkflowDetailResponse();
+    const firstAttemptEntry = response.timeline.find((entry) => entry.kind === "attempt");
+    if (!firstAttemptEntry?.attempt) {
+      throw new Error("workflow fixture must contain an attempt");
+    }
+
+    firstAttemptEntry.attempt = {
+      ...firstAttemptEntry.attempt,
+      attemptId: "H3HxTB12",
+      attemptIndex: 1,
+      upstreamRequestId: "H3HxTB12",
+      responseSummary: {
+        ...(firstAttemptEntry.attempt.responseSummary ?? {}),
+        responseContentEncoding: null,
+        headers: {
+          contentEncoding: null,
+          upstreamRequestId: "H3HxTB12",
+        },
+        responseBodyCapture: {
+          availableAtInvocationLevel: false,
+          size: 98,
+          detailLevel: "attempt_metrics",
+          unavailableReason: "non_final_attempt_response_body_not_captured",
+        },
+      },
+    };
+
+    const finalAttemptEntry = {
+      ...firstAttemptEntry,
+      blockId: "attempt-2",
+      occurredAt: "2026-07-15T13:56:08Z",
+      title: "Attempt 2",
+      subtitle: "pool-beta@example.com",
+      status: "success",
+      attempt: {
+        ...firstAttemptEntry.attempt,
+        attemptId: "W1scc2SS",
+        occurredAt: "2026-07-15T13:56:08Z",
+        attemptIndex: 2,
+        upstreamAccountId: 43,
+        upstreamAccountName: "pool-beta@example.com",
+        status: "success",
+        phase: "completed",
+        httpStatus: 200,
+        failureKind: null,
+        errorMessage: null,
+        downstreamErrorMessage: null,
+        upstreamRequestId: "W1scc2SS",
+        responseSummary: {
+          ...(firstAttemptEntry.attempt.responseSummary ?? {}),
+          status: "success",
+          phase: "completed",
+          httpStatus: 200,
+          failureKind: null,
+          errorMessage: null,
+          downstreamErrorMessage: null,
+          responseContentEncoding: "identity",
+          headers: {
+            contentEncoding: "identity",
+            upstreamRequestId: "W1scc2SS",
+          },
+          responseBodyCapture: {
+            availableAtInvocationLevel: true,
+            size: 181_382,
+            detailLevel: "full",
+          },
+        },
+      },
+    };
+    response.hero = {
+      ...response.hero,
+      timelineAttemptCount: 2,
+      poolAttemptCount: 2,
+      upstreamAccountId: 43,
+      upstreamAccountName: "pool-beta@example.com",
+    };
+    const firstAttemptIndex = response.timeline.indexOf(firstAttemptEntry);
+    response.timeline.splice(firstAttemptIndex + 1, 0, finalAttemptEntry);
+
+    apiMocks.fetchInvocationWorkflowDetail.mockResolvedValue(response);
+    render(<InvocationWorkflowDetailPanel record={createRecord()} />);
+
+    await waitFor(() => (host?.textContent ?? "").includes("H3HxTB12"));
+
+    const nonFinalResponseBodyButton = Array.from(host?.querySelectorAll("button") ?? []).find(
+      (candidate): candidate is HTMLButtonElement =>
+        candidate instanceof HTMLButtonElement &&
+        candidate.textContent?.includes("响应体") &&
+        candidate.textContent?.includes("98 B"),
+    );
+    expect(nonFinalResponseBodyButton).not.toBeNull();
+
+    act(() => {
+      nonFinalResponseBodyButton?.click();
+    });
+    await flushAsyncWork();
+
+    expect(apiMocks.fetchInvocationResponseBody).not.toHaveBeenCalled();
+    expect(host?.textContent ?? "").toContain("响应体不可用");
+    expect(host?.textContent ?? "").not.toContain("加载响应体…");
+    expect(nonFinalResponseBodyButton?.textContent ?? "").not.toContain("181,382 B");
+  });
+
   it("does not request workflow detail for transient records without a persisted id", async () => {
     render(<InvocationWorkflowDetailPanel record={createRecord({ id: 0 })} />);
 


### PR DESCRIPTION
## Summary

- Scope invocation-level response metadata to the final real upstream attempt.
- Keep H3HxTB12 response details at HTTP 502 / 98 B / attempt metrics instead of exposing W1scc2SS response data.
- Add backend and frontend regression coverage plus a Storybook state for the retry boundary.

## Test Plan

- `cargo check` via pre-commit hook
- `cargo test invocation_cost_audit_tests -- --nocapture`
- `cargo test account_attempt_list_returns_workflow_entries_and_final_success_usage_only -- --nocapture`
- `cd web && bun run test -- src/features/invocations/InvocationWorkflowDetailPanel.test.tsx src/features/account-pool/UpstreamAccountAttemptTimeline.test.tsx`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- `cargo test --all` remains blocked by an existing stack overflow in `proxy_openai_v1_header_sticky_stream_body_override_beats_blocked_policy_header`.

## References

Spec: `docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md`
Spec Disposition: update
Specs:
- `docs/specs/dqstf-invocation-detail-routing-payload-viewer/SPEC.md`
Solutions:
- `docs/solutions/performance/proxy-capture-body-replay-safety.md`
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: n/a(no project-doc change)

## Operational Scope

- No production changes were made on machine 101.
