### PR TITLE
fix(dashboard): bound read model reconciliation

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -65,6 +65,10 @@ related_specs:
 - 如果某个 topic 仍需要短 TTL 的服务端 DB 基础快照缓存，cache key 只能包含稳定请求参数与明确允许的自然日锚点等低抖动维度；移动中的 exact `rangeStart/rangeEnd`、live runtime 状态、最新持久化行 ID 这类高抖动因子必须留在响应阶段 overlay，否则 singleflight 会被打散，订阅与 HTTP 都会继续重复重算同一份基底。对应的 invalidate 粒度也必须与同一 selection 对齐；单个 terminal 事件只能清掉匹配 selection，不能把整张 dashboard snapshot cache 一起 flush。
 - 对 `dashboard.activity.current` 这类 open-range topic，`live` 广播不应该再反向触发完整 DB snapshot builder。终态在 accepted/enqueued 后应同步以幂等 delta 写入共享内存累计 baseline；固定 5 秒 deadline 只负责合并发布内存 snapshot。DB baseline 以更长、明确的 reconcile cadence（例如 60 秒）刷新，reconcile 失败保留 last-good totals 与 live overlay，而不是重新把 terminal burst 变成 cache invalidation 风暴。
 - rolling duration 窗口若没有完整的到期反向 delta，不能只重写响应的 `rangeStart/rangeEnd` 后复用较旧 baseline；这会把窗口外记录伪装成当前 totals。此时必须把该窗口的缓存上限收紧到其允许的可见时效预算，或先实现可验证的 expiry delta，再延长 DB reconcile cadence。
+- expiry delta 本身也是内存队列：baseline boundary load、in-flight replay 和后续 live terminal 必须共用排序与容量约束。expiry horizon 应在 boundary query 前解析并随 entry 保存，命中不得越过已捕获上界；live-only expiry 无法覆盖 archive 前缀时应明确 fallback，不能缓存不完整的反向增量。
+- Dashboard open-range 的 5 秒 publish 与 60 秒 reconcile 必须由两个独立 deadline 驱动。terminal burst 只能合并内存发布；成功、并发写入后重放、last-good 和失败都要推进 reconcile attempt deadline，避免错误路径绕过节流。
+- coverage repair 应优先 owner 正在使用的闭合小时，并受 bucket 数与 elapsed 双预算约束；历史全量 backlog 连续无进展时应指数退避，永久 payload-required blocked target 不得被计入 actionable backlog 或触发高频 hourly refresh。
+- `response_source=memory` 只能描述实际请求没有执行 DB build 的结果。若本次先构建 DB baseline 再返回 last-good，必须同时记录 `build_attempted=true`、`build_source` 与 reconcile outcome，不能用最终 payload 来源掩盖本次数据库成本。
 - topic 刷新必须使用连接级 owner subscriber 引用计数，而不是内部 broadcast receiver 数量；没有 owner subscriber 时只标记 dirty。重新订阅时应清除旧 replay 连续性并构建 fresh snapshot，避免把失活期间积累的旧 ring 当作权威连续状态回放。
 - Summary open-range 的 terminal refresh 应使用固定 `500ms` deadline；同一 deadline 内后续事件只累计 `coalesced_event_count`，不延长窗口。刷新失败保留 last-good totals，并记录 `refresh_outcome`、`last_good_age_ms` 与有界 retry backoff。
 - proxy terminal follow-up 如果没有真实 quota owner subscriber，应直接跳过 quota refresh；不要用 broadcaster receiver 数量作为 owner-facing 订阅判断，也不要继续构建无生产消费者的 legacy Summary 窗口。

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -70,6 +70,8 @@
 - 后台任务拿到唯一 background slot 后再判断是否 due，会把“未到期的空跑 tick”变成对其他维护任务的饥饿源。
 - skip 必须有日志和后续 ticker，否则会变成静默丢任务。
 - write controller 必须有有界队列、flush 触发（时间窗口 / row count / 最大等待）、coalesced row count、oldest age、flush elapsed、queue depth、enqueue failed 与 dropped count 证据；否则只是把 SQLite 锁问题藏到内存里。
+- 面向累计读模型的 terminal queue 不能长期保留完整业务记录。应在 enqueue 时投影为紧凑 delta，同时设置字节数与条数双硬限；触限时保留 last-good totals 并进入 dirty reconcile，不能静默截断后继续宣称 healthy。
+- terminal 持久化 ACK 必须携带单调 row cursor，并在所有 warm selection 与 in-flight baseline cursor 越过后才回收 delta。只按时间 TTL 清理会在 flush lag 或多 selection 并发时造成漏计。
 - buffered progress 不能立刻广播“已持久化”的 DB snapshot；要么广播内存态，要么等后续 reconcile/terminal 更新。否则会把 stale DB state 伪装成实时状态。
 - 如果选择内存态广播，就必须让所有相关读方共享同一个 runtime store，包括 SSE、records open-resync、current summary、current timeseries、账号活动 in-flight 统计与 prompt-cache working conversations；否则去掉 DB running 写后会产生多套不一致实时视图。
 - Dashboard / account activity 这类短 TTL 聚合快照，如果允许 `<=2s` 的服务端合并刷新预算，就不应再把 live runtime 状态或最新持久化行 ID 放进 cache key；否则表面上有 singleflight，实测仍会长期 `wait_on_in_flight=0`，既保不住实时性，也保不住 SQLite。
@@ -82,6 +84,7 @@
 - proxy snapshot/broadcast 在 `database is locked` 下应 fail-soft skip 并记录结构化证据，依赖已发出的 SSE 事件和后续 HTTP reconcile 补齐 UI；不要在请求尾部立即重试并放大锁争用。
 - write-side live read model 只有在维护成本本身也受控时才值得做：前台请求内同步维护最小必要 working-set / in-progress truth，后台 rebuild 和补偿刷新则继续挂到统一 pressure gate/cooldown，避免为了止住读热点又新增一组不受控维护写入。
 - 对 Dashboard 这类连续 terminal 流量下的累计 KPI，不能把固定 SSE publish cadence 等同于 DB reconcile cadence。terminal enqueue 后应以稳定 event key 幂等更新内存 baseline，5 秒窗口仅合并 fanout；SQLite 只承担 warm restore、最长间隔的 reconcile 与异常 fallback。reconcile lock/error 时保留 last-good snapshot，并记录 baseline age、delta/duplicate count、reconcile outcome 与 sequence-gap 证据。
+- baseline cursor、聚合查询与 pending-key 判定应共享同一 SQLite read transaction；构建完成后重放 cursor 之后的 compact delta 即可接受 baseline。因并发写入而丢弃完整构建并立即重试，会在稳定流量下形成 build-and-discard 风暴。
 - 不要让 P1 terminal flush 在同一锁窗口内继续执行 P2 rollup/account-touch 派生写；这会把“记录最终一致”重新变成“请求尾锁放大”。P1 成功后把 P2 放回队列，等待下一轮时间窗口或 pressure 允许。
 
 ## 何时升级方案

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -1,5 +1,6 @@
 # 主应用常驻订阅纯 SSE 化与统一快照/回放基础设施 - History
 
+- 2026-07-28：线上复查发现原 write-side Dashboard 读模型仍无界保留完整 terminal records，且 reconcile 在并发写入后丢弃完整构建并立即重试。合同因此收紧为 compact delta 双硬限、持久化 ACK/cursor 安全回收、同事务 baseline cursor 与 60 秒 reconcile；5 秒 cadence 只允许内存发布，rolling 窗口由 expiry delta 保持精确。
 - 2026-07-25：Dashboard open-range 终态累计从“5 秒 topic refresh 失效 DB cache 后重建”改为 write-side idempotent delta。`today / 1d / 7d` 的 topic 与 HTTP 共享同一 warm baseline，5 秒窗口仅合并发布，60 秒 cadence 才进行 DB reconcile；reconcile 失败继续发布 last-good totals 与 runtime live overlay。
 
 ## Key Decisions

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -30,7 +30,7 @@
 - 已实现：open-range `stats.summary.current` 的 Dashboard live snapshot 直接 overlay `in-progress / retry / phase / avg wait`，字段未变化时不推进 cursor；terminal Records 按固定 `500ms` deadline 合并 totals refresh，失败保留 last-good payload，并使用 `500ms -> 1s -> 2s -> 5s` 有界退避。
 - 已实现：proxy terminal follow-up 不再构建或广播五个 legacy Summary 窗口；只在存在真实 `quota.current` owner subscriber 时保留 quota follow-up，避免无消费者的请求尾部重算 SQLite。
 - 已实现：summary `non_success_tokens` 的 live 部分复用账号活动 hourly v2 coverage，完整小时读 rollup、边界与 coverage hole 走 scalar exact tail；健康路径不再调用整窗账号活动 raw aggregate。
-- 已实现：Dashboard open-range terminal totals 在 persistence enqueue 成功后同步 fan-out 到共享内存 baseline；`dashboard.activity.current` 的固定 5 秒 deadline 只发布内存 snapshot，不再失效 DB cache。`today` baseline 由初始 build 与最多每 60 秒一次的 reconcile 维护；rolling `1d / 7d` 在尚未具备完整 expiry delta 前保持 5 秒的精确窗口刷新边界。reconcile 失败保留 last-good totals，live overlay 继续更新。
+- 已实现：Dashboard open-range terminal totals 在 persistence enqueue 成功后同步 fan-out 到共享内存 baseline；固定 5 秒 deadline 只发布内存 snapshot。compact delta、persistence ACK/cursor 回收、`64 MiB / 10,000` 双硬限、rolling expiry delta 与 60 秒 cursor-consistent reconcile 已形成完整生命周期；reconcile 失败时保留 last-good totals 与 live overlay。
 
 ## Migrated consumers
 

--- a/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
@@ -61,6 +61,9 @@
 - 覆盖范围内页面首屏不得先发 HTTP bootstrap；可见数据 hydration 必须等待 topic `snapshot` 或可恢复的 `replay` 完成。
 - `stats.summary.current` 只服务 open-range owner-facing 当前态；`yesterday`、`previous7d` 等闭区间 summary 在当前应用里不得建立 pure SSE 订阅，必须继续走 HTTP exact path。
 - Summary open-range topic 的当前态由 live overlay 直接更新，terminal Records 只按固定 `500ms` deadline 合并累计 totals 刷新；刷新失败保留 last-good snapshot，并按有界退避重试。
+- Dashboard open-range terminal 事件必须投影为紧凑 delta，并受 `64 MiB / 10,000` 双硬限保护；持久化 ACK 只能在所有 warm selection 与 in-flight baseline cursor 安全越过对应 row id 后触发回收。触限、ACK 序列缺口或持久化状态不确定时必须进入 `dirty_last_good`，不得静默丢弃累计态。
+- `dashboard.activity.current` 的 5 秒 terminal cadence 只能渲染和发布内存快照；`today / 1d / 7d` 的 SQLite baseline reconcile 每 selection 最多每 60 秒一次，且 baseline cursor、聚合读取与 pending 判定必须位于同一 read transaction。并发写入通过 cursor 后增量重放吸收，不得丢弃已完成构建并立即重试。
+- rolling `1d / 7d` 必须以紧凑 expiry delta 保持半开窗口精确，`today` 在本地午夜 rollover 后重建 baseline；closed-range 继续使用 exact DB 路径。
 - topic 刷新是否运行必须依据连接级 owner subscriber 引用计数；没有 owner subscriber 时只标记缓存 dirty，重新订阅时生成 fresh snapshot，不回放失去连续权威性的旧 ring。
 - 健康连接状态下，覆盖范围内页面不得触发后台 HTTP reconcile、`subscribeToSseOpen` resync fetch、定时拉取校准或页面私有 fallback。
 - 恢复规则只允许二选一：

--- a/docs/specs/gz5ns-dashboard-natural-day-kpi-semantics/HISTORY.md
+++ b/docs/specs/gz5ns-dashboard-natural-day-kpi-semantics/HISTORY.md
@@ -1,5 +1,6 @@
 # Dashboard 自然日七卡 KPI 语义与布局重构 演进历史（#gz5ns）
 
+- 2026-07-28：开放窗口累计态进一步冻结为“5 秒内存发布 + 60 秒 DB 对账”。`today` 以本地午夜 rollover 重建，rolling `1d / 7d` 以 compact expiry delta 精确移除离窗事件，禁止用陈旧 baseline 仅替换响应边界。
 - 2026-07-25：自然日与 rolling KPI 的开放窗口读侧改用共享内存累计 baseline，保持现有字段和 5 秒可见时效；closed-range comparison 仍为 HTTP exact，未混入实时累计态。
 
 > 这里记录会影响 Agent 理解“为什么一步步变成现在这样”的关键演进；单次任务流水账不放这里，规范正文仍以 `./SPEC.md` 为准。

--- a/docs/specs/gz5ns-dashboard-natural-day-kpi-semantics/SPEC.md
+++ b/docs/specs/gz5ns-dashboard-natural-day-kpi-semantics/SPEC.md
@@ -86,6 +86,7 @@
 - `今日成本` 左下展示前 7 个完整自然日均值，右上展示与昨日同进度 delta，右下展示失败/中断成本。
 - `今日 Tokens` 左下展示缓存命中率，右上展示与昨日同进度 delta，右下展示失败/中断 tokens。
 - Dashboard 自然日 comparison summary 中，`previous7d` 属于 closed-range exact window；owner-facing 当前应用不得为它建立 `stats.summary.current` 订阅，只能在首屏、范围切换、作用域切换与本地下一个午夜 rollover 时走 `fetchSummary("previous7d")`。
+- Dashboard `today` 累计态在本地午夜 rollover 后必须重建 baseline；rolling `1d / 7d` 必须通过 compact expiry delta 对离开半开窗口的事件执行反向更新。不得仅改写响应边界后复用包含窗口外记录的旧 totals。
 - `今日` / `昨日` 自然日顶部金额图在切到 `金额` metric 时，展示随时间推进的累计堆叠面积：底层为 `Success`，上层为 `Non-success`，两层和始终等于累计总金额。
 - 账号详情页复用同一自然日金额图实现，不引入“主 Dashboard 用堆叠、账号详情保留单面积”的作用域分叉。
 

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/HISTORY.md
@@ -1,5 +1,6 @@
 # Dashboard 工作区卡片双视图与上游账号活动聚合 演进历史（#z6ysw）
 
+- 2026-07-28：线上 `v2.50.8` 复查确认 v2 coverage 长期缺失仍令活跃 Dashboard 窗口持续 exact fallback。修复边界改为 owner 活跃窗口优先的 `2 buckets / 2s` repair，并把历史无进展扫描收敛到封顶 15 分钟的指数退避；永久 blocked target 与 actionable backlog 分开判责。
 - 2026-07-25：针对持续 terminal 流量下每 5 秒 `dashboard_full` 重建的线上压力，Dashboard/account open-range 读侧改为共享内存累计 baseline。终态 write-side fan-out 不依赖可能滞后的 subscription mutation listener；缓存最长 60 秒后 reconcile，失败保留 last-good 快照。
 
 > 这里记录会影响 Agent 理解“为什么一步步变成现在这样”的关键演进；单次任务流水账不放这里，规范正文仍以 `./SPEC.md` 为准。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -11,7 +11,7 @@
 ## Coverage / rollout summary
 
 - 已修复账号活动 v2 coverage 的升级自愈：新的 live/archive repair generation 会先撤销旧 marker、仅清零 v2 派生字段并重置独立回放进度；完整小时只在该小时现存 live rows 全部越过 repair cursor 后写 marker，marker 缺口继续走 exact raw/archive fallback。整桶重算写入独立的 per-bucket invocation watermark，使滞后 repair 只跳过已被权威重算包含的行，但不会提前宣告 coverage；coverage、rollup、cursor 与 exact tail 固定在同一 SQLite 读事务。已覆盖错误 marker + 稀疏 rollup + 游标追平、重复启动幂等、部分回放与 covered-hour late live tail，通用 rollup、原始调用和 legacy 字段保持不变。
-- 已实现：`today / 1d / 7d` Dashboard 与上游账号活动 HTTP/SSE 共享 cache-backed memory-first baseline。terminal record 以 `(invokeId, occurredAt)` 幂等增量更新累计账号/总览 usage；`today` 以 60 秒 reconcile 与错误 last-good fallback 负责最终对账，rolling `1d / 7d` 在完整 expiry delta 落地前保留 5 秒精确窗口刷新边界。
+- 已实现：`today / 1d / 7d` Dashboard 与上游账号活动 HTTP/SSE 共享 cache-backed memory-first baseline。terminal record 以 `(invokeId, occurredAt)` 幂等增量更新累计账号/总览 usage；open range 以 60 秒 reconcile 与错误 last-good fallback 负责最终对账。rolling `1d / 7d` 的 baseline、in-flight replay 与后续 terminal 都写入按时间排序的 bounded expiry queue；expiry 覆盖不足或窗口跨入 archive 前缀时拒绝伪内存命中并明确 exact fallback。
 - 已实现：Dashboard 上游账号视图拆为汇总优先与快照绑定的 recent 批量补齐；首屏使用局部骨架，范围刷新保留旧卡片，recent 失败保留汇总并局部重试。
 - 已实现：`includeRecent=false` 的第一阶段对保留期外数据执行 archive 内部分组聚合，只返回账号指标而不读取、排序或传输 invocation preview；兼容 combined 响应与第二阶段 recent 接口继续按相同精确快照边界读取 bounded preview。
 - 已实现：Dashboard 工作区头部控制条重新对齐 spec 基线，桌面布局恢复为“左侧 tabs、右侧 当前对话 badge + 排序按钮”的紧凑顺序，不再出现 `badge -> tabs -> 排序` 的错误节奏；对应视觉证据已刷新为当前实现。
@@ -72,19 +72,19 @@
 - 已实现：账号活动快照的终态 live 数据改为账号级窄聚合与按模型用量分组，避免为整个 range 传输完整 invocation preview 行；运行态 runtime overlay、归档折叠、四个时间范围和公开响应字段保持原有语义。
 - 已实现：账号卡 recent 调用改为每个候选账号按时间倒序的受限读取，数量仍严格受请求 `recentLimit` 限制；`upstream-account-activity` 与 dashboard full path 不再为整个 `7d` range 读取 persisted `running/pending` preview 行，缺失于 runtime store 的旧运行态只允许在 bounded recent 中出现，不再计入 owner-facing totals。
 - 已实现：账号卡 recent 调用在 SQLite batch flush 前也会读取同一 runtime store；同键 runtime 行覆盖非终态 DB shell，短暂 terminal overlay 立即可见，落库后不会形成重复行。
-- 已实现：non-`yesterday` 的 `dashboard-activity` 基础快照缓存已收敛为“稳定请求参数 + `today` 本地日期锚点 + 5 秒 TTL”选择键，不再把移动中的 exact `rangeStart/rangeEnd`、live runtime 状态或最新持久化行 ID 放进 cache key；fresh live overlay、exact 响应边界与 `live_revision` 继续在响应阶段叠加，允许 terminal totals 最多 `<=5s` 滞后，同时保持当前态与 recent 的 owner-facing 实时语义不变。
+- 已实现：non-`yesterday` 的 `dashboard-activity` 基础快照使用“稳定请求参数 + `today` 本地日期锚点”选择键；terminal totals 同步投影到有界内存累计态并按 `<=5s` 发布，SQLite baseline 每 selection 最多每 `60s` 对账一次。fresh live overlay、exact 响应边界与 `live_revision` 继续在响应阶段叠加。
 - 已实现：`/api/stats/upstream-account-activity` 改走独立账户活动 builder，不再借道 dashboard full snapshot 的 summary/model-performance 组装；后端新增 `route / builder / purpose / in_progress_only / limit / preview_read_mode / candidate_preview_id_count / hydrated_preview_row_count / cache_bypass_reason / cache_ttl_ms / cache_entry_age_ms / cache_entry_count / in_flight_count` 结构化 telemetry，用于复盘读侧放大、缓存命中率与 DB 压力重合。
-- 已实现：`dashboard.activity.current` 的 open-range topic refresh 不再在每个 `records` / `DashboardActivityLive` 广播上反向调用完整 `fetch_dashboard_activity`。live 广播现在直接覆写 subscription hub 内存 snapshot 的当前态字段并立即 fanout，terminal `records` 仅触发 `<=5s` 节流后的 DB refresh，且 refresh 前会主动失效内部 dashboard snapshot cache，避免 topic 层 deferred refresh 又命中旧 TTL 快照。
+- 已实现：`dashboard.activity.current` 的 open-range topic refresh 不再在每个 `records` / `DashboardActivityLive` 广播上反向调用完整 DB builder。live 广播直接覆写 subscription hub 内存 snapshot 的当前态字段；terminal `records` 只触发固定 `<=5s` 的内存发布，不再失效 snapshot cache 或安排同频 DB refresh。
 - 已实现：summary / Dashboard full / `/api/stats/upstream-account-activity` 共享 `usage_breakdown` range builder 现已切到 `upstream_account_usage_breakdown_hourly` 内部 rollup + exact boundary tail。`7d` / `previous7d` 健康路径不再对整段 live raw rows 做 `model + reasoning` 聚合；archive 缺 replay marker 时仅按缺口 batch 触发显式 fallback，并统一输出 `route / builder / window / full_hour_bucket_count / rollup_row_count / partial_hour_row_count / archive_batch_count / fallback_reason` telemetry。
 - 已补齐 rollout repair：`dashboard / upstream-account` 共享的 `usage_breakdown` builder 不再把 `upstream_account_usage_breakdown_hourly` 误当成“历史 materialized archive 必然已 replay”的 legacy target；bootstrap 会把缺真实 breakdown rows 的旧 archive batch 重新标成 pending，由 historical rollup materialization 回补，而不是把 `7d` 精度问题静默留在线上。
 - 已补齐 legacy pruned archive fallback 收口：`upstream_account_usage_breakdown_hourly` 从 full-payload-required target 集合拆出，裁剪 payload 的历史 batch 会结构化 replay 并写入 breakdown replay marker，读侧健康路径不再因该 target 缺口反复打开 archive fallback；新增 telemetry 区分 `structured_rollup_unknown_reasoning` 与 `blocked_payload_required`。
-- 已实现账号活动 v2 hourly rollup：`upstream_account_stats_hourly` 新增独立 v2 聚合字段与 replay target，Dashboard full 和 upstream-account 共用“covered full hours rollup + uncovered contiguous hours exact fallback + boundary exact tail” builder。live 与 archive repair 使用独立 cursor，marker 完成前不消费默认零值；缓存继续保持稳定 selection + 5 秒 TTL，并新增 refresh/invalidation reason、selection fingerprint 与 coverage telemetry。
+- 已实现账号活动 v2 hourly rollup：`upstream_account_stats_hourly` 新增独立 v2 聚合字段与 replay target，Dashboard full 和 upstream-account 共用“covered full hours rollup + uncovered contiguous hours exact fallback + boundary exact tail” builder。live 与 archive repair 使用独立 cursor，marker 完成前不消费默认零值；活跃窗口缺口按 `2 buckets / 2s` 优先修复，历史无进展回填按 `15s -> 1m -> 5m -> 15m` 退避。
 - 已实现：Summary `non_success_tokens` 复用同一账号活动 v2 coverage planner，完整小时从 `activity_v2_non_success_tokens` 汇总，边界/缺口使用有界 scalar exact tail，移除健康路径对整窗账号活动 raw aggregate 的依赖。
-- 已实现：Dashboard 与 Summary topic 刷新均以连接级 owner subscriber lease 为门控；无 active owner subscriber 时缓存只标记 dirty，重连时重新构建 fresh snapshot。Dashboard 的 5 秒 TTL 未改变，日志新增 `refresh_reason`、`invalidation_reason`、`active_subscriber_count`、`selection_fingerprint` 与 `base_snapshot_age_ms`。
+- 已实现：Dashboard 与 Summary topic 刷新均以连接级 owner subscriber lease 为门控；无 active owner subscriber 时缓存只标记 dirty，重连时重新构建 fresh snapshot。Dashboard 保持 `<=5s` owner-visible terminal 时效，但 DB reconcile 收敛为 `60s`；日志可区分内存发布、DB build、last-good、hard-limit、coverage repair 与 backoff。
 
 ## Remaining Gaps
 
-- 无功能性缺口。提交前仅需完成最终 review、测试收口与截图提交授权确认。
+- 当前无已知 contract gap；线上仍需用新增 telemetry 验证 RSS、coverage hole、reconcile cadence 与 SQLite pressure 的实际收敛情况。
 
 ## Related Changes
 

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md
@@ -57,6 +57,9 @@
 - `上游账号` 视图仅支持 `today / yesterday / 1d / 7d`；当共享 range 为 `usage` 时，该 tab 必须 disabled，且若当前停留在账号 tab，必须自动回退到 `对话`。
 - 账号活动接口必须一次返回每个账号的 `upstreamAccountId`、`displayName`、`groupName`、`planType`、`enabled`、`displayStatus`、`enableStatus`、`workStatus`、`healthStatus`、`syncState`、`lastError`、`lastActionReasonMessage`、`requestCount`、`successCount`、`failureCount`、`nonSuccessCount`、`totalTokens`、`successTokens`、`nonSuccessTokens`、`failureTokens`、`cacheHitRate`、`tokensPerMinute`、`spendRate`、`totalCost`、`failureCost`、`firstByteAvgMs`、`avgTotalMs`、`inProgressInvocationCount`、`inProgressPhaseCounts`、`retryInvocationCount`、`effectiveRoutingRule` 与 `recentInvocations[4]`。
 - `today / 1d / 7d` 的账号累计活动必须按小时做精确 partial merge：只有存在 `upstream_account_activity_hourly_v2` coverage marker 的完整小时可读 `upstream_account_stats_hourly` v2 字段；边界小时与 marker 缺口必须使用半开区间 exact fallback，禁止把默认零值视为有效覆盖或静默漏计。
+- 活跃 `today / 1d / 7d` 窗口缺失的闭合小时 coverage 必须优先后台修复，每轮最多 `2` 个 bucket、最多 `2s`，并在同一事务内完成 exact 聚合、幂等 upsert、watermark 与 marker；owner 请求路径只读取 coverage 状态，不得触发 repair。
+- 活跃 coverage priority repair 只允许改写仍由 live 表覆盖的小时；archive-derived 小时必须交给 archive replay，禁止 live-only 空结果清零其 v2 rollup 后写入 coverage marker。
+- 历史 coverage backlog 无进展时必须按 `15s -> 1m -> 5m -> 15m` 退避；真实更新、新 repair generation 或活跃窗口 priority work 必须恢复 15 秒节奏，永久 blocked payload-required target 不计入 actionable backlog。
 - v2 rollup 必须保留未分配账号、non-success/failure token 与 cost、累计 latency，以及 timestamp/value 成对选择的 latest latency；`recentInvocations` 与当前运行态仍分别来自 bounded recent 和 runtime overlay，不得混入 hourly totals。
 - Future-only status note: 仅对未来新写入的 `pure_downstream_closed`，账号活动聚合必须把 `warning_success` 计入 `successCount/successTokens/totalCost/totalTokens/latency`，并排除出 `failureCount/nonSuccessCount/failureTokens/failureCost`；`recentInvocations` 仍要明确显示独立状态“警告成功”，普通 `success` 筛选不混入该状态。
 - `warning_success` 的紧凑状态位在 Dashboard 对话卡片与上游账号 recent 行中可以继续只显示 warning 图标，但 hover / focus / long-press 后必须通过共享 UI tooltip 披露完整状态文案与诊断；不得退回浏览器原生 `title` 黑框提示。
@@ -110,7 +113,8 @@
 - `dashboard-activity.accounts[]` 与 `upstream-account-activity.accounts[]` 必须携带最小账号状态快照字段：`enabled/displayStatus/enableStatus/workStatus/healthStatus/syncState/lastError/lastActionReasonMessage`；这些字段只服务 Dashboard 状态 badge 与健康入口，不改变账号活动聚合口径。
 - `includeAccounts=false` 必须支持顶部轻量使用，只返回同源 `summary` 与快照元数据；该路径不得先构建、排序完整账号 preview/archive 明细再丢弃，只能读取 summary/read-model、live overlay 与短尾速率窗口所需数据；账号 tab 首次打开后升级为 `includeAccounts=true`，并用该 full snapshot 同步刷新顶部和账号卡片。
 - Dashboard full 与 upstream-account 的 open-range 账号聚合必须按“covered full hours rollup + uncovered contiguous hours exact fallback + boundary exact tail”合并；健康路径不得整窗调用账号活动 raw aggregate。缺口与边界必须通过结构化 telemetry 标明，禁止静默漏计。
-- Dashboard 的 terminal refresh 继续使用既有 `5s` TTL；判责字段必须区分 `initial_build`、`ttl_expired` 与 `scheduled_terminal_refresh`，并记录真实 owner subscriber 数量、selection fingerprint 与 base snapshot age。
+- Dashboard 的 terminal 变化必须在固定 `5s` deadline 内从内存累计态发布；open-range SQLite baseline reconcile 每 selection 最多每 `60s` 一次。判责字段必须区分 `memory_publish`、`initial_build`、`scheduled_reconcile`、`last_good` 与 coverage fallback，并记录真实 owner subscriber 数量、selection fingerprint、baseline cursor、pending delta 规模和 base snapshot age。
+- rolling expiry delta 必须覆盖实际 cache reuse 截止点，baseline 与后续 terminal replay 均需按时间写入；每个 selection 的 expiry 队列同样受 `64 MiB / 10,000` 双硬限，触限时进入 last-good/reconcile，不得无界读取或继续宣称 healthy。窗口跨入 archive 前缀但缺少等价 archive expiry 时必须明确走 exact fallback。
 - `DashboardActivityOverview` 与 `TodayStatsOverview` 不得再用 `buildDashboardTodayRateSnapshot`、timeseries recent snapshot 或 `modelPerformance.total.*` 驱动顶部当前 KPI；顶部实时卡与账号标题当前值只允许读取 `dashboard-activity.summary` / `accounts[]` 的同源后端字段。
 
 ### SHOULD

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -8245,71 +8245,55 @@ impl ModelPerformanceAccumulator {
     }
 
     fn add_terminal_record(&mut self, record: &ApiInvocation) {
+        self.add_terminal_delta(&dashboard_activity_terminal_delta(record));
+    }
+
+    fn add_terminal_delta(&mut self, delta: &DashboardActivityTerminalDelta) {
         let group = UsageBreakdownGroupKey {
-            model: record
-                .response_model
-                .as_deref()
-                .or(record.model.as_deref())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .unwrap_or("unknown")
-                .to_string(),
-            reasoning_effort: record
-                .reasoning_effort
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string),
+            model: delta.model.clone(),
+            reasoning_effort: delta.reasoning_effort.clone(),
         };
-        self.add_terminal_record_values(record);
+        self.add_terminal_delta_values(delta);
         self.models
             .entry(group)
             .or_default()
-            .add_terminal_record_values(record);
+            .add_terminal_delta_values(delta);
     }
 
-    fn add_terminal_record_values(&mut self, record: &ApiInvocation) {
-        let classification = resolve_failure_classification(
-            record.status.as_deref(),
-            record.error_message.as_deref(),
-            record.failure_kind.as_deref(),
-            record.failure_class.as_deref(),
-            record.is_actionable.map(i64::from),
-        );
-        let success_like = runtime_record_is_success_for_summary(record)
-            && classification.failure_class == FailureClass::None;
-        let success_billed = success_like && record.cost.is_some();
+    fn add_terminal_delta_values(&mut self, delta: &DashboardActivityTerminalDelta) {
+        let success_like = delta.success;
+        let success_billed = success_like && delta.has_cost;
         if success_billed {
-            self.total_tokens += record.total_tokens.unwrap_or_default().max(0);
+            self.total_tokens += delta.total_tokens;
         }
         if let Some(stream_duration_ms) = success_like
-            .then_some(record.t_upstream_stream_ms)
+            .then_some(delta.t_upstream_stream_ms)
             .flatten()
             .filter(|value| value.is_finite() && *value > 0.0)
         {
             if success_billed {
-                self.stream_output_tokens += record.output_tokens.unwrap_or_default().max(0);
+                self.stream_output_tokens += delta.output_tokens;
                 self.stream_duration_ms += stream_duration_ms;
             }
             self.response_sample_count += 1;
             self.response_sum_ms += stream_duration_ms;
         }
         if success_billed
-            && record
+            && delta
                 .t_upstream_ttfb_ms
                 .is_some_and(|value| value.is_finite() && value > 0.0)
             && let Some(first_response_byte_total_ms) =
                 crate::stats::resolve_first_response_byte_total_ms(
-                    record.t_req_read_ms,
-                    record.t_req_parse_ms,
-                    record.t_upstream_connect_ms,
-                    record.t_upstream_ttfb_ms,
+                    delta.t_req_read_ms,
+                    delta.t_req_parse_ms,
+                    delta.t_upstream_connect_ms,
+                    delta.t_upstream_ttfb_ms,
                 )
         {
             self.first_byte_sample_count += 1;
             self.first_byte_sum_ms += first_response_byte_total_ms;
         }
-        if let Some(first_token_ms) = record
+        if let Some(first_token_ms) = delta
             .first_token_ms
             .filter(|value| value.is_finite() && *value >= 0.0)
         {
@@ -8317,7 +8301,7 @@ impl ModelPerformanceAccumulator {
             self.first_token_sum_ms += first_token_ms;
         }
         if success_billed
-            && let Some(total_ms) = record
+            && let Some(total_ms) = delta
                 .t_total_ms
                 .filter(|value| value.is_finite() && *value >= 0.0)
         {
@@ -8325,6 +8309,80 @@ impl ModelPerformanceAccumulator {
             self.cumulative_usage_duration_sum_ms += total_ms;
             // The persisted baseline stores only the prior interval union, so a single new
             // interval cannot be merged exactly until reconciliation rebuilds that union.
+            self.wall_clock_usage_duration_ms = None;
+        }
+    }
+
+    fn subtract_terminal_delta(&mut self, delta: &DashboardActivityTerminalDelta) {
+        let group = UsageBreakdownGroupKey {
+            model: delta.model.clone(),
+            reasoning_effort: delta.reasoning_effort.clone(),
+        };
+        self.subtract_terminal_delta_values(delta);
+        if let Some(model) = self.models.get_mut(&group) {
+            model.subtract_terminal_delta_values(delta);
+            if model.total_tokens == 0
+                && model.response_sample_count == 0
+                && model.first_byte_sample_count == 0
+                && model.first_token_sample_count == 0
+                && model.cumulative_usage_duration_sample_count == 0
+            {
+                self.models.remove(&group);
+            }
+        }
+    }
+
+    fn subtract_terminal_delta_values(&mut self, delta: &DashboardActivityTerminalDelta) {
+        let success_billed = delta.success && delta.has_cost;
+        if success_billed {
+            self.total_tokens = self.total_tokens.saturating_sub(delta.total_tokens);
+        }
+        if let Some(stream_duration_ms) = delta
+            .success
+            .then_some(delta.t_upstream_stream_ms)
+            .flatten()
+            .filter(|value| value.is_finite() && *value > 0.0)
+        {
+            if success_billed {
+                self.stream_output_tokens = self
+                    .stream_output_tokens
+                    .saturating_sub(delta.output_tokens);
+                self.stream_duration_ms = (self.stream_duration_ms - stream_duration_ms).max(0.0);
+            }
+            self.response_sample_count = self.response_sample_count.saturating_sub(1);
+            self.response_sum_ms = (self.response_sum_ms - stream_duration_ms).max(0.0);
+        }
+        if success_billed
+            && delta
+                .t_upstream_ttfb_ms
+                .is_some_and(|value| value.is_finite() && value > 0.0)
+            && let Some(value) = crate::stats::resolve_first_response_byte_total_ms(
+                delta.t_req_read_ms,
+                delta.t_req_parse_ms,
+                delta.t_upstream_connect_ms,
+                delta.t_upstream_ttfb_ms,
+            )
+        {
+            self.first_byte_sample_count = self.first_byte_sample_count.saturating_sub(1);
+            self.first_byte_sum_ms = (self.first_byte_sum_ms - value).max(0.0);
+        }
+        if let Some(value) = delta
+            .first_token_ms
+            .filter(|value| value.is_finite() && *value >= 0.0)
+        {
+            self.first_token_sample_count = self.first_token_sample_count.saturating_sub(1);
+            self.first_token_sum_ms = (self.first_token_sum_ms - value).max(0.0);
+        }
+        if success_billed
+            && let Some(value) = delta
+                .t_total_ms
+                .filter(|value| value.is_finite() && *value >= 0.0)
+        {
+            self.cumulative_usage_duration_sample_count = self
+                .cumulative_usage_duration_sample_count
+                .saturating_sub(1);
+            self.cumulative_usage_duration_sum_ms =
+                (self.cumulative_usage_duration_sum_ms - value).max(0.0);
             self.wall_clock_usage_duration_ms = None;
         }
     }
@@ -10096,8 +10154,8 @@ async fn query_live_upstream_account_activity_existing_invocation_ids(
     Ok(existing_ids)
 }
 
-async fn query_live_dashboard_activity_persisted_terminal_ids(
-    pool: &Pool<Sqlite>,
+async fn query_live_dashboard_activity_persisted_terminal_ids_tx(
+    connection: &mut SqliteConnection,
     source_scope: InvocationSourceScope,
     keys: &[(String, String)],
 ) -> Result<HashMap<(String, String), i64>, ApiError> {
@@ -10130,7 +10188,7 @@ async fn query_live_dashboard_activity_persisted_terminal_ids(
         persisted.extend(
             query
                 .build_query_as::<(i64, String, String)>()
-                .fetch_all(pool)
+                .fetch_all(&mut *connection)
                 .await?
                 .into_iter()
                 .map(|(id, invoke_id, occurred_at)| ((invoke_id, occurred_at), id)),
@@ -10139,14 +10197,81 @@ async fn query_live_dashboard_activity_persisted_terminal_ids(
     Ok(persisted)
 }
 
-async fn query_live_dashboard_activity_snapshot_cursor(
-    pool: &Pool<Sqlite>,
+async fn query_live_dashboard_activity_snapshot_cursor_tx(
+    connection: &mut SqliteConnection,
 ) -> Result<i64, ApiError> {
     Ok(
         sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM codex_invocations")
-            .fetch_one(pool)
+            .fetch_one(&mut *connection)
             .await?,
     )
+}
+
+async fn query_live_dashboard_activity_reconcile_probe(
+    pool: &Pool<Sqlite>,
+    source_scope: InvocationSourceScope,
+    keys: &[(String, String)],
+) -> Result<(i64, HashMap<(String, String), i64>), ApiError> {
+    let mut tx = pool.begin().await?;
+    let cursor = query_live_dashboard_activity_snapshot_cursor_tx(tx.as_mut()).await?;
+    let persisted =
+        query_live_dashboard_activity_persisted_terminal_ids_tx(tx.as_mut(), source_scope, keys)
+            .await?;
+    tx.commit().await?;
+    Ok((cursor, persisted))
+}
+
+async fn query_live_dashboard_activity_snapshot_cursor(
+    pool: &Pool<Sqlite>,
+) -> Result<i64, ApiError> {
+    let mut connection = pool.acquire().await?;
+    query_live_dashboard_activity_snapshot_cursor_tx(&mut connection).await
+}
+
+async fn try_begin_dashboard_activity_consistency_barrier(
+    pool: &Pool<Sqlite>,
+) -> Result<Option<sqlx::Transaction<'static, Sqlite>>, ApiError> {
+    match tokio::time::timeout(
+        Duration::from_millis(10),
+        pool.begin_with("BEGIN IMMEDIATE"),
+    )
+    .await
+    {
+        Ok(Ok(transaction)) => Ok(Some(transaction)),
+        Ok(Err(err)) => {
+            let err = anyhow::Error::new(err);
+            if crate::is_sqlite_lock_error(&err) {
+                debug!(error = %err, "dashboard consistency barrier is currently unavailable");
+                Ok(None)
+            } else {
+                Err(err.into())
+            }
+        }
+        Err(_) => {
+            debug!(
+                "dashboard consistency barrier timed out before acquiring the write reservation"
+            );
+            Ok(None)
+        }
+    }
+}
+
+async fn begin_dashboard_activity_consistency_barrier(
+    pool: &Pool<Sqlite>,
+) -> Result<sqlx::Transaction<'static, Sqlite>, ApiError> {
+    Ok(pool.begin_with("BEGIN IMMEDIATE").await?)
+}
+
+async fn finish_dashboard_activity_consistency_barrier(
+    transaction: sqlx::Transaction<'static, Sqlite>,
+    commit: bool,
+) -> Result<(), ApiError> {
+    if commit {
+        transaction.commit().await?;
+    } else {
+        transaction.rollback().await?;
+    }
+    Ok(())
 }
 
 async fn query_archive_upstream_account_activity_overlapping_live_ids(
@@ -11252,9 +11377,11 @@ pub(crate) const DASHBOARD_ACTIVITY_RATE_WINDOW_MINUTES: i64 = 5;
 /// layered onto the cached baseline synchronously, so this is not an owner-visible freshness
 /// budget.
 pub(crate) const DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS: u64 = 60;
-const DASHBOARD_ACTIVITY_ROLLING_SNAPSHOT_CACHE_TTL_SECS: u64 = 5;
 const DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS: usize = 50_000;
 const DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS: usize = 10_000;
+const DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES: usize = 64 * 1024 * 1024;
+const DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_ENTRIES: usize = 64;
+const DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_EXPIRY_BYTES: usize = 64 * 1024 * 1024;
 const DASHBOARD_ACTIVITY_LAST_GOOD_MAX_AGE: Duration = Duration::from_secs(15 * 60);
 
 #[derive(Debug, Clone)]
@@ -11369,38 +11496,74 @@ impl DashboardActivityAccountLatencyAccumulator {
         }
     }
 
-    fn add_terminal_record(&mut self, record: &ApiInvocation, success: bool) {
-        if let Some(first_token_ms) = record
+    fn add_terminal_delta(&mut self, delta: &DashboardActivityTerminalDelta) {
+        if let Some(first_token_ms) = delta
             .first_token_ms
             .filter(|value| value.is_finite() && *value >= 0.0)
         {
             self.first_token_sample_count += 1;
             self.first_token_sum_ms += first_token_ms;
         }
-        if !success {
+        if !delta.success {
             return;
         }
-        if record
+        if delta
             .t_upstream_ttfb_ms
             .filter(|value| value.is_finite() && *value > 0.0)
             .is_some()
             && let Some(first_response_byte_total_ms) =
                 crate::stats::resolve_first_response_byte_total_ms(
-                    record.t_req_read_ms,
-                    record.t_req_parse_ms,
-                    record.t_upstream_connect_ms,
-                    record.t_upstream_ttfb_ms,
+                    delta.t_req_read_ms,
+                    delta.t_req_parse_ms,
+                    delta.t_upstream_connect_ms,
+                    delta.t_upstream_ttfb_ms,
                 )
         {
             self.first_response_byte_total_sample_count += 1;
             self.first_response_byte_total_sum_ms += first_response_byte_total_ms;
         }
-        if let Some(total_latency_ms) = record
+        if let Some(total_latency_ms) = delta
             .t_total_ms
             .filter(|value| value.is_finite() && *value >= 0.0)
         {
             self.total_latency_sample_count += 1;
             self.total_latency_sum_ms += total_latency_ms;
+        }
+    }
+
+    fn subtract_terminal_delta(&mut self, delta: &DashboardActivityTerminalDelta) {
+        if let Some(value) = delta
+            .first_token_ms
+            .filter(|value| value.is_finite() && *value >= 0.0)
+        {
+            self.first_token_sample_count = self.first_token_sample_count.saturating_sub(1);
+            self.first_token_sum_ms = (self.first_token_sum_ms - value).max(0.0);
+        }
+        if !delta.success {
+            return;
+        }
+        if delta
+            .t_upstream_ttfb_ms
+            .is_some_and(|value| value.is_finite() && value > 0.0)
+            && let Some(value) = crate::stats::resolve_first_response_byte_total_ms(
+                delta.t_req_read_ms,
+                delta.t_req_parse_ms,
+                delta.t_upstream_connect_ms,
+                delta.t_upstream_ttfb_ms,
+            )
+        {
+            self.first_response_byte_total_sample_count = self
+                .first_response_byte_total_sample_count
+                .saturating_sub(1);
+            self.first_response_byte_total_sum_ms =
+                (self.first_response_byte_total_sum_ms - value).max(0.0);
+        }
+        if let Some(value) = delta
+            .t_total_ms
+            .filter(|value| value.is_finite() && *value >= 0.0)
+        {
+            self.total_latency_sample_count = self.total_latency_sample_count.saturating_sub(1);
+            self.total_latency_sum_ms = (self.total_latency_sum_ms - value).max(0.0);
         }
     }
 
@@ -11433,11 +11596,24 @@ struct DashboardActivitySnapshotCacheOutcome {
     selection_fingerprint: u64,
     terminal_delta_count: u64,
     duplicate_delta_count: u64,
+    pending_delta_count: usize,
+    pending_delta_estimated_bytes: usize,
+    persisted_ack_pending_count: usize,
+    delta_pruned_count: u64,
+    expiry_delta_count: usize,
+    hard_limit_reason: &'static str,
+    baseline_cursor: i64,
+    sequence_gap_count: u64,
+    build_attempted: bool,
+    snapshot_origin: &'static str,
 }
 
 fn dashboard_activity_read_model_state(
     outcome: DashboardActivitySnapshotCacheOutcome,
 ) -> &'static str {
+    if outcome.hard_limit_reason != "none" || outcome.sequence_gap_count > 0 {
+        return "dirty_last_good";
+    }
     match outcome.cache_hit_or_miss {
         "last_good_fallback" => "stale_last_good",
         "cache_miss_build" => "reconciled",
@@ -11459,15 +11635,17 @@ pub(crate) struct DashboardActivityTerminalDeltaOutcome {
     pub(crate) applied_selection_count: usize,
     pub(crate) duplicate: bool,
     pub(crate) skipped_out_of_range_count: usize,
+    pub(crate) hard_limit_reason: Option<&'static str>,
+    pub(crate) terminal_sequence: Option<u64>,
 }
 
-fn dashboard_activity_selection_includes_terminal(
+fn dashboard_activity_selection_includes_compact_terminal(
     selection: &DashboardActivitySnapshotSelection,
-    record: &ApiInvocation,
+    delta: &DashboardActivityTerminalDelta,
     occurred_at: DateTime<Utc>,
 ) -> bool {
     if !matches!(selection.range.as_str(), "today" | "1d" | "7d")
-        || (selection.source_scope == "proxy_only" && record.source != SOURCE_PROXY)
+        || (selection.source_scope == "proxy_only" && delta.source != SOURCE_PROXY)
     {
         return false;
     }
@@ -11478,6 +11656,18 @@ fn dashboard_activity_selection_includes_terminal(
         return false;
     };
     occurred_at >= range.start && occurred_at < range.end
+}
+
+fn dashboard_activity_selection_includes_terminal(
+    selection: &DashboardActivitySnapshotSelection,
+    record: &ApiInvocation,
+    occurred_at: DateTime<Utc>,
+) -> bool {
+    dashboard_activity_selection_includes_compact_terminal(
+        selection,
+        &dashboard_activity_terminal_delta(record),
+        occurred_at,
+    )
 }
 
 fn dashboard_activity_selection_source_scope(
@@ -11492,41 +11682,64 @@ fn dashboard_activity_selection_source_scope(
 
 fn dashboard_activity_entry_includes_terminal(
     entry: &DashboardActivitySnapshotCacheEntry,
-    record: &ApiInvocation,
+    delta: &DashboardActivityTerminalDelta,
 ) -> bool {
-    record.id > 0 && record.id <= entry.baseline_snapshot_cursor
+    delta
+        .persisted_row_id
+        .is_some_and(|row_id| row_id <= entry.baseline_snapshot_cursor)
 }
 
-fn dashboard_activity_terminal_costs(record: &ApiInvocation) -> Option<UsageCostBreakdownResponse> {
-    record.cost.map(|total_cost| {
-        if let (Some(input), Some(cache_write), Some(cache_read), Some(output), Some(reasoning)) = (
-            record.cost_input,
-            record.cost_cache_write,
-            record.cost_cache_read,
-            record.cost_output,
-            record.cost_reasoning,
-        ) {
-            UsageCostBreakdownResponse {
-                input,
-                cache_write,
-                cache_read,
-                output,
-                reasoning,
-                unknown: 0.0,
-            }
-        } else {
-            UsageCostBreakdownResponse {
-                unknown: total_cost,
-                ..UsageCostBreakdownResponse::default()
-            }
+fn dashboard_activity_baseline_includes_pending_delta(
+    delta: &DashboardActivityTerminalDelta,
+    baseline_cursor: i64,
+    persisted_terminal_ids: &HashMap<(String, String), i64>,
+) -> bool {
+    delta
+        .persisted_row_id
+        .is_some_and(|row_id| row_id <= baseline_cursor)
+        || persisted_terminal_ids.contains_key(&delta.key())
+}
+
+fn replay_dashboard_activity_pending_deltas_without_expiry(
+    snapshot: &mut DashboardActivitySnapshot,
+    selection: &DashboardActivitySnapshotSelection,
+    pending_terminal_deltas: &VecDeque<DashboardActivityTerminalDelta>,
+    baseline_cursor: i64,
+    persisted_terminal_ids: &HashMap<(String, String), i64>,
+) -> usize {
+    let mut replayed = 0usize;
+    for delta in pending_terminal_deltas {
+        let Some(occurred_at) = parse_to_utc_datetime(&delta.occurred_at) else {
+            continue;
+        };
+        if dashboard_activity_selection_includes_compact_terminal(selection, delta, occurred_at)
+            && !dashboard_activity_baseline_includes_pending_delta(
+                delta,
+                baseline_cursor,
+                persisted_terminal_ids,
+            )
+        {
+            apply_dashboard_activity_compact_terminal_delta(snapshot, delta);
+            replayed += 1;
         }
-    })
+    }
+    replayed
 }
 
-fn add_dashboard_activity_terminal_usage(
-    usage: &mut UsageBreakdownResponse,
-    record: &ApiInvocation,
-) {
+fn dashboard_activity_terminal_delta(record: &ApiInvocation) -> DashboardActivityTerminalDelta {
+    let classification = resolve_failure_classification(
+        record.status.as_deref(),
+        record.error_message.as_deref(),
+        record.failure_kind.as_deref(),
+        record.failure_class.as_deref(),
+        record.is_actionable.map(i64::from),
+    );
+    let success = runtime_record_is_success_for_summary(record)
+        && classification.failure_class == FailureClass::None;
+    let failure = matches!(
+        classification.failure_class,
+        FailureClass::ServiceFailure | FailureClass::ClientFailure | FailureClass::ClientAbort
+    );
     let cache_read_tokens = record.cache_input_tokens.unwrap_or_default().max(0);
     let cache_write_tokens = record
         .cache_write_tokens
@@ -11537,12 +11750,105 @@ fn add_dashboard_activity_terminal_usage(
                 .saturating_sub(cache_read_tokens)
         })
         .max(0);
-    let output_tokens = record.output_tokens.unwrap_or_default().max(0);
-    let costs = dashboard_activity_terminal_costs(record);
+    let model = record
+        .response_model
+        .as_deref()
+        .or(record.model.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown")
+        .to_string();
+    let reasoning_effort = record
+        .reasoning_effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let upstream_account_name = record
+        .upstream_account_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let breakdown_complete = record.cost.is_some()
+        && record.cost_input.is_some()
+        && record.cost_cache_write.is_some()
+        && record.cost_cache_read.is_some()
+        && record.cost_output.is_some()
+        && record.cost_reasoning.is_some();
+    let total_cost = record.cost.unwrap_or_default().max(0.0);
+    let string_bytes = record.invoke_id.len()
+        + record.occurred_at.len()
+        + record.source.len()
+        + model.len()
+        + reasoning_effort.as_ref().map_or(0, String::len)
+        + upstream_account_name.as_ref().map_or(0, String::len);
+    DashboardActivityTerminalDelta {
+        terminal_sequence: 0,
+        invoke_id: record.invoke_id.clone(),
+        occurred_at: record.occurred_at.clone(),
+        source: record.source.clone(),
+        model,
+        reasoning_effort,
+        upstream_account_id: record.upstream_account_id,
+        upstream_account_name,
+        success,
+        failure,
+        total_tokens: record.total_tokens.unwrap_or_default().max(0),
+        cache_write_tokens,
+        cache_read_tokens,
+        output_tokens: record.output_tokens.unwrap_or_default().max(0),
+        has_cost: record.cost.is_some(),
+        total_cost,
+        cost_input: record
+            .cost_input
+            .filter(|_| breakdown_complete)
+            .unwrap_or_default(),
+        cost_cache_write: record
+            .cost_cache_write
+            .filter(|_| breakdown_complete)
+            .unwrap_or_default(),
+        cost_cache_read: record
+            .cost_cache_read
+            .filter(|_| breakdown_complete)
+            .unwrap_or_default(),
+        cost_output: record
+            .cost_output
+            .filter(|_| breakdown_complete)
+            .unwrap_or_default(),
+        cost_reasoning: record
+            .cost_reasoning
+            .filter(|_| breakdown_complete)
+            .unwrap_or_default(),
+        cost_unknown: if breakdown_complete { 0.0 } else { total_cost },
+        t_total_ms: record.t_total_ms,
+        t_req_read_ms: record.t_req_read_ms,
+        t_req_parse_ms: record.t_req_parse_ms,
+        t_upstream_connect_ms: record.t_upstream_connect_ms,
+        t_upstream_ttfb_ms: record.t_upstream_ttfb_ms,
+        first_token_ms: record.first_token_ms,
+        t_upstream_stream_ms: record.t_upstream_stream_ms,
+        persisted_row_id: (record.id > 0).then_some(record.id),
+        estimated_bytes: std::mem::size_of::<DashboardActivityTerminalDelta>() + string_bytes,
+    }
+}
 
-    usage.cache_write_tokens += cache_write_tokens;
-    usage.cache_read_tokens += cache_read_tokens;
-    usage.output_tokens += output_tokens;
+fn add_dashboard_activity_terminal_usage(
+    usage: &mut UsageBreakdownResponse,
+    delta: &DashboardActivityTerminalDelta,
+) {
+    let costs = delta.has_cost.then_some(UsageCostBreakdownResponse {
+        input: delta.cost_input,
+        cache_write: delta.cost_cache_write,
+        cache_read: delta.cost_cache_read,
+        output: delta.cost_output,
+        reasoning: delta.cost_reasoning,
+        unknown: delta.cost_unknown,
+    });
+
+    usage.cache_write_tokens += delta.cache_write_tokens;
+    usage.cache_read_tokens += delta.cache_read_tokens;
+    usage.output_tokens += delta.output_tokens;
     if let Some(costs) = &costs {
         let target = usage
             .costs
@@ -11555,27 +11861,16 @@ fn add_dashboard_activity_terminal_usage(
         target.unknown += costs.unknown;
     }
 
-    let model = record
-        .response_model
-        .as_deref()
-        .or(record.model.as_deref())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("unknown");
-    let reasoning_effort = record
-        .reasoning_effort
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
     let model_usage = usage.models.iter_mut().find(|entry| {
-        entry.model == model && entry.reasoning_effort.as_deref() == reasoning_effort
+        entry.model == delta.model
+            && entry.reasoning_effort.as_deref() == delta.reasoning_effort.as_deref()
     });
     let entry = if let Some(entry) = model_usage {
         entry
     } else {
         usage.models.push(UsageBreakdownModelResponse {
-            model: model.to_string(),
-            reasoning_effort: reasoning_effort.map(str::to_string),
+            model: delta.model.clone(),
+            reasoning_effort: delta.reasoning_effort.clone(),
             cache_write_tokens: 0,
             cache_read_tokens: 0,
             output_tokens: 0,
@@ -11583,9 +11878,9 @@ fn add_dashboard_activity_terminal_usage(
         });
         usage.models.last_mut().expect("just inserted usage model")
     };
-    entry.cache_write_tokens += cache_write_tokens;
-    entry.cache_read_tokens += cache_read_tokens;
-    entry.output_tokens += output_tokens;
+    entry.cache_write_tokens += delta.cache_write_tokens;
+    entry.cache_read_tokens += delta.cache_read_tokens;
+    entry.output_tokens += delta.output_tokens;
     if let Some(costs) = costs {
         let target = entry
             .costs
@@ -11604,18 +11899,72 @@ fn add_dashboard_activity_terminal_usage(
     });
 }
 
+fn subtract_dashboard_activity_terminal_usage(
+    usage: &mut UsageBreakdownResponse,
+    delta: &DashboardActivityTerminalDelta,
+) {
+    usage.cache_write_tokens = usage
+        .cache_write_tokens
+        .saturating_sub(delta.cache_write_tokens);
+    usage.cache_read_tokens = usage
+        .cache_read_tokens
+        .saturating_sub(delta.cache_read_tokens);
+    usage.output_tokens = usage.output_tokens.saturating_sub(delta.output_tokens);
+    if let Some(costs) = usage.costs.as_mut() {
+        costs.input = (costs.input - delta.cost_input).max(0.0);
+        costs.cache_write = (costs.cache_write - delta.cost_cache_write).max(0.0);
+        costs.cache_read = (costs.cache_read - delta.cost_cache_read).max(0.0);
+        costs.output = (costs.output - delta.cost_output).max(0.0);
+        costs.reasoning = (costs.reasoning - delta.cost_reasoning).max(0.0);
+        costs.unknown = (costs.unknown - delta.cost_unknown).max(0.0);
+    }
+    if let Some(entry) = usage.models.iter_mut().find(|entry| {
+        entry.model == delta.model
+            && entry.reasoning_effort.as_deref() == delta.reasoning_effort.as_deref()
+    }) {
+        entry.cache_write_tokens = entry
+            .cache_write_tokens
+            .saturating_sub(delta.cache_write_tokens);
+        entry.cache_read_tokens = entry
+            .cache_read_tokens
+            .saturating_sub(delta.cache_read_tokens);
+        entry.output_tokens = entry.output_tokens.saturating_sub(delta.output_tokens);
+        if let Some(costs) = entry.costs.as_mut() {
+            costs.input = (costs.input - delta.cost_input).max(0.0);
+            costs.cache_write = (costs.cache_write - delta.cost_cache_write).max(0.0);
+            costs.cache_read = (costs.cache_read - delta.cost_cache_read).max(0.0);
+            costs.output = (costs.output - delta.cost_output).max(0.0);
+            costs.reasoning = (costs.reasoning - delta.cost_reasoning).max(0.0);
+            costs.unknown = (costs.unknown - delta.cost_unknown).max(0.0);
+        }
+    }
+    usage.models.retain(|entry| {
+        entry.cache_write_tokens != 0
+            || entry.cache_read_tokens != 0
+            || entry.output_tokens != 0
+            || entry.costs.as_ref().is_some_and(|costs| {
+                costs.input != 0.0
+                    || costs.cache_write != 0.0
+                    || costs.cache_read != 0.0
+                    || costs.output != 0.0
+                    || costs.reasoning != 0.0
+                    || costs.unknown != 0.0
+            })
+    });
+}
+
 fn dashboard_activity_terminal_account(
     snapshot: &DashboardActivitySnapshot,
-    record: &ApiInvocation,
+    delta: &DashboardActivityTerminalDelta,
 ) -> DashboardActivityAccountResponse {
-    let upstream_account_id = record.upstream_account_id;
+    let upstream_account_id = delta.upstream_account_id;
     DashboardActivityAccountResponse {
         account_key: upstream_account_id
             .map(|id| format!("upstream:{id}"))
             .unwrap_or_else(|| "unassigned".to_string()),
         upstream_account_id,
         display_name: upstream_account_id
-            .and_then(|_| record.upstream_account_name.clone())
+            .and_then(|_| delta.upstream_account_name.clone())
             .filter(|name| !name.trim().is_empty())
             .unwrap_or_else(|| {
                 upstream_account_id
@@ -11683,43 +12032,28 @@ fn dashboard_activity_terminal_account(
     }
 }
 
-fn apply_dashboard_activity_terminal_delta(
+fn apply_dashboard_activity_compact_terminal_delta(
     snapshot: &mut DashboardActivitySnapshot,
-    record: &ApiInvocation,
+    delta: &DashboardActivityTerminalDelta,
 ) {
-    let classification = resolve_failure_classification(
-        record.status.as_deref(),
-        record.error_message.as_deref(),
-        record.failure_kind.as_deref(),
-        record.failure_class.as_deref(),
-        record.is_actionable.map(i64::from),
-    );
-    let success = runtime_record_is_success_for_summary(record)
-        && classification.failure_class == FailureClass::None;
-    let failure = matches!(
-        classification.failure_class,
-        FailureClass::ServiceFailure | FailureClass::ClientFailure | FailureClass::ClientAbort
-    );
-    let non_success = !success;
-    let total_tokens = record.total_tokens.unwrap_or_default().max(0);
-    let total_cost = record.cost.unwrap_or_default().max(0.0);
+    let non_success = !delta.success;
 
     let stats = &mut snapshot.summary.stats;
     stats.total_count += 1;
-    stats.success_count += i64::from(success);
-    stats.failure_count += i64::from(failure);
-    stats.total_tokens += total_tokens;
-    stats.total_cost += total_cost;
+    stats.success_count += i64::from(delta.success);
+    stats.failure_count += i64::from(delta.failure);
+    stats.total_tokens += delta.total_tokens;
+    stats.total_cost += delta.total_cost;
     if non_success {
         if let Some(non_success_cost) = stats.non_success_cost.as_mut() {
-            *non_success_cost += total_cost;
+            *non_success_cost += delta.total_cost;
         }
         if let Some(non_success_tokens) = stats.non_success_tokens.as_mut() {
-            *non_success_tokens += total_tokens;
+            *non_success_tokens += delta.total_tokens;
         }
     }
     if let Some(usage) = stats.usage_breakdown.as_mut() {
-        add_dashboard_activity_terminal_usage(usage, record);
+        add_dashboard_activity_terminal_usage(usage, delta);
     }
 
     let model_performance_available = snapshot.summary.model_performance.available;
@@ -11730,20 +12064,20 @@ fn apply_dashboard_activity_terminal_delta(
     if snapshot.model_performance_accumulator_ready {
         snapshot
             .summary_model_performance_accumulator
-            .add_terminal_record(record);
+            .add_terminal_delta(delta);
         snapshot.summary.model_performance = snapshot
             .summary_model_performance_accumulator
             .clone()
             .into_response(snapshot_range, model_performance_available);
         snapshot
             .account_model_performance_accumulators
-            .entry(record.upstream_account_id)
+            .entry(delta.upstream_account_id)
             .or_default()
-            .add_terminal_record(record);
+            .add_terminal_delta(delta);
     }
     let account_model_performance = snapshot
         .account_model_performance_accumulators
-        .get(&record.upstream_account_id)
+        .get(&delta.upstream_account_id)
         .cloned()
         .unwrap_or_default()
         .into_response(snapshot_range, model_performance_available);
@@ -11751,54 +12085,193 @@ fn apply_dashboard_activity_terminal_delta(
     if !snapshot
         .accounts
         .iter()
-        .any(|account| account.upstream_account_id == record.upstream_account_id)
+        .any(|account| account.upstream_account_id == delta.upstream_account_id)
     {
         snapshot
             .accounts
-            .push(dashboard_activity_terminal_account(snapshot, record));
+            .push(dashboard_activity_terminal_account(snapshot, delta));
     }
     let account_latency = snapshot
         .account_latency_accumulators
-        .entry(record.upstream_account_id)
+        .entry(delta.upstream_account_id)
         .or_default();
-    account_latency.add_terminal_record(record, success);
+    account_latency.add_terminal_delta(delta);
     let account_latency = *account_latency;
     let account = snapshot
         .accounts
         .iter_mut()
-        .find(|account| account.upstream_account_id == record.upstream_account_id)
+        .find(|account| account.upstream_account_id == delta.upstream_account_id)
         .expect("terminal account inserted when absent");
     account.request_count += 1;
-    account.success_count += i64::from(success);
-    account.failure_count += i64::from(failure);
+    account.success_count += i64::from(delta.success);
+    account.failure_count += i64::from(delta.failure);
     account.non_success_count += i64::from(non_success);
-    account.total_tokens += total_tokens;
-    account.total_cost += total_cost;
-    if success {
-        account.success_tokens += total_tokens;
+    account.total_tokens += delta.total_tokens;
+    account.total_cost += delta.total_cost;
+    if delta.success {
+        account.success_tokens += delta.total_tokens;
     } else {
-        account.non_success_tokens += total_tokens;
+        account.non_success_tokens += delta.total_tokens;
     }
-    if failure {
-        account.failure_tokens += total_tokens;
-        account.failure_cost += total_cost;
+    if delta.failure {
+        account.failure_tokens += delta.total_tokens;
+        account.failure_cost += delta.total_cost;
     }
     if non_success {
-        account.non_success_cost += total_cost;
+        account.non_success_cost += delta.total_cost;
     }
     if account
         .last_invocation_at
         .as_deref()
-        .is_none_or(|current| record.occurred_at.as_str() > current)
+        .is_none_or(|current| delta.occurred_at.as_str() > current)
     {
-        account.last_invocation_at = Some(record.occurred_at.clone());
+        account.last_invocation_at = Some(delta.occurred_at.clone());
     }
-    add_dashboard_activity_terminal_usage(&mut account.usage_breakdown, record);
+    add_dashboard_activity_terminal_usage(&mut account.usage_breakdown, delta);
     account_latency.apply_to_account(account);
     account.cache_hit_rate = (account.total_tokens > 0)
         .then_some(account.usage_breakdown.cache_read_tokens as f64 / account.total_tokens as f64);
     account.model_performance = account_model_performance;
     sort_dashboard_activity_accounts(&mut snapshot.accounts);
+}
+
+fn apply_dashboard_activity_terminal_delta(
+    snapshot: &mut DashboardActivitySnapshot,
+    record: &ApiInvocation,
+) {
+    apply_dashboard_activity_compact_terminal_delta(
+        snapshot,
+        &dashboard_activity_terminal_delta(record),
+    );
+}
+
+fn subtract_dashboard_activity_compact_terminal_delta(
+    snapshot: &mut DashboardActivitySnapshot,
+    delta: &DashboardActivityTerminalDelta,
+) {
+    let non_success = !delta.success;
+    let stats = &mut snapshot.summary.stats;
+    stats.total_count = stats.total_count.saturating_sub(1);
+    stats.success_count = stats.success_count.saturating_sub(i64::from(delta.success));
+    stats.failure_count = stats.failure_count.saturating_sub(i64::from(delta.failure));
+    stats.total_tokens = stats.total_tokens.saturating_sub(delta.total_tokens);
+    stats.total_cost = (stats.total_cost - delta.total_cost).max(0.0);
+    if non_success {
+        if let Some(value) = stats.non_success_cost.as_mut() {
+            *value = (*value - delta.total_cost).max(0.0);
+        }
+        if let Some(value) = stats.non_success_tokens.as_mut() {
+            *value = value.saturating_sub(delta.total_tokens);
+        }
+    }
+    if let Some(usage) = stats.usage_breakdown.as_mut() {
+        subtract_dashboard_activity_terminal_usage(usage, delta);
+    }
+    let snapshot_range = ExactUtcRange {
+        start: snapshot.range_start,
+        end: snapshot.range_end,
+    };
+    let available = snapshot.summary.model_performance.available;
+    if snapshot.model_performance_accumulator_ready {
+        snapshot
+            .summary_model_performance_accumulator
+            .subtract_terminal_delta(delta);
+        snapshot.summary.model_performance = snapshot
+            .summary_model_performance_accumulator
+            .clone()
+            .into_response(snapshot_range, available);
+        if let Some(accumulator) = snapshot
+            .account_model_performance_accumulators
+            .get_mut(&delta.upstream_account_id)
+        {
+            accumulator.subtract_terminal_delta(delta);
+        }
+    }
+    if let Some(latency) = snapshot
+        .account_latency_accumulators
+        .get_mut(&delta.upstream_account_id)
+    {
+        latency.subtract_terminal_delta(delta);
+    }
+    let account_performance = snapshot
+        .account_model_performance_accumulators
+        .get(&delta.upstream_account_id)
+        .cloned()
+        .unwrap_or_default()
+        .into_response(snapshot_range, available);
+    if let Some(account) = snapshot
+        .accounts
+        .iter_mut()
+        .find(|account| account.upstream_account_id == delta.upstream_account_id)
+    {
+        account.request_count = account.request_count.saturating_sub(1);
+        account.success_count = account
+            .success_count
+            .saturating_sub(i64::from(delta.success));
+        account.failure_count = account
+            .failure_count
+            .saturating_sub(i64::from(delta.failure));
+        account.non_success_count = account
+            .non_success_count
+            .saturating_sub(i64::from(non_success));
+        account.total_tokens = account.total_tokens.saturating_sub(delta.total_tokens);
+        account.total_cost = (account.total_cost - delta.total_cost).max(0.0);
+        if delta.success {
+            account.success_tokens = account.success_tokens.saturating_sub(delta.total_tokens);
+        } else {
+            account.non_success_tokens = account
+                .non_success_tokens
+                .saturating_sub(delta.total_tokens);
+        }
+        if delta.failure {
+            account.failure_tokens = account.failure_tokens.saturating_sub(delta.total_tokens);
+            account.failure_cost = (account.failure_cost - delta.total_cost).max(0.0);
+        }
+        if non_success {
+            account.non_success_cost = (account.non_success_cost - delta.total_cost).max(0.0);
+        }
+        if account.last_invocation_at.as_deref() == Some(delta.occurred_at.as_str()) {
+            account.last_invocation_at = None;
+        }
+        subtract_dashboard_activity_terminal_usage(&mut account.usage_breakdown, delta);
+        if let Some(latency) = snapshot
+            .account_latency_accumulators
+            .get(&delta.upstream_account_id)
+            .copied()
+        {
+            latency.apply_to_account(account);
+        }
+        account.cache_hit_rate = (account.total_tokens > 0).then_some(
+            account.usage_breakdown.cache_read_tokens as f64 / account.total_tokens as f64,
+        );
+        account.model_performance = account_performance;
+    }
+    snapshot
+        .accounts
+        .retain(|account| account.request_count > 0);
+    sort_dashboard_activity_accounts(&mut snapshot.accounts);
+}
+
+fn restore_dashboard_activity_last_invocation_after_expiry(
+    snapshot: &mut DashboardActivitySnapshot,
+    expired: &DashboardActivityTerminalDelta,
+    remaining_expiry_deltas: &VecDeque<DashboardActivityTerminalDelta>,
+) {
+    let Some(account) = snapshot
+        .accounts
+        .iter_mut()
+        .find(|account| account.upstream_account_id == expired.upstream_account_id)
+    else {
+        return;
+    };
+    if account.last_invocation_at.is_some() || account.request_count <= 0 {
+        return;
+    }
+    account.last_invocation_at = remaining_expiry_deltas
+        .iter()
+        .filter(|delta| delta.upstream_account_id == expired.upstream_account_id)
+        .max_by_key(|delta| parse_to_utc_datetime(&delta.occurred_at))
+        .map(|delta| delta.occurred_at.clone());
 }
 
 /// Applies an accepted terminal record to every warm open-range baseline. This is deliberately
@@ -11808,10 +12281,11 @@ pub(crate) async fn apply_dashboard_activity_terminal_record(
     state: &AppState,
     record: &ApiInvocation,
 ) -> DashboardActivityTerminalDeltaOutcome {
-    let Some(occurred_at) = parse_to_utc_datetime(&record.occurred_at) else {
+    let mut delta = dashboard_activity_terminal_delta(record);
+    let Some(occurred_at) = parse_to_utc_datetime(&delta.occurred_at) else {
         return DashboardActivityTerminalDeltaOutcome::default();
     };
-    let key = (record.invoke_id.clone(), record.occurred_at.clone());
+    let key = delta.key();
     let mut outcome = DashboardActivityTerminalDeltaOutcome::default();
     let mut cache = state.dashboard_activity_snapshot_cache.lock().await;
     if cache.read_model.applied_terminal_keys.contains_key(&key) {
@@ -11819,63 +12293,281 @@ pub(crate) async fn apply_dashboard_activity_terminal_record(
         outcome.duplicate = true;
         return outcome;
     }
-    cache
-        .read_model
-        .applied_terminal_keys
-        .insert(key, Instant::now());
+    cache.read_model.next_terminal_sequence =
+        cache.read_model.next_terminal_sequence.saturating_add(1);
+    delta.terminal_sequence = cache.read_model.next_terminal_sequence;
+    outcome.terminal_sequence = Some(delta.terminal_sequence);
+    insert_dashboard_activity_applied_terminal_key(&mut cache.read_model, key);
     cache.read_model.terminal_delta_count += 1;
-    cache
-        .read_model
-        .applied_terminal_keys
-        .retain(|_, applied_at| applied_at.elapsed() <= Duration::from_secs(7 * 24 * 60 * 60));
-    if cache.read_model.applied_terminal_keys.len()
-        > DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS
-    {
-        let mut keys = cache
-            .read_model
-            .applied_terminal_keys
-            .iter()
-            .map(|(key, applied_at)| (key.clone(), *applied_at))
-            .collect::<Vec<_>>();
-        keys.sort_by_key(|(_, applied_at)| *applied_at);
-        for (key, _) in keys.into_iter().take(
-            cache.read_model.applied_terminal_keys.len()
-                - DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS,
-        ) {
-            cache.read_model.applied_terminal_keys.remove(&key);
-        }
+    prune_dashboard_activity_applied_terminal_keys(&mut cache.read_model);
+    if delta.persisted_row_id.is_some() {
+        settle_dashboard_activity_terminal_sequence(&mut cache.read_model, delta.terminal_sequence);
     }
-
+    let hard_limit_reason = dashboard_activity_terminal_delta_needs_persistence_ack(&delta)
+        .then(|| dashboard_activity_terminal_delta_hard_limit_reason(&cache.read_model, &delta))
+        .flatten();
+    if let Some(reason) = hard_limit_reason {
+        cache.read_model.hard_limit_reason = Some(reason);
+        cache.read_model.hard_limit_sequence = Some(delta.terminal_sequence);
+        cache.read_model.pending_terminal_overflow_count += 1;
+        outcome.hard_limit_reason = Some(reason);
+        tracing::warn!(
+            hard_limit_reason = reason,
+            pending_delta_count = cache.read_model.pending_terminal_deltas.len(),
+            pending_delta_estimated_bytes = cache.read_model.pending_delta_estimated_bytes,
+            persisted_ack_pending_count = cache.read_model.persisted_ack_pending_count,
+            "dashboard activity read model entered dirty last-good protection"
+        );
+        return outcome;
+    }
+    let mut expiry_hard_limit = None;
     for (selection, entry) in &mut cache.entries {
-        if !dashboard_activity_selection_includes_terminal(selection, record, occurred_at) {
+        if !dashboard_activity_selection_includes_compact_terminal(selection, &delta, occurred_at) {
             outcome.skipped_out_of_range_count += 1;
             continue;
         }
-        if dashboard_activity_entry_includes_terminal(entry, record) {
+        if dashboard_activity_entry_includes_terminal(entry, &delta) {
             continue;
         }
-        apply_dashboard_activity_terminal_delta(&mut entry.response, record);
+        if let Err(reason) = insert_dashboard_activity_expiry_delta(
+            &mut entry.expiry_terminal_deltas,
+            &mut entry.expiry_delta_estimated_bytes,
+            entry.expiry_covered_until,
+            &delta,
+            occurred_at,
+        ) {
+            entry.expiry_covered_until = Some(DateTime::<Utc>::MIN_UTC);
+            expiry_hard_limit = Some(reason);
+            continue;
+        }
+        apply_dashboard_activity_compact_terminal_delta(&mut entry.response, &delta);
         outcome.applied_selection_count += 1;
     }
-    cache
-        .read_model
-        .pending_terminal_records
-        .push_back(record.clone());
-    let oldest_supported = Utc::now() - ChronoDuration::days(7);
-    cache.read_model.pending_terminal_records.retain(|pending| {
-        parse_to_utc_datetime(&pending.occurred_at)
-            .is_some_and(|occurred_at| occurred_at >= oldest_supported)
-    });
-    if cache.read_model.pending_terminal_records.len()
-        > DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS
-    {
-        cache.read_model.pending_terminal_overflow_count += 1;
-        tracing::warn!(
-            pending_terminal_record_count = cache.read_model.pending_terminal_records.len(),
-            "dashboard activity read model retained pending terminal records beyond the advisory limit"
+    let evicted_entry_count = prune_dashboard_activity_snapshot_entries(&mut cache, None);
+    if evicted_entry_count > 0 {
+        prune_dashboard_activity_terminal_deltas(&mut cache);
+        tracing::debug!(
+            evicted_entry_count,
+            cache_entry_count = cache.entries.len(),
+            "evicted dashboard activity snapshots to enforce the global cache budget"
         );
     }
+    if let Some(reason) = expiry_hard_limit {
+        cache.read_model.hard_limit_reason = Some(reason);
+        cache.read_model.pending_terminal_overflow_count += 1;
+        outcome.hard_limit_reason = Some(reason);
+    }
+    if !dashboard_activity_terminal_delta_needs_persistence_ack(&delta) {
+        return outcome;
+    }
+    cache.read_model.pending_delta_estimated_bytes = cache
+        .read_model
+        .pending_delta_estimated_bytes
+        .saturating_add(delta.estimated_bytes);
+    cache.read_model.pending_terminal_deltas.push_back(delta);
     outcome
+}
+
+fn prune_dashboard_activity_applied_terminal_keys(read_model: &mut DashboardActivityReadModel) {
+    let max_age = Duration::from_secs(7 * 24 * 60 * 60);
+    while let Some((key, applied_at)) = read_model.applied_terminal_key_order.front() {
+        let is_live_entry = read_model.applied_terminal_keys.get(key) == Some(applied_at);
+        if is_live_entry
+            && read_model.applied_terminal_keys.len()
+                <= DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS
+            && applied_at.elapsed() <= max_age
+        {
+            break;
+        }
+        let key = key.clone();
+        let applied_at = *applied_at;
+        read_model.applied_terminal_key_order.pop_front();
+        if read_model.applied_terminal_keys.get(&key) == Some(&applied_at) {
+            read_model.applied_terminal_keys.remove(&key);
+        }
+    }
+}
+
+fn insert_dashboard_activity_applied_terminal_key(
+    read_model: &mut DashboardActivityReadModel,
+    key: (String, String),
+) {
+    let applied_at = Instant::now();
+    read_model
+        .applied_terminal_keys
+        .insert(key.clone(), applied_at);
+    read_model
+        .applied_terminal_key_order
+        .push_back((key, applied_at));
+}
+
+fn dashboard_activity_terminal_delta_hard_limit_reason(
+    read_model: &DashboardActivityReadModel,
+    delta: &DashboardActivityTerminalDelta,
+) -> Option<&'static str> {
+    if read_model.pending_terminal_deltas.len()
+        >= DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS
+    {
+        Some("count_limit")
+    } else if read_model
+        .pending_delta_estimated_bytes
+        .saturating_add(delta.estimated_bytes)
+        > DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES
+    {
+        Some("byte_limit")
+    } else {
+        None
+    }
+}
+
+fn dashboard_activity_terminal_delta_needs_persistence_ack(
+    delta: &DashboardActivityTerminalDelta,
+) -> bool {
+    delta.persisted_row_id.is_none()
+}
+
+fn prune_dashboard_activity_terminal_deltas(cache: &mut DashboardActivitySnapshotCacheState) {
+    let minimum_cursor = cache
+        .entries
+        .values()
+        .map(|entry| entry.baseline_snapshot_cursor)
+        .chain(
+            cache
+                .in_flight
+                .values()
+                .filter_map(|flight| flight.baseline_cursor),
+        )
+        .min();
+    let can_prune_all_persisted = cache.entries.is_empty() && cache.in_flight.is_empty();
+    let before = cache.read_model.pending_terminal_deltas.len();
+    cache.read_model.pending_terminal_deltas.retain(|delta| {
+        let Some(row_id) = delta.persisted_row_id else {
+            return true;
+        };
+        !(can_prune_all_persisted || minimum_cursor.is_some_and(|cursor| cursor >= row_id))
+    });
+    let pruned = before.saturating_sub(cache.read_model.pending_terminal_deltas.len());
+    cache.read_model.delta_pruned_count = cache
+        .read_model
+        .delta_pruned_count
+        .saturating_add(pruned as u64);
+    cache.read_model.pending_delta_estimated_bytes = cache
+        .read_model
+        .pending_terminal_deltas
+        .iter()
+        .map(|delta| delta.estimated_bytes)
+        .sum();
+    cache.read_model.persisted_ack_pending_count = cache
+        .read_model
+        .pending_terminal_deltas
+        .iter()
+        .filter(|delta| delta.persisted_row_id.is_some())
+        .count();
+}
+
+fn prune_dashboard_activity_snapshot_entries(
+    cache: &mut DashboardActivitySnapshotCacheState,
+    protected_selection: Option<&DashboardActivitySnapshotSelection>,
+) -> usize {
+    let mut evicted = 0usize;
+    loop {
+        let expiry_bytes = cache
+            .entries
+            .values()
+            .map(|entry| entry.expiry_delta_estimated_bytes)
+            .sum::<usize>();
+        if cache.entries.len() <= DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_ENTRIES
+            && expiry_bytes <= DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_EXPIRY_BYTES
+        {
+            break;
+        }
+
+        let candidate = cache
+            .entries
+            .iter()
+            .filter(|(selection, _)| protected_selection != Some(*selection))
+            .min_by_key(|(_, entry)| entry.cached_at)
+            .map(|(selection, _)| selection.clone())
+            .or_else(|| protected_selection.cloned());
+        let Some(candidate) = candidate else {
+            break;
+        };
+        cache.entries.remove(&candidate);
+        cache.invalidation_reasons.remove(&candidate);
+        evicted += 1;
+    }
+    evicted
+}
+
+fn dashboard_activity_hard_limit_is_settled(read_model: &DashboardActivityReadModel) -> bool {
+    read_model
+        .hard_limit_sequence
+        .is_none_or(|sequence| read_model.settled_terminal_sequence >= sequence)
+}
+
+fn dashboard_activity_read_model_requires_reconcile(
+    read_model: &DashboardActivityReadModel,
+) -> bool {
+    read_model.hard_limit_reason.is_some() && dashboard_activity_hard_limit_is_settled(read_model)
+}
+
+fn settle_dashboard_activity_terminal_sequence(
+    read_model: &mut DashboardActivityReadModel,
+    terminal_sequence: u64,
+) {
+    if terminal_sequence <= read_model.settled_terminal_sequence {
+        return;
+    }
+    read_model
+        .settled_terminal_sequences
+        .insert(terminal_sequence);
+    while let Some(next_sequence) = read_model.settled_terminal_sequence.checked_add(1)
+        && read_model.settled_terminal_sequences.remove(&next_sequence)
+    {
+        read_model.settled_terminal_sequence = next_sequence;
+    }
+}
+
+fn clear_dashboard_activity_hard_limit_after_baseline(read_model: &mut DashboardActivityReadModel) {
+    if dashboard_activity_hard_limit_is_settled(read_model)
+        && read_model.pending_terminal_deltas.len()
+            < DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS
+        && read_model.pending_delta_estimated_bytes
+            < DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES
+    {
+        read_model.hard_limit_reason = None;
+        read_model.hard_limit_sequence = None;
+    }
+}
+
+pub(crate) async fn acknowledge_dashboard_activity_terminal_record(
+    cache: &Arc<tokio::sync::Mutex<DashboardActivitySnapshotCacheState>>,
+    invoke_id: &str,
+    occurred_at: &str,
+    row_id: i64,
+    terminal_sequence: Option<u64>,
+) {
+    let mut cache = cache.lock().await;
+    if let Some(terminal_sequence) = terminal_sequence {
+        settle_dashboard_activity_terminal_sequence(&mut cache.read_model, terminal_sequence);
+    }
+    let mut ack_sequence_gap = false;
+    for delta in &mut cache.read_model.pending_terminal_deltas {
+        if delta.invoke_id == invoke_id && delta.occurred_at == occurred_at {
+            ack_sequence_gap = delta
+                .persisted_row_id
+                .is_some_and(|persisted| persisted != row_id);
+            delta.persisted_row_id = Some(row_id);
+            break;
+        }
+    }
+    if ack_sequence_gap {
+        cache.read_model.sequence_gap_count += 1;
+        cache.read_model.hard_limit_reason = Some("ack_sequence_gap");
+    }
+    // A writer retry can acknowledge a delta after every warm cursor already allowed it to be
+    // pruned. Matching row IDs are therefore idempotent; only a conflicting ACK is a gap.
+    prune_dashboard_activity_terminal_deltas(&mut cache);
 }
 
 /// The write-side delta is registered before an asynchronous SQLite enqueue. If the queue
@@ -11884,16 +12576,33 @@ pub(crate) async fn apply_dashboard_activity_terminal_record(
 pub(crate) async fn rollback_dashboard_activity_terminal_record(
     state: &AppState,
     record: &ApiInvocation,
+    terminal_sequence: Option<u64>,
 ) {
     let key = (record.invoke_id.clone(), record.occurred_at.clone());
     let mut cache = state.dashboard_activity_snapshot_cache.lock().await;
     cache.read_model.applied_terminal_keys.remove(&key);
     cache
         .read_model
-        .pending_terminal_records
-        .retain(|pending| (pending.invoke_id.clone(), pending.occurred_at.clone()) != key);
+        .pending_terminal_deltas
+        .retain(|pending| pending.key() != key);
+    cache.read_model.pending_delta_estimated_bytes = cache
+        .read_model
+        .pending_terminal_deltas
+        .iter()
+        .map(|delta| delta.estimated_bytes)
+        .sum();
+    cache.read_model.persisted_ack_pending_count = cache
+        .read_model
+        .pending_terminal_deltas
+        .iter()
+        .filter(|delta| delta.persisted_row_id.is_some())
+        .count();
+    if let Some(terminal_sequence) = terminal_sequence {
+        settle_dashboard_activity_terminal_sequence(&mut cache.read_model, terminal_sequence);
+    }
     cache.entries.clear();
     cache.invalidation_reasons.clear();
+    clear_dashboard_activity_hard_limit_after_baseline(&mut cache.read_model);
 }
 
 /// Recovery can replace a previously persisted running row with its terminal form. Its positive
@@ -12606,12 +13315,142 @@ fn dashboard_activity_snapshot_selection_anchor(
         .to_string()
 }
 
-fn dashboard_activity_snapshot_cache_ttl(range_name: &str) -> Duration {
-    if parse_duration_spec(range_name).is_ok() {
-        Duration::from_secs(DASHBOARD_ACTIVITY_ROLLING_SNAPSHOT_CACHE_TTL_SECS)
-    } else {
-        Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS)
+fn dashboard_activity_snapshot_cache_ttl(_range_name: &str) -> Duration {
+    Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS)
+}
+
+fn dashboard_activity_snapshot_cache_can_track_expiry(
+    range_name: &str,
+    range: ExactUtcRange,
+    retention_cutoff: DateTime<Utc>,
+) -> bool {
+    parse_duration_spec(range_name).is_err() || range.start >= retention_cutoff
+}
+
+fn dashboard_activity_entry_expiry_covers(
+    entry: &DashboardActivitySnapshotCacheEntry,
+    range: ExactUtcRange,
+) -> bool {
+    entry
+        .expiry_covered_until
+        .is_none_or(|covered_until| range.start <= covered_until)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DashboardActivitySnapshotReuseMode {
+    Current,
+    LastGoodReconcileBackoff,
+}
+
+fn dashboard_activity_snapshot_reuse_mode(
+    entry: &DashboardActivitySnapshotCacheEntry,
+    range: ExactUtcRange,
+    cache_ttl: Duration,
+) -> Option<DashboardActivitySnapshotReuseMode> {
+    let within_reconcile_deadline = entry.last_reconcile_attempted_at.elapsed() <= cache_ttl;
+    if dashboard_activity_entry_expiry_covers(entry, range) {
+        return within_reconcile_deadline.then_some(DashboardActivitySnapshotReuseMode::Current);
     }
+    if !entry.last_reconcile_failed || !within_reconcile_deadline {
+        return None;
+    }
+    Some(DashboardActivitySnapshotReuseMode::LastGoodReconcileBackoff)
+}
+
+fn mark_dashboard_activity_reconcile_failed(entry: &mut DashboardActivitySnapshotCacheEntry) {
+    entry.last_reconcile_attempted_at = Instant::now();
+    entry.last_reconcile_failed = true;
+}
+
+fn insert_dashboard_activity_expiry_delta(
+    deltas: &mut VecDeque<DashboardActivityTerminalDelta>,
+    estimated_bytes: &mut usize,
+    expiry_covered_until: Option<DateTime<Utc>>,
+    delta: &DashboardActivityTerminalDelta,
+    occurred_at: DateTime<Utc>,
+) -> Result<(), &'static str> {
+    if expiry_covered_until.is_none_or(|covered_until| occurred_at >= covered_until) {
+        return Ok(());
+    }
+    if deltas.len() >= DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS {
+        return Err("expiry_count_limit");
+    }
+    if estimated_bytes.saturating_add(delta.estimated_bytes)
+        > DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES
+    {
+        return Err("expiry_byte_limit");
+    }
+    let insert_at = deltas
+        .iter()
+        .position(|existing| {
+            parse_to_utc_datetime(&existing.occurred_at)
+                .is_some_and(|existing_at| existing_at > occurred_at)
+        })
+        .unwrap_or(deltas.len());
+    deltas.insert(insert_at, delta.clone());
+    *estimated_bytes = estimated_bytes.saturating_add(delta.estimated_bytes);
+    Ok(())
+}
+
+async fn load_dashboard_activity_expiry_deltas(
+    pool: &Pool<Sqlite>,
+    selection: &DashboardActivitySnapshotSelection,
+    range: ExactUtcRange,
+    baseline_cursor: i64,
+) -> Result<
+    (
+        VecDeque<DashboardActivityTerminalDelta>,
+        Option<DateTime<Utc>>,
+        usize,
+        Option<&'static str>,
+    ),
+    ApiError,
+> {
+    if parse_duration_spec(&selection.range).is_err() {
+        return Ok((VecDeque::new(), None, 0, None));
+    }
+    // Resolve the moving range immediately before the query. The resulting upper bound is also
+    // stored on the cache entry, so time spent querying can only shorten reuse instead of leaving
+    // an uncovered expiry interval after a slow baseline build.
+    let expiry_covered_until = resolve_dashboard_activity_cached_range(
+        &selection.range,
+        selection
+            .time_zone
+            .parse::<Tz>()
+            .map_err(|_| ApiError::from(anyhow!("invalid dashboard activity cache timezone")))?,
+    )?
+    .start
+        + ChronoDuration::seconds(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS as i64);
+    let mut query = build_invocation_select_query();
+    query
+        .push(" AND id <= ")
+        .push_bind(baseline_cursor)
+        .push(" AND occurred_at >= ")
+        .push_bind(db_occurred_at_lower_bound(range.start))
+        .push(" AND occurred_at < ")
+        .push_bind(db_occurred_at_upper_bound(expiry_covered_until))
+        .push(" AND LOWER(TRIM(COALESCE(status, ''))) NOT IN ('running', 'pending')");
+    if selection.source_scope == "proxy_only" {
+        query.push(" AND source = ").push_bind(SOURCE_PROXY);
+    }
+    query.push(" ORDER BY occurred_at ASC, id ASC");
+    let mut rows = query.build_query_as::<ApiInvocation>().fetch(pool);
+    let mut deltas = VecDeque::new();
+    let mut estimated_bytes = 0usize;
+    while let Some(record) = rows.try_next().await? {
+        let delta = dashboard_activity_terminal_delta(&record);
+        if deltas.len() >= DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS {
+            return Ok((VecDeque::new(), None, 0, Some("expiry_count_limit")));
+        }
+        if estimated_bytes.saturating_add(delta.estimated_bytes)
+            > DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES
+        {
+            return Ok((VecDeque::new(), None, 0, Some("expiry_byte_limit")));
+        }
+        estimated_bytes = estimated_bytes.saturating_add(delta.estimated_bytes);
+        deltas.push_back(delta);
+    }
+    Ok((deltas, Some(expiry_covered_until), estimated_bytes, None))
 }
 
 fn resolve_dashboard_activity_exact_range(
@@ -14459,6 +15298,16 @@ async fn load_dashboard_activity_snapshot_cached(
                 selection_fingerprint: 0,
                 terminal_delta_count: 0,
                 duplicate_delta_count: 0,
+                pending_delta_count: 0,
+                pending_delta_estimated_bytes: 0,
+                persisted_ack_pending_count: 0,
+                delta_pruned_count: 0,
+                expiry_delta_count: 0,
+                hard_limit_reason: "none",
+                baseline_cursor: 0,
+                sequence_gap_count: 0,
+                build_attempted: true,
+                snapshot_origin: "exact_db",
             },
         ));
     }
@@ -14474,10 +15323,136 @@ async fn load_dashboard_activity_snapshot_cached(
         include_accounts,
         include_recent,
     );
+    let baseline_build_gate = {
+        let cache = state.dashboard_activity_snapshot_cache.lock().await;
+        cache.baseline_build_gate.clone()
+    };
+    if !dashboard_activity_snapshot_cache_can_track_expiry(
+        range_name,
+        range,
+        shanghai_retention_cutoff(state.config.invocation_max_days),
+    ) {
+        let started_at = Instant::now();
+        let _baseline_build_guard = baseline_build_gate.lock().await;
+        let reconcile_gate = state.sqlite_batch_writer.dashboard_reconcile_gate();
+        let reconcile_guard = reconcile_gate.lock().await;
+        let mut consistency_connection =
+            Some(begin_dashboard_activity_consistency_barrier(&state.pool).await?);
+        // Once BEGIN IMMEDIATE owns the SQLite write barrier, the batch writer can drain its
+        // channel into its retained batch instead of backing up behind this process-local gate.
+        drop(reconcile_guard);
+        let build_result: Result<_, ApiError> = async {
+            let baseline_cursor = if let Some(connection) = consistency_connection.as_mut() {
+                query_live_dashboard_activity_snapshot_cursor_tx(connection.as_mut()).await?
+            } else {
+                query_live_dashboard_activity_snapshot_cursor(&state.pool).await?
+            };
+            let snapshot = load_dashboard_activity_snapshot_for_range(
+                state,
+                range_name,
+                reporting_tz,
+                range,
+                recent_limit,
+                include_accounts,
+                include_recent,
+                in_progress_counts_override,
+            )
+            .await?;
+            let pending_terminal_keys_after_build = {
+                let cache = state.dashboard_activity_snapshot_cache.lock().await;
+                cache
+                    .read_model
+                    .pending_terminal_deltas
+                    .iter()
+                    .filter_map(|delta| {
+                        let occurred_at = parse_to_utc_datetime(&delta.occurred_at)?;
+                        dashboard_activity_selection_includes_compact_terminal(
+                            &selection,
+                            delta,
+                            occurred_at,
+                        )
+                        .then_some(delta.key())
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let persisted_terminal_ids = if let Some(connection) = consistency_connection.as_mut() {
+                query_live_dashboard_activity_persisted_terminal_ids_tx(
+                    connection.as_mut(),
+                    dashboard_activity_selection_source_scope(&selection),
+                    &pending_terminal_keys_after_build,
+                )
+                .await?
+            } else {
+                HashMap::new()
+            };
+            Ok((snapshot, baseline_cursor, persisted_terminal_ids))
+        }
+        .await;
+        // Keep ACK pruning behind the exact snapshot replay. Once the consistency transaction
+        // is released, the writer may persist and acknowledge a terminal that arrived during the
+        // build; without this guard it could remove the pending delta before this older baseline
+        // has incorporated it.
+        let cache = state.dashboard_activity_snapshot_cache.lock().await;
+        if let Some(connection) = consistency_connection.take() {
+            finish_dashboard_activity_consistency_barrier(connection, build_result.is_ok()).await?;
+        }
+        let (mut snapshot, baseline_cursor, persisted_terminal_ids) = build_result?;
+        if !dashboard_activity_hard_limit_is_settled(&cache.read_model) {
+            return Err(ApiError::from(anyhow!(
+                "dashboard activity hard-limit terminal writes are not persisted yet"
+            )));
+        }
+        let replayed_pending_delta_count = replay_dashboard_activity_pending_deltas_without_expiry(
+            &mut snapshot,
+            &selection,
+            &cache.read_model.pending_terminal_deltas,
+            baseline_cursor,
+            &persisted_terminal_ids,
+        );
+        tracing::debug!(
+            selection_fingerprint = dashboard_activity_selection_fingerprint(&selection),
+            replayed_pending_delta_count,
+            "replayed pending dashboard deltas over archive-prefix exact snapshot"
+        );
+        let terminal_delta_count = cache.read_model.terminal_delta_count;
+        let duplicate_delta_count = cache.read_model.duplicate_delta_count;
+        let pending_delta_count = cache.read_model.pending_terminal_deltas.len();
+        let pending_delta_estimated_bytes = cache.read_model.pending_delta_estimated_bytes;
+        let persisted_ack_pending_count = cache.read_model.persisted_ack_pending_count;
+        let delta_pruned_count = cache.read_model.delta_pruned_count;
+        let hard_limit_reason = cache.read_model.hard_limit_reason.unwrap_or("none");
+        let sequence_gap_count = cache.read_model.sequence_gap_count;
+        return Ok((
+            snapshot,
+            DashboardActivitySnapshotCacheOutcome {
+                cache_hit_or_miss: "uncached",
+                cache_bypass_reason: "archive_expiry_unavailable",
+                coalesced_waiter_count: 0,
+                db_build_elapsed_ms: started_at.elapsed().as_millis() as u64,
+                cache_ttl_ms: 0,
+                cache_entry_age_ms: 0,
+                cache_entry_count: 0,
+                in_flight_count: 0,
+                refresh_reason: "exact_uncached",
+                selection_fingerprint: 0,
+                terminal_delta_count,
+                duplicate_delta_count,
+                pending_delta_count,
+                pending_delta_estimated_bytes,
+                persisted_ack_pending_count,
+                delta_pruned_count,
+                expiry_delta_count: 0,
+                hard_limit_reason,
+                baseline_cursor,
+                sequence_gap_count,
+                build_attempted: true,
+                snapshot_origin: "exact_db_with_pending_overlay",
+            },
+        ));
+    }
     let mut waited_on_in_flight = false;
     let mut max_waiter_count = 0_usize;
     let mut saw_expired_entry = false;
-    let mut concurrent_reconcile_retry_count = 0usize;
     let cache_ttl = dashboard_activity_snapshot_cache_ttl(range_name);
     let cache_ttl_ms = cache_ttl.as_millis() as u64;
     let selection_fingerprint = dashboard_activity_selection_fingerprint(&selection);
@@ -14485,8 +15460,6 @@ async fn load_dashboard_activity_snapshot_cached(
     loop {
         let mut wait_on: Option<tokio::sync::watch::Receiver<bool>> = None;
         let mut flight_guard: Option<DashboardActivitySnapshotFlightGuard> = None;
-        let mut terminal_delta_count_before_build = 0_u64;
-        let mut pending_terminal_keys_before_build = Vec::new();
         {
             let mut cache = state.dashboard_activity_snapshot_cache.lock().await;
             saw_expired_entry |= cache
@@ -14500,29 +15473,84 @@ async fn load_dashboard_activity_snapshot_cached(
             let in_flight_count = cache.in_flight.len();
             let terminal_delta_count = cache.read_model.terminal_delta_count;
             let duplicate_delta_count = cache.read_model.duplicate_delta_count;
-            if let Some(entry) = cache.entries.get(&selection)
-                && entry.last_reconcile_attempted_at.elapsed() <= cache_ttl
+            let pending_delta_count = cache.read_model.pending_terminal_deltas.len();
+            let pending_delta_estimated_bytes = cache.read_model.pending_delta_estimated_bytes;
+            let persisted_ack_pending_count = cache.read_model.persisted_ack_pending_count;
+            let delta_pruned_count = cache.read_model.delta_pruned_count;
+            let hard_limit_reason = cache.read_model.hard_limit_reason.unwrap_or("none");
+            let sequence_gap_count = cache.read_model.sequence_gap_count;
+            let settled_dirty_state =
+                dashboard_activity_read_model_requires_reconcile(&cache.read_model);
+            if !settled_dirty_state
+                && let Some(entry) = cache.entries.get_mut(&selection)
+                && let Some(reuse_mode) =
+                    dashboard_activity_snapshot_reuse_mode(entry, range, cache_ttl)
             {
+                let mut expired_count = 0usize;
+                if reuse_mode == DashboardActivitySnapshotReuseMode::Current {
+                    while entry.expiry_terminal_deltas.front().is_some_and(|delta| {
+                        parse_to_utc_datetime(&delta.occurred_at)
+                            .is_some_and(|occurred_at| occurred_at < range.start)
+                    }) {
+                        if let Some(delta) = entry.expiry_terminal_deltas.pop_front() {
+                            entry.expiry_delta_estimated_bytes = entry
+                                .expiry_delta_estimated_bytes
+                                .saturating_sub(delta.estimated_bytes);
+                            subtract_dashboard_activity_compact_terminal_delta(
+                                &mut entry.response,
+                                &delta,
+                            );
+                            restore_dashboard_activity_last_invocation_after_expiry(
+                                &mut entry.response,
+                                &delta,
+                                &entry.expiry_terminal_deltas,
+                            );
+                            expired_count += 1;
+                        }
+                    }
+                }
                 let cache_entry_age_ms = entry.cached_at.elapsed().as_millis() as u64;
+                let is_last_good =
+                    reuse_mode == DashboardActivitySnapshotReuseMode::LastGoodReconcileBackoff;
                 return Ok((
                     entry.response.clone(),
                     DashboardActivitySnapshotCacheOutcome {
-                        cache_hit_or_miss: if waited_on_in_flight {
+                        cache_hit_or_miss: if is_last_good {
+                            "last_good_fallback"
+                        } else if waited_on_in_flight {
                             "wait_on_in_flight"
                         } else {
                             "cache_hit"
                         },
-                        cache_bypass_reason: "none",
+                        cache_bypass_reason: if is_last_good {
+                            "expiry_reconcile_backoff"
+                        } else {
+                            "none"
+                        },
                         coalesced_waiter_count: max_waiter_count,
                         db_build_elapsed_ms: 0,
                         cache_ttl_ms,
                         cache_entry_age_ms,
                         cache_entry_count,
                         in_flight_count,
-                        refresh_reason: "within_ttl",
+                        refresh_reason: if is_last_good {
+                            "reconcile_backoff"
+                        } else {
+                            "within_ttl"
+                        },
                         selection_fingerprint,
                         terminal_delta_count,
                         duplicate_delta_count,
+                        pending_delta_count,
+                        pending_delta_estimated_bytes,
+                        persisted_ack_pending_count,
+                        delta_pruned_count,
+                        expiry_delta_count: expired_count,
+                        hard_limit_reason,
+                        baseline_cursor: entry.baseline_snapshot_cursor,
+                        sequence_gap_count,
+                        build_attempted: false,
+                        snapshot_origin: if is_last_good { "last_good" } else { "memory" },
                     },
                 ));
             }
@@ -14532,27 +15560,13 @@ async fn load_dashboard_activity_snapshot_cached(
                 max_waiter_count = max_waiter_count.max(in_flight.waiter_count);
                 wait_on = Some(in_flight.signal.subscribe());
             } else {
-                terminal_delta_count_before_build = cache.read_model.terminal_delta_count;
-                pending_terminal_keys_before_build = cache
-                    .read_model
-                    .pending_terminal_records
-                    .iter()
-                    .filter_map(|record| {
-                        let occurred_at = parse_to_utc_datetime(&record.occurred_at)?;
-                        dashboard_activity_selection_includes_terminal(
-                            &selection,
-                            record,
-                            occurred_at,
-                        )
-                        .then_some((record.invoke_id.clone(), record.occurred_at.clone()))
-                    })
-                    .collect();
                 let (signal, _receiver) = tokio::sync::watch::channel(false);
                 cache.in_flight.insert(
                     selection.clone(),
                     DashboardActivitySnapshotInFlight {
                         signal,
                         waiter_count: 0,
+                        baseline_cursor: None,
                     },
                 );
                 flight_guard = Some(DashboardActivitySnapshotFlightGuard::new(
@@ -14571,20 +15585,94 @@ async fn load_dashboard_activity_snapshot_cached(
         }
 
         let build_started_at = Instant::now();
-        let (snapshot_cursor_before_build, persisted_terminal_ids_before_build, probe_error) =
-            match query_live_dashboard_activity_snapshot_cursor(&state.pool).await {
-                Ok(snapshot_cursor) => match query_live_dashboard_activity_persisted_terminal_ids(
-                    &state.pool,
-                    dashboard_activity_selection_source_scope(&selection),
-                    &pending_terminal_keys_before_build,
-                )
-                .await
-                {
-                    Ok(persisted_terminal_ids) => (snapshot_cursor, persisted_terminal_ids, None),
-                    Err(err) => (snapshot_cursor, HashMap::new(), Some(err)),
-                },
-                Err(err) => (0, HashMap::new(), Some(err)),
+        let _baseline_build_guard = baseline_build_gate.lock().await;
+        let reconcile_gate = state.sqlite_batch_writer.dashboard_reconcile_gate();
+        let reconcile_guard = reconcile_gate.lock().await;
+        let has_last_good = {
+            let cache = state.dashboard_activity_snapshot_cache.lock().await;
+            cache.entries.contains_key(&selection)
+        };
+        let mut consistency_connection = if has_last_good {
+            try_begin_dashboard_activity_consistency_barrier(&state.pool).await?
+        } else {
+            Some(begin_dashboard_activity_consistency_barrier(&state.pool).await?)
+        };
+        // SQLite now serializes commits against the consistency transaction. Releasing the
+        // process-local gate lets the writer retain failed work without filling its input queue.
+        drop(reconcile_guard);
+        let consistency_barrier_unavailable = consistency_connection.is_none();
+        if consistency_barrier_unavailable {
+            let mut cache = state.dashboard_activity_snapshot_cache.lock().await;
+            if let Some(entry) = cache.entries.get_mut(&selection) {
+                mark_dashboard_activity_reconcile_failed(entry);
+                let response = entry.response.clone();
+                let cache_entry_age_ms = entry.cached_at.elapsed().as_millis() as u64;
+                let baseline_cursor = entry.baseline_snapshot_cursor;
+                let in_flight = cache.in_flight.remove(&selection);
+                if let Some(guard) = flight_guard.as_mut() {
+                    guard.disarm();
+                }
+                let coalesced_waiter_count =
+                    in_flight.as_ref().map_or(0, |flight| flight.waiter_count);
+                if let Some(in_flight) = in_flight {
+                    let _ = in_flight.signal.send(true);
+                }
+                return Ok((
+                    response,
+                    DashboardActivitySnapshotCacheOutcome {
+                        cache_hit_or_miss: "last_good_fallback",
+                        cache_bypass_reason: "consistency_barrier_unavailable",
+                        coalesced_waiter_count,
+                        db_build_elapsed_ms: build_started_at.elapsed().as_millis() as u64,
+                        cache_ttl_ms,
+                        cache_entry_age_ms,
+                        cache_entry_count: cache.entries.len(),
+                        in_flight_count: cache.in_flight.len(),
+                        refresh_reason: "reconcile_lock_contended",
+                        selection_fingerprint,
+                        terminal_delta_count: cache.read_model.terminal_delta_count,
+                        duplicate_delta_count: cache.read_model.duplicate_delta_count,
+                        pending_delta_count: cache.read_model.pending_terminal_deltas.len(),
+                        pending_delta_estimated_bytes: cache
+                            .read_model
+                            .pending_delta_estimated_bytes,
+                        persisted_ack_pending_count: cache.read_model.persisted_ack_pending_count,
+                        delta_pruned_count: cache.read_model.delta_pruned_count,
+                        expiry_delta_count: 0,
+                        hard_limit_reason: cache.read_model.hard_limit_reason.unwrap_or("none"),
+                        baseline_cursor,
+                        sequence_gap_count: cache.read_model.sequence_gap_count,
+                        build_attempted: false,
+                        snapshot_origin: "last_good",
+                    },
+                ));
+            }
+            let in_flight = cache.in_flight.remove(&selection);
+            if let Some(guard) = flight_guard.as_mut() {
+                guard.disarm();
+            }
+            if let Some(in_flight) = in_flight {
+                let _ = in_flight.signal.send(true);
+            }
+            return Err(ApiError::from(anyhow!(
+                "dashboard activity consistency barrier unavailable for initial snapshot"
+            )));
+        }
+        let (snapshot_cursor_before_build, probe_error) =
+            match if let Some(connection) = consistency_connection.as_mut() {
+                query_live_dashboard_activity_snapshot_cursor_tx(connection.as_mut()).await
+            } else {
+                query_live_dashboard_activity_snapshot_cursor(&state.pool).await
+            } {
+                Ok(snapshot_cursor) => (snapshot_cursor, None),
+                Err(err) => (0, Some(err)),
             };
+        {
+            let mut cache = state.dashboard_activity_snapshot_cache.lock().await;
+            if let Some(flight) = cache.in_flight.get_mut(&selection) {
+                flight.baseline_cursor = Some(snapshot_cursor_before_build);
+            }
+        }
         let mut result = if let Some(err) = probe_error {
             Err(err)
         } else {
@@ -14600,39 +15688,80 @@ async fn load_dashboard_activity_snapshot_cached(
             )
             .await
         };
-        let pending_terminal_keys_after_build = {
-            let cache = state.dashboard_activity_snapshot_cache.lock().await;
-            cache
-                .read_model
-                .pending_terminal_records
-                .iter()
-                .filter_map(|record| {
-                    let occurred_at = parse_to_utc_datetime(&record.occurred_at)?;
-                    dashboard_activity_selection_includes_terminal(&selection, record, occurred_at)
-                        .then_some((record.invoke_id.clone(), record.occurred_at.clone()))
-                })
-                .collect::<HashSet<_>>()
-        };
-        let persisted_terminal_ids_after_build = if result.is_ok() {
-            match query_live_dashboard_activity_persisted_terminal_ids(
-                &state.pool,
-                dashboard_activity_selection_source_scope(&selection),
-                &pending_terminal_keys_after_build
+        let (snapshot_cursor_after_build, persisted_terminal_ids_after_build) = if result.is_ok() {
+            let pending_terminal_keys_after_build = {
+                let cache = state.dashboard_activity_snapshot_cache.lock().await;
+                cache
+                    .read_model
+                    .pending_terminal_deltas
                     .iter()
-                    .cloned()
-                    .collect::<Vec<_>>(),
-            )
-            .await
-            {
-                Ok(persisted_terminal_ids) => persisted_terminal_ids,
+                    .filter_map(|delta| {
+                        let occurred_at = parse_to_utc_datetime(&delta.occurred_at)?;
+                        dashboard_activity_selection_includes_compact_terminal(
+                            &selection,
+                            delta,
+                            occurred_at,
+                        )
+                        .then_some(delta.key())
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let probe = if let Some(connection) = consistency_connection.as_mut() {
+                query_live_dashboard_activity_persisted_terminal_ids_tx(
+                    connection.as_mut(),
+                    dashboard_activity_selection_source_scope(&selection),
+                    &pending_terminal_keys_after_build,
+                )
+                .await
+                .map(|ids| (snapshot_cursor_before_build, ids))
+            } else {
+                Ok((snapshot_cursor_before_build, HashMap::new()))
+            };
+            match probe {
+                Ok(probe) => probe,
                 Err(err) => {
                     result = Err(err);
-                    HashMap::new()
+                    (snapshot_cursor_before_build, HashMap::new())
                 }
             }
         } else {
-            HashMap::new()
+            (snapshot_cursor_before_build, HashMap::new())
         };
+        let (
+            mut expiry_terminal_deltas,
+            mut expiry_covered_until,
+            mut expiry_delta_estimated_bytes,
+            mut expiry_tracking_failure_reason,
+        ) = if result.is_ok() {
+            match load_dashboard_activity_expiry_deltas(
+                &state.pool,
+                &selection,
+                range,
+                snapshot_cursor_after_build,
+            )
+            .await
+            {
+                Ok(expiry) => expiry,
+                Err(err) => {
+                    result = Err(err);
+                    (VecDeque::new(), None, 0, None)
+                }
+            }
+        } else {
+            (VecDeque::new(), None, 0, None)
+        };
+        if consistency_barrier_unavailable {
+            expiry_tracking_failure_reason = Some("consistency_barrier_unavailable");
+            expiry_terminal_deltas.clear();
+            expiry_delta_estimated_bytes = 0;
+            expiry_covered_until = None;
+        }
+        if let Some(connection) = consistency_connection.take()
+            && let Err(err) =
+                finish_dashboard_activity_consistency_barrier(connection, result.is_ok()).await
+        {
+            result = Err(err);
+        }
         let db_build_elapsed_ms = build_started_at.elapsed().as_millis() as u64;
 
         let mut cache = state.dashboard_activity_snapshot_cache.lock().await;
@@ -14650,96 +15779,80 @@ async fn load_dashboard_activity_snapshot_cached(
             guard.disarm();
         }
         let coalesced_waiter_count = in_flight.as_ref().map_or(0, |flight| flight.waiter_count);
-        let pending_terminal_keys_before_build = pending_terminal_keys_before_build
-            .into_iter()
-            .collect::<HashSet<_>>();
-        let relevant_terminal_persisted_during_build =
-            pending_terminal_keys_after_build.iter().any(|key| {
-                !persisted_terminal_ids_before_build.contains_key(key)
-                    && persisted_terminal_ids_after_build.contains_key(key)
-            });
-        if relevant_terminal_persisted_during_build {
-            if let Some(entry) = cache.entries.get_mut(&selection) {
-                // The write-side delta has already been applied to this last-good entry. Do not
-                // renew its reconciliation deadline: rolling ranges must rebuild from their
-                // current boundary even while terminal persistence is continuously advancing.
-                let cache_entry_age_ms = entry.cached_at.elapsed().as_millis() as u64;
-                let snapshot = entry.response.clone();
-                if let Some(in_flight) = in_flight {
-                    let _ = in_flight.signal.send(true);
-                }
-                tracing::debug!(
-                    selection_fingerprint,
-                    snapshot_cursor_before_build,
-                    terminal_delta_count_before_build,
-                    terminal_delta_count_after_build = cache.read_model.terminal_delta_count,
-                    pending_terminal_key_count_before_build =
-                        pending_terminal_keys_before_build.len(),
-                    pending_terminal_key_count_after_build =
-                        pending_terminal_keys_after_build.len(),
-                    cache_entry_age_ms,
-                    "dashboard activity reconciliation observed a concurrent terminal write; retained last-good snapshot"
-                );
-                return Ok((
-                    snapshot,
-                    DashboardActivitySnapshotCacheOutcome {
-                        cache_hit_or_miss: "last_good_fallback",
-                        cache_bypass_reason: "reconcile_write_advanced",
-                        coalesced_waiter_count,
-                        db_build_elapsed_ms,
-                        cache_ttl_ms,
-                        cache_entry_age_ms,
-                        cache_entry_count: cache.entries.len(),
-                        in_flight_count: cache.in_flight.len(),
-                        refresh_reason: "reconcile_write_advanced",
-                        selection_fingerprint,
-                        terminal_delta_count: cache.read_model.terminal_delta_count,
-                        duplicate_delta_count: cache.read_model.duplicate_delta_count,
-                    },
-                ));
-            }
-            if let Some(in_flight) = in_flight.as_ref() {
-                let _ = in_flight.signal.send(true);
-            }
-            if concurrent_reconcile_retry_count == 0 {
-                concurrent_reconcile_retry_count += 1;
-                drop(cache);
-                continue;
-            }
-            tracing::warn!(
-                selection_fingerprint,
-                concurrent_reconcile_retry_count,
-                "dashboard activity reconciliation accepted a bounded concurrent-write retry"
-            );
+        if result.is_ok() && !dashboard_activity_hard_limit_is_settled(&cache.read_model) {
+            result = Err(ApiError::from(anyhow!(
+                "dashboard activity hard-limit terminal writes are not persisted yet"
+            )));
         }
         if let Ok(snapshot) = result.as_mut() {
             // Pending records are shared by every in-flight selection. Do not consume them from
             // the first completed build: another selection may have started before the same
             // terminal reached SQLite and still needs to replay its delta.
-            for record in &cache.read_model.pending_terminal_records {
-                let Some(occurred_at) = parse_to_utc_datetime(&record.occurred_at) else {
+            for delta in &cache.read_model.pending_terminal_deltas {
+                let Some(occurred_at) = parse_to_utc_datetime(&delta.occurred_at) else {
                     continue;
                 };
-                if dashboard_activity_selection_includes_terminal(&selection, record, occurred_at) {
-                    let key = (record.invoke_id.clone(), record.occurred_at.clone());
-                    if persisted_terminal_ids_before_build.contains_key(&key) {
+                if dashboard_activity_selection_includes_compact_terminal(
+                    &selection,
+                    delta,
+                    occurred_at,
+                ) {
+                    if dashboard_activity_baseline_includes_pending_delta(
+                        delta,
+                        snapshot_cursor_after_build,
+                        &persisted_terminal_ids_after_build,
+                    ) {
                         continue;
                     }
-                    apply_dashboard_activity_terminal_delta(snapshot, record);
+                    if expiry_tracking_failure_reason.is_none()
+                        && let Err(reason) = insert_dashboard_activity_expiry_delta(
+                            &mut expiry_terminal_deltas,
+                            &mut expiry_delta_estimated_bytes,
+                            expiry_covered_until,
+                            delta,
+                            occurred_at,
+                        )
+                    {
+                        expiry_tracking_failure_reason = Some(reason);
+                        expiry_terminal_deltas.clear();
+                        expiry_delta_estimated_bytes = 0;
+                        expiry_covered_until = None;
+                    }
+                    apply_dashboard_activity_compact_terminal_delta(snapshot, delta);
                 }
             }
         }
         if let Some(in_flight) = in_flight {
-            if let Ok(snapshot) = &result {
+            if let Ok(snapshot) = &result
+                && expiry_tracking_failure_reason.is_none()
+            {
                 cache.entries.insert(
                     selection.clone(),
                     DashboardActivitySnapshotCacheEntry {
                         cached_at: Instant::now(),
                         last_reconcile_attempted_at: Instant::now(),
-                        baseline_snapshot_cursor: snapshot_cursor_before_build,
+                        last_reconcile_failed: false,
+                        baseline_snapshot_cursor: snapshot_cursor_after_build,
+                        expiry_covered_until,
+                        expiry_terminal_deltas,
+                        expiry_delta_estimated_bytes,
                         response: snapshot.clone(),
                     },
                 );
+                let evicted_entry_count =
+                    prune_dashboard_activity_snapshot_entries(&mut cache, Some(&selection));
+                if evicted_entry_count > 0 {
+                    tracing::debug!(
+                        selection_fingerprint,
+                        evicted_entry_count,
+                        cache_entry_count = cache.entries.len(),
+                        "evicted dashboard activity snapshots after baseline insertion"
+                    );
+                }
+                prune_dashboard_activity_terminal_deltas(&mut cache);
+                clear_dashboard_activity_hard_limit_after_baseline(&mut cache.read_model);
+            } else if expiry_tracking_failure_reason.is_some() {
+                cache.entries.remove(&selection);
             }
             let _ = in_flight.signal.send(true);
         }
@@ -14747,13 +15860,23 @@ async fn load_dashboard_activity_snapshot_cached(
         let in_flight_count = cache.in_flight.len();
         let terminal_delta_count = cache.read_model.terminal_delta_count;
         let duplicate_delta_count = cache.read_model.duplicate_delta_count;
+        let pending_delta_count = cache.read_model.pending_terminal_deltas.len();
+        let pending_delta_estimated_bytes = cache.read_model.pending_delta_estimated_bytes;
+        let persisted_ack_pending_count = cache.read_model.persisted_ack_pending_count;
+        let delta_pruned_count = cache.read_model.delta_pruned_count;
+        let hard_limit_reason = cache.read_model.hard_limit_reason.unwrap_or("none");
+        let sequence_gap_count = cache.read_model.sequence_gap_count;
 
         return match result {
             Ok(snapshot) => Ok((
                 snapshot,
                 DashboardActivitySnapshotCacheOutcome {
-                    cache_hit_or_miss: "cache_miss_build",
-                    cache_bypass_reason: "none",
+                    cache_hit_or_miss: if expiry_tracking_failure_reason.is_some() {
+                        "uncached"
+                    } else {
+                        "cache_miss_build"
+                    },
+                    cache_bypass_reason: expiry_tracking_failure_reason.unwrap_or("none"),
                     coalesced_waiter_count,
                     db_build_elapsed_ms,
                     cache_ttl_ms,
@@ -14764,13 +15887,27 @@ async fn load_dashboard_activity_snapshot_cached(
                     selection_fingerprint,
                     terminal_delta_count,
                     duplicate_delta_count,
+                    pending_delta_count,
+                    pending_delta_estimated_bytes,
+                    persisted_ack_pending_count,
+                    delta_pruned_count,
+                    expiry_delta_count: 0,
+                    hard_limit_reason,
+                    baseline_cursor: snapshot_cursor_after_build,
+                    sequence_gap_count,
+                    build_attempted: true,
+                    snapshot_origin: if expiry_tracking_failure_reason.is_some() {
+                        "exact_db_expiry_untracked"
+                    } else {
+                        "db_reconciled"
+                    },
                 },
             )),
             Err(err) => {
                 let Some(entry) = cache.entries.get_mut(&selection) else {
                     return Err(err);
                 };
-                entry.last_reconcile_attempted_at = Instant::now();
+                mark_dashboard_activity_reconcile_failed(entry);
                 let cache_entry_age_ms = entry.cached_at.elapsed().as_millis() as u64;
                 tracing::warn!(
                     selection_fingerprint,
@@ -14795,6 +15932,16 @@ async fn load_dashboard_activity_snapshot_cached(
                         selection_fingerprint,
                         terminal_delta_count,
                         duplicate_delta_count,
+                        pending_delta_count,
+                        pending_delta_estimated_bytes,
+                        persisted_ack_pending_count,
+                        delta_pruned_count,
+                        expiry_delta_count: 0,
+                        hard_limit_reason,
+                        baseline_cursor: entry.baseline_snapshot_cursor,
+                        sequence_gap_count,
+                        build_attempted: true,
+                        snapshot_origin: "last_good",
                     },
                 ))
             }
@@ -14987,10 +16134,22 @@ pub(crate) async fn fetch_dashboard_activity(
             invalidation_reason = "none",
             selection_fingerprint = cache_outcome.selection_fingerprint,
             base_snapshot_age_ms = cache_outcome.cache_entry_age_ms,
-            response_source = if cache_outcome.cache_hit_or_miss == "cache_miss_build" { "fallback_db" } else { "memory" },
+            response_source = if cache_outcome.build_attempted { "fallback_db" } else { "memory" },
             read_model_state = dashboard_activity_read_model_state(cache_outcome),
+            build_attempted = cache_outcome.build_attempted,
+            build_source = if cache_outcome.build_attempted { "sqlite_baseline" } else { "none" },
+            snapshot_origin = cache_outcome.snapshot_origin,
+            baseline_cursor = cache_outcome.baseline_cursor,
             terminal_delta_count = cache_outcome.terminal_delta_count,
             duplicate_delta_count = cache_outcome.duplicate_delta_count,
+            pending_delta_count = cache_outcome.pending_delta_count,
+            pending_delta_estimated_bytes = cache_outcome.pending_delta_estimated_bytes,
+            persisted_ack_pending_count = cache_outcome.persisted_ack_pending_count,
+            delta_pruned_count = cache_outcome.delta_pruned_count,
+            expiry_delta_count = cache_outcome.expiry_delta_count,
+            hard_limit_reason = cache_outcome.hard_limit_reason,
+            sequence_gap_count = cache_outcome.sequence_gap_count,
+            reconcile_outcome = cache_outcome.cache_bypass_reason,
             live_overlay_elapsed_ms,
             preview_read_mode = build_telemetry.preview_read_mode,
             candidate_preview_id_count = build_telemetry.candidate_preview_id_count,
@@ -15030,10 +16189,22 @@ pub(crate) async fn fetch_dashboard_activity(
             invalidation_reason = "none",
             selection_fingerprint = cache_outcome.selection_fingerprint,
             base_snapshot_age_ms = cache_outcome.cache_entry_age_ms,
-            response_source = if cache_outcome.cache_hit_or_miss == "cache_miss_build" { "fallback_db" } else { "memory" },
+            response_source = if cache_outcome.build_attempted { "fallback_db" } else { "memory" },
             read_model_state = dashboard_activity_read_model_state(cache_outcome),
+            build_attempted = cache_outcome.build_attempted,
+            build_source = if cache_outcome.build_attempted { "sqlite_baseline" } else { "none" },
+            snapshot_origin = cache_outcome.snapshot_origin,
+            baseline_cursor = cache_outcome.baseline_cursor,
             terminal_delta_count = cache_outcome.terminal_delta_count,
             duplicate_delta_count = cache_outcome.duplicate_delta_count,
+            pending_delta_count = cache_outcome.pending_delta_count,
+            pending_delta_estimated_bytes = cache_outcome.pending_delta_estimated_bytes,
+            persisted_ack_pending_count = cache_outcome.persisted_ack_pending_count,
+            delta_pruned_count = cache_outcome.delta_pruned_count,
+            expiry_delta_count = cache_outcome.expiry_delta_count,
+            hard_limit_reason = cache_outcome.hard_limit_reason,
+            sequence_gap_count = cache_outcome.sequence_gap_count,
+            reconcile_outcome = cache_outcome.cache_bypass_reason,
             live_overlay_elapsed_ms,
             preview_read_mode = build_telemetry.preview_read_mode,
             candidate_preview_id_count = build_telemetry.candidate_preview_id_count,
@@ -16722,7 +17893,7 @@ mod dashboard_activity_read_model_tests {
             .expect("insert terminal invocation");
         }
 
-        let persisted = query_live_dashboard_activity_persisted_terminal_ids(
+        let (cursor, persisted) = query_live_dashboard_activity_reconcile_probe(
             &pool,
             InvocationSourceScope::All,
             &[
@@ -16733,7 +17904,9 @@ mod dashboard_activity_read_model_tests {
         .await
         .expect("look up multiple persisted terminal records");
 
+        assert_eq!(cursor, 2);
         assert_eq!(persisted.len(), 2);
+        assert!(persisted.values().all(|row_id| *row_id <= cursor));
         assert_eq!(
             persisted.get(&("terminal-a".to_string(), "2026-07-28 10:00:00".to_string())),
             Some(&1)
@@ -16745,14 +17918,14 @@ mod dashboard_activity_read_model_tests {
     }
 
     #[test]
-    fn rolling_snapshots_refresh_before_the_reported_window_drifts() {
+    fn open_range_snapshots_share_the_sixty_second_reconcile_cadence() {
         assert_eq!(
             dashboard_activity_snapshot_cache_ttl("1d"),
-            Duration::from_secs(5)
+            Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS)
         );
         assert_eq!(
             dashboard_activity_snapshot_cache_ttl("7d"),
-            Duration::from_secs(5)
+            Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS)
         );
         assert_eq!(
             dashboard_activity_snapshot_cache_ttl("today"),
@@ -16842,6 +18015,335 @@ mod dashboard_activity_read_model_tests {
     }
 
     #[test]
+    fn expiry_delta_reverses_terminal_totals_without_a_database_build() {
+        let mut snapshot = DashboardActivitySnapshot::test_stub("7d");
+        snapshot.summary.stats.usage_breakdown = Some(UsageBreakdownResponse {
+            cache_write_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 0,
+            costs: None,
+            models: Vec::new(),
+        });
+        let record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        let delta = dashboard_activity_terminal_delta(&record);
+        apply_dashboard_activity_compact_terminal_delta(&mut snapshot, &delta);
+        subtract_dashboard_activity_compact_terminal_delta(&mut snapshot, &delta);
+
+        assert_eq!(snapshot.summary.stats.total_count, 0);
+        assert_eq!(snapshot.summary.stats.total_tokens, 0);
+        assert_eq!(snapshot.summary.stats.total_cost, 0.0);
+        assert!(snapshot.accounts.is_empty());
+        assert_eq!(
+            snapshot
+                .summary
+                .stats
+                .usage_breakdown
+                .as_ref()
+                .expect("usage breakdown")
+                .output_tokens,
+            0
+        );
+    }
+
+    #[test]
+    fn expiry_restores_the_latest_retained_invocation_for_the_account() {
+        let mut snapshot = DashboardActivitySnapshot::test_stub("7d");
+        let record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        let expired = dashboard_activity_terminal_delta(&record);
+        apply_dashboard_activity_compact_terminal_delta(&mut snapshot, &expired);
+
+        let mut retained = expired.clone();
+        retained.invoke_id = "retained-latest".to_string();
+        retained.occurred_at = "2026-07-20 10:30:00".to_string();
+        apply_dashboard_activity_compact_terminal_delta(&mut snapshot, &retained);
+        snapshot
+            .accounts
+            .first_mut()
+            .expect("account")
+            .last_invocation_at = Some(expired.occurred_at.clone());
+
+        subtract_dashboard_activity_compact_terminal_delta(&mut snapshot, &expired);
+        restore_dashboard_activity_last_invocation_after_expiry(
+            &mut snapshot,
+            &expired,
+            &VecDeque::from([retained.clone()]),
+        );
+
+        assert_eq!(
+            snapshot
+                .accounts
+                .first()
+                .and_then(|account| account.last_invocation_at.as_deref()),
+            Some(retained.occurred_at.as_str())
+        );
+    }
+
+    #[test]
+    fn rolling_cache_reuse_stops_at_captured_expiry_horizon() {
+        let covered_until = Utc::now();
+        let entry = DashboardActivitySnapshotCacheEntry {
+            cached_at: Instant::now(),
+            last_reconcile_attempted_at: Instant::now(),
+            last_reconcile_failed: false,
+            baseline_snapshot_cursor: 42,
+            expiry_covered_until: Some(covered_until),
+            expiry_terminal_deltas: VecDeque::new(),
+            expiry_delta_estimated_bytes: 0,
+            response: DashboardActivitySnapshot::test_stub("7d"),
+        };
+
+        assert!(dashboard_activity_entry_expiry_covers(
+            &entry,
+            ExactUtcRange {
+                start: covered_until,
+                end: covered_until + ChronoDuration::days(7),
+            },
+        ));
+        assert!(!dashboard_activity_entry_expiry_covers(
+            &entry,
+            ExactUtcRange {
+                start: covered_until + ChronoDuration::milliseconds(1),
+                end: covered_until + ChronoDuration::days(7),
+            },
+        ));
+
+        let uncovered_range = ExactUtcRange {
+            start: covered_until + ChronoDuration::milliseconds(1),
+            end: covered_until + ChronoDuration::days(7),
+        };
+        assert_eq!(
+            dashboard_activity_snapshot_reuse_mode(
+                &entry,
+                uncovered_range,
+                Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS),
+            ),
+            None
+        );
+
+        let mut failed_entry = entry;
+        failed_entry.last_reconcile_failed = true;
+        assert_eq!(
+            dashboard_activity_snapshot_reuse_mode(
+                &failed_entry,
+                uncovered_range,
+                Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS),
+            ),
+            Some(DashboardActivitySnapshotReuseMode::LastGoodReconcileBackoff)
+        );
+
+        let mut retry_due = failed_entry;
+        retry_due.last_reconcile_attempted_at =
+            Instant::now() - Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS + 1);
+        assert_eq!(
+            dashboard_activity_snapshot_reuse_mode(
+                &retry_due,
+                uncovered_range,
+                Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn reconcile_failure_starts_last_good_backoff() {
+        let covered_until = Utc::now() - ChronoDuration::seconds(1);
+        let range = ExactUtcRange {
+            start: Utc::now(),
+            end: Utc::now() + ChronoDuration::days(7),
+        };
+        let mut entry = DashboardActivitySnapshotCacheEntry {
+            cached_at: Instant::now()
+                - Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS + 1),
+            last_reconcile_attempted_at: Instant::now()
+                - Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS + 1),
+            last_reconcile_failed: false,
+            baseline_snapshot_cursor: 42,
+            expiry_covered_until: Some(covered_until),
+            expiry_terminal_deltas: VecDeque::new(),
+            expiry_delta_estimated_bytes: 0,
+            response: DashboardActivitySnapshot::test_stub("7d"),
+        };
+
+        assert_eq!(
+            dashboard_activity_snapshot_reuse_mode(
+                &entry,
+                range,
+                Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS),
+            ),
+            None
+        );
+        mark_dashboard_activity_reconcile_failed(&mut entry);
+        assert_eq!(
+            dashboard_activity_snapshot_reuse_mode(
+                &entry,
+                range,
+                Duration::from_secs(DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_TTL_SECS),
+            ),
+            Some(DashboardActivitySnapshotReuseMode::LastGoodReconcileBackoff)
+        );
+    }
+
+    #[test]
+    fn snapshot_cache_enforces_global_entry_and_expiry_budgets() {
+        fn selection(index: usize) -> DashboardActivitySnapshotSelection {
+            DashboardActivitySnapshotSelection {
+                range: "7d".to_string(),
+                range_anchor: "rolling".to_string(),
+                time_zone: "UTC".to_string(),
+                source_scope: "all".to_string(),
+                recent_limit: index,
+                include_accounts: true,
+                include_recent: true,
+            }
+        }
+
+        fn entry(age_secs: u64, expiry_bytes: usize) -> DashboardActivitySnapshotCacheEntry {
+            DashboardActivitySnapshotCacheEntry {
+                cached_at: Instant::now() - Duration::from_secs(age_secs),
+                last_reconcile_attempted_at: Instant::now(),
+                last_reconcile_failed: false,
+                baseline_snapshot_cursor: 42,
+                expiry_covered_until: None,
+                expiry_terminal_deltas: VecDeque::new(),
+                expiry_delta_estimated_bytes: expiry_bytes,
+                response: DashboardActivitySnapshot::test_stub("7d"),
+            }
+        }
+
+        let mut cache = DashboardActivitySnapshotCacheState::default();
+        for index in 0..=DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_ENTRIES {
+            cache.entries.insert(
+                selection(index),
+                entry(
+                    (DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_ENTRIES - index) as u64,
+                    0,
+                ),
+            );
+        }
+        assert_eq!(
+            prune_dashboard_activity_snapshot_entries(&mut cache, None),
+            1
+        );
+        assert_eq!(
+            cache.entries.len(),
+            DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_ENTRIES
+        );
+        assert!(!cache.entries.contains_key(&selection(0)));
+
+        cache.entries.clear();
+        let protected = selection(2);
+        cache.entries.insert(
+            selection(1),
+            entry(
+                2,
+                DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_EXPIRY_BYTES / 2 + 1,
+            ),
+        );
+        cache.entries.insert(
+            protected.clone(),
+            entry(
+                1,
+                DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_EXPIRY_BYTES / 2 + 1,
+            ),
+        );
+        assert_eq!(
+            prune_dashboard_activity_snapshot_entries(&mut cache, Some(&protected)),
+            1
+        );
+        assert_eq!(cache.entries.len(), 1);
+        assert!(cache.entries.contains_key(&protected));
+    }
+
+    #[test]
+    fn rolling_cache_bypasses_ranges_with_an_archive_prefix() {
+        let now = Utc::now();
+        let range = ExactUtcRange {
+            start: now - ChronoDuration::days(7),
+            end: now,
+        };
+
+        assert!(!dashboard_activity_snapshot_cache_can_track_expiry(
+            "7d",
+            range,
+            now - ChronoDuration::days(1),
+        ));
+        assert!(dashboard_activity_snapshot_cache_can_track_expiry(
+            "7d",
+            range,
+            now - ChronoDuration::days(8),
+        ));
+        assert!(dashboard_activity_snapshot_cache_can_track_expiry(
+            "today",
+            range,
+            now - ChronoDuration::days(1),
+        ));
+    }
+
+    #[test]
+    fn rolling_expiry_queue_orders_live_deltas_and_enforces_hard_limits() {
+        let covered_until = Utc::now() + ChronoDuration::minutes(1);
+        let record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        let mut later = dashboard_activity_terminal_delta(&record);
+        later.occurred_at = format_naive(
+            (covered_until - ChronoDuration::seconds(10))
+                .with_timezone(&Shanghai)
+                .naive_local(),
+        );
+        let mut earlier = later.clone();
+        earlier.invoke_id = "expiry-earlier".to_string();
+        earlier.occurred_at = format_naive(
+            (covered_until - ChronoDuration::seconds(20))
+                .with_timezone(&Shanghai)
+                .naive_local(),
+        );
+        let mut deltas = VecDeque::new();
+        let mut estimated_bytes = 0usize;
+
+        insert_dashboard_activity_expiry_delta(
+            &mut deltas,
+            &mut estimated_bytes,
+            Some(covered_until),
+            &later,
+            parse_to_utc_datetime(&later.occurred_at).expect("later timestamp"),
+        )
+        .expect("insert later expiry delta");
+        insert_dashboard_activity_expiry_delta(
+            &mut deltas,
+            &mut estimated_bytes,
+            Some(covered_until),
+            &earlier,
+            parse_to_utc_datetime(&earlier.occurred_at).expect("earlier timestamp"),
+        )
+        .expect("insert earlier expiry delta");
+
+        assert_eq!(
+            deltas.front().map(|delta| delta.invoke_id.as_str()),
+            Some("expiry-earlier")
+        );
+        assert_eq!(
+            estimated_bytes,
+            later.estimated_bytes + earlier.estimated_bytes
+        );
+
+        let mut full = std::iter::repeat_n(
+            later.clone(),
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS,
+        )
+        .collect::<VecDeque<_>>();
+        let mut full_bytes = 0usize;
+        assert_eq!(
+            insert_dashboard_activity_expiry_delta(
+                &mut full,
+                &mut full_bytes,
+                Some(covered_until),
+                &earlier,
+                parse_to_utc_datetime(&earlier.occurred_at).expect("earlier timestamp"),
+            ),
+            Err("expiry_count_limit")
+        );
+    }
+
+    #[test]
     fn terminal_delta_model_performance_matches_sql_qualification() {
         let mut accumulator = ModelPerformanceAccumulator::default();
         let mut record = invocation_cost_audit_tests::sample_invocation(Some(25));
@@ -16868,13 +18370,381 @@ mod dashboard_activity_read_model_tests {
         let entry = DashboardActivitySnapshotCacheEntry {
             cached_at: Instant::now(),
             last_reconcile_attempted_at: Instant::now(),
+            last_reconcile_failed: false,
             baseline_snapshot_cursor: 42,
+            expiry_covered_until: None,
+            expiry_terminal_deltas: VecDeque::new(),
+            expiry_delta_estimated_bytes: 0,
             response: DashboardActivitySnapshot::test_stub("7d"),
         };
 
-        assert!(dashboard_activity_entry_includes_terminal(&entry, &record));
+        assert!(dashboard_activity_entry_includes_terminal(
+            &entry,
+            &dashboard_activity_terminal_delta(&record),
+        ));
         record.id = 43;
-        assert!(!dashboard_activity_entry_includes_terminal(&entry, &record));
+        assert!(!dashboard_activity_entry_includes_terminal(
+            &entry,
+            &dashboard_activity_terminal_delta(&record),
+        ));
+    }
+
+    #[test]
+    fn acknowledged_terminal_below_baseline_cursor_is_not_replayed() {
+        let record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        let mut delta = dashboard_activity_terminal_delta(&record);
+        delta.persisted_row_id = Some(42);
+
+        assert!(dashboard_activity_baseline_includes_pending_delta(
+            &delta,
+            42,
+            &HashMap::new(),
+        ));
+        assert!(!dashboard_activity_baseline_includes_pending_delta(
+            &delta,
+            41,
+            &HashMap::new(),
+        ));
+    }
+
+    #[test]
+    fn terminal_persisted_during_build_is_suppressed_by_the_post_build_probe() {
+        let record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        let delta = dashboard_activity_terminal_delta(&record);
+        let persisted_after_build = HashMap::from([(delta.key(), 43)]);
+
+        assert!(dashboard_activity_baseline_includes_pending_delta(
+            &delta,
+            43,
+            &persisted_after_build,
+        ));
+    }
+
+    #[test]
+    fn archive_prefix_snapshot_replays_only_unpersisted_terminal_deltas() {
+        let mut record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        record.id = 0;
+        record.occurred_at = (Utc::now() - ChronoDuration::hours(1))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        let unpersisted = dashboard_activity_terminal_delta(&record);
+        let mut persisted = unpersisted.clone();
+        persisted.invoke_id = "already-persisted".to_string();
+        persisted.persisted_row_id = Some(42);
+        let occurred_at = parse_to_utc_datetime(&unpersisted.occurred_at)
+            .expect("terminal timestamp should parse");
+        let selection = build_dashboard_activity_snapshot_selection(
+            "7d",
+            ExactUtcRange {
+                start: occurred_at - ChronoDuration::days(1),
+                end: occurred_at + ChronoDuration::days(1),
+            },
+            chrono_tz::UTC,
+            InvocationSourceScope::All,
+            4,
+            true,
+            true,
+        );
+        let mut snapshot = DashboardActivitySnapshot::test_stub("7d");
+
+        let replayed = replay_dashboard_activity_pending_deltas_without_expiry(
+            &mut snapshot,
+            &selection,
+            &VecDeque::from([unpersisted, persisted]),
+            42,
+            &HashMap::new(),
+        );
+
+        assert_eq!(replayed, 1);
+        assert_eq!(snapshot.summary.stats.total_count, 1);
+    }
+
+    #[test]
+    fn compact_terminal_delta_enforces_count_and_byte_hard_limits() {
+        let record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        let delta = dashboard_activity_terminal_delta(&record);
+        let mut read_model = DashboardActivityReadModel {
+            pending_terminal_deltas: std::iter::repeat_n(
+                delta.clone(),
+                DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS,
+            )
+            .collect(),
+            ..DashboardActivityReadModel::default()
+        };
+        assert_eq!(
+            dashboard_activity_terminal_delta_hard_limit_reason(&read_model, &delta),
+            Some("count_limit")
+        );
+
+        read_model.pending_terminal_deltas.clear();
+        read_model.pending_delta_estimated_bytes =
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES - delta.estimated_bytes + 1;
+        assert_eq!(
+            dashboard_activity_terminal_delta_hard_limit_reason(&read_model, &delta),
+            Some("byte_limit")
+        );
+    }
+
+    #[test]
+    fn persisted_recovery_delta_does_not_wait_for_a_writer_ack() {
+        let mut record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        record.id = 42;
+        let delta = dashboard_activity_terminal_delta(&record);
+
+        assert!(!dashboard_activity_terminal_delta_needs_persistence_ack(
+            &delta
+        ));
+    }
+
+    #[test]
+    fn hard_limit_dirty_state_waits_for_the_rejected_terminal_to_settle() {
+        let mut read_model = DashboardActivityReadModel {
+            hard_limit_reason: Some("count_limit"),
+            hard_limit_sequence: Some(10),
+            settled_terminal_sequence: 9,
+            ..DashboardActivityReadModel::default()
+        };
+
+        clear_dashboard_activity_hard_limit_after_baseline(&mut read_model);
+        assert_eq!(read_model.hard_limit_reason, Some("count_limit"));
+        assert_eq!(read_model.hard_limit_sequence, Some(10));
+
+        read_model.settled_terminal_sequence = 10;
+        clear_dashboard_activity_hard_limit_after_baseline(&mut read_model);
+        assert_eq!(read_model.hard_limit_reason, None);
+        assert_eq!(read_model.hard_limit_sequence, None);
+    }
+
+    #[test]
+    fn settled_hard_limit_forces_reconcile_before_cache_reuse() {
+        let mut read_model = DashboardActivityReadModel {
+            hard_limit_reason: Some("count_limit"),
+            hard_limit_sequence: Some(10),
+            settled_terminal_sequence: 9,
+            ..DashboardActivityReadModel::default()
+        };
+
+        assert!(!dashboard_activity_read_model_requires_reconcile(
+            &read_model
+        ));
+        read_model.settled_terminal_sequence = 10;
+        assert!(dashboard_activity_read_model_requires_reconcile(
+            &read_model
+        ));
+    }
+
+    #[test]
+    fn twenty_thousand_terminal_deltas_never_exceed_the_hard_limits() {
+        let record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        let mut read_model = DashboardActivityReadModel::default();
+        let mut rejected = 0usize;
+
+        for index in 0..20_000 {
+            let mut delta = dashboard_activity_terminal_delta(&record);
+            delta.invoke_id = format!("terminal-{index}");
+            if dashboard_activity_terminal_delta_hard_limit_reason(&read_model, &delta).is_some() {
+                rejected += 1;
+                continue;
+            }
+            read_model.pending_delta_estimated_bytes = read_model
+                .pending_delta_estimated_bytes
+                .saturating_add(delta.estimated_bytes);
+            read_model.pending_terminal_deltas.push_back(delta);
+        }
+
+        assert_eq!(
+            read_model.pending_terminal_deltas.len(),
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_TERMINALS
+        );
+        assert_eq!(rejected, 10_000);
+        assert!(
+            read_model.pending_delta_estimated_bytes
+                <= DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES
+        );
+    }
+
+    #[test]
+    fn applied_terminal_keys_remain_bounded_on_hard_limit_rejection() {
+        let mut read_model = DashboardActivityReadModel::default();
+        for index in 0..=DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS {
+            insert_dashboard_activity_applied_terminal_key(
+                &mut read_model,
+                (
+                    format!("invoke-{index}"),
+                    format!("2026-07-28 10:{:02}:00", index % 60),
+                ),
+            );
+        }
+
+        prune_dashboard_activity_applied_terminal_keys(&mut read_model);
+
+        assert_eq!(
+            read_model.applied_terminal_keys.len(),
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS
+        );
+        assert_eq!(
+            read_model.applied_terminal_key_order.len(),
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS
+        );
+
+        let rolled_back_key = read_model
+            .applied_terminal_key_order
+            .front()
+            .expect("oldest applied key")
+            .0
+            .clone();
+        read_model.applied_terminal_keys.remove(&rolled_back_key);
+        prune_dashboard_activity_applied_terminal_keys(&mut read_model);
+        assert_eq!(
+            read_model.applied_terminal_key_order.len(),
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS - 1
+        );
+
+        insert_dashboard_activity_applied_terminal_key(
+            &mut read_model,
+            (
+                "steady-state".to_string(),
+                "2026-07-28 11:00:00".to_string(),
+            ),
+        );
+        prune_dashboard_activity_applied_terminal_keys(&mut read_model);
+        assert_eq!(
+            read_model.applied_terminal_keys.len(),
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS
+        );
+        assert_eq!(
+            read_model.applied_terminal_key_order.len(),
+            DASHBOARD_ACTIVITY_READ_MODEL_MAX_TERMINAL_KEYS
+        );
+    }
+
+    #[test]
+    fn acknowledged_delta_waits_for_every_warm_cursor_before_pruning() {
+        let mut record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        record.id = 42;
+        let delta = dashboard_activity_terminal_delta(&record);
+        let mut cache = DashboardActivitySnapshotCacheState::default();
+        cache.read_model.pending_delta_estimated_bytes = delta.estimated_bytes;
+        cache.read_model.persisted_ack_pending_count = 1;
+        cache.read_model.pending_terminal_deltas.push_back(delta);
+        let selection = build_dashboard_activity_snapshot_selection(
+            "7d",
+            ExactUtcRange {
+                start: Utc::now() - ChronoDuration::days(7),
+                end: Utc::now(),
+            },
+            chrono_tz::UTC,
+            InvocationSourceScope::All,
+            4,
+            true,
+            true,
+        );
+        cache.entries.insert(
+            selection,
+            DashboardActivitySnapshotCacheEntry {
+                cached_at: Instant::now(),
+                last_reconcile_attempted_at: Instant::now(),
+                last_reconcile_failed: false,
+                baseline_snapshot_cursor: 41,
+                expiry_covered_until: None,
+                expiry_terminal_deltas: VecDeque::new(),
+                expiry_delta_estimated_bytes: 0,
+                response: DashboardActivitySnapshot::test_stub("7d"),
+            },
+        );
+
+        prune_dashboard_activity_terminal_deltas(&mut cache);
+        assert_eq!(cache.read_model.pending_terminal_deltas.len(), 1);
+        cache
+            .entries
+            .values_mut()
+            .next()
+            .expect("warm selection")
+            .baseline_snapshot_cursor = 42;
+        prune_dashboard_activity_terminal_deltas(&mut cache);
+        assert!(cache.read_model.pending_terminal_deltas.is_empty());
+        assert_eq!(cache.read_model.delta_pruned_count, 1);
+    }
+
+    #[tokio::test]
+    async fn repeated_ack_after_safe_prune_is_idempotent() {
+        let mut record = invocation_cost_audit_tests::sample_invocation(Some(25));
+        record.id = 42;
+        let mut delta = dashboard_activity_terminal_delta(&record);
+        delta.terminal_sequence = 1;
+        let terminal_sequence = delta.terminal_sequence;
+        let mut cache = DashboardActivitySnapshotCacheState::default();
+        cache
+            .read_model
+            .applied_terminal_keys
+            .insert(delta.key(), Instant::now());
+        cache.read_model.pending_delta_estimated_bytes = delta.estimated_bytes;
+        cache.read_model.pending_terminal_deltas.push_back(delta);
+        let cache = Arc::new(tokio::sync::Mutex::new(cache));
+
+        acknowledge_dashboard_activity_terminal_record(
+            &cache,
+            &record.invoke_id,
+            &record.occurred_at,
+            record.id,
+            Some(terminal_sequence),
+        )
+        .await;
+        acknowledge_dashboard_activity_terminal_record(
+            &cache,
+            &record.invoke_id,
+            &record.occurred_at,
+            record.id,
+            Some(terminal_sequence),
+        )
+        .await;
+
+        let cache = cache.lock().await;
+        assert!(cache.read_model.pending_terminal_deltas.is_empty());
+        assert_eq!(cache.read_model.sequence_gap_count, 0);
+        assert_eq!(cache.read_model.hard_limit_reason, None);
+    }
+
+    #[test]
+    fn out_of_order_terminal_ack_only_advances_the_contiguous_watermark() {
+        let mut read_model = DashboardActivityReadModel::default();
+
+        settle_dashboard_activity_terminal_sequence(&mut read_model, 2);
+        assert_eq!(read_model.settled_terminal_sequence, 0);
+        assert!(read_model.settled_terminal_sequences.contains(&2));
+
+        settle_dashboard_activity_terminal_sequence(&mut read_model, 1);
+        assert_eq!(read_model.settled_terminal_sequence, 2);
+        assert!(read_model.settled_terminal_sequences.is_empty());
+    }
+
+    #[test]
+    fn expiry_keeps_model_with_first_byte_samples() {
+        let mut accumulator = ModelPerformanceAccumulator::default();
+        let mut expiring = dashboard_activity_terminal_delta(
+            &invocation_cost_audit_tests::sample_invocation(Some(25)),
+        );
+        expiring.t_upstream_stream_ms = Some(100.0);
+        expiring.first_token_ms = None;
+        expiring.t_total_ms = None;
+        expiring.t_upstream_ttfb_ms = None;
+        accumulator.add_terminal_delta(&expiring);
+
+        let mut retained = expiring.clone();
+        retained.invoke_id = "retained-first-byte".to_string();
+        retained.total_tokens = 0;
+        retained.output_tokens = 0;
+        retained.t_upstream_stream_ms = None;
+        retained.t_upstream_ttfb_ms = Some(250.0);
+        accumulator.add_terminal_delta(&retained);
+        accumulator.subtract_terminal_delta(&expiring);
+
+        let group = UsageBreakdownGroupKey {
+            model: retained.model,
+            reasoning_effort: retained.reasoning_effort,
+        };
+        let retained_model = accumulator.models.get(&group).expect("first-byte model");
+        assert_eq!(retained_model.first_byte_sample_count, 1);
     }
 }
 

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -2,7 +2,7 @@ use super::*;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use tokio::sync::watch;
 
@@ -1182,11 +1182,59 @@ pub(crate) struct DashboardActivitySnapshotCacheEntry {
     pub(crate) cached_at: Instant,
     /// Controls the next reconciliation attempt independently from the DB baseline age.
     pub(crate) last_reconcile_attempted_at: Instant,
-    /// The live invocation cursor observed immediately before the DB baseline build. The entry
-    /// is accepted only when that cursor stays stable for the build, so persisted terminal
-    /// records at or below it are already represented by the baseline.
+    /// Only failed reconciliations may throttle an expiry-horizon rebuild. A healthy entry whose
+    /// rolling coverage is exhausted must reconcile immediately.
+    pub(crate) last_reconcile_failed: bool,
+    /// The live invocation cursor observed immediately before the DB baseline build. Pending
+    /// terminal deltas beyond this cursor are replayed before the entry is published.
     pub(crate) baseline_snapshot_cursor: i64,
+    /// Rolling ranges may only reuse the baseline while their moving lower bound remains within
+    /// the terminal rows captured for expiry subtraction. Calendar ranges do not need this gate.
+    pub(crate) expiry_covered_until: Option<DateTime<Utc>>,
+    pub(crate) expiry_terminal_deltas: VecDeque<DashboardActivityTerminalDelta>,
+    pub(crate) expiry_delta_estimated_bytes: usize,
     pub(crate) response: DashboardActivitySnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DashboardActivityTerminalDelta {
+    pub(crate) terminal_sequence: u64,
+    pub(crate) invoke_id: String,
+    pub(crate) occurred_at: String,
+    pub(crate) source: String,
+    pub(crate) model: String,
+    pub(crate) reasoning_effort: Option<String>,
+    pub(crate) upstream_account_id: Option<i64>,
+    pub(crate) upstream_account_name: Option<String>,
+    pub(crate) success: bool,
+    pub(crate) failure: bool,
+    pub(crate) total_tokens: i64,
+    pub(crate) cache_write_tokens: i64,
+    pub(crate) cache_read_tokens: i64,
+    pub(crate) output_tokens: i64,
+    pub(crate) has_cost: bool,
+    pub(crate) total_cost: f64,
+    pub(crate) cost_input: f64,
+    pub(crate) cost_cache_write: f64,
+    pub(crate) cost_cache_read: f64,
+    pub(crate) cost_output: f64,
+    pub(crate) cost_reasoning: f64,
+    pub(crate) cost_unknown: f64,
+    pub(crate) t_total_ms: Option<f64>,
+    pub(crate) t_req_read_ms: Option<f64>,
+    pub(crate) t_req_parse_ms: Option<f64>,
+    pub(crate) t_upstream_connect_ms: Option<f64>,
+    pub(crate) t_upstream_ttfb_ms: Option<f64>,
+    pub(crate) first_token_ms: Option<f64>,
+    pub(crate) t_upstream_stream_ms: Option<f64>,
+    pub(crate) persisted_row_id: Option<i64>,
+    pub(crate) estimated_bytes: usize,
+}
+
+impl DashboardActivityTerminalDelta {
+    pub(crate) fn key(&self) -> (String, String) {
+        (self.invoke_id.clone(), self.occurred_at.clone())
+    }
 }
 
 /// Write-side state layered over the last DB-backed Dashboard snapshot.
@@ -1197,7 +1245,17 @@ pub(crate) struct DashboardActivitySnapshotCacheEntry {
 #[derive(Debug, Default)]
 pub(crate) struct DashboardActivityReadModel {
     pub(crate) applied_terminal_keys: HashMap<(String, String), Instant>,
-    pub(crate) pending_terminal_records: VecDeque<ApiInvocation>,
+    pub(crate) applied_terminal_key_order: VecDeque<((String, String), Instant)>,
+    pub(crate) pending_terminal_deltas: VecDeque<DashboardActivityTerminalDelta>,
+    pub(crate) pending_delta_estimated_bytes: usize,
+    pub(crate) persisted_ack_pending_count: usize,
+    pub(crate) delta_pruned_count: u64,
+    pub(crate) hard_limit_reason: Option<&'static str>,
+    pub(crate) hard_limit_sequence: Option<u64>,
+    pub(crate) next_terminal_sequence: u64,
+    pub(crate) settled_terminal_sequence: u64,
+    pub(crate) settled_terminal_sequences: BTreeSet<u64>,
+    pub(crate) sequence_gap_count: u64,
     pub(crate) terminal_delta_count: u64,
     pub(crate) duplicate_delta_count: u64,
     pub(crate) pending_terminal_overflow_count: u64,
@@ -1207,6 +1265,7 @@ pub(crate) struct DashboardActivityReadModel {
 pub(crate) struct DashboardActivitySnapshotInFlight {
     pub(crate) signal: watch::Sender<bool>,
     pub(crate) waiter_count: usize,
+    pub(crate) baseline_cursor: Option<i64>,
 }
 
 #[derive(Debug, Default)]
@@ -1217,6 +1276,10 @@ pub(crate) struct DashboardActivitySnapshotCacheState {
         HashMap<DashboardActivitySnapshotSelection, DashboardActivitySnapshotInFlight>,
     pub(crate) invalidation_reasons: HashMap<DashboardActivitySnapshotSelection, &'static str>,
     pub(crate) read_model: DashboardActivityReadModel,
+    /// Serializes DB-backed baseline builds across distinct selections. Per-selection
+    /// singleflight only coalesces identical requests and cannot prevent competing SQLite
+    /// consistency transactions for different ranges.
+    pub(crate) baseline_build_gate: Arc<Mutex<()>>,
 }
 
 #[derive(Debug)]

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -3894,7 +3894,11 @@ mod tests {
                 DashboardActivitySnapshotCacheEntry {
                     cached_at: Instant::now(),
                     last_reconcile_attempted_at: Instant::now(),
+                    last_reconcile_failed: false,
                     baseline_snapshot_cursor: 0,
+                    expiry_covered_until: None,
+                    expiry_terminal_deltas: VecDeque::new(),
+                    expiry_delta_estimated_bytes: 0,
                     response: DashboardActivitySnapshot::test_stub("today"),
                 },
             );
@@ -3903,7 +3907,11 @@ mod tests {
                 DashboardActivitySnapshotCacheEntry {
                     cached_at: Instant::now(),
                     last_reconcile_attempted_at: Instant::now(),
+                    last_reconcile_failed: false,
                     baseline_snapshot_cursor: 0,
+                    expiry_covered_until: None,
+                    expiry_terminal_deltas: VecDeque::new(),
+                    expiry_delta_estimated_bytes: 0,
                     response: DashboardActivitySnapshot::test_stub("7d"),
                 },
             );
@@ -3912,6 +3920,7 @@ mod tests {
                 DashboardActivitySnapshotInFlight {
                     signal: signal_a,
                     waiter_count: 2,
+                    baseline_cursor: None,
                 },
             );
             guard.in_flight.insert(
@@ -3919,6 +3928,7 @@ mod tests {
                 DashboardActivitySnapshotInFlight {
                     signal: signal_b,
                     waiter_count: 3,
+                    baseline_cursor: None,
                 },
             );
         }

--- a/src/maintenance/archive/hourly_rollups.rs
+++ b/src/maintenance/archive/hourly_rollups.rs
@@ -1368,34 +1368,28 @@ pub(crate) async fn upsert_invocation_hourly_rollups_tx(
             }
         }
 
-        if upsert_upstream_account_activity_v2 {
-            let normalized_status = row
-                .status
-                .as_deref()
-                .unwrap_or_default()
-                .trim()
-                .to_ascii_lowercase();
-            if !matches!(normalized_status.as_str(), "running" | "pending") {
-                let upstream_account_id = row
-                    .resolved_upstream_account_id()
-                    .unwrap_or(UPSTREAM_ACCOUNT_ACTIVITY_UNASSIGNED_ID);
-                let entry = upstream_account_activity_v2
-                    .entry((bucket_start_epoch, row.source.clone(), upstream_account_id))
-                    .or_insert_with(|| UpstreamAccountStatsDelta {
-                        first_byte_histogram: empty_approx_histogram(),
-                        first_response_byte_total_histogram: empty_approx_histogram(),
-                        first_token_histogram: empty_approx_histogram(),
-                        ..UpstreamAccountStatsDelta::default()
-                    });
-                accumulate_upstream_account_activity_v2_delta(entry, row);
-                if prompt_cache_key_from_payload(row.payload.as_deref()).is_none()
-                    && entry
-                        .latest_unkeyed_conversation_at
-                        .as_deref()
-                        .is_none_or(|latest| row.occurred_at.as_str() > latest)
-                {
-                    entry.latest_unkeyed_conversation_at = Some(row.occurred_at.clone());
-                }
+        if upsert_upstream_account_activity_v2
+            && invocation_row_counts_toward_account_activity_v2(row)
+        {
+            let upstream_account_id = row
+                .resolved_upstream_account_id()
+                .unwrap_or(UPSTREAM_ACCOUNT_ACTIVITY_UNASSIGNED_ID);
+            let entry = upstream_account_activity_v2
+                .entry((bucket_start_epoch, row.source.clone(), upstream_account_id))
+                .or_insert_with(|| UpstreamAccountStatsDelta {
+                    first_byte_histogram: empty_approx_histogram(),
+                    first_response_byte_total_histogram: empty_approx_histogram(),
+                    first_token_histogram: empty_approx_histogram(),
+                    ..UpstreamAccountStatsDelta::default()
+                });
+            accumulate_upstream_account_activity_v2_delta(entry, row);
+            if prompt_cache_key_from_payload(row.payload.as_deref()).is_none()
+                && entry
+                    .latest_unkeyed_conversation_at
+                    .as_deref()
+                    .is_none_or(|latest| row.occurred_at.as_str() > latest)
+            {
+                entry.latest_unkeyed_conversation_at = Some(row.occurred_at.clone());
             }
         }
 
@@ -2697,7 +2691,10 @@ pub(crate) async fn recompute_invocation_hourly_rollups_for_ids_tx(
     let rows = load_live_invocation_hourly_rows_for_bucket_epochs_tx(tx, &bucket_epochs).await?;
     upsert_invocation_hourly_rollups_tx(tx, &rows, &INVOCATION_HOURLY_ROLLUP_TARGETS).await?;
     let mut bucket_watermarks = BTreeMap::<i64, i64>::new();
-    for row in &rows {
+    for row in rows
+        .iter()
+        .filter(|row| invocation_row_counts_toward_account_activity_v2(row))
+    {
         let bucket_epoch = invocation_bucket_start_epoch(&row.occurred_at)?;
         bucket_watermarks
             .entry(bucket_epoch)
@@ -2777,8 +2774,13 @@ pub(crate) async fn replay_live_invocation_hourly_rollups(pool: &Pool<Sqlite>) -
 
     let last_id = rows.last().map(|row| row.id).unwrap_or(cursor_id);
     let mut tx = pool.begin().await?;
-    let targets = live_invocation_rollup_targets(account_activity_v2_cursor, cursor_id);
-    upsert_invocation_hourly_rollups_tx(tx.as_mut(), &rows, &targets).await?;
+    upsert_live_invocation_hourly_rollups_tx(
+        tx.as_mut(),
+        &rows,
+        account_activity_v2_cursor,
+        cursor_id,
+    )
+    .await?;
     save_hourly_rollup_live_progress_tx(tx.as_mut(), HOURLY_ROLLUP_DATASET_INVOCATIONS, last_id)
         .await?;
     if account_activity_v2_cursor == cursor_id {
@@ -2858,8 +2860,8 @@ pub(crate) async fn replay_live_invocation_hourly_rollups_tx(
     }
 
     let last_id = rows.last().map(|row| row.id).unwrap_or(cursor_id);
-    let targets = live_invocation_rollup_targets(account_activity_v2_cursor, cursor_id);
-    upsert_invocation_hourly_rollups_tx(tx, &rows, &targets).await?;
+    upsert_live_invocation_hourly_rollups_tx(tx, &rows, account_activity_v2_cursor, cursor_id)
+        .await?;
     save_hourly_rollup_live_progress_tx(tx, HOURLY_ROLLUP_DATASET_INVOCATIONS, last_id).await?;
     if account_activity_v2_cursor == cursor_id {
         save_hourly_rollup_live_progress_tx(
@@ -2872,18 +2874,45 @@ pub(crate) async fn replay_live_invocation_hourly_rollups_tx(
     Ok(rows.len() as u64)
 }
 
-fn live_invocation_rollup_targets(
+async fn upsert_live_invocation_hourly_rollups_tx(
+    tx: &mut SqliteConnection,
+    rows: &[InvocationHourlySourceRecord],
     account_activity_v2_cursor: i64,
     shared_cursor: i64,
-) -> Vec<&'static str> {
-    INVOCATION_HOURLY_ROLLUP_TARGETS
+) -> Result<()> {
+    let base_targets = INVOCATION_HOURLY_ROLLUP_TARGETS
         .iter()
         .copied()
-        .filter(|target| {
-            account_activity_v2_cursor == shared_cursor
-                || *target != HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2
-        })
-        .collect()
+        .filter(|target| *target != HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2)
+        .collect::<Vec<_>>();
+    upsert_invocation_hourly_rollups_tx(tx, rows, &base_targets).await?;
+
+    if account_activity_v2_cursor == shared_cursor {
+        let bucket_watermarks =
+            load_account_activity_v2_bucket_repair_watermarks_for_rows_tx(tx, rows).await?;
+        let v2_rows = rows
+            .iter()
+            .filter(|row| {
+                invocation_bucket_start_epoch(&row.occurred_at)
+                    .map(|bucket_epoch| {
+                        row.id
+                            > bucket_watermarks
+                                .get(&bucket_epoch)
+                                .copied()
+                                .unwrap_or_default()
+                    })
+                    .unwrap_or(true)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        upsert_invocation_hourly_rollups_tx(
+            tx,
+            &v2_rows,
+            &[HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2],
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 pub(crate) async fn repair_live_invocation_account_activity_v2_once(
@@ -2985,6 +3014,224 @@ pub(crate) async fn repair_live_invocation_account_activity_v2_once(
         "repaired live account activity v2 rollup batch"
     );
     Ok(rows.len() as u64)
+}
+
+const ACTIVE_ACCOUNT_ACTIVITY_V2_REPAIR_BUCKET_LIMIT: usize = 2;
+const ACTIVE_ACCOUNT_ACTIVITY_V2_REPAIR_BUDGET: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ActiveAccountActivityV2RepairOutcome {
+    pub(crate) priority_bucket_count: usize,
+    pub(crate) repaired_bucket_count: usize,
+    pub(crate) elapsed_ms: u64,
+}
+
+pub(crate) async fn repair_active_account_activity_v2_coverage(
+    pool: &Pool<Sqlite>,
+) -> Result<ActiveAccountActivityV2RepairOutcome> {
+    let started_at = Instant::now();
+    let mut generation_tx = pool.begin().await?;
+    ensure_account_activity_v2_repair_generation_tx(generation_tx.as_mut()).await?;
+    generation_tx.commit().await?;
+    let current_bucket = align_bucket_epoch(Utc::now().timestamp(), 3_600, 0);
+    let configured_oldest_bucket = current_bucket - 7 * 24 * 3_600;
+    let Some(oldest_live_occurred_at) =
+        sqlx::query_scalar::<_, Option<String>>("SELECT MIN(occurred_at) FROM codex_invocations")
+            .fetch_one(pool)
+            .await?
+    else {
+        return Ok(ActiveAccountActivityV2RepairOutcome {
+            elapsed_ms: started_at.elapsed().as_millis() as u64,
+            ..ActiveAccountActivityV2RepairOutcome::default()
+        });
+    };
+    let oldest_live_bucket = align_bucket_epoch(
+        parse_to_utc_datetime(&oldest_live_occurred_at)
+            .ok_or_else(|| anyhow!("failed to parse oldest live invocation timestamp"))?
+            .timestamp(),
+        3_600,
+        0,
+    );
+    // This priority path is intentionally live-only. Archive buckets are repaired by archive
+    // replay; selecting them here would clear valid archive-derived v2 values before loading no
+    // live rows and then incorrectly mark the zero bucket covered.
+    let oldest_bucket = configured_oldest_bucket.max(oldest_live_bucket);
+    if oldest_bucket >= current_bucket {
+        return Ok(ActiveAccountActivityV2RepairOutcome {
+            elapsed_ms: started_at.elapsed().as_millis() as u64,
+            ..ActiveAccountActivityV2RepairOutcome::default()
+        });
+    }
+    let missing_buckets = sqlx::query_scalar::<_, i64>(
+        r#"
+        WITH RECURSIVE active_buckets(bucket_start_epoch) AS (
+            SELECT ?1
+            UNION ALL
+            SELECT bucket_start_epoch + 3600
+            FROM active_buckets
+            WHERE bucket_start_epoch + 3600 < ?2
+        )
+        SELECT active_buckets.bucket_start_epoch
+        FROM active_buckets
+        LEFT JOIN hourly_rollup_materialized_buckets AS coverage
+          ON coverage.target = ?3
+         AND coverage.source = ?4
+         AND coverage.bucket_start_epoch = active_buckets.bucket_start_epoch
+        WHERE coverage.bucket_start_epoch IS NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM archive_batches AS archived
+              WHERE archived.dataset = ?5
+                AND archived.status = ?6
+                AND (
+                    (
+                        (archived.coverage_start_at IS NULL OR archived.coverage_end_at IS NULL)
+                        AND archived.month_key = strftime(
+                            '%Y-%m',
+                            active_buckets.bucket_start_epoch,
+                            'unixepoch',
+                            '+8 hours'
+                        )
+                    )
+                    OR (
+                        archived.coverage_start_at IS NOT NULL
+                        AND archived.coverage_end_at IS NOT NULL
+                        AND (CASE
+                                WHEN instr(archived.coverage_start_at, 'T') > 0
+                                    THEN CAST(strftime('%s', archived.coverage_start_at) AS INTEGER)
+                                ELSE CAST(strftime('%s', archived.coverage_start_at || '+08:00') AS INTEGER)
+                             END) < active_buckets.bucket_start_epoch + 3600
+                        AND (CASE
+                                WHEN instr(archived.coverage_end_at, 'T') > 0
+                                    THEN CAST(strftime('%s', archived.coverage_end_at) AS INTEGER)
+                                ELSE CAST(strftime('%s', archived.coverage_end_at || '+08:00') AS INTEGER)
+                             END) >= active_buckets.bucket_start_epoch
+                    )
+                )
+          )
+        ORDER BY active_buckets.bucket_start_epoch DESC
+        LIMIT ?7
+        "#,
+    )
+    .bind(oldest_bucket)
+    .bind(current_bucket)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2)
+    .bind(HOURLY_ROLLUP_MATERIALIZED_SOURCE_NONE)
+    .bind(HOURLY_ROLLUP_DATASET_INVOCATIONS)
+    .bind(ARCHIVE_STATUS_COMPLETED)
+    .bind(ACTIVE_ACCOUNT_ACTIVITY_V2_REPAIR_BUCKET_LIMIT as i64)
+    .fetch_all(pool)
+    .await?;
+    let priority_bucket_count = missing_buckets.len();
+    let mut repaired_bucket_count = 0usize;
+
+    for bucket_start_epoch in missing_buckets {
+        if started_at.elapsed() >= ACTIVE_ACCOUNT_ACTIVITY_V2_REPAIR_BUDGET {
+            break;
+        }
+        let mut tx = pool.begin().await?;
+        ensure_account_activity_v2_repair_generation_tx(tx.as_mut()).await?;
+        sqlx::query(
+            r#"
+            UPDATE upstream_account_stats_hourly
+            SET activity_v2_request_count = 0,
+                activity_v2_success_count = 0,
+                activity_v2_failure_count = 0,
+                activity_v2_non_success_count = 0,
+                activity_v2_total_tokens = 0,
+                activity_v2_success_tokens = 0,
+                activity_v2_non_success_tokens = 0,
+                activity_v2_failure_tokens = 0,
+                activity_v2_failure_cost = 0,
+                activity_v2_non_success_cost = 0,
+                activity_v2_cache_input_tokens = 0,
+                activity_v2_total_cost = 0,
+                activity_v2_first_response_sample_count = 0,
+                activity_v2_first_response_sum_ms = 0,
+                activity_v2_first_token_sample_count = 0,
+                activity_v2_first_token_sum_ms = 0,
+                activity_v2_first_token_max_ms = 0,
+                activity_v2_first_token_histogram = '[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]',
+                activity_v2_total_latency_sample_count = 0,
+                activity_v2_total_latency_sum_ms = 0,
+                activity_v2_last_invocation_at = NULL,
+                activity_v2_latest_unkeyed_conversation_at = NULL,
+                activity_v2_latest_first_response_at = NULL,
+                activity_v2_latest_first_response_ms = NULL,
+                activity_v2_latest_total_latency_at = NULL,
+                activity_v2_latest_total_latency_ms = NULL,
+                updated_at = datetime('now')
+            WHERE bucket_start_epoch = ?1
+            "#,
+        )
+        .bind(bucket_start_epoch)
+        .execute(tx.as_mut())
+        .await?;
+        let rows = load_live_invocation_hourly_rows_for_bucket_epochs_tx(
+            tx.as_mut(),
+            &[bucket_start_epoch],
+        )
+        .await?;
+        upsert_invocation_hourly_rollups_tx(
+            tx.as_mut(),
+            &rows,
+            &[HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2],
+        )
+        .await?;
+        let bucket_max_id = rows
+            .iter()
+            .filter(|row| invocation_row_counts_toward_account_activity_v2(row))
+            .map(|row| row.id)
+            .max()
+            .unwrap_or_default();
+        save_account_activity_v2_bucket_repair_watermark_tx(
+            tx.as_mut(),
+            bucket_start_epoch,
+            bucket_max_id,
+        )
+        .await?;
+        mark_hourly_rollup_bucket_materialized_tx(
+            tx.as_mut(),
+            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2,
+            bucket_start_epoch,
+            HOURLY_ROLLUP_MATERIALIZED_SOURCE_NONE,
+        )
+        .await?;
+        tx.commit().await?;
+        repaired_bucket_count += 1;
+    }
+
+    let outcome = ActiveAccountActivityV2RepairOutcome {
+        priority_bucket_count,
+        repaired_bucket_count,
+        elapsed_ms: started_at.elapsed().as_millis() as u64,
+    };
+    if repaired_bucket_count > 0 {
+        tracing::info!(
+            priority_mode = "active_dashboard_coverage",
+            coverage_priority_bucket_count = priority_bucket_count,
+            repaired_bucket_count,
+            priority_batch_limit = ACTIVE_ACCOUNT_ACTIVITY_V2_REPAIR_BUCKET_LIMIT,
+            priority_elapsed_budget_ms =
+                ACTIVE_ACCOUNT_ACTIVITY_V2_REPAIR_BUDGET.as_millis() as u64,
+            elapsed_ms = outcome.elapsed_ms,
+            wake_reason = "active_window_coverage_hole",
+            "repaired active Dashboard account activity v2 coverage"
+        );
+    }
+    Ok(outcome)
+}
+
+fn invocation_row_counts_toward_account_activity_v2(row: &InvocationHourlySourceRecord) -> bool {
+    !matches!(
+        row.status
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "running" | "pending"
+    )
 }
 
 async fn save_account_activity_v2_bucket_repair_watermark_tx(

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -43,6 +43,7 @@ pub(crate) async fn sync_hourly_rollups_from_live_tables(pool: &Pool<Sqlite>) ->
 }
 
 async fn sync_hourly_rollups_from_live_tables_once(pool: &Pool<Sqlite>) -> Result<()> {
+    repair_active_account_activity_v2_coverage(pool).await?;
     loop {
         let updated = replay_live_invocation_hourly_rollups(pool).await?;
         if updated == 0 {
@@ -2037,6 +2038,36 @@ pub(crate) async fn refresh_hourly_rollups_for_read_surfaces_best_effort(
             error = %err,
             reason,
             "background hourly rollup refresh failed; keeping existing rollups for read surfaces"
+        );
+    }
+}
+
+pub(crate) async fn repair_active_account_activity_v2_coverage_best_effort(
+    pool: &Pool<Sqlite>,
+    hourly_rollup_sync_lock: &Mutex<()>,
+    reason: &'static str,
+) {
+    let gate = crate::db_pressure::global_db_pressure_gate();
+    let _permit = match gate.try_begin_background("account_activity_v2_priority_repair") {
+        Ok(permit) => permit,
+        Err(deny_reason) => {
+            debug!(
+                reason,
+                deny_reason = %deny_reason,
+                wake_reason = "active_window_coverage_check",
+                "active Dashboard coverage repair deferred by database pressure gate"
+            );
+            return;
+        }
+    };
+    let _guard = hourly_rollup_sync_lock.lock().await;
+    if let Err(err) = repair_active_account_activity_v2_coverage(pool).await {
+        gate.record_error("account_activity_v2_priority_repair", &err);
+        warn!(
+            error = %err,
+            reason,
+            wake_reason = "active_window_coverage_check",
+            "active Dashboard coverage repair failed"
         );
     }
 }

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -167,7 +167,16 @@ pub(crate) fn startup_backfill_next_delay(
 ) -> Duration {
     if run.force_idle {
         Duration::from_secs(STARTUP_BACKFILL_IDLE_INTERVAL_SECS)
-    } else if run.hit_scan_limit || run.updated > 0 {
+    } else if run.updated > 0 {
+        Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS)
+    } else if run.hit_scan_limit && run.scanned > 0 {
+        Duration::from_secs(match zero_update_streak {
+            0 | 1 => 15,
+            2 => 60,
+            3 => 5 * 60,
+            _ => 15 * 60,
+        })
+    } else if run.hit_scan_limit {
         Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS)
     } else if run.scanned == 0 || zero_update_streak > 0 {
         Duration::from_secs(STARTUP_BACKFILL_IDLE_INTERVAL_SECS)
@@ -413,6 +422,7 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
     .await
     .ok();
     let mut had_failure = false;
+    let mut ran_actionable_task = false;
     for task in StartupBackfillTask::ordered_tasks() {
         if cancel.is_cancelled() {
             info!(
@@ -429,19 +439,32 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             );
             continue;
         }
-        if let Err(err) = run_startup_backfill_task_if_due(&state, *task).await {
-            had_failure = true;
-            crate::db_pressure::global_db_pressure_gate().record_error("startup_backfill", &err);
-            warn!(task = task.log_label(), error = %err, "startup backfill supervisor pass failed");
+        match run_startup_backfill_task_if_due(&state, *task).await {
+            Ok(ran) => ran_actionable_task |= ran,
+            Err(err) => {
+                had_failure = true;
+                crate::db_pressure::global_db_pressure_gate()
+                    .record_error("startup_backfill", &err);
+                warn!(task = task.log_label(), error = %err, "startup backfill supervisor pass failed");
+            }
         }
     }
 
-    refresh_hourly_rollups_for_read_surfaces_best_effort(
-        &state.pool,
-        state.hourly_rollup_sync_lock.as_ref(),
-        "startup backfill maintenance pass",
-    )
-    .await;
+    if ran_actionable_task {
+        refresh_hourly_rollups_for_read_surfaces_best_effort(
+            &state.pool,
+            state.hourly_rollup_sync_lock.as_ref(),
+            "startup backfill maintenance pass",
+        )
+        .await;
+    } else {
+        repair_active_account_activity_v2_coverage_best_effort(
+            &state.pool,
+            state.hourly_rollup_sync_lock.as_ref(),
+            "startup backfill active coverage check",
+        )
+        .await;
+    }
 
     let backfill_updated_rows = sqlx::query_scalar::<_, i64>(
         r#"
@@ -503,7 +526,7 @@ pub(crate) fn startup_backfill_task_enabled(state: &AppState, task: StartupBackf
 pub(crate) async fn run_startup_backfill_task_if_due(
     state: &Arc<AppState>,
     task: StartupBackfillTask,
-) -> Result<()> {
+) -> Result<bool> {
     run_startup_backfill_task_if_due_with_gate(
         state,
         task,
@@ -516,13 +539,13 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
     state: &Arc<AppState>,
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
-) -> Result<()> {
+) -> Result<bool> {
     if !startup_backfill_task_enabled(state.as_ref(), task) {
         debug!(
             task = task.log_label(),
             "startup backfill task is disabled by config"
         );
-        return Ok(());
+        return Ok(false);
     }
 
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
@@ -540,7 +563,7 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
             last_updated = progress.last_updated,
             "startup backfill task is not due"
         );
-        return Ok(());
+        return Ok(false);
     }
 
     let _permit = match gate.try_begin_background("startup_backfill") {
@@ -551,15 +574,20 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                 reason = %reason,
                 "startup backfill task skipped because database pressure gate is closed"
             );
-            return Ok(());
+            return Ok(false);
         }
     };
 
     mark_startup_backfill_running(&state.pool, &task_name, progress.cursor_id).await?;
 
     let started_at = Instant::now();
-    match run_startup_backfill_task(state, task, progress.cursor_id, progress.zero_update_streak)
-        .await
+    let actionable = match run_startup_backfill_task(
+        state,
+        task,
+        progress.cursor_id,
+        progress.zero_update_streak,
+    )
+    .await
     {
         Ok((run, detail)) => {
             let zero_update_streak = if run.updated == 0 {
@@ -592,10 +620,21 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                 zero_update_streak,
                 elapsed_ms = started_at.elapsed().as_millis() as u64,
                 next_run_after = %next_run_after,
+                actionable_backlog_count = u64::from(run.hit_scan_limit),
+                blocked_backlog_count = u64::from(run.force_idle && run.scanned > 0),
+                backoff_stage = match startup_backfill_next_delay(&run, zero_update_streak).as_secs() {
+                    0..=15 => "15s",
+                    16..=60 => "1m",
+                    61..=300 => "5m",
+                    301..=900 => "15m",
+                    _ => "idle",
+                },
+                wake_reason = if run.updated > 0 { "progress" } else if run.hit_scan_limit { "actionable_backlog" } else { "scheduled" },
                 detail = %detail,
                 samples = %startup_backfill_samples_text(&run.samples),
                 "startup backfill pass finished"
             );
+            startup_backfill_run_is_actionable(&run)
         }
         Err(err) => {
             let retry_after = format_utc_iso(
@@ -623,10 +662,15 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                 error = %err,
                 "startup backfill pass failed"
             );
+            false
         }
-    }
+    };
 
-    Ok(())
+    Ok(actionable)
+}
+
+fn startup_backfill_run_is_actionable(run: &StartupBackfillRunState) -> bool {
+    run.updated > 0 || (run.hit_scan_limit && !run.force_idle)
 }
 
 pub(crate) async fn run_startup_backfill_task(
@@ -1156,6 +1200,62 @@ pub(crate) fn spawn_startup_backfill_maintenance(
 #[cfg(test)]
 mod startup_backfill_tests {
     use super::*;
+
+    #[test]
+    fn actionable_no_progress_backoff_caps_at_fifteen_minutes() {
+        let run = StartupBackfillRunState {
+            scanned: 2,
+            updated: 0,
+            hit_scan_limit: true,
+            ..StartupBackfillRunState::default()
+        };
+        assert_eq!(
+            startup_backfill_next_delay(&run, 1),
+            Duration::from_secs(15)
+        );
+        assert_eq!(
+            startup_backfill_next_delay(&run, 2),
+            Duration::from_secs(60)
+        );
+        assert_eq!(
+            startup_backfill_next_delay(&run, 3),
+            Duration::from_secs(5 * 60)
+        );
+        assert_eq!(
+            startup_backfill_next_delay(&run, 4),
+            Duration::from_secs(15 * 60)
+        );
+        assert_eq!(
+            startup_backfill_next_delay(&run, 99),
+            Duration::from_secs(15 * 60)
+        );
+    }
+
+    #[test]
+    fn only_progress_or_non_idle_backlog_triggers_rollup_refresh() {
+        assert!(startup_backfill_run_is_actionable(
+            &StartupBackfillRunState {
+                updated: 1,
+                ..StartupBackfillRunState::default()
+            }
+        ));
+        assert!(startup_backfill_run_is_actionable(
+            &StartupBackfillRunState {
+                hit_scan_limit: true,
+                ..StartupBackfillRunState::default()
+            }
+        ));
+        assert!(!startup_backfill_run_is_actionable(
+            &StartupBackfillRunState {
+                scanned: 1,
+                force_idle: true,
+                ..StartupBackfillRunState::default()
+            }
+        ));
+        assert!(!startup_backfill_run_is_actionable(
+            &StartupBackfillRunState::default()
+        ));
+    }
 
     #[test]
     fn historical_rollup_backfill_run_state_backs_off_when_only_blocked_archives_remain() {

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -923,10 +923,16 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
                     record,
                     capture_started: Some(capture_started),
                     raw_capture: true,
+                    dashboard_terminal_sequence: delta.terminal_sequence,
                 },
             ));
     if !terminal_enqueued {
-        rollback_dashboard_activity_terminal_record(state, &inserted_record).await;
+        rollback_dashboard_activity_terminal_record(
+            state,
+            &inserted_record,
+            delta.terminal_sequence,
+        )
+        .await;
         let terminal_tombstone_cleared = state
             .proxy_runtime_invocations
             .clear_terminal_tombstone(&inserted_record.invoke_id, &inserted_record.occurred_at);

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -1684,6 +1684,8 @@ pub(crate) async fn recover_guard_dropped_pool_early_phase_orphan(
         );
     }
 
+    let dashboard_reconcile_gate = state.sqlite_batch_writer.dashboard_reconcile_gate();
+    let _dashboard_reconcile_guard = dashboard_reconcile_gate.lock().await;
     let mut tx = state.pool.begin().await?;
     let recovered_attempts = match pending_attempt_record.attempt_id {
         Some(attempt_id) => {
@@ -1787,6 +1789,8 @@ pub(crate) async fn recover_guard_dropped_pool_invocation_orphan(
 ) -> Result<()> {
     state.sqlite_batch_writer.flush_now(&state.pool).await?;
 
+    let dashboard_reconcile_gate = state.sqlite_batch_writer.dashboard_reconcile_gate();
+    let _dashboard_reconcile_guard = dashboard_reconcile_gate.lock().await;
     let recovered_invocations = recover_proxy_invocations_with_scope(
         &state.pool,
         ProxyInvocationRecoveryScope::Selectors(std::slice::from_ref(&selector)),
@@ -1846,6 +1850,8 @@ pub(crate) async fn recover_stale_pool_early_phase_orphans_runtime(
         .lock()
         .unwrap_or_else(|err| err.into_inner())
         .clone();
+    let dashboard_reconcile_gate = state.sqlite_batch_writer.dashboard_reconcile_gate();
+    let _dashboard_reconcile_guard = dashboard_reconcile_gate.lock().await;
     let mut tx = state.pool.begin().await?;
     let stale_candidates = load_stale_pool_upstream_request_attempt_candidate_rows_tx(
         tx.as_mut(),
@@ -3471,10 +3477,16 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_terminal_record(
                     record,
                     capture_started: None,
                     raw_capture: false,
+                    dashboard_terminal_sequence: delta.terminal_sequence,
                 },
             ));
     if !terminal_enqueued {
-        rollback_dashboard_activity_terminal_record(state, &persisted_record).await;
+        rollback_dashboard_activity_terminal_record(
+            state,
+            &persisted_record,
+            delta.terminal_sequence,
+        )
+        .await;
         let terminal_tombstone_cleared = state
             .proxy_runtime_invocations
             .clear_terminal_tombstone(&persisted_record.invoke_id, &persisted_record.occurred_at);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -121,12 +121,16 @@ pub(crate) async fn run() -> Result<()> {
     let proxy_runtime_invocations = Arc::new(ProxyRuntimeInvocationStore::default());
     let dashboard_network_speed_cache =
         Arc::new(DashboardNetworkSpeedCache::new(process_started_at_utc));
+    let dashboard_activity_snapshot_cache =
+        Arc::new(Mutex::new(DashboardActivitySnapshotCacheState::default()));
     let sqlite_batch_writer = SqliteBatchWriter::spawn(
         pool.clone(),
         shutdown.clone(),
         prompt_cache_conversation_cache.clone(),
     );
     sqlite_batch_writer.set_terminal_runtime_store(proxy_runtime_invocations.clone());
+    sqlite_batch_writer
+        .set_dashboard_activity_snapshot_cache(dashboard_activity_snapshot_cache.clone());
     let pool_account_selection_runtime = Arc::new(PoolAccountSelectionRuntime::default());
     let subscription_hub = Arc::new(SubscriptionHub::new());
 
@@ -166,9 +170,7 @@ pub(crate) async fn run() -> Result<()> {
         pricing_settings_update_lock: Arc::new(Mutex::new(())),
         pricing_catalog,
         prompt_cache_conversation_cache,
-        dashboard_activity_snapshot_cache: Arc::new(Mutex::new(
-            DashboardActivitySnapshotCacheState::default(),
-        )),
+        dashboard_activity_snapshot_cache,
         maintenance_stats_cache: Arc::new(Mutex::new(StatsMaintenanceCacheState::default())),
         system_status_cache: Arc::new(Mutex::new(SystemStatusCacheState::default())),
         pool_routing_reservations: Arc::new(std::sync::Mutex::new(HashMap::new())),

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -74,6 +74,7 @@ pub(crate) struct BatchedTerminalInvocationWrite {
     pub(crate) record: ProxyCaptureRecord,
     pub(crate) capture_started: Option<Instant>,
     pub(crate) raw_capture: bool,
+    pub(crate) dashboard_terminal_sequence: Option<u64>,
 }
 
 impl BatchedTerminalInvocationWrite {
@@ -164,12 +165,20 @@ impl PendingBatch {
         self.enqueued_rows += 1;
         match write {
             SqliteBatchWrite::TerminalInvocation(terminal) => {
-                if self
-                    .terminal_invocations
-                    .insert(terminal.key(), terminal)
-                    .is_some()
-                {
-                    self.coalesced_rows += 1;
+                let key = terminal.key();
+                match self.terminal_invocations.entry(key) {
+                    std::collections::btree_map::Entry::Vacant(entry) => {
+                        entry.insert(terminal);
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut entry) => {
+                        let preserved_sequence = terminal
+                            .dashboard_terminal_sequence
+                            .or(entry.get().dashboard_terminal_sequence);
+                        let mut terminal = terminal;
+                        terminal.dashboard_terminal_sequence = preserved_sequence;
+                        entry.insert(terminal);
+                        self.coalesced_rows += 1;
+                    }
                 }
             }
             SqliteBatchWrite::AttemptProgress(progress) => {
@@ -265,6 +274,9 @@ pub(crate) struct SqliteBatchWriter {
     pending_depth: Arc<AtomicUsize>,
     dropped_writes: Arc<AtomicU64>,
     terminal_runtime_store: Arc<std::sync::Mutex<Option<Arc<ProxyRuntimeInvocationStore>>>>,
+    dashboard_activity_snapshot_cache:
+        Arc<std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>>,
+    dashboard_reconcile_gate: Arc<Mutex<()>>,
     #[cfg(test)]
     prompt_cache_conversation_cache: Option<Arc<Mutex<PromptCacheConversationsCacheState>>>,
     handle: Mutex<Option<JoinHandle<()>>>,
@@ -285,6 +297,8 @@ impl SqliteBatchWriter {
         let pending_depth = Arc::new(AtomicUsize::new(0));
         let dropped_writes = Arc::new(AtomicU64::new(0));
         let terminal_runtime_store = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_activity_snapshot_cache = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_reconcile_gate = Arc::new(Mutex::new(()));
         let cache_for_task = prompt_cache_conversation_cache.clone();
         let handle = tokio::spawn(run_sqlite_batch_writer(
             pool,
@@ -293,6 +307,8 @@ impl SqliteBatchWriter {
             pending_depth.clone(),
             Some(cache_for_task),
             terminal_runtime_store.clone(),
+            dashboard_activity_snapshot_cache.clone(),
+            dashboard_reconcile_gate.clone(),
         ));
         Arc::new(Self {
             write_sender,
@@ -300,6 +316,8 @@ impl SqliteBatchWriter {
             pending_depth,
             dropped_writes,
             terminal_runtime_store,
+            dashboard_activity_snapshot_cache,
+            dashboard_reconcile_gate,
             #[cfg(test)]
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
             handle: Mutex::new(Some(handle)),
@@ -329,6 +347,8 @@ impl SqliteBatchWriter {
             pending_depth: Arc::new(AtomicUsize::new(0)),
             dropped_writes: Arc::new(AtomicU64::new(0)),
             terminal_runtime_store: Arc::new(std::sync::Mutex::new(None)),
+            dashboard_activity_snapshot_cache: Arc::new(std::sync::Mutex::new(None)),
+            dashboard_reconcile_gate: Arc::new(Mutex::new(())),
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
             handle: Mutex::new(None),
             buffered_writes: Some(Arc::new(std::sync::Mutex::new(Vec::new()))),
@@ -354,6 +374,19 @@ impl SqliteBatchWriter {
         if let Ok(mut guard) = self.terminal_runtime_store.lock() {
             *guard = Some(runtime_store);
         }
+    }
+
+    pub(crate) fn set_dashboard_activity_snapshot_cache(
+        &self,
+        cache: Arc<Mutex<DashboardActivitySnapshotCacheState>>,
+    ) {
+        if let Ok(mut guard) = self.dashboard_activity_snapshot_cache.lock() {
+            *guard = Some(cache);
+        }
+    }
+
+    pub(crate) fn dashboard_reconcile_gate(&self) -> Arc<Mutex<()>> {
+        self.dashboard_reconcile_gate.clone()
     }
 
     pub(crate) fn enqueue(&self, write: SqliteBatchWrite) -> bool {
@@ -483,13 +516,29 @@ impl SqliteBatchWriter {
             batch.push(write);
         }
         let terminal_runtime_store = Arc::new(std::sync::Mutex::new(None));
-        let deferred = flush_pending_batch_inner(pool, &batch, None, &terminal_runtime_store)
-            .await
-            .expect("flush pending sqlite batch writes");
+        let dashboard_activity_snapshot_cache = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_reconcile_gate = Arc::new(Mutex::new(()));
+        let deferred = flush_pending_batch_inner(
+            pool,
+            &batch,
+            None,
+            &terminal_runtime_store,
+            &dashboard_activity_snapshot_cache,
+            &dashboard_reconcile_gate,
+        )
+        .await
+        .expect("flush pending sqlite batch writes");
         if !deferred.is_empty() {
-            flush_pending_batch_inner(pool, &deferred, None, &terminal_runtime_store)
-                .await
-                .expect("flush deferred pending sqlite batch writes");
+            flush_pending_batch_inner(
+                pool,
+                &deferred,
+                None,
+                &terminal_runtime_store,
+                &dashboard_activity_snapshot_cache,
+                &dashboard_reconcile_gate,
+            )
+            .await
+            .expect("flush deferred pending sqlite batch writes");
         }
     }
 
@@ -518,6 +567,8 @@ impl SqliteBatchWriter {
                 &batch,
                 self.prompt_cache_conversation_cache.as_ref(),
                 &self.terminal_runtime_store,
+                &self.dashboard_activity_snapshot_cache,
+                &self.dashboard_reconcile_gate,
             )
             .await
             .expect("flush buffered sqlite batch writes for test");
@@ -536,6 +587,7 @@ impl SqliteBatchWriter {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_sqlite_batch_writer(
     pool: Pool<Sqlite>,
     mut write_receiver: mpsc::Receiver<SqliteBatchWrite>,
@@ -543,6 +595,10 @@ pub(crate) async fn run_sqlite_batch_writer(
     pending_depth: Arc<AtomicUsize>,
     prompt_cache_conversation_cache: Option<Arc<Mutex<PromptCacheConversationsCacheState>>>,
     terminal_runtime_store: Arc<std::sync::Mutex<Option<Arc<ProxyRuntimeInvocationStore>>>>,
+    dashboard_activity_snapshot_cache: Arc<
+        std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>,
+    >,
+    dashboard_reconcile_gate: Arc<Mutex<()>>,
 ) {
     let mut ticker = interval(SQLITE_BATCH_FLUSH_INTERVAL);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -571,6 +627,8 @@ pub(crate) async fn run_sqlite_batch_writer(
                             FlushReason::Barrier,
                             prompt_cache_conversation_cache.as_ref(),
                             &terminal_runtime_store,
+                            &dashboard_activity_snapshot_cache,
+                            &dashboard_reconcile_gate,
                         )
                         .await
                         {
@@ -609,6 +667,8 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 FlushReason::Shutdown,
                                 prompt_cache_conversation_cache.as_ref(),
                                 &terminal_runtime_store,
+                                &dashboard_activity_snapshot_cache,
+                                &dashboard_reconcile_gate,
                             )
                             .await
                             {
@@ -646,6 +706,8 @@ pub(crate) async fn run_sqlite_batch_writer(
                             FlushReason::Shutdown,
                             prompt_cache_conversation_cache.as_ref(),
                             &terminal_runtime_store,
+                            &dashboard_activity_snapshot_cache,
+                            &dashboard_reconcile_gate,
                         )
                         .await;
                     }
@@ -661,6 +723,8 @@ pub(crate) async fn run_sqlite_batch_writer(
                             FlushReason::RowLimit,
                             prompt_cache_conversation_cache.as_ref(),
                             &terminal_runtime_store,
+                            &dashboard_activity_snapshot_cache,
+                            &dashboard_reconcile_gate,
                         )
                         .await
                     {
@@ -700,6 +764,8 @@ pub(crate) async fn run_sqlite_batch_writer(
                             flush_reason,
                             prompt_cache_conversation_cache.as_ref(),
                             &terminal_runtime_store,
+                            &dashboard_activity_snapshot_cache,
+                            &dashboard_reconcile_gate,
                         )
                         .await
                     {
@@ -736,6 +802,10 @@ pub(crate) async fn flush_pending_batch(
     reason: FlushReason,
     prompt_cache_conversation_cache: Option<&Arc<Mutex<PromptCacheConversationsCacheState>>>,
     terminal_runtime_store: &Arc<std::sync::Mutex<Option<Arc<ProxyRuntimeInvocationStore>>>>,
+    dashboard_activity_snapshot_cache: &Arc<
+        std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>,
+    >,
+    dashboard_reconcile_gate: &Arc<Mutex<()>>,
 ) -> Option<RetainedBatch> {
     if batch.is_empty() {
         return None;
@@ -787,6 +857,8 @@ pub(crate) async fn flush_pending_batch(
         &batch,
         prompt_cache_conversation_cache,
         terminal_runtime_store,
+        dashboard_activity_snapshot_cache,
+        dashboard_reconcile_gate,
     )
     .await
     {
@@ -887,9 +959,14 @@ pub(crate) async fn flush_pending_batch_inner(
     batch: &PendingBatch,
     prompt_cache_conversation_cache: Option<&Arc<Mutex<PromptCacheConversationsCacheState>>>,
     terminal_runtime_store: &Arc<std::sync::Mutex<Option<Arc<ProxyRuntimeInvocationStore>>>>,
+    dashboard_activity_snapshot_cache: &Arc<
+        std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>,
+    >,
+    dashboard_reconcile_gate: &Arc<Mutex<()>>,
 ) -> Result<PendingBatch> {
     let mut deferred_batch = PendingBatch::default();
     let mut should_invalidate_prompt_cache_conversations = false;
+    let _dashboard_reconcile_guard = dashboard_reconcile_gate.lock().await;
     for terminal in batch.terminal_invocations.values() {
         let persisted = if terminal.raw_capture {
             let capture_started = terminal.capture_started.unwrap_or_else(Instant::now);
@@ -926,6 +1003,20 @@ pub(crate) async fn flush_pending_batch_inner(
         let Some((invocation_id, occurred_at)) = derived_identity else {
             continue;
         };
+        let dashboard_cache = dashboard_activity_snapshot_cache
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone());
+        if let Some(cache) = dashboard_cache {
+            acknowledge_dashboard_activity_terminal_record(
+                &cache,
+                &terminal.record.invoke_id,
+                &terminal.record.occurred_at,
+                invocation_id,
+                terminal.dashboard_terminal_sequence,
+            )
+            .await;
+        }
         if prompt_cache_key_from_payload(terminal.record.payload.as_deref())
             .as_deref()
             .is_some_and(|key| !key.trim().is_empty())
@@ -1168,6 +1259,60 @@ mod tests {
             "pending attempt should be inserted synchronously"
         );
         pending
+    }
+
+    fn terminal_write_for_coalescing(
+        invoke_id: &str,
+        dashboard_terminal_sequence: Option<u64>,
+    ) -> BatchedTerminalInvocationWrite {
+        let request_info = RequestCaptureInfo::default();
+        BatchedTerminalInvocationWrite {
+            record: build_running_proxy_capture_record(
+                invoke_id,
+                "2026-07-01 10:00:00",
+                ProxyCaptureTarget::Responses,
+                &request_info,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            capture_started: None,
+            raw_capture: false,
+            dashboard_terminal_sequence,
+        }
+    }
+
+    #[test]
+    fn terminal_batch_coalescing_preserves_the_persistence_ack_sequence() {
+        let mut batch = PendingBatch::default();
+        batch.push(SqliteBatchWrite::TerminalInvocation(
+            terminal_write_for_coalescing("coalesced-terminal", Some(7)),
+        ));
+        batch.push(SqliteBatchWrite::TerminalInvocation(
+            terminal_write_for_coalescing("coalesced-terminal", None),
+        ));
+
+        let terminal = batch
+            .terminal_invocations
+            .values()
+            .next()
+            .expect("coalesced terminal");
+        assert_eq!(terminal.dashboard_terminal_sequence, Some(7));
+        assert_eq!(batch.coalesced_rows, 1);
     }
 
     #[tokio::test]
@@ -1575,6 +1720,7 @@ mod tests {
                 BatchedTerminalInvocationWrite {
                     capture_started: None,
                     raw_capture: false,
+                    dashboard_terminal_sequence: None,
                     record,
                 },
             )],
@@ -1676,6 +1822,7 @@ mod tests {
             BatchedTerminalInvocationWrite {
                 capture_started: None,
                 raw_capture: false,
+                dashboard_terminal_sequence: None,
                 record,
             },
         )));
@@ -1768,6 +1915,7 @@ mod tests {
             BatchedTerminalInvocationWrite {
                 capture_started: None,
                 raw_capture: false,
+                dashboard_terminal_sequence: None,
                 record,
             },
         )));

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -15501,7 +15501,7 @@ async fn dashboard_activity_summary_only_excludes_archived_rows_for_live_ids() {
 }
 
 #[tokio::test]
-async fn dashboard_activity_cache_selection_reuses_today_snapshot_within_five_second_ttl() {
+async fn dashboard_activity_cache_selection_reuses_today_snapshot_within_reconcile_interval() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
@@ -16086,6 +16086,398 @@ async fn account_activity_v2_partial_merge_reads_only_covered_hours_from_rollup(
     assert_eq!(account.success_count, 2);
     assert_eq!(account.total_tokens, 300);
     assert_f64_close(account.total_cost, 0.30);
+}
+
+#[tokio::test]
+async fn account_activity_v2_priority_repair_materializes_active_closed_hours() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let current_hour_epoch = align_bucket_epoch(Utc::now().timestamp(), 3_600, 0);
+    let repair_hour_epoch = current_hour_epoch - 2 * 3_600;
+    sqlx::query(
+        r#"
+        INSERT INTO hourly_rollup_live_progress (dataset, cursor_id, updated_at)
+        VALUES (?1, 1, datetime('now'))
+        "#,
+    )
+    .bind(INVOCATION_ACCOUNT_ACTIVITY_V2_REPAIR_GENERATION_DATASET)
+    .execute(&state.pool)
+    .await
+    .expect("seed current account activity v2 repair generation");
+    let occurred_at = Utc
+        .timestamp_opt(repair_hour_epoch + 10 * 60, 0)
+        .single()
+        .expect("priority repair invocation time");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id, occurred_at, source, status, detail_level,
+            total_tokens, cost, payload, raw_response
+        )
+        VALUES ('v2-priority-repair', ?1, ?2, 'failed', ?3, 45, 0.45, ?4, '{}')
+        "#,
+    )
+    .bind(format_naive(
+        occurred_at.with_timezone(&Shanghai).naive_local(),
+    ))
+    .bind(SOURCE_PROXY)
+    .bind(DETAIL_LEVEL_FULL)
+    .bind(r#"{"upstreamAccountId":42}"#)
+    .execute(&state.pool)
+    .await
+    .expect("insert priority repair source row");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id, occurred_at, source, status, detail_level,
+            total_tokens, cost, payload, raw_response
+        )
+        VALUES ('v2-priority-running', ?1, ?2, 'running', ?3, 99, 0.99, ?4, '{}')
+        "#,
+    )
+    .bind(format_naive(
+        (occurred_at + ChronoDuration::minutes(1))
+            .with_timezone(&Shanghai)
+            .naive_local(),
+    ))
+    .bind(SOURCE_PROXY)
+    .bind(DETAIL_LEVEL_FULL)
+    .bind(r#"{"upstreamAccountId":42}"#)
+    .execute(&state.pool)
+    .await
+    .expect("insert in-flight row in priority repair bucket");
+    let archived_hour_epoch = current_hour_epoch - 6 * 24 * 3_600;
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_account_stats_hourly (
+            bucket_start_epoch, source, upstream_account_id,
+            activity_v2_request_count, activity_v2_total_tokens
+        )
+        VALUES (?1, ?2, 42, 9, 900)
+        "#,
+    )
+    .bind(archived_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .execute(&state.pool)
+    .await
+    .expect("insert archive-derived v2 rollup outside live coverage");
+
+    let outcome = repair_active_account_activity_v2_coverage(&state.pool)
+        .await
+        .expect("repair active account activity coverage");
+
+    assert_eq!(outcome.priority_bucket_count, 2);
+    assert_eq!(outcome.repaired_bucket_count, 2);
+    let covered = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT COUNT(*)
+        FROM hourly_rollup_materialized_buckets
+        WHERE target = ?1 AND bucket_start_epoch = ?2 AND source = ?3
+        "#,
+    )
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2)
+    .bind(repair_hour_epoch)
+    .bind(HOURLY_ROLLUP_MATERIALIZED_SOURCE_NONE)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load priority repair marker");
+    assert_eq!(covered, 1);
+    let current_hour_covered = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT COUNT(*)
+        FROM hourly_rollup_materialized_buckets
+        WHERE target = ?1 AND bucket_start_epoch = ?2 AND source = ?3
+        "#,
+    )
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2)
+    .bind(current_hour_epoch)
+    .bind(HOURLY_ROLLUP_MATERIALIZED_SOURCE_NONE)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load current-hour marker");
+    assert_eq!(current_hour_covered, 0);
+    let rollup = sqlx::query_as::<_, (i64, i64, i64, f64)>(
+        r#"
+        SELECT activity_v2_request_count,
+               activity_v2_failure_count,
+               activity_v2_non_success_tokens,
+               activity_v2_total_cost
+        FROM upstream_account_stats_hourly
+        WHERE bucket_start_epoch = ?1 AND source = ?2 AND upstream_account_id = 42
+        "#,
+    )
+    .bind(repair_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load priority repaired rollup");
+    assert_eq!(rollup.0, 1);
+    assert_eq!(rollup.1, 1);
+    assert_eq!(rollup.2, 45);
+    assert_f64_close(rollup.3, 0.45);
+    let repair_watermark = sqlx::query_scalar::<_, i64>(
+        "SELECT cursor_id FROM account_activity_v2_bucket_repair_watermarks WHERE bucket_start_epoch = ?1",
+    )
+    .bind(repair_hour_epoch)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load terminal-only priority repair watermark");
+    assert_eq!(repair_watermark, 1);
+    assert_eq!(
+        replay_live_invocation_hourly_rollups(&state.pool)
+            .await
+            .expect("replay rows after priority repair"),
+        2
+    );
+    let replayed_request_count = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT activity_v2_request_count
+        FROM upstream_account_stats_hourly
+        WHERE bucket_start_epoch = ?1 AND source = ?2 AND upstream_account_id = 42
+        "#,
+    )
+    .bind(repair_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load v2 request count after shared replay");
+    assert_eq!(replayed_request_count, 1);
+    let archived_rollup = sqlx::query_as::<_, (i64, i64)>(
+        r#"
+        SELECT activity_v2_request_count, activity_v2_total_tokens
+        FROM upstream_account_stats_hourly
+        WHERE bucket_start_epoch = ?1 AND source = ?2 AND upstream_account_id = 42
+        "#,
+    )
+    .bind(archived_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load preserved archive-derived v2 rollup");
+    assert_eq!(archived_rollup, (9, 900));
+}
+
+#[tokio::test]
+async fn account_activity_v2_priority_repair_skips_archive_overlapping_live_hours() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let current_hour_epoch = align_bucket_epoch(Utc::now().timestamp(), 3_600, 0);
+    let overlap_hour_epoch = current_hour_epoch - 2 * 3_600;
+    let overlap_start = Utc
+        .timestamp_opt(overlap_hour_epoch, 0)
+        .single()
+        .expect("archive overlap start");
+    let overlap_end = overlap_start + ChronoDuration::hours(1);
+    sqlx::query(
+        r#"
+        INSERT INTO hourly_rollup_live_progress (dataset, cursor_id, updated_at)
+        VALUES (?1, 1, datetime('now'))
+        "#,
+    )
+    .bind(INVOCATION_ACCOUNT_ACTIVITY_V2_REPAIR_GENERATION_DATASET)
+    .execute(&state.pool)
+    .await
+    .expect("seed current account activity v2 repair generation");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id, occurred_at, source, status, detail_level,
+            total_tokens, cost, payload, raw_response
+        )
+        VALUES ('v2-overlap-live', ?1, ?2, 'success', ?3, 10, 0.10, ?4, '{}')
+        "#,
+    )
+    .bind(format_naive(
+        (overlap_start + ChronoDuration::minutes(10))
+            .with_timezone(&Shanghai)
+            .naive_local(),
+    ))
+    .bind(SOURCE_PROXY)
+    .bind(DETAIL_LEVEL_FULL)
+    .bind(r#"{"upstreamAccountId":42}"#)
+    .execute(&state.pool)
+    .await
+    .expect("insert live row overlapping archive coverage");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_account_stats_hourly (
+            bucket_start_epoch, source, upstream_account_id,
+            activity_v2_request_count, activity_v2_total_tokens
+        )
+        VALUES (?1, ?2, 42, 9, 900)
+        "#,
+    )
+    .bind(overlap_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .execute(&state.pool)
+    .await
+    .expect("insert archive-derived values in overlapping hour");
+    sqlx::query(
+        r#"
+        INSERT INTO archive_batches (
+            dataset, month_key, file_path, sha256, row_count, status,
+            coverage_start_at, coverage_end_at, created_at
+        )
+        VALUES (?1, ?2, ?3, 'overlap-sha', 1, ?4, ?5, ?6, datetime('now'))
+        "#,
+    )
+    .bind(HOURLY_ROLLUP_DATASET_INVOCATIONS)
+    .bind(
+        overlap_start
+            .with_timezone(&Shanghai)
+            .format("%Y-%m")
+            .to_string(),
+    )
+    .bind("/tmp/account-activity-v2-overlap.sqlite.gz")
+    .bind(ARCHIVE_STATUS_COMPLETED)
+    .bind(format_naive(
+        overlap_start.with_timezone(&Shanghai).naive_local(),
+    ))
+    .bind(format_naive(
+        (overlap_end - ChronoDuration::seconds(1))
+            .with_timezone(&Shanghai)
+            .naive_local(),
+    ))
+    .execute(&state.pool)
+    .await
+    .expect("insert overlapping archive manifest");
+
+    repair_active_account_activity_v2_coverage(&state.pool)
+        .await
+        .expect("run active coverage repair");
+
+    let overlap_rollup = sqlx::query_as::<_, (i64, i64)>(
+        r#"
+        SELECT activity_v2_request_count, activity_v2_total_tokens
+        FROM upstream_account_stats_hourly
+        WHERE bucket_start_epoch = ?1 AND source = ?2 AND upstream_account_id = 42
+        "#,
+    )
+    .bind(overlap_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load preserved overlap rollup");
+    assert_eq!(overlap_rollup, (9, 900));
+    let overlap_covered = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT COUNT(*)
+        FROM hourly_rollup_materialized_buckets
+        WHERE target = ?1 AND bucket_start_epoch = ?2 AND source = ?3
+        "#,
+    )
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2)
+    .bind(overlap_hour_epoch)
+    .bind(HOURLY_ROLLUP_MATERIALIZED_SOURCE_NONE)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load overlap coverage marker");
+    assert_eq!(overlap_covered, 0);
+}
+
+#[tokio::test]
+async fn account_activity_v2_priority_repair_preserves_unknown_archive_coverage() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let current_hour_epoch = align_bucket_epoch(Utc::now().timestamp(), 3_600, 0);
+    let repair_hour_epoch = current_hour_epoch - 2 * 3_600;
+    let repair_time = Utc
+        .timestamp_opt(repair_hour_epoch + 10 * 60, 0)
+        .single()
+        .expect("repair invocation time");
+    sqlx::query(
+        "INSERT INTO hourly_rollup_live_progress (dataset, cursor_id, updated_at) \
+         VALUES (?1, 1, datetime('now'))",
+    )
+    .bind(INVOCATION_ACCOUNT_ACTIVITY_V2_REPAIR_GENERATION_DATASET)
+    .execute(&state.pool)
+    .await
+    .expect("seed current account activity v2 repair generation");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id, occurred_at, source, status, detail_level,
+            total_tokens, cost, payload, raw_response
+        )
+        VALUES ('v2-unknown-archive-live', ?1, ?2, 'success', ?3, 10, 0.10, ?4, '{}')
+        "#,
+    )
+    .bind(format_naive(
+        repair_time.with_timezone(&Shanghai).naive_local(),
+    ))
+    .bind(SOURCE_PROXY)
+    .bind(DETAIL_LEVEL_FULL)
+    .bind(r#"{"upstreamAccountId":42}"#)
+    .execute(&state.pool)
+    .await
+    .expect("insert live row in unknown archive month");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_account_stats_hourly (
+            bucket_start_epoch, source, upstream_account_id,
+            activity_v2_request_count, activity_v2_total_tokens
+        )
+        VALUES (?1, ?2, 42, 9, 900)
+        "#,
+    )
+    .bind(repair_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .execute(&state.pool)
+    .await
+    .expect("insert archive-derived values with unknown coverage");
+    sqlx::query(
+        r#"
+        INSERT INTO archive_batches (
+            dataset, month_key, file_path, sha256, row_count, status, created_at
+        )
+        VALUES (?1, ?2, ?3, 'unknown-coverage-sha', 1, ?4, datetime('now'))
+        "#,
+    )
+    .bind(HOURLY_ROLLUP_DATASET_INVOCATIONS)
+    .bind(
+        repair_time
+            .with_timezone(&Shanghai)
+            .format("%Y-%m")
+            .to_string(),
+    )
+    .bind("/tmp/account-activity-v2-unknown-coverage.sqlite.gz")
+    .bind(ARCHIVE_STATUS_COMPLETED)
+    .execute(&state.pool)
+    .await
+    .expect("insert archive manifest without coverage bounds");
+
+    repair_active_account_activity_v2_coverage(&state.pool)
+        .await
+        .expect("run active coverage repair");
+
+    let rollup = sqlx::query_as::<_, (i64, i64)>(
+        "SELECT activity_v2_request_count, activity_v2_total_tokens \
+         FROM upstream_account_stats_hourly \
+         WHERE bucket_start_epoch = ?1 AND source = ?2 AND upstream_account_id = 42",
+    )
+    .bind(repair_hour_epoch)
+    .bind(SOURCE_PROXY)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load preserved unknown-coverage rollup");
+    assert_eq!(rollup, (9, 900));
+    let covered = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM hourly_rollup_materialized_buckets \
+         WHERE target = ?1 AND bucket_start_epoch = ?2 AND source = ?3",
+    )
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_ACTIVITY_V2)
+    .bind(repair_hour_epoch)
+    .bind(HOURLY_ROLLUP_MATERIALIZED_SOURCE_NONE)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load unknown-coverage marker");
+    assert_eq!(covered, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- replace retained full invocation records with bounded compact terminal deltas and cursor-aware persistence acknowledgements
- reconcile open-range Dashboard baselines at a fixed 60-second cadence while keeping 5-second publications memory-only and last-good safe
- prioritize active-window account activity v2 coverage repair and back off idle historical work up to 15 minutes
- add source, cursor, delta lifecycle, coverage repair, and backfill telemetry without changing public HTTP or SSE contracts

## Testing
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- targeted Dashboard read-model, archive, startup-backfill, and SQLite writer suites
- `cargo test -q`: 1775 passed, 45 ignored; two existing load-sensitive timeout tests failed under the full parallel suite and both passed when rerun individually
- independent Codex review converged with no actionable findings

## References
### Specs
- `docs/specs/5932d-sse-proxy-live-sync/SPEC.md`
- `docs/specs/z6ysw-dashboard-account-activity-tabs/SPEC.md`
- `docs/specs/gz5ns-dashboard-natural-day-kpi-semantics/SPEC.md`

Spec Disposition: update
Spec Sync: done
Spec Drift: none

### Solutions
- `docs/solutions/performance/sqlite-write-pressure-backpressure.md`
- `docs/solutions/performance/realtime-dashboard-reconcile-budget.md`

Solutions Sync: done

### Project Docs
-

Project Docs Sync: n/a(no project-doc change)

## Notes
- Public API, SSE topic/schema, Dashboard ranges, sorting, recent truncation, and owner-facing behavior remain unchanged.
- No UI-affecting changes; visual evidence is not applicable.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->