### PR TITLE
fix: prioritize terminal persistence under SQLite pressure

### DIFF
--- a/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
+++ b/docs/solutions/performance/realtime-dashboard-reconcile-budget.md
@@ -67,6 +67,8 @@ related_specs:
 - rolling duration 窗口若没有完整的到期反向 delta，不能只重写响应的 `rangeStart/rangeEnd` 后复用较旧 baseline；这会把窗口外记录伪装成当前 totals。此时必须把该窗口的缓存上限收紧到其允许的可见时效预算，或先实现可验证的 expiry delta，再延长 DB reconcile cadence。
 - expiry delta 本身也是内存队列：baseline boundary load、in-flight replay 和后续 live terminal 必须共用排序与容量约束。expiry horizon 应在 boundary query 前解析并随 entry 保存，命中不得越过已捕获上界；live-only expiry 无法覆盖 archive 前缀时应明确 fallback，不能缓存不完整的反向增量。
 - Dashboard open-range 的 5 秒 publish 与 60 秒 reconcile 必须由两个独立 deadline 驱动。terminal burst 只能合并内存发布；成功、并发写入后重放、last-good 和失败都要推进 reconcile attempt deadline，避免错误路径绕过节流。
+- 当 SQLite writer 已处于 busy/locked cooldown 时，60 秒 reconcile 不是提高优先级的理由。已有 baseline 的 open-range selection 应返回带 live overlay 的 last-good snapshot，并将 `reconcile_outcome=deferred`、`reconcile_skip_reason=writer_pressure`、baseline age 和下一次 due 时间写入 telemetry；超出明确的最大延后窗口后才尝试补偿构建。
+- terminal persistence journal 只负责有限窗口的 admission/replay，不取代累计 read model。5 秒 topic publish 必须继续只读内存 snapshot，不能因为 journal pending 就触发同步 DB builder；P1 SQLite ACK 与 P2 derived work 的延迟应分别判责。
 - coverage repair 应优先 owner 正在使用的闭合小时，并受 bucket 数与 elapsed 双预算约束；历史全量 backlog 连续无进展时应指数退避，永久 payload-required blocked target 不得被计入 actionable backlog 或触发高频 hourly refresh。
 - `response_source=memory` 只能描述实际请求没有执行 DB build 的结果。若本次先构建 DB baseline 再返回 last-good，必须同时记录 `build_attempted=true`、`build_source` 与 reconcile outcome，不能用最终 payload 来源掩盖本次数据库成本。
 - topic 刷新必须使用连接级 owner subscriber 引用计数，而不是内部 broadcast receiver 数量；没有 owner subscriber 时只标记 dirty。重新订阅时应清除旧 replay 连续性并构建 fresh snapshot，避免把失活期间积累的旧 ring 当作权威连续状态回放。

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -86,6 +86,9 @@
 - 对 Dashboard 这类连续 terminal 流量下的累计 KPI，不能把固定 SSE publish cadence 等同于 DB reconcile cadence。terminal enqueue 后应以稳定 event key 幂等更新内存 baseline，5 秒窗口仅合并 fanout；SQLite 只承担 warm restore、最长间隔的 reconcile 与异常 fallback。reconcile lock/error 时保留 last-good snapshot，并记录 baseline age、delta/duplicate count、reconcile outcome 与 sequence-gap 证据。
 - baseline cursor、聚合查询与 pending-key 判定应共享同一 SQLite read transaction；构建完成后重放 cursor 之后的 compact delta 即可接受 baseline。因并发写入而丢弃完整构建并立即重试，会在稳定流量下形成 build-and-discard 风暴。
 - 不要让 P1 terminal flush 在同一锁窗口内继续执行 P2 rollup/account-touch 派生写；这会把“记录最终一致”重新变成“请求尾锁放大”。P1 成功后把 P2 放回队列，等待下一轮时间窗口或 pressure 允许。
+- 对业务优先的 terminal admission，可在数据库同目录维护带校验的 append-only journal：先 journal append，再异步入 SQLite；按固定短窗口 group commit，SQLite ACK 后删除完整确认的 segment。必须把 journal pending records/bytes、ACK age、replay count 与 overflow durability mode 作为结构化 telemetry。journal overflow 选择内存可用性时，不得宣称 crash-safe。
+- Dashboard read model 遇到 writer pressure 时不得为了 60 秒 reconcile 再竞争一次 SQLite barrier。已有 last-good baseline 的 selection 应以 expiry delta 继续服务，并将 reconcile deferred 明确记录；必须设置最长 defer 上限，超过上限再做一次补偿尝试。
+- 不可恢复的历史 payload backlog 必须标为 source-unavailable，并退出 actionable backlog。仅在 archive/payload 恢复事件唤醒，外加每日受行数和耗时限制的 probe；否则退避 ticker 会把永久缺失输入伪装成持续工作。
 
 ## 何时升级方案
 

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -97,6 +97,12 @@
 - `web/src/hooks/useStats.ts`
 - `web/src/hooks/useTimeseries.ts`
 
+## Write-Side Pressure Behavior
+
+- Terminal records are admitted through a local segmented journal before the asynchronous SQLite writer. The journal batches durable sync at a bounded interval and replays unacknowledged records on restart.
+- Dashboard open-range topic publishing continues to render the shared in-memory snapshot during writer pressure. A last-good baseline may defer a reconcile for up to five minutes; closed-range responses retain their exact database behavior.
+- P1 terminal persistence is isolated from P2 derived rollups, account touches, and system-task completion writes. P2 work waits for the pressure gate instead of extending the terminal lock window.
+
 ## Remaining gaps
 
 - 无功能性缺口；提交前仅需完成最终验证与 review 收口。

--- a/docs/specs/gz5ns-dashboard-natural-day-kpi-semantics/IMPLEMENTATION.md
+++ b/docs/specs/gz5ns-dashboard-natural-day-kpi-semantics/IMPLEMENTATION.md
@@ -65,3 +65,8 @@
 
 - `./SPEC.md`
 - `./HISTORY.md`
+
+## Durable Terminal Admission
+
+- 当前自然日与 rolling KPI 的 terminal delta 在 SQLite 接纳受阻时仍保留于进程内 read model，并由同目录 terminal journal 保障有限窗口内的重启重放。
+- journal 达到容量上限时系统选择可用性优先：保留内存实时视图并以 `memory_overflow` telemetry 明确标识 durability downgrade；不将该状态伪装为健康持久化。

--- a/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
+++ b/docs/specs/z6ysw-dashboard-account-activity-tabs/IMPLEMENTATION.md
@@ -86,6 +86,12 @@
 
 - 当前无已知 contract gap；线上仍需用新增 telemetry 验证 RSS、coverage hole、reconcile cadence 与 SQLite pressure 的实际收敛情况。
 
+## Pressure Reconcile Guard
+
+- `today`、`1d` 和 `7d` 的 account activity 继续以共享内存 read model 服务 5 秒可见刷新。
+- 当 SQLite writer 进入 pressure cooldown 且已有完整 baseline 时，reconcile 明确标为 `writer_pressure` deferred，而不是再启动一个竞争写锁的 baseline build。
+- deferred snapshot 仍执行 rolling-window expiry delta；超过五分钟的 baseline 不会继续静默复用，必须尝试一次精确补偿构建。
+
 ## Related Changes
 
 - `src/api/slices/invocations_and_summary.rs`

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -11383,6 +11383,7 @@ const DASHBOARD_ACTIVITY_READ_MODEL_MAX_PENDING_BYTES: usize = 64 * 1024 * 1024;
 const DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_ENTRIES: usize = 64;
 const DASHBOARD_ACTIVITY_SNAPSHOT_CACHE_MAX_EXPIRY_BYTES: usize = 64 * 1024 * 1024;
 const DASHBOARD_ACTIVITY_LAST_GOOD_MAX_AGE: Duration = Duration::from_secs(15 * 60);
+const DASHBOARD_ACTIVITY_PRESSURE_RECONCILE_MAX_AGE: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Debug, Clone)]
 pub(crate) struct DashboardActivitySnapshot {
@@ -13360,6 +13361,12 @@ fn dashboard_activity_snapshot_reuse_mode(
 fn mark_dashboard_activity_reconcile_failed(entry: &mut DashboardActivitySnapshotCacheEntry) {
     entry.last_reconcile_attempted_at = Instant::now();
     entry.last_reconcile_failed = true;
+}
+
+fn dashboard_activity_pressure_reconcile_deferred(
+    entry: &DashboardActivitySnapshotCacheEntry,
+) -> bool {
+    entry.cached_at.elapsed() <= DASHBOARD_ACTIVITY_PRESSURE_RECONCILE_MAX_AGE
 }
 
 fn insert_dashboard_activity_expiry_delta(
@@ -15551,6 +15558,68 @@ async fn load_dashboard_activity_snapshot_cached(
                         sequence_gap_count,
                         build_attempted: false,
                         snapshot_origin: if is_last_good { "last_good" } else { "memory" },
+                    },
+                ));
+            }
+
+            let writer_pressure = crate::db_pressure::global_db_pressure_gate()
+                .snapshot()
+                .pressure_cooldown_remaining_ms
+                > 0;
+            if !settled_dirty_state
+                && writer_pressure
+                && let Some(entry) = cache.entries.get_mut(&selection)
+                && dashboard_activity_pressure_reconcile_deferred(entry)
+            {
+                let mut expired_count = 0usize;
+                while entry.expiry_terminal_deltas.front().is_some_and(|delta| {
+                    parse_to_utc_datetime(&delta.occurred_at)
+                        .is_some_and(|occurred_at| occurred_at < range.start)
+                }) {
+                    if let Some(delta) = entry.expiry_terminal_deltas.pop_front() {
+                        entry.expiry_delta_estimated_bytes = entry
+                            .expiry_delta_estimated_bytes
+                            .saturating_sub(delta.estimated_bytes);
+                        subtract_dashboard_activity_compact_terminal_delta(
+                            &mut entry.response,
+                            &delta,
+                        );
+                        restore_dashboard_activity_last_invocation_after_expiry(
+                            &mut entry.response,
+                            &delta,
+                            &entry.expiry_terminal_deltas,
+                        );
+                        expired_count += 1;
+                    }
+                }
+                entry.last_reconcile_attempted_at = Instant::now();
+                entry.last_reconcile_failed = true;
+                let cache_entry_age_ms = entry.cached_at.elapsed().as_millis() as u64;
+                return Ok((
+                    entry.response.clone(),
+                    DashboardActivitySnapshotCacheOutcome {
+                        cache_hit_or_miss: "last_good_fallback",
+                        cache_bypass_reason: "writer_pressure",
+                        coalesced_waiter_count: max_waiter_count,
+                        db_build_elapsed_ms: 0,
+                        cache_ttl_ms,
+                        cache_entry_age_ms,
+                        cache_entry_count,
+                        in_flight_count,
+                        refresh_reason: "reconcile_deferred",
+                        selection_fingerprint,
+                        terminal_delta_count,
+                        duplicate_delta_count,
+                        pending_delta_count,
+                        pending_delta_estimated_bytes,
+                        persisted_ack_pending_count,
+                        delta_pruned_count,
+                        expiry_delta_count: expired_count,
+                        hard_limit_reason,
+                        baseline_cursor: entry.baseline_snapshot_cursor,
+                        sequence_gap_count,
+                        build_attempted: false,
+                        snapshot_origin: "memory",
                     },
                 ));
             }
@@ -18142,6 +18211,25 @@ mod dashboard_activity_read_model_tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn pressure_deferral_stops_after_five_minutes() {
+        let mut entry = DashboardActivitySnapshotCacheEntry {
+            cached_at: Instant::now(),
+            last_reconcile_attempted_at: Instant::now(),
+            last_reconcile_failed: false,
+            baseline_snapshot_cursor: 42,
+            expiry_covered_until: None,
+            expiry_terminal_deltas: VecDeque::new(),
+            expiry_delta_estimated_bytes: 0,
+            response: DashboardActivitySnapshot::test_stub("7d"),
+        };
+        assert!(dashboard_activity_pressure_reconcile_deferred(&entry));
+
+        entry.cached_at =
+            Instant::now() - DASHBOARD_ACTIVITY_PRESSURE_RECONCILE_MAX_AGE - Duration::from_secs(1);
+        assert!(!dashboard_activity_pressure_reconcile_deferred(&entry));
     }
 
     #[test]

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -15494,26 +15494,24 @@ async fn load_dashboard_activity_snapshot_cached(
                     dashboard_activity_snapshot_reuse_mode(entry, range, cache_ttl)
             {
                 let mut expired_count = 0usize;
-                if reuse_mode == DashboardActivitySnapshotReuseMode::Current {
-                    while entry.expiry_terminal_deltas.front().is_some_and(|delta| {
-                        parse_to_utc_datetime(&delta.occurred_at)
-                            .is_some_and(|occurred_at| occurred_at < range.start)
-                    }) {
-                        if let Some(delta) = entry.expiry_terminal_deltas.pop_front() {
-                            entry.expiry_delta_estimated_bytes = entry
-                                .expiry_delta_estimated_bytes
-                                .saturating_sub(delta.estimated_bytes);
-                            subtract_dashboard_activity_compact_terminal_delta(
-                                &mut entry.response,
-                                &delta,
-                            );
-                            restore_dashboard_activity_last_invocation_after_expiry(
-                                &mut entry.response,
-                                &delta,
-                                &entry.expiry_terminal_deltas,
-                            );
-                            expired_count += 1;
-                        }
+                while entry.expiry_terminal_deltas.front().is_some_and(|delta| {
+                    parse_to_utc_datetime(&delta.occurred_at)
+                        .is_some_and(|occurred_at| occurred_at < range.start)
+                }) {
+                    if let Some(delta) = entry.expiry_terminal_deltas.pop_front() {
+                        entry.expiry_delta_estimated_bytes = entry
+                            .expiry_delta_estimated_bytes
+                            .saturating_sub(delta.estimated_bytes);
+                        subtract_dashboard_activity_compact_terminal_delta(
+                            &mut entry.response,
+                            &delta,
+                        );
+                        restore_dashboard_activity_last_invocation_after_expiry(
+                            &mut entry.response,
+                            &delta,
+                            &entry.expiry_terminal_deltas,
+                        );
+                        expired_count += 1;
                     }
                 }
                 let cache_entry_age_ms = entry.cached_at.elapsed().as_millis() as u64;
@@ -15569,6 +15567,7 @@ async fn load_dashboard_activity_snapshot_cached(
             if !settled_dirty_state
                 && writer_pressure
                 && let Some(entry) = cache.entries.get_mut(&selection)
+                && dashboard_activity_entry_expiry_covers(entry, range)
                 && dashboard_activity_pressure_reconcile_deferred(entry)
             {
                 let mut expired_count = 0usize;

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -1364,7 +1364,7 @@ pub(crate) async fn invalidate_prompt_cache_conversations_cache(
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct ParsedUsage {
     pub(crate) input_tokens: Option<i64>,
     pub(crate) output_tokens: Option<i64>,
@@ -1373,7 +1373,7 @@ pub(crate) struct ParsedUsage {
     pub(crate) total_tokens: Option<i64>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub(crate) struct ProxyCostBreakdown {
     pub(crate) input: f64,
     pub(crate) cache_write: f64,
@@ -1388,7 +1388,7 @@ impl ProxyCostBreakdown {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct RawPayloadMeta {
     pub(crate) path: Option<String>,
     pub(crate) size_bytes: i64,
@@ -1440,7 +1440,7 @@ pub(crate) struct ResponseCaptureInfo {
     pub(crate) upstream_request_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub(crate) struct StageTimings {
     pub(crate) t_total_ms: f64,
     pub(crate) t_req_read_ms: f64,
@@ -1453,7 +1453,7 @@ pub(crate) struct StageTimings {
     pub(crate) t_persist_ms: f64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ProxyCaptureRecord {
     pub(crate) invoke_id: String,
     pub(crate) occurred_at: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,7 @@ mod sqlite_batch_writer;
     reason = "Statistics row tuples mirror persisted query shapes."
 )]
 mod stats;
+mod terminal_journal;
 #[cfg(test)]
 mod tests;
 mod upstream_accounts;
@@ -186,6 +187,7 @@ const STARTUP_BACKFILL_STATUS_IDLE: &str = "idle";
 const STARTUP_BACKFILL_STATUS_RUNNING: &str = "running";
 const STARTUP_BACKFILL_STATUS_OK: &str = "ok";
 const STARTUP_BACKFILL_STATUS_FAILED: &str = "failed";
+const STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE: &str = "source_unavailable";
 const STARTUP_BACKFILL_TASK_UPSTREAM_ACTIVITY_LIVE: &str = "upstream_activity_live_backfill_v1";
 const STARTUP_BACKFILL_TASK_UPSTREAM_ACTIVITY_ARCHIVES: &str =
     "upstream_activity_archive_backfill_v1";

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -943,6 +943,18 @@ pub(crate) async fn run_data_retention_maintenance(
     summary.invocation_rows_archived += invocation_archive.0;
     summary.archive_batches_touched += invocation_archive.1;
     summary.raw_files_removed += invocation_archive.2;
+    if !dry_run && (pruned.1 > 0 || invocation_archive.1 > 0) {
+        wake_source_unavailable_backfills(
+            pool,
+            StartupBackfillTask::UpstreamActivityArchives.name(),
+            if pruned.1 > 0 {
+                "invocation_detail_prune_archive_materialized"
+            } else {
+                "invocation_archive_materialized"
+            },
+        )
+        .await?;
+    }
 
     if should_stop_data_retention_maintenance(shutdown) {
         return Ok(summary);

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -944,6 +944,15 @@ pub(crate) async fn run_data_retention_maintenance(
     summary.archive_batches_touched += invocation_archive.1;
     summary.raw_files_removed += invocation_archive.2;
     if !dry_run && (pruned.1 > 0 || invocation_archive.1 > 0) {
+        let manifest_refresh = refresh_archive_upstream_activity_manifest(pool, false)
+            .await
+            .context("failed to refresh upstream activity manifest after invocation archive materialization")?;
+        debug!(
+            refreshed_batches = manifest_refresh.refreshed_batches,
+            pending_batches = manifest_refresh.pending_batches,
+            account_rows_written = manifest_refresh.account_rows_written,
+            "refreshed upstream activity manifest before waking archive backfill"
+        );
         wake_source_unavailable_backfills(
             pool,
             StartupBackfillTask::UpstreamActivityArchives.name(),

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -97,6 +97,9 @@ pub(crate) struct StartupBackfillProgressRow {
     last_scanned: i64,
     last_updated: i64,
     last_status: String,
+    suspension_reason: Option<String>,
+    next_probe_at: Option<String>,
+    wake_generation: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -110,6 +113,9 @@ pub(crate) struct StartupBackfillProgress {
     pub(crate) last_scanned: u64,
     pub(crate) last_updated: u64,
     pub(crate) last_status: String,
+    pub(crate) suspension_reason: Option<String>,
+    pub(crate) next_probe_at: Option<String>,
+    pub(crate) wake_generation: u64,
 }
 
 impl StartupBackfillProgress {
@@ -124,6 +130,9 @@ impl StartupBackfillProgress {
             last_scanned: 0,
             last_updated: 0,
             last_status: STARTUP_BACKFILL_STATUS_IDLE.to_string(),
+            suspension_reason: None,
+            next_probe_at: None,
+            wake_generation: 0,
         }
     }
 
@@ -147,6 +156,9 @@ impl From<StartupBackfillProgressRow> for StartupBackfillProgress {
             last_scanned: value.last_scanned.max(0) as u64,
             last_updated: value.last_updated.max(0) as u64,
             last_status: value.last_status,
+            suspension_reason: value.suspension_reason,
+            next_probe_at: value.next_probe_at,
+            wake_generation: value.wake_generation.max(0) as u64,
         }
     }
 }
@@ -158,6 +170,7 @@ pub(crate) struct StartupBackfillRunState {
     updated: u64,
     hit_scan_limit: bool,
     force_idle: bool,
+    source_unavailable: bool,
     samples: Vec<String>,
 }
 
@@ -165,7 +178,9 @@ pub(crate) fn startup_backfill_next_delay(
     run: &StartupBackfillRunState,
     zero_update_streak: u32,
 ) -> Duration {
-    if run.force_idle {
+    if run.source_unavailable {
+        Duration::from_secs(24 * 60 * 60)
+    } else if run.force_idle {
         Duration::from_secs(STARTUP_BACKFILL_IDLE_INTERVAL_SECS)
     } else if run.updated > 0 {
         Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS)
@@ -238,6 +253,7 @@ pub(crate) fn historical_rollup_startup_backfill_run_state(
             .max(bucket_progress),
         hit_scan_limit: pending_after > 0 && !permanently_blocked,
         force_idle: pending_after == 0 || permanently_blocked,
+        source_unavailable: permanently_blocked,
         samples: Vec::new(),
     }
 }
@@ -308,7 +324,10 @@ pub(crate) async fn load_startup_backfill_progress(
             last_finished_at,
             last_scanned,
             last_updated,
-            last_status
+            last_status,
+            suspension_reason,
+            next_probe_at,
+            wake_generation
         FROM startup_backfill_progress
         WHERE task_name = ?1
         LIMIT 1
@@ -338,13 +357,18 @@ pub(crate) async fn mark_startup_backfill_running(
             last_finished_at,
             last_scanned,
             last_updated,
-            last_status
+            last_status,
+            suspension_reason,
+            next_probe_at,
+            wake_generation
         )
-        VALUES (?1, ?2, NULL, 0, ?3, NULL, 0, 0, ?4)
+        VALUES (?1, ?2, NULL, 0, ?3, NULL, 0, 0, ?4, NULL, NULL, 0)
         ON CONFLICT(task_name) DO UPDATE SET
             next_run_after = NULL,
             last_started_at = excluded.last_started_at,
-            last_status = excluded.last_status
+            last_status = excluded.last_status,
+            suspension_reason = NULL,
+            next_probe_at = NULL
         "#,
     )
     .bind(task_name)
@@ -363,6 +387,7 @@ pub(crate) struct StartupBackfillProgressUpdate<'a> {
     pub(crate) zero_update_streak: u32,
     pub(crate) next_run_after: &'a str,
     pub(crate) status: &'a str,
+    pub(crate) suspension_reason: Option<&'a str>,
 }
 
 pub(crate) async fn save_startup_backfill_progress(
@@ -382,9 +407,12 @@ pub(crate) async fn save_startup_backfill_progress(
             last_finished_at,
             last_scanned,
             last_updated,
-            last_status
+            last_status,
+            suspension_reason,
+            next_probe_at,
+            wake_generation
         )
-        VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, ?7, ?8)
+        VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, ?7, ?8, ?9, ?10, 0)
         ON CONFLICT(task_name) DO UPDATE SET
             cursor_id = excluded.cursor_id,
             next_run_after = excluded.next_run_after,
@@ -392,7 +420,9 @@ pub(crate) async fn save_startup_backfill_progress(
             last_finished_at = excluded.last_finished_at,
             last_scanned = excluded.last_scanned,
             last_updated = excluded.last_updated,
-            last_status = excluded.last_status
+            last_status = excluded.last_status,
+            suspension_reason = excluded.suspension_reason,
+            next_probe_at = excluded.next_probe_at
         "#,
     )
     .bind(task_name)
@@ -403,9 +433,48 @@ pub(crate) async fn save_startup_backfill_progress(
     .bind(update.scanned as i64)
     .bind(update.updated as i64)
     .bind(update.status)
+    .bind(update.suspension_reason)
+    .bind(if update.suspension_reason.is_some() {
+        Some(update.next_run_after)
+    } else {
+        None
+    })
     .execute(pool)
     .await?;
     Ok(())
+}
+
+pub(crate) async fn wake_source_unavailable_backfills(
+    pool: &Pool<Sqlite>,
+    task_name: &str,
+    wake_reason: &'static str,
+) -> Result<u64> {
+    let outcome = sqlx::query(
+        r#"
+        UPDATE startup_backfill_progress
+        SET
+            next_run_after = NULL,
+            next_probe_at = NULL,
+            suspension_reason = NULL,
+            wake_generation = wake_generation + 1,
+            last_status = ?1
+        WHERE task_name = ?2
+          AND last_status = ?3
+        "#,
+    )
+    .bind(STARTUP_BACKFILL_STATUS_IDLE)
+    .bind(task_name)
+    .bind(STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE)
+    .execute(pool)
+    .await?;
+    let woken = outcome.rows_affected();
+    if woken > 0 {
+        info!(
+            task_name,
+            wake_reason, woken, "woke source-unavailable startup backfill"
+        );
+    }
+    Ok(woken)
 }
 
 pub(crate) async fn run_startup_backfill_maintenance_pass(
@@ -586,6 +655,7 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
         task,
         progress.cursor_id,
         progress.zero_update_streak,
+        progress.last_status == STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE,
     )
     .await
     {
@@ -606,7 +676,12 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                     updated: run.updated,
                     zero_update_streak,
                     next_run_after: &next_run_after,
-                    status: STARTUP_BACKFILL_STATUS_OK,
+                    status: if run.source_unavailable {
+                        STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE
+                    } else {
+                        STARTUP_BACKFILL_STATUS_OK
+                    },
+                    suspension_reason: run.source_unavailable.then_some("source_unavailable"),
                 },
             )
             .await?;
@@ -621,7 +696,9 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                 elapsed_ms = started_at.elapsed().as_millis() as u64,
                 next_run_after = %next_run_after,
                 actionable_backlog_count = u64::from(run.hit_scan_limit),
-                blocked_backlog_count = u64::from(run.force_idle && run.scanned > 0),
+                blocked_backlog_count = u64::from(run.source_unavailable),
+                suspension_reason = if run.source_unavailable { "source_unavailable" } else { "none" },
+                probe_budget_exhausted = false,
                 backoff_stage = match startup_backfill_next_delay(&run, zero_update_streak).as_secs() {
                     0..=15 => "15s",
                     16..=60 => "1m",
@@ -629,7 +706,7 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                     301..=900 => "15m",
                     _ => "idle",
                 },
-                wake_reason = if run.updated > 0 { "progress" } else if run.hit_scan_limit { "actionable_backlog" } else { "scheduled" },
+                wake_reason = if run.updated > 0 { "progress" } else if run.source_unavailable { "daily_probe" } else if run.hit_scan_limit { "actionable_backlog" } else { "scheduled" },
                 detail = %detail,
                 samples = %startup_backfill_samples_text(&run.samples),
                 "startup backfill pass finished"
@@ -650,6 +727,7 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                     zero_update_streak: progress.zero_update_streak,
                     next_run_after: &retry_after,
                     status: STARTUP_BACKFILL_STATUS_FAILED,
+                    suspension_reason: None,
                 },
             )
             .await?;
@@ -678,8 +756,13 @@ pub(crate) async fn run_startup_backfill_task(
     task: StartupBackfillTask,
     cursor_id: i64,
     zero_update_streak: u32,
+    source_unavailable_probe: bool,
 ) -> Result<(StartupBackfillRunState, String)> {
-    let max_elapsed = Some(Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS));
+    let max_elapsed = Some(if source_unavailable_probe {
+        Duration::from_secs(2)
+    } else {
+        Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)
+    });
     let raw_path_fallback_root = state.config.database_path.parent();
     match task {
         StartupBackfillTask::ProxyUsage => {
@@ -706,6 +789,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 detail,
@@ -748,6 +832,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 detail,
@@ -775,6 +860,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 detail,
@@ -802,6 +888,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 detail,
@@ -827,6 +914,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 detail,
@@ -854,6 +942,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 detail,
@@ -875,6 +964,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 "failure classification recalculated".to_string(),
@@ -895,6 +985,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 "attempt_public_id live rows".to_string(),
@@ -916,6 +1007,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: outcome.summary.updated_rows,
                     hit_scan_limit: outcome.hit_budget,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: outcome.samples,
                 },
                 format!(
@@ -936,6 +1028,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: updated_accounts,
                     hit_scan_limit: false,
                     force_idle: false,
+                    source_unavailable: false,
                     samples: Vec::new(),
                 },
                 format!("pending_accounts={pending_accounts}"),
@@ -944,7 +1037,11 @@ pub(crate) async fn run_startup_backfill_task(
         StartupBackfillTask::UpstreamActivityArchives => {
             let summary = backfill_upstream_account_last_activity_from_archives(
                 &state.pool,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(if source_unavailable_probe {
+                    100
+                } else {
+                    STARTUP_BACKFILL_SCAN_LIMIT
+                }),
                 max_elapsed,
             )
             .await?;
@@ -959,6 +1056,7 @@ pub(crate) async fn run_startup_backfill_task(
                     updated: summary.updated_accounts,
                     hit_scan_limit: pending_accounts > 0 && summary.hit_budget,
                     force_idle,
+                    source_unavailable: pending_accounts > 0 && force_idle,
                     samples: Vec::new(),
                 },
                 format!(
@@ -989,6 +1087,7 @@ pub(crate) async fn run_startup_backfill_task(
                     hit_scan_limit: cache_summary.hit_budget || hourly_summary.hit_budget,
                     force_idle: cache_summary.pending_batches == 0
                         && hourly_summary.pending_batches == 0,
+                    source_unavailable: false,
                     samples: Vec::new(),
                 },
                 format!(
@@ -1059,6 +1158,7 @@ pub(crate) async fn run_startup_backfill_task(
                         updated: 0,
                         hit_scan_limit: false,
                         force_idle: true,
+                        source_unavailable: false,
                         samples: Vec::new(),
                     },
                     "pending_archive_batches=0".to_string(),

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -915,17 +915,16 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
         response_source = "memory",
         "registered raw terminal record in dashboard activity read model before sqlite enqueue"
     );
-    let terminal_enqueued =
+    let terminal_enqueue =
         state
             .sqlite_batch_writer
-            .enqueue(SqliteBatchWrite::TerminalInvocation(
-                BatchedTerminalInvocationWrite {
-                    record,
-                    capture_started: Some(capture_started),
-                    raw_capture: true,
-                    dashboard_terminal_sequence: delta.terminal_sequence,
-                },
-            ));
+            .enqueue_terminal(BatchedTerminalInvocationWrite {
+                record,
+                capture_started: Some(capture_started),
+                raw_capture: true,
+                dashboard_terminal_sequence: delta.terminal_sequence,
+            });
+    let terminal_enqueued = terminal_enqueue.enqueued;
     if !terminal_enqueued {
         rollback_dashboard_activity_terminal_record(
             state,
@@ -941,6 +940,8 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
             occurred_at = %inserted_record.occurred_at,
             enqueue_failed_by_class = "raw_terminal_invocation",
             terminal_tombstone_cleared,
+            durability_mode = terminal_enqueue.durability_mode.as_str(),
+            journal_sequence = ?terminal_enqueue.journal_sequence,
             business_unblocked_record_write = true,
             record_flush_deferred_or_failed = "raw_terminal_invocation_enqueue_failed",
             "raw proxy capture record dropped by sqlite write controller"
@@ -949,6 +950,10 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
         debug!(
             invoke_id = %invoke_id,
             terminal_record_enqueue_elapsed = enqueue_started.elapsed().as_millis() as u64,
+            durability_mode = terminal_enqueue.durability_mode.as_str(),
+            journal_sequence = ?terminal_enqueue.journal_sequence,
+            journal_pending_records = terminal_enqueue.journal_pending_records,
+            journal_pending_bytes = terminal_enqueue.journal_pending_bytes,
             business_unblocked_record_write = true,
             record_flush_deferred_or_failed = "raw_terminal_invocation_enqueued_async",
             "raw proxy capture record queued for sqlite write controller"

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -3469,17 +3469,16 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_terminal_record(
         response_source = "memory",
         "registered terminal record in dashboard activity read model before sqlite enqueue"
     );
-    let terminal_enqueued =
+    let terminal_enqueue =
         state
             .sqlite_batch_writer
-            .enqueue(SqliteBatchWrite::TerminalInvocation(
-                BatchedTerminalInvocationWrite {
-                    record,
-                    capture_started: None,
-                    raw_capture: false,
-                    dashboard_terminal_sequence: delta.terminal_sequence,
-                },
-            ));
+            .enqueue_terminal(BatchedTerminalInvocationWrite {
+                record,
+                capture_started: None,
+                raw_capture: false,
+                dashboard_terminal_sequence: delta.terminal_sequence,
+            });
+    let terminal_enqueued = terminal_enqueue.enqueued;
     if !terminal_enqueued {
         rollback_dashboard_activity_terminal_record(
             state,
@@ -3495,6 +3494,8 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_terminal_record(
             occurred_at = %persisted_record.occurred_at,
             enqueue_failed_by_class = "terminal_invocation",
             terminal_tombstone_cleared,
+            durability_mode = terminal_enqueue.durability_mode.as_str(),
+            journal_sequence = ?terminal_enqueue.journal_sequence,
             business_unblocked_record_write = true,
             record_flush_deferred_or_failed = "terminal_invocation_enqueue_failed",
             "terminal proxy capture record dropped by sqlite write controller"
@@ -3503,6 +3504,10 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_terminal_record(
         debug!(
             invoke_id = %invoke_id,
             terminal_record_enqueue_elapsed = enqueue_started.elapsed().as_millis() as u64,
+            durability_mode = terminal_enqueue.durability_mode.as_str(),
+            journal_sequence = ?terminal_enqueue.journal_sequence,
+            journal_pending_records = terminal_enqueue.journal_pending_records,
+            journal_pending_bytes = terminal_enqueue.journal_pending_bytes,
             business_unblocked_record_write = true,
             record_flush_deferred_or_failed = "terminal_invocation_enqueued_async",
             "terminal proxy capture record queued for sqlite write controller"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -127,6 +127,7 @@ pub(crate) async fn run() -> Result<()> {
         pool.clone(),
         shutdown.clone(),
         prompt_cache_conversation_cache.clone(),
+        &config.database_path,
     );
     sqlite_batch_writer.set_terminal_runtime_store(proxy_runtime_invocations.clone());
     sqlite_batch_writer

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3715,6 +3715,16 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     .await
     .context("failed to ensure startup_backfill_progress table existence")?;
 
+    for (column, definition) in [
+        ("suspension_reason", "TEXT"),
+        ("next_probe_at", "TEXT"),
+        ("wake_generation", "INTEGER NOT NULL DEFAULT 0"),
+    ] {
+        ensure_column_with_definition(pool, "startup_backfill_progress", column, definition)
+            .await
+            .with_context(|| format!("failed to ensure startup_backfill_progress.{column}"))?;
+    }
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS system_task_runs (

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    path::Path,
     sync::{
         Arc,
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -18,6 +19,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use super::*;
+use crate::terminal_journal::{
+    TerminalJournal, TerminalJournalAppendOutcome, TerminalJournalDurabilityMode,
+    TerminalJournalStats,
+};
 
 pub(crate) const SQLITE_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 pub(crate) const SQLITE_BATCH_MAX_ROWS: usize = 100;
@@ -75,6 +80,15 @@ pub(crate) struct BatchedTerminalInvocationWrite {
     pub(crate) capture_started: Option<Instant>,
     pub(crate) raw_capture: bool,
     pub(crate) dashboard_terminal_sequence: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TerminalEnqueueOutcome {
+    pub(crate) enqueued: bool,
+    pub(crate) durability_mode: TerminalJournalDurabilityMode,
+    pub(crate) journal_sequence: Option<u64>,
+    pub(crate) journal_pending_records: usize,
+    pub(crate) journal_pending_bytes: u64,
 }
 
 impl BatchedTerminalInvocationWrite {
@@ -229,6 +243,34 @@ impl PendingBatch {
         std::mem::take(self)
     }
 
+    fn take_p1_terminals(&mut self) -> Self {
+        let terminal_invocations = std::mem::take(&mut self.terminal_invocations);
+        if terminal_invocations.is_empty() {
+            return Self::default();
+        }
+        Self {
+            enqueued_rows: terminal_invocations.len(),
+            terminal_invocations,
+            oldest_at: self.oldest_at,
+            ..Self::default()
+        }
+    }
+
+    fn merge_p2(&mut self, mut other: Self) {
+        self.attempt_progress.extend(other.attempt_progress.drain());
+        self.invocation_derived.extend(other.invocation_derived);
+        self.account_selected_touches
+            .extend(other.account_selected_touches.drain());
+        self.system_task_finishes
+            .extend(other.system_task_finishes.drain());
+        self.enqueued_rows = self.enqueued_rows.saturating_add(other.enqueued_rows);
+        self.coalesced_rows = self.coalesced_rows.saturating_add(other.coalesced_rows);
+        self.oldest_at = match (self.oldest_at, other.oldest_at) {
+            (Some(current), Some(other)) => Some(current.min(other)),
+            (current, other) => current.or(other),
+        };
+    }
+
     #[cfg(test)]
     fn into_writes(self) -> Vec<SqliteBatchWrite> {
         let mut writes = Vec::with_capacity(self.logical_rows());
@@ -276,6 +318,7 @@ pub(crate) struct SqliteBatchWriter {
     terminal_runtime_store: Arc<std::sync::Mutex<Option<Arc<ProxyRuntimeInvocationStore>>>>,
     dashboard_activity_snapshot_cache:
         Arc<std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>>,
+    terminal_journal: Arc<std::sync::Mutex<Option<TerminalJournal>>>,
     dashboard_reconcile_gate: Arc<Mutex<()>>,
     #[cfg(test)]
     prompt_cache_conversation_cache: Option<Arc<Mutex<PromptCacheConversationsCacheState>>>,
@@ -291,6 +334,7 @@ impl SqliteBatchWriter {
         pool: Pool<Sqlite>,
         _shutdown: CancellationToken,
         prompt_cache_conversation_cache: Arc<Mutex<PromptCacheConversationsCacheState>>,
+        database_path: &Path,
     ) -> Arc<Self> {
         let (write_sender, write_receiver) = mpsc::channel(SQLITE_BATCH_CHANNEL_CAPACITY);
         let (control_sender, control_receiver) = mpsc::channel(128);
@@ -298,6 +342,18 @@ impl SqliteBatchWriter {
         let dropped_writes = Arc::new(AtomicU64::new(0));
         let terminal_runtime_store = Arc::new(std::sync::Mutex::new(None));
         let dashboard_activity_snapshot_cache = Arc::new(std::sync::Mutex::new(None));
+        let terminal_journal = match TerminalJournal::open(database_path) {
+            Ok(journal) => Some(journal),
+            Err(err) => {
+                warn!(error = %err, path = %database_path.display(), "terminal journal unavailable; using memory durability fallback");
+                None
+            }
+        };
+        let replay_writes = terminal_journal
+            .as_ref()
+            .map(|journal| journal.stats().replay_count)
+            .unwrap_or_default();
+        let terminal_journal = Arc::new(std::sync::Mutex::new(terminal_journal));
         let dashboard_reconcile_gate = Arc::new(Mutex::new(()));
         let cache_for_task = prompt_cache_conversation_cache.clone();
         let handle = tokio::spawn(run_sqlite_batch_writer(
@@ -309,14 +365,16 @@ impl SqliteBatchWriter {
             terminal_runtime_store.clone(),
             dashboard_activity_snapshot_cache.clone(),
             dashboard_reconcile_gate.clone(),
+            terminal_journal.clone(),
         ));
-        Arc::new(Self {
+        let writer = Arc::new(Self {
             write_sender,
             control_sender,
             pending_depth,
             dropped_writes,
             terminal_runtime_store,
             dashboard_activity_snapshot_cache,
+            terminal_journal,
             dashboard_reconcile_gate,
             #[cfg(test)]
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
@@ -325,7 +383,19 @@ impl SqliteBatchWriter {
             buffered_writes: None,
             #[cfg(test)]
             auto_flush_terminal_for_test: std::sync::atomic::AtomicBool::new(true),
-        })
+        });
+        writer.terminal_journal.lock().ok().and_then(|mut journal| {
+            journal
+                .as_mut()
+                .map(TerminalJournal::queue_replay_for_dispatch)
+        });
+        if replay_writes > 0 {
+            warn!(
+                replay_count = replay_writes,
+                "requeued terminal journal records during startup"
+            );
+        }
+        writer
     }
 
     #[cfg(test)]
@@ -348,6 +418,7 @@ impl SqliteBatchWriter {
             dropped_writes: Arc::new(AtomicU64::new(0)),
             terminal_runtime_store: Arc::new(std::sync::Mutex::new(None)),
             dashboard_activity_snapshot_cache: Arc::new(std::sync::Mutex::new(None)),
+            terminal_journal: Arc::new(std::sync::Mutex::new(None)),
             dashboard_reconcile_gate: Arc::new(Mutex::new(())),
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
             handle: Mutex::new(None),
@@ -425,6 +496,103 @@ impl SqliteBatchWriter {
                 false
             }
         }
+    }
+
+    pub(crate) fn enqueue_terminal(
+        &self,
+        terminal: BatchedTerminalInvocationWrite,
+    ) -> TerminalEnqueueOutcome {
+        #[cfg(test)]
+        if self.buffered_writes.is_some() {
+            let enqueued = self.enqueue(SqliteBatchWrite::TerminalInvocation(terminal));
+            return TerminalEnqueueOutcome {
+                enqueued,
+                durability_mode: TerminalJournalDurabilityMode::MemoryOverflow,
+                journal_sequence: None,
+                journal_pending_records: 0,
+                journal_pending_bytes: 0,
+            };
+        }
+
+        let journal = self
+            .terminal_journal
+            .lock()
+            .ok()
+            .and_then(|mut journal| {
+                journal.as_mut().map(|journal| {
+                    journal.append(
+                        &terminal.record,
+                        terminal.raw_capture,
+                        terminal.capture_started,
+                    )
+                })
+            })
+            .unwrap_or(TerminalJournalAppendOutcome {
+                durability_mode: TerminalJournalDurabilityMode::MemoryOverflow,
+                sequence: None,
+                pending_records: 0,
+                pending_bytes: 0,
+            });
+        let enqueued = self.enqueue_terminal_write(
+            SqliteBatchWrite::TerminalInvocation(terminal),
+            journal.durability_mode,
+        );
+        TerminalEnqueueOutcome {
+            enqueued,
+            durability_mode: journal.durability_mode,
+            journal_sequence: journal.sequence,
+            journal_pending_records: journal.pending_records,
+            journal_pending_bytes: journal.pending_bytes,
+        }
+    }
+
+    fn enqueue_terminal_write(
+        &self,
+        write: SqliteBatchWrite,
+        durability_mode: TerminalJournalDurabilityMode,
+    ) -> bool {
+        self.pending_depth.fetch_add(1, Ordering::Relaxed);
+        match self.write_sender.try_send(write) {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Full(write)) => {
+                self.pending_depth.fetch_sub(1, Ordering::Relaxed);
+                let deferred = matches!(durability_mode, TerminalJournalDurabilityMode::Journal)
+                    && self
+                        .terminal_journal
+                        .lock()
+                        .ok()
+                        .and_then(|mut journal| {
+                            journal.as_mut().map(|journal| match write {
+                                SqliteBatchWrite::TerminalInvocation(terminal) => {
+                                    journal.defer_write(terminal)
+                                }
+                                _ => false,
+                            })
+                        })
+                        .unwrap_or(false);
+                if !deferred {
+                    self.dropped_writes.fetch_add(1, Ordering::Relaxed);
+                    warn!(
+                        "terminal journal-backed deferred queue could not accept sqlite batch write"
+                    );
+                }
+                deferred
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.pending_depth.fetch_sub(1, Ordering::Relaxed);
+                self.dropped_writes.fetch_add(1, Ordering::Relaxed);
+                warn!("terminal journal-backed retry could not reach closed sqlite batch writer");
+                false
+            }
+        }
+    }
+
+    pub(crate) fn terminal_journal_stats(&self) -> TerminalJournalStats {
+        self.terminal_journal
+            .lock()
+            .ok()
+            .and_then(|journal| journal.as_ref().map(TerminalJournal::stats))
+            .unwrap_or_default()
     }
 
     pub(crate) async fn flush_now(&self, _pool: &Pool<Sqlite>) -> Result<()> {
@@ -599,9 +767,12 @@ pub(crate) async fn run_sqlite_batch_writer(
         std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>,
     >,
     dashboard_reconcile_gate: Arc<Mutex<()>>,
+    terminal_journal: Arc<std::sync::Mutex<Option<TerminalJournal>>>,
 ) {
     let mut ticker = interval(SQLITE_BATCH_FLUSH_INTERVAL);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut journal_ticker = interval(crate::terminal_journal::TERMINAL_JOURNAL_SYNC_INTERVAL);
+    journal_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut pending = PendingBatch::default();
     let mut control_closed = false;
 
@@ -629,6 +800,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &terminal_runtime_store,
                             &dashboard_activity_snapshot_cache,
                             &dashboard_reconcile_gate,
+                            &terminal_journal,
                         )
                         .await
                         {
@@ -669,6 +841,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 &terminal_runtime_store,
                                 &dashboard_activity_snapshot_cache,
                                 &dashboard_reconcile_gate,
+                                &terminal_journal,
                             )
                             .await
                             {
@@ -697,6 +870,27 @@ pub(crate) async fn run_sqlite_batch_writer(
                     control_closed = true;
                 }
             }
+            _ = journal_ticker.tick() => {
+                if let Ok(mut guard) = terminal_journal.lock()
+                    && let Some(journal) = guard.as_mut()
+                {
+                    let deferred_capacity = SQLITE_BATCH_MAX_ROWS.saturating_sub(pending.logical_rows());
+                    let deferred = journal.take_deferred_writes(deferred_capacity);
+                    for terminal in deferred {
+                        pending.push(SqliteBatchWrite::TerminalInvocation(terminal));
+                    }
+                    if let Some(group_commit_elapsed_ms) = journal.sync_if_due() {
+                        let stats = journal.stats();
+                        debug!(
+                            group_commit_elapsed_ms,
+                            journal_pending_records = stats.pending_records,
+                            journal_pending_bytes = stats.pending_bytes,
+                            journal_segment_count = stats.segment_count,
+                            "terminal journal group commit completed"
+                        );
+                    }
+                }
+            }
             maybe_write = write_receiver.recv() => {
                 let Some(write) = maybe_write else {
                     if !pending.is_empty() {
@@ -708,6 +902,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &terminal_runtime_store,
                             &dashboard_activity_snapshot_cache,
                             &dashboard_reconcile_gate,
+                            &terminal_journal,
                         )
                         .await;
                     }
@@ -725,6 +920,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &terminal_runtime_store,
                             &dashboard_activity_snapshot_cache,
                             &dashboard_reconcile_gate,
+                            &terminal_journal,
                         )
                         .await
                     {
@@ -766,6 +962,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &terminal_runtime_store,
                             &dashboard_activity_snapshot_cache,
                             &dashboard_reconcile_gate,
+                            &terminal_journal,
                         )
                         .await
                     {
@@ -796,9 +993,13 @@ pub(crate) fn drain_queued_batch_writes(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Flush dependencies mirror the single-writer ownership boundaries."
+)]
 pub(crate) async fn flush_pending_batch(
     pool: &Pool<Sqlite>,
-    batch: PendingBatch,
+    mut batch: PendingBatch,
     reason: FlushReason,
     prompt_cache_conversation_cache: Option<&Arc<Mutex<PromptCacheConversationsCacheState>>>,
     terminal_runtime_store: &Arc<std::sync::Mutex<Option<Arc<ProxyRuntimeInvocationStore>>>>,
@@ -806,6 +1007,7 @@ pub(crate) async fn flush_pending_batch(
         std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>,
     >,
     dashboard_reconcile_gate: &Arc<Mutex<()>>,
+    terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
 ) -> Option<RetainedBatch> {
     if batch.is_empty() {
         return None;
@@ -822,27 +1024,69 @@ pub(crate) async fn flush_pending_batch(
     let oldest_age_ms = batch.age().as_millis() as u64;
 
     let flush_reason = reason.as_str();
+    let p1_batch = batch.take_p1_terminals();
+    if !p1_batch.is_empty() {
+        match flush_pending_batch_inner(
+            pool,
+            &p1_batch,
+            prompt_cache_conversation_cache,
+            terminal_runtime_store,
+            dashboard_activity_snapshot_cache,
+            dashboard_reconcile_gate,
+        )
+        .await
+        {
+            Ok(deferred) => {
+                if let Ok(mut journal) = terminal_journal.lock()
+                    && let Some(journal) = journal.as_mut()
+                {
+                    for terminal in p1_batch.terminal_invocations.values() {
+                        journal.acknowledge(
+                            &terminal.record.invoke_id,
+                            &terminal.record.occurred_at,
+                            terminal.raw_capture,
+                        );
+                    }
+                }
+                batch.merge_p2(deferred);
+            }
+            Err(err) => {
+                crate::db_pressure::global_db_pressure_gate()
+                    .record_error("sqlite_batch_writer_p1", &err);
+                warn!(
+                    error = %err,
+                    flush_priority = "P1",
+                    terminal_invocation_count,
+                    oldest_age_ms,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    flush_reason,
+                    "sqlite batch writer P1 terminal flush failed"
+                );
+                batch.terminal_invocations = p1_batch.terminal_invocations;
+                return Some(RetainedBatch {
+                    batch,
+                    failed: true,
+                });
+            }
+        }
+    }
+
+    if batch.is_empty() {
+        return None;
+    }
     let permit = if reason.bypass_pressure_gate() {
         None
     } else {
         match crate::db_pressure::global_db_pressure_gate()
-            .try_begin_background("sqlite_batch_writer")
+            .try_begin_background("sqlite_batch_writer_p2")
         {
             Ok(permit) => Some(permit),
-            Err(reason) => {
+            Err(deny_reason) => {
                 debug!(
-                    deny_reason = %reason,
-                    enqueued_rows,
-                    coalesced_rows,
-                    terminal_invocation_count,
-                    attempt_count,
-                    invocation_count,
-                    account_touch_count,
-                    system_task_count,
-                    system_task_scope = %system_task_scope,
-                    oldest_age_ms,
-                    flush_reason,
-                    "sqlite batch writer deferred flush because pressure gate is closed"
+                    deny_reason = %deny_reason,
+                    flush_priority = "P2",
+                    p2_deferred_count = batch.logical_rows(),
+                    "sqlite batch writer deferred P2 flush because pressure gate is closed"
                 );
                 return Some(RetainedBatch {
                     batch,
@@ -864,21 +1108,15 @@ pub(crate) async fn flush_pending_batch(
     {
         Ok(deferred_batch) => deferred_batch,
         Err(err) => {
-            crate::db_pressure::global_db_pressure_gate().record_error("sqlite_batch_writer", &err);
+            crate::db_pressure::global_db_pressure_gate()
+                .record_error("sqlite_batch_writer_p2", &err);
             warn!(
                 error = %err,
-                enqueued_rows,
-                coalesced_rows,
-                terminal_invocation_count,
-                attempt_count,
-                invocation_count,
-                account_touch_count,
-                system_task_count,
-                system_task_scope = %system_task_scope,
-                oldest_age_ms,
+                flush_priority = "P2",
+                p2_deferred_count = batch.logical_rows(),
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 flush_reason,
-                "sqlite batch writer flush failed"
+                "sqlite batch writer P2 flush failed"
             );
             drop(permit);
             return Some(RetainedBatch {
@@ -1472,6 +1710,7 @@ mod tests {
             pool.clone(),
             shutdown.clone(),
             Arc::new(Mutex::new(PromptCacheConversationsCacheState::default())),
+            &std::env::temp_dir().join(format!("sqlite-batch-writer-{}.db", nanoid::nanoid!())),
         );
 
         assert!(
@@ -1520,6 +1759,7 @@ mod tests {
             pool.clone(),
             shutdown.clone(),
             Arc::new(Mutex::new(PromptCacheConversationsCacheState::default())),
+            &std::env::temp_dir().join(format!("sqlite-batch-writer-{}.db", nanoid::nanoid!())),
         );
 
         assert!(
@@ -1910,6 +2150,7 @@ mod tests {
             pool.clone(),
             CancellationToken::new(),
             Arc::new(Mutex::new(PromptCacheConversationsCacheState::default())),
+            &std::env::temp_dir().join(format!("sqlite-batch-writer-{}.db", nanoid::nanoid!())),
         );
         assert!(writer.enqueue(SqliteBatchWrite::TerminalInvocation(
             BatchedTerminalInvocationWrite {

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -323,6 +323,8 @@ pub(crate) struct SqliteBatchWriter {
     #[cfg(test)]
     prompt_cache_conversation_cache: Option<Arc<Mutex<PromptCacheConversationsCacheState>>>,
     handle: Mutex<Option<JoinHandle<()>>>,
+    journal_sync_shutdown: CancellationToken,
+    journal_sync_handle: Mutex<Option<JoinHandle<()>>>,
     #[cfg(test)]
     buffered_writes: Option<Arc<std::sync::Mutex<Vec<SqliteBatchWrite>>>>,
     #[cfg(test)]
@@ -332,7 +334,7 @@ pub(crate) struct SqliteBatchWriter {
 impl SqliteBatchWriter {
     pub(crate) fn spawn(
         pool: Pool<Sqlite>,
-        _shutdown: CancellationToken,
+        shutdown: CancellationToken,
         prompt_cache_conversation_cache: Arc<Mutex<PromptCacheConversationsCacheState>>,
         database_path: &Path,
     ) -> Arc<Self> {
@@ -355,6 +357,14 @@ impl SqliteBatchWriter {
             .unwrap_or_default();
         let terminal_journal = Arc::new(std::sync::Mutex::new(terminal_journal));
         let dashboard_reconcile_gate = Arc::new(Mutex::new(()));
+        let journal_sync_shutdown = shutdown.child_token();
+        #[cfg(not(test))]
+        let journal_sync_handle = Some(tokio::spawn(run_terminal_journal_sync(
+            terminal_journal.clone(),
+            journal_sync_shutdown.clone(),
+        )));
+        #[cfg(test)]
+        let journal_sync_handle = None;
         let cache_for_task = prompt_cache_conversation_cache.clone();
         let handle = tokio::spawn(run_sqlite_batch_writer(
             pool,
@@ -379,6 +389,8 @@ impl SqliteBatchWriter {
             #[cfg(test)]
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
             handle: Mutex::new(Some(handle)),
+            journal_sync_shutdown,
+            journal_sync_handle: Mutex::new(journal_sync_handle),
             #[cfg(test)]
             buffered_writes: None,
             #[cfg(test)]
@@ -422,6 +434,8 @@ impl SqliteBatchWriter {
             dashboard_reconcile_gate: Arc::new(Mutex::new(())),
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
             handle: Mutex::new(None),
+            journal_sync_shutdown: CancellationToken::new(),
+            journal_sync_handle: Mutex::new(None),
             buffered_writes: Some(Arc::new(std::sync::Mutex::new(Vec::new()))),
             auto_flush_terminal_for_test: std::sync::atomic::AtomicBool::new(true),
         })
@@ -667,6 +681,12 @@ impl SqliteBatchWriter {
         if let Err(err) = handle.await {
             warn!(error = %err, "sqlite batch writer task failed during shutdown");
         }
+        self.journal_sync_shutdown.cancel();
+        if let Some(handle) = self.journal_sync_handle.lock().await.take()
+            && let Err(err) = handle.await
+        {
+            warn!(error = %err, "terminal journal sync task failed during shutdown");
+        }
     }
 
     #[cfg(test)]
@@ -771,8 +791,8 @@ pub(crate) async fn run_sqlite_batch_writer(
 ) {
     let mut ticker = interval(SQLITE_BATCH_FLUSH_INTERVAL);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    let mut journal_ticker = interval(crate::terminal_journal::TERMINAL_JOURNAL_SYNC_INTERVAL);
-    journal_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut deferred_ticker = interval(crate::terminal_journal::TERMINAL_JOURNAL_SYNC_INTERVAL);
+    deferred_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut pending = PendingBatch::default();
     let mut control_closed = false;
 
@@ -791,6 +811,11 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &mut pending,
                             &pending_depth,
                             queued_depth_snapshot,
+                        );
+                        drain_terminal_journal_deferred_writes(
+                            &terminal_journal,
+                            &mut pending,
+                            usize::MAX,
                         );
                         let result = match flush_pending_batch(
                             &pool,
@@ -829,6 +854,11 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &mut pending,
                             &pending_depth,
                             queued_depth_snapshot,
+                        );
+                        drain_terminal_journal_deferred_writes(
+                            &terminal_journal,
+                            &mut pending,
+                            usize::MAX,
                         );
                         let result = if pending.is_empty() {
                             Ok(())
@@ -870,29 +900,21 @@ pub(crate) async fn run_sqlite_batch_writer(
                     control_closed = true;
                 }
             }
-            _ = journal_ticker.tick() => {
-                if let Ok(mut guard) = terminal_journal.lock()
-                    && let Some(journal) = guard.as_mut()
-                {
-                    let deferred_capacity = SQLITE_BATCH_MAX_ROWS.saturating_sub(pending.logical_rows());
-                    let deferred = journal.take_deferred_writes(deferred_capacity);
-                    for terminal in deferred {
-                        pending.push(SqliteBatchWrite::TerminalInvocation(terminal));
-                    }
-                    if let Some(group_commit_elapsed_ms) = journal.sync_if_due() {
-                        let stats = journal.stats();
-                        debug!(
-                            group_commit_elapsed_ms,
-                            journal_pending_records = stats.pending_records,
-                            journal_pending_bytes = stats.pending_bytes,
-                            journal_segment_count = stats.segment_count,
-                            "terminal journal group commit completed"
-                        );
-                    }
-                }
+            _ = deferred_ticker.tick() => {
+                let deferred_capacity = SQLITE_BATCH_MAX_ROWS.saturating_sub(pending.logical_rows());
+                drain_terminal_journal_deferred_writes(
+                    &terminal_journal,
+                    &mut pending,
+                    deferred_capacity,
+                );
             }
             maybe_write = write_receiver.recv() => {
                 let Some(write) = maybe_write else {
+                    drain_terminal_journal_deferred_writes(
+                        &terminal_journal,
+                        &mut pending,
+                        usize::MAX,
+                    );
                     if !pending.is_empty() {
                         let _ = flush_pending_batch(
                             &pool,
@@ -970,6 +992,60 @@ pub(crate) async fn run_sqlite_batch_writer(
                     }
                 }
             }
+        }
+    }
+}
+
+#[cfg(not(test))]
+async fn run_terminal_journal_sync(
+    terminal_journal: Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    shutdown: CancellationToken,
+) {
+    let mut ticker = interval(crate::terminal_journal::TERMINAL_JOURNAL_SYNC_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                if let Ok(mut guard) = terminal_journal.lock()
+                    && let Some(journal) = guard.as_mut()
+                    && let Err(err) = journal.force_sync()
+                {
+                    warn!(error = %err, "terminal journal final group commit failed during shutdown");
+                }
+                return;
+            }
+            _ = ticker.tick() => {
+                if let Ok(mut guard) = terminal_journal.lock()
+                    && let Some(journal) = guard.as_mut()
+                    && let Some(group_commit_elapsed_ms) = journal.sync_if_due()
+                {
+                    let stats = journal.stats();
+                    debug!(
+                        group_commit_elapsed_ms,
+                        journal_pending_records = stats.pending_records,
+                        journal_pending_bytes = stats.pending_bytes,
+                        journal_segment_count = stats.segment_count,
+                        "terminal journal group commit completed"
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn drain_terminal_journal_deferred_writes(
+    terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    pending: &mut PendingBatch,
+    max_writes: usize,
+) {
+    if max_writes == 0 {
+        return;
+    }
+    if let Ok(mut guard) = terminal_journal.lock()
+        && let Some(journal) = guard.as_mut()
+    {
+        for terminal in journal.take_deferred_writes(max_writes) {
+            pending.push(SqliteBatchWrite::TerminalInvocation(terminal));
         }
     }
 }
@@ -2111,6 +2187,41 @@ mod tests {
         );
 
         writer.shutdown_and_drain().await;
+    }
+
+    #[test]
+    fn barrier_drain_includes_deferred_journal_terminals() {
+        let root =
+            std::env::temp_dir().join(format!("batch-writer-deferred-{}", nanoid::nanoid!()));
+        std::fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let mut journal = TerminalJournal::open(&database_path).expect("open terminal journal");
+        let record = crate::tests::test_proxy_capture_record(
+            "batch-writer-deferred-terminal",
+            "2026-07-29T00:00:00Z",
+        );
+        assert!(journal.defer_write(BatchedTerminalInvocationWrite {
+            record,
+            capture_started: None,
+            raw_capture: true,
+            dashboard_terminal_sequence: None,
+        }));
+        let journal = Arc::new(std::sync::Mutex::new(Some(journal)));
+        let mut pending = PendingBatch::default();
+
+        drain_terminal_journal_deferred_writes(&journal, &mut pending, usize::MAX);
+
+        assert_eq!(pending.terminal_invocations.len(), 1);
+        assert!(
+            journal
+                .lock()
+                .expect("lock terminal journal")
+                .as_mut()
+                .expect("terminal journal available")
+                .take_deferred_writes(usize::MAX)
+                .is_empty()
+        );
+        std::fs::remove_dir_all(root).expect("remove journal test directory");
     }
 
     #[tokio::test]

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -81,8 +81,15 @@ struct JournalSegment {
 
 impl JournalSegment {
     fn is_fully_acknowledged(&self) -> bool {
-        !self.sequences.is_empty() && self.sequences.len() == self.acknowledged.len()
+        self.sequences.is_empty() || self.sequences.len() == self.acknowledged.len()
     }
+}
+
+#[derive(Debug)]
+struct LoadedJournalSegment {
+    segment: JournalSegment,
+    entries: Vec<JournalTerminalRecord>,
+    acknowledgement_sequences: HashSet<u64>,
 }
 
 #[derive(Debug)]
@@ -98,12 +105,12 @@ pub(crate) struct TerminalJournal {
     last_sync_at: Instant,
     last_checkpoint_at: Instant,
     overflowed: bool,
+    sync_failed: bool,
 }
 
 impl TerminalJournal {
     pub(crate) fn open(database_path: &Path) -> Result<Self> {
-        let parent = database_path.parent().unwrap_or_else(|| Path::new("."));
-        let directory = parent.join("terminal_journal");
+        let directory = terminal_journal_directory(database_path);
         fs::create_dir_all(&directory).with_context(|| {
             format!(
                 "failed to create terminal journal directory {}",
@@ -125,65 +132,58 @@ impl TerminalJournal {
         paths.sort();
 
         let mut segments = BTreeMap::new();
-        let mut pending_by_key = HashMap::new();
-        let mut replay = Vec::new();
+        let mut entries = Vec::new();
+        let mut acknowledged_sequences = HashSet::new();
         let mut next_sequence = 1_u64;
         let mut pending_bytes = 0_u64;
         for path in paths {
-            let (segment, entries) = load_segment(&path)?;
-            if let Some(segment) = segment {
-                next_sequence = next_sequence.max(segment.last_sequence.saturating_add(1));
-                pending_bytes = pending_bytes.saturating_add(segment.bytes);
-                for entry in &entries {
-                    pending_by_key
-                        .entry(entry_key(entry))
-                        .or_insert_with(Vec::new)
-                        .push(entry.sequence);
-                }
-                replay.extend(
-                    entries
-                        .into_iter()
-                        .filter(|entry| !segment.acknowledged.contains(&entry.sequence)),
-                );
-                segments.insert(segment.first_sequence, segment);
-            }
+            let loaded = load_segment(&path)?;
+            next_sequence = next_sequence.max(loaded.segment.last_sequence.saturating_add(1));
+            pending_bytes = pending_bytes.saturating_add(loaded.segment.bytes);
+            acknowledged_sequences.extend(loaded.acknowledgement_sequences);
+            entries.extend(loaded.entries);
+            segments.insert(loaded.segment.first_sequence, loaded.segment);
         }
 
         let current_start = segments
             .last_key_value()
             .map(|(_, segment)| segment.first_sequence)
             .unwrap_or(next_sequence);
-        if let Some(segment) = segments.get_mut(&current_start) {
-            segment.current = true;
-        } else {
+        segments.entry(current_start).or_insert_with(|| {
             let path = segment_path(&directory, current_start);
-            let file = open_append_file(&path)?;
-            segments.insert(
-                current_start,
-                JournalSegment {
-                    path,
-                    first_sequence: current_start,
-                    last_sequence: current_start.saturating_sub(1),
-                    bytes: 0,
-                    sequences: HashSet::new(),
-                    acknowledged: HashSet::new(),
-                    current: true,
-                },
+            JournalSegment {
+                path,
+                first_sequence: current_start,
+                last_sequence: current_start.saturating_sub(1),
+                bytes: 0,
+                sequences: HashSet::new(),
+                acknowledged: HashSet::new(),
+                current: true,
+            }
+        });
+        for segment in segments.values_mut() {
+            segment.acknowledged.extend(
+                acknowledged_sequences
+                    .intersection(&segment.sequences)
+                    .copied(),
             );
-            return Ok(Self {
-                directory,
-                current_file: file,
-                segments,
-                pending_by_key,
-                next_sequence,
-                pending_bytes,
-                replay,
-                deferred_writes: VecDeque::new(),
-                last_sync_at: Instant::now(),
-                last_checkpoint_at: Instant::now(),
-                overflowed: pending_bytes >= TERMINAL_JOURNAL_MAX_BYTES,
-            });
         }
+        let mut pending_by_key = HashMap::new();
+        let mut replay = Vec::new();
+        for entry in entries {
+            if acknowledged_sequences.contains(&entry.sequence) {
+                continue;
+            }
+            pending_by_key
+                .entry(entry_key(&entry))
+                .or_insert_with(Vec::new)
+                .push(entry.sequence);
+            replay.push(entry);
+        }
+        segments
+            .get_mut(&current_start)
+            .expect("current terminal journal segment exists")
+            .current = true;
 
         let current_path = segments
             .get(&current_start)
@@ -202,6 +202,7 @@ impl TerminalJournal {
             last_sync_at: Instant::now(),
             last_checkpoint_at: Instant::now(),
             overflowed: pending_bytes >= TERMINAL_JOURNAL_MAX_BYTES,
+            sync_failed: false,
         })
     }
 
@@ -216,6 +217,9 @@ impl TerminalJournal {
             record.occurred_at.clone(),
             raw_capture,
         );
+        if self.sync_failed {
+            return self.append_outcome(TerminalJournalDurabilityMode::MemoryOverflow, None);
+        }
         if self.pending_by_key.contains_key(&key) {
             return self.append_outcome(TerminalJournalDurabilityMode::Journal, None);
         }
@@ -279,53 +283,88 @@ impl TerminalJournal {
         match self.current_file.sync_data() {
             Ok(()) => {
                 self.last_sync_at = Instant::now();
+                self.sync_failed = false;
                 Some(started.elapsed().as_millis() as u64)
             }
             Err(err) => {
                 warn!(error = %err, "terminal journal group commit failed");
                 self.overflowed = true;
+                self.sync_failed = true;
                 None
             }
         }
     }
 
     pub(crate) fn force_sync(&mut self) -> Result<()> {
-        self.current_file
-            .sync_data()
-            .context("failed to sync terminal journal")?;
-        self.last_sync_at = Instant::now();
-        Ok(())
+        match self.current_file.sync_data() {
+            Ok(()) => {
+                self.last_sync_at = Instant::now();
+                self.sync_failed = false;
+                Ok(())
+            }
+            Err(err) => {
+                self.overflowed = true;
+                self.sync_failed = true;
+                Err(err).context("failed to sync terminal journal")
+            }
+        }
     }
 
     pub(crate) fn acknowledge(&mut self, invoke_id: &str, occurred_at: &str, raw_capture: bool) {
         let key = (invoke_id.to_string(), occurred_at.to_string(), raw_capture);
-        let Some(sequences) = self.pending_by_key.remove(&key) else {
+        let Some(sequences) = self.pending_by_key.get(&key).cloned() else {
             return;
         };
+        let mut pending_sequences = Vec::new();
         for sequence in sequences {
             let Ok(encoded) = encode_acknowledgement_line(sequence) else {
                 warn!(
                     sequence,
                     "terminal journal acknowledgement serialization failed"
                 );
+                pending_sequences.push(sequence);
                 continue;
             };
             if let Err(err) = self.current_file.write_all(&encoded) {
                 warn!(error = %err, sequence, "terminal journal acknowledgement append failed");
+                pending_sequences.push(sequence);
                 continue;
             }
-            for segment in self.segments.values_mut() {
-                if segment.sequences.contains(&sequence) {
-                    segment.acknowledged.insert(sequence);
-                    segment.bytes = segment.bytes.saturating_add(encoded.len() as u64);
-                    self.pending_bytes = self.pending_bytes.saturating_add(encoded.len() as u64);
-                    break;
-                }
+            let acknowledgement_target = self.segments.iter().find_map(|(start, segment)| {
+                segment.sequences.contains(&sequence).then_some(*start)
+            });
+            if let Some(start) = acknowledgement_target {
+                self.segments
+                    .get_mut(&start)
+                    .expect("terminal journal acknowledgement target exists")
+                    .acknowledged
+                    .insert(sequence);
             }
+            let current_start = self
+                .segments
+                .iter()
+                .find_map(|(start, segment)| segment.current.then_some(*start))
+                .expect("current terminal journal segment exists");
+            let updated_current_bytes = self
+                .segments
+                .get(&current_start)
+                .expect("current terminal journal segment exists")
+                .bytes
+                .saturating_add(encoded.len() as u64);
+            self.segments
+                .get_mut(&current_start)
+                .expect("current terminal journal segment exists")
+                .bytes = updated_current_bytes;
+            self.pending_bytes = self.pending_bytes.saturating_add(encoded.len() as u64);
+        }
+        if pending_sequences.is_empty() {
+            self.pending_by_key.remove(&key);
+        } else {
+            self.pending_by_key.insert(key, pending_sequences);
         }
         self.last_checkpoint_at = Instant::now();
         self.remove_fully_acknowledged_segments();
-        if self.pending_bytes < TERMINAL_JOURNAL_MAX_BYTES * 3 / 5 {
+        if !self.sync_failed && self.pending_bytes < TERMINAL_JOURNAL_MAX_BYTES * 3 / 5 {
             self.overflowed = false;
         }
     }
@@ -453,6 +492,15 @@ fn segment_path(directory: &Path, first_sequence: u64) -> PathBuf {
     directory.join(format!("terminal-{first_sequence:020}.jsonl"))
 }
 
+fn terminal_journal_directory(database_path: &Path) -> PathBuf {
+    let parent = database_path.parent().unwrap_or_else(|| Path::new("."));
+    let database_id = format!(
+        "{:x}",
+        Sha256::digest(database_path.as_os_str().as_encoded_bytes())
+    );
+    parent.join(format!("terminal_journal-{database_id}"))
+}
+
 fn open_append_file(path: &Path) -> Result<File> {
     OpenOptions::new()
         .create(true)
@@ -462,7 +510,7 @@ fn open_append_file(path: &Path) -> Result<File> {
         .with_context(|| format!("failed to open terminal journal segment {}", path.display()))
 }
 
-fn load_segment(path: &Path) -> Result<(Option<JournalSegment>, Vec<JournalTerminalRecord>)> {
+fn load_segment(path: &Path) -> Result<LoadedJournalSegment> {
     let raw = fs::read(path)
         .with_context(|| format!("failed to read terminal journal segment {}", path.display()))?;
     let mut entries = Vec::new();
@@ -513,29 +561,42 @@ fn load_segment(path: &Path) -> Result<(Option<JournalSegment>, Vec<JournalTermi
     if corrupt_tail {
         repair_corrupt_segment_tail(path, &raw[..valid_bytes])?;
     }
-    let Some(first) = entries.first() else {
-        return Ok((None, Vec::new()));
-    };
+    let first_sequence = terminal_journal_segment_start(path)?;
     let last_sequence = entries
         .last()
         .map(|entry| entry.sequence)
-        .unwrap_or(first.sequence);
+        .unwrap_or(first_sequence.saturating_sub(1));
     let sequences = entries
         .iter()
         .map(|entry| entry.sequence)
         .collect::<HashSet<_>>();
-    Ok((
-        Some(JournalSegment {
+    Ok(LoadedJournalSegment {
+        segment: JournalSegment {
             path: path.to_path_buf(),
-            first_sequence: first.sequence,
+            first_sequence,
             last_sequence,
             bytes: valid_bytes as u64,
             sequences,
-            acknowledged,
+            acknowledged: HashSet::new(),
             current: false,
-        }),
+        },
         entries,
-    ))
+        acknowledgement_sequences: acknowledged,
+    })
+}
+
+fn terminal_journal_segment_start(path: &Path) -> Result<u64> {
+    path.file_stem()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("terminal-"))
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "invalid terminal journal segment filename: {}",
+                path.display()
+            )
+        })
 }
 
 fn encode_entry_line(entry: &JournalTerminalRecord) -> Result<Vec<u8>> {
@@ -685,7 +746,7 @@ mod tests {
 
         let reopened = TerminalJournal::open(&database_path).expect("reopen repaired journal");
         assert_eq!(reopened.stats().replay_count, 2);
-        let evidence_count = fs::read_dir(root.join("terminal_journal"))
+        let evidence_count = fs::read_dir(terminal_journal_directory(&database_path))
             .expect("read journal directory")
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext != "jsonl"))
@@ -722,6 +783,158 @@ mod tests {
                 .is_some_and(|segment| segment.current)
         );
 
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn sync_failure_downgrades_following_appends_to_memory_mode() {
+        let root =
+            std::env::temp_dir().join(format!("terminal-journal-sync-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let record =
+            crate::tests::test_proxy_capture_record("journal-sync-failed", "2026-07-29T00:00:00Z");
+        let mut journal = TerminalJournal::open(&database_path).expect("open journal");
+        journal.sync_failed = true;
+
+        let outcome = journal.append(&record, false, None);
+        assert_eq!(
+            outcome.durability_mode,
+            TerminalJournalDurabilityMode::MemoryOverflow
+        );
+        assert_eq!(outcome.sequence, None);
+
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn acknowledged_restart_key_does_not_block_a_new_terminal_entry() {
+        let root =
+            std::env::temp_dir().join(format!("terminal-journal-rekey-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let record =
+            crate::tests::test_proxy_capture_record("journal-rekey", "2026-07-29T00:00:00Z");
+
+        let mut journal = TerminalJournal::open(&database_path).expect("open journal");
+        journal.append(&record, false, None);
+        journal.force_sync().expect("sync entry");
+        journal.acknowledge(&record.invoke_id, &record.occurred_at, false);
+        journal.force_sync().expect("sync acknowledgement");
+        drop(journal);
+
+        let mut reopened = TerminalJournal::open(&database_path).expect("reopen journal");
+        assert_eq!(reopened.stats().pending_records, 0);
+        let outcome = reopened.append(&record, false, None);
+        assert_eq!(
+            outcome.durability_mode,
+            TerminalJournalDurabilityMode::Journal
+        );
+        assert!(outcome.sequence.is_some());
+        reopened.force_sync().expect("sync replacement entry");
+        drop(reopened);
+
+        let reopened = TerminalJournal::open(&database_path).expect("reopen replacement entry");
+        assert_eq!(reopened.stats().replay_count, 1);
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn restart_applies_acknowledgement_written_in_a_later_segment() {
+        let root =
+            std::env::temp_dir().join(format!("terminal-journal-cross-ack-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let first =
+            crate::tests::test_proxy_capture_record("journal-cross-ack-1", "2026-07-29T00:00:00Z");
+        let retained =
+            crate::tests::test_proxy_capture_record("journal-cross-ack-2", "2026-07-29T00:01:00Z");
+        let current =
+            crate::tests::test_proxy_capture_record("journal-cross-ack-3", "2026-07-29T00:02:00Z");
+
+        let mut journal = TerminalJournal::open(&database_path).expect("open journal");
+        journal.append(&first, false, None);
+        journal.append(&retained, false, None);
+        let first_segment = journal
+            .segments
+            .iter()
+            .find_map(|(start, segment)| segment.current.then_some(*start))
+            .expect("first segment");
+        journal
+            .segments
+            .get_mut(&first_segment)
+            .expect("first segment")
+            .bytes = TERMINAL_JOURNAL_SEGMENT_BYTES;
+        journal.append(&current, false, None);
+        let current_segment = journal
+            .segments
+            .iter()
+            .find_map(|(start, segment)| segment.current.then_some(*start))
+            .expect("current segment");
+        let first_segment_bytes = journal
+            .segments
+            .get(&first_segment)
+            .expect("first segment")
+            .bytes;
+        let current_segment_bytes = journal
+            .segments
+            .get(&current_segment)
+            .expect("current segment")
+            .bytes;
+
+        journal.acknowledge(&first.invoke_id, &first.occurred_at, false);
+        assert_eq!(
+            journal
+                .segments
+                .get(&first_segment)
+                .expect("first segment")
+                .bytes,
+            first_segment_bytes
+        );
+        assert!(
+            journal
+                .segments
+                .get(&current_segment)
+                .expect("current segment")
+                .bytes
+                > current_segment_bytes
+        );
+        journal.force_sync().expect("sync journal");
+        drop(journal);
+
+        let mut reopened = TerminalJournal::open(&database_path).expect("reopen journal");
+        let replay = reopened.take_replay();
+        let replayed_ids = replay
+            .iter()
+            .map(|write| write.record.invoke_id.as_str())
+            .collect::<HashSet<_>>();
+        assert_eq!(replayed_ids.len(), 2);
+        assert!(replayed_ids.contains(retained.invoke_id.as_str()));
+        assert!(replayed_ids.contains(current.invoke_id.as_str()));
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn journals_are_isolated_for_databases_in_the_same_directory() {
+        let root =
+            std::env::temp_dir().join(format!("terminal-journal-isolation-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let first_database = root.join("first.db");
+        let second_database = root.join("second.db");
+        let record =
+            crate::tests::test_proxy_capture_record("journal-isolated", "2026-07-29T00:00:00Z");
+
+        let mut first = TerminalJournal::open(&first_database).expect("open first journal");
+        first.append(&record, false, None);
+        first.force_sync().expect("sync first journal");
+        drop(first);
+
+        let second = TerminalJournal::open(&second_database).expect("open second journal");
+        assert_eq!(second.stats().replay_count, 0);
+        assert_ne!(
+            terminal_journal_directory(&first_database),
+            terminal_journal_directory(&second_database)
+        );
         fs::remove_dir_all(root).expect("remove journal test directory");
     }
 }

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -1,0 +1,727 @@
+use std::{
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::warn;
+
+use crate::{BatchedTerminalInvocationWrite, ProxyCaptureRecord};
+
+pub(crate) const TERMINAL_JOURNAL_SEGMENT_BYTES: u64 = 16 * 1024 * 1024;
+pub(crate) const TERMINAL_JOURNAL_MAX_BYTES: u64 = 512 * 1024 * 1024;
+pub(crate) const TERMINAL_JOURNAL_SYNC_INTERVAL: Duration = Duration::from_millis(20);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TerminalJournalDurabilityMode {
+    Journal,
+    MemoryOverflow,
+}
+
+impl TerminalJournalDurabilityMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Journal => "journal",
+            Self::MemoryOverflow => "memory_overflow",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TerminalJournalAppendOutcome {
+    pub(crate) durability_mode: TerminalJournalDurabilityMode,
+    pub(crate) sequence: Option<u64>,
+    pub(crate) pending_records: usize,
+    pub(crate) pending_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct TerminalJournalStats {
+    pub(crate) pending_records: usize,
+    pub(crate) pending_bytes: u64,
+    pub(crate) segment_count: usize,
+    pub(crate) replay_count: usize,
+    pub(crate) checkpoint_lag_ms: u64,
+    pub(crate) overflowed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JournalTerminalRecord {
+    sequence: u64,
+    raw_capture: bool,
+    #[serde(default)]
+    capture_elapsed_ms: Option<u64>,
+    record: ProxyCaptureRecord,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JournalLine {
+    #[serde(default)]
+    entry: Option<JournalTerminalRecord>,
+    #[serde(default)]
+    acknowledged_sequence: Option<u64>,
+    checksum: String,
+}
+
+#[derive(Debug)]
+struct JournalSegment {
+    path: PathBuf,
+    first_sequence: u64,
+    last_sequence: u64,
+    bytes: u64,
+    sequences: HashSet<u64>,
+    acknowledged: HashSet<u64>,
+    current: bool,
+}
+
+impl JournalSegment {
+    fn is_fully_acknowledged(&self) -> bool {
+        !self.sequences.is_empty() && self.sequences.len() == self.acknowledged.len()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TerminalJournal {
+    directory: PathBuf,
+    current_file: File,
+    segments: BTreeMap<u64, JournalSegment>,
+    pending_by_key: HashMap<(String, String, bool), Vec<u64>>,
+    next_sequence: u64,
+    pending_bytes: u64,
+    replay: Vec<JournalTerminalRecord>,
+    deferred_writes: VecDeque<BatchedTerminalInvocationWrite>,
+    last_sync_at: Instant,
+    last_checkpoint_at: Instant,
+    overflowed: bool,
+}
+
+impl TerminalJournal {
+    pub(crate) fn open(database_path: &Path) -> Result<Self> {
+        let parent = database_path.parent().unwrap_or_else(|| Path::new("."));
+        let directory = parent.join("terminal_journal");
+        fs::create_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to create terminal journal directory {}",
+                directory.display()
+            )
+        })?;
+
+        let mut paths = fs::read_dir(&directory)
+            .with_context(|| {
+                format!(
+                    "failed to list terminal journal directory {}",
+                    directory.display()
+                )
+            })?
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "jsonl"))
+            .collect::<Vec<_>>();
+        paths.sort();
+
+        let mut segments = BTreeMap::new();
+        let mut pending_by_key = HashMap::new();
+        let mut replay = Vec::new();
+        let mut next_sequence = 1_u64;
+        let mut pending_bytes = 0_u64;
+        for path in paths {
+            let (segment, entries) = load_segment(&path)?;
+            if let Some(segment) = segment {
+                next_sequence = next_sequence.max(segment.last_sequence.saturating_add(1));
+                pending_bytes = pending_bytes.saturating_add(segment.bytes);
+                for entry in &entries {
+                    pending_by_key
+                        .entry(entry_key(entry))
+                        .or_insert_with(Vec::new)
+                        .push(entry.sequence);
+                }
+                replay.extend(
+                    entries
+                        .into_iter()
+                        .filter(|entry| !segment.acknowledged.contains(&entry.sequence)),
+                );
+                segments.insert(segment.first_sequence, segment);
+            }
+        }
+
+        let current_start = segments
+            .last_key_value()
+            .map(|(_, segment)| segment.first_sequence)
+            .unwrap_or(next_sequence);
+        if let Some(segment) = segments.get_mut(&current_start) {
+            segment.current = true;
+        } else {
+            let path = segment_path(&directory, current_start);
+            let file = open_append_file(&path)?;
+            segments.insert(
+                current_start,
+                JournalSegment {
+                    path,
+                    first_sequence: current_start,
+                    last_sequence: current_start.saturating_sub(1),
+                    bytes: 0,
+                    sequences: HashSet::new(),
+                    acknowledged: HashSet::new(),
+                    current: true,
+                },
+            );
+            return Ok(Self {
+                directory,
+                current_file: file,
+                segments,
+                pending_by_key,
+                next_sequence,
+                pending_bytes,
+                replay,
+                deferred_writes: VecDeque::new(),
+                last_sync_at: Instant::now(),
+                last_checkpoint_at: Instant::now(),
+                overflowed: pending_bytes >= TERMINAL_JOURNAL_MAX_BYTES,
+            });
+        }
+
+        let current_path = segments
+            .get(&current_start)
+            .expect("current terminal journal segment exists")
+            .path
+            .clone();
+        Ok(Self {
+            directory,
+            current_file: open_append_file(&current_path)?,
+            segments,
+            pending_by_key,
+            next_sequence,
+            pending_bytes,
+            replay,
+            deferred_writes: VecDeque::new(),
+            last_sync_at: Instant::now(),
+            last_checkpoint_at: Instant::now(),
+            overflowed: pending_bytes >= TERMINAL_JOURNAL_MAX_BYTES,
+        })
+    }
+
+    pub(crate) fn append(
+        &mut self,
+        record: &ProxyCaptureRecord,
+        raw_capture: bool,
+        capture_started: Option<Instant>,
+    ) -> TerminalJournalAppendOutcome {
+        let key = (
+            record.invoke_id.clone(),
+            record.occurred_at.clone(),
+            raw_capture,
+        );
+        if self.pending_by_key.contains_key(&key) {
+            return self.append_outcome(TerminalJournalDurabilityMode::Journal, None);
+        }
+        let entry = JournalTerminalRecord {
+            sequence: self.next_sequence,
+            raw_capture,
+            capture_elapsed_ms: capture_started
+                .map(|started| started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64),
+            record: record.clone(),
+        };
+        let Ok(encoded) = encode_entry_line(&entry) else {
+            warn!(invoke_id = %record.invoke_id, occurred_at = %record.occurred_at, "terminal journal serialization failed; using memory fallback");
+            self.overflowed = true;
+            return self.append_outcome(TerminalJournalDurabilityMode::MemoryOverflow, None);
+        };
+        let encoded_len = encoded.len() as u64;
+        if self.pending_bytes.saturating_add(encoded_len) > TERMINAL_JOURNAL_MAX_BYTES {
+            self.overflowed = true;
+            warn!(
+                journal_pending_bytes = self.pending_bytes,
+                journal_max_bytes = TERMINAL_JOURNAL_MAX_BYTES,
+                invoke_id = %record.invoke_id,
+                occurred_at = %record.occurred_at,
+                "terminal journal reached capacity; using memory fallback"
+            );
+            return self.append_outcome(TerminalJournalDurabilityMode::MemoryOverflow, None);
+        }
+        if let Err(err) = self.rotate_if_needed(encoded_len) {
+            warn!(error = %err, "terminal journal rotation failed; using memory fallback");
+            self.overflowed = true;
+            return self.append_outcome(TerminalJournalDurabilityMode::MemoryOverflow, None);
+        }
+        if let Err(err) = self.current_file.write_all(&encoded) {
+            warn!(error = %err, "terminal journal append failed; using memory fallback");
+            self.overflowed = true;
+            return self.append_outcome(TerminalJournalDurabilityMode::MemoryOverflow, None);
+        }
+        let current_start = self
+            .segments
+            .iter()
+            .find_map(|(start, segment)| segment.current.then_some(*start))
+            .expect("current terminal journal segment exists");
+        let segment = self
+            .segments
+            .get_mut(&current_start)
+            .expect("current terminal journal segment exists");
+        segment.last_sequence = entry.sequence;
+        segment.bytes = segment.bytes.saturating_add(encoded_len);
+        segment.sequences.insert(entry.sequence);
+        self.pending_by_key.insert(key, vec![entry.sequence]);
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.pending_bytes = self.pending_bytes.saturating_add(encoded_len);
+        self.append_outcome(TerminalJournalDurabilityMode::Journal, Some(entry.sequence))
+    }
+
+    pub(crate) fn sync_if_due(&mut self) -> Option<u64> {
+        if self.last_sync_at.elapsed() < TERMINAL_JOURNAL_SYNC_INTERVAL {
+            return None;
+        }
+        let started = Instant::now();
+        match self.current_file.sync_data() {
+            Ok(()) => {
+                self.last_sync_at = Instant::now();
+                Some(started.elapsed().as_millis() as u64)
+            }
+            Err(err) => {
+                warn!(error = %err, "terminal journal group commit failed");
+                self.overflowed = true;
+                None
+            }
+        }
+    }
+
+    pub(crate) fn force_sync(&mut self) -> Result<()> {
+        self.current_file
+            .sync_data()
+            .context("failed to sync terminal journal")?;
+        self.last_sync_at = Instant::now();
+        Ok(())
+    }
+
+    pub(crate) fn acknowledge(&mut self, invoke_id: &str, occurred_at: &str, raw_capture: bool) {
+        let key = (invoke_id.to_string(), occurred_at.to_string(), raw_capture);
+        let Some(sequences) = self.pending_by_key.remove(&key) else {
+            return;
+        };
+        for sequence in sequences {
+            let Ok(encoded) = encode_acknowledgement_line(sequence) else {
+                warn!(
+                    sequence,
+                    "terminal journal acknowledgement serialization failed"
+                );
+                continue;
+            };
+            if let Err(err) = self.current_file.write_all(&encoded) {
+                warn!(error = %err, sequence, "terminal journal acknowledgement append failed");
+                continue;
+            }
+            for segment in self.segments.values_mut() {
+                if segment.sequences.contains(&sequence) {
+                    segment.acknowledged.insert(sequence);
+                    segment.bytes = segment.bytes.saturating_add(encoded.len() as u64);
+                    self.pending_bytes = self.pending_bytes.saturating_add(encoded.len() as u64);
+                    break;
+                }
+            }
+        }
+        self.last_checkpoint_at = Instant::now();
+        self.remove_fully_acknowledged_segments();
+        if self.pending_bytes < TERMINAL_JOURNAL_MAX_BYTES * 3 / 5 {
+            self.overflowed = false;
+        }
+    }
+
+    pub(crate) fn take_replay(&mut self) -> Vec<BatchedTerminalInvocationWrite> {
+        let replay = std::mem::take(&mut self.replay);
+        replay
+            .into_iter()
+            .map(|entry| BatchedTerminalInvocationWrite {
+                record: entry.record,
+                capture_started: entry.capture_elapsed_ms.and_then(|elapsed_ms| {
+                    Instant::now().checked_sub(Duration::from_millis(elapsed_ms))
+                }),
+                raw_capture: entry.raw_capture,
+                dashboard_terminal_sequence: None,
+            })
+            .collect()
+    }
+
+    pub(crate) fn defer_write(&mut self, write: BatchedTerminalInvocationWrite) -> bool {
+        self.deferred_writes.push_back(write);
+        true
+    }
+
+    pub(crate) fn queue_replay_for_dispatch(&mut self) {
+        let replay = self.take_replay();
+        self.deferred_writes.extend(replay);
+    }
+
+    pub(crate) fn take_deferred_writes(
+        &mut self,
+        max_writes: usize,
+    ) -> Vec<BatchedTerminalInvocationWrite> {
+        let count = max_writes.min(self.deferred_writes.len());
+        self.deferred_writes.drain(..count).collect()
+    }
+
+    pub(crate) fn stats(&self) -> TerminalJournalStats {
+        TerminalJournalStats {
+            pending_records: self.pending_by_key.len(),
+            pending_bytes: self.pending_bytes,
+            segment_count: self.segments.len(),
+            replay_count: self.replay.len(),
+            checkpoint_lag_ms: self.last_checkpoint_at.elapsed().as_millis() as u64,
+            overflowed: self.overflowed,
+        }
+    }
+
+    fn append_outcome(
+        &self,
+        durability_mode: TerminalJournalDurabilityMode,
+        sequence: Option<u64>,
+    ) -> TerminalJournalAppendOutcome {
+        let stats = self.stats();
+        TerminalJournalAppendOutcome {
+            durability_mode,
+            sequence,
+            pending_records: stats.pending_records,
+            pending_bytes: stats.pending_bytes,
+        }
+    }
+
+    fn rotate_if_needed(&mut self, next_len: u64) -> Result<()> {
+        let current_start = self
+            .segments
+            .iter()
+            .find_map(|(start, segment)| segment.current.then_some(*start))
+            .expect("current terminal journal segment exists");
+        let should_rotate = self.segments.get(&current_start).is_some_and(|segment| {
+            segment.bytes > 0
+                && segment.bytes.saturating_add(next_len) > TERMINAL_JOURNAL_SEGMENT_BYTES
+        });
+        if !should_rotate {
+            return Ok(());
+        }
+        self.current_file
+            .sync_data()
+            .context("failed to sync terminal journal before rotation")?;
+        let start = self.next_sequence;
+        let path = segment_path(&self.directory, start);
+        let next_file = open_append_file(&path)?;
+        self.segments
+            .get_mut(&current_start)
+            .expect("current terminal journal segment exists")
+            .current = false;
+        self.current_file = next_file;
+        self.segments.insert(
+            start,
+            JournalSegment {
+                path,
+                first_sequence: start,
+                last_sequence: start.saturating_sub(1),
+                bytes: 0,
+                sequences: HashSet::new(),
+                acknowledged: HashSet::new(),
+                current: true,
+            },
+        );
+        self.remove_fully_acknowledged_segments();
+        Ok(())
+    }
+
+    fn remove_fully_acknowledged_segments(&mut self) {
+        let removable = self
+            .segments
+            .iter()
+            .filter_map(|(start, segment)| {
+                (!segment.current && segment.is_fully_acknowledged()).then_some(*start)
+            })
+            .collect::<Vec<_>>();
+        for start in removable {
+            if let Some(segment) = self.segments.remove(&start) {
+                if let Err(err) = fs::remove_file(&segment.path) {
+                    warn!(error = %err, path = %segment.path.display(), "failed to remove acknowledged terminal journal segment");
+                    self.segments.insert(start, segment);
+                } else {
+                    self.pending_bytes = self.pending_bytes.saturating_sub(segment.bytes);
+                }
+            }
+        }
+    }
+}
+
+fn segment_path(directory: &Path, first_sequence: u64) -> PathBuf {
+    directory.join(format!("terminal-{first_sequence:020}.jsonl"))
+}
+
+fn open_append_file(path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .read(true)
+        .open(path)
+        .with_context(|| format!("failed to open terminal journal segment {}", path.display()))
+}
+
+fn load_segment(path: &Path) -> Result<(Option<JournalSegment>, Vec<JournalTerminalRecord>)> {
+    let raw = fs::read(path)
+        .with_context(|| format!("failed to read terminal journal segment {}", path.display()))?;
+    let mut entries = Vec::new();
+    let mut acknowledged = HashSet::new();
+    let mut valid_bytes = 0usize;
+    let mut corrupt_tail = false;
+    for (line_number, raw_line) in raw.split_inclusive(|byte| *byte == b'\n').enumerate() {
+        if !raw_line.ends_with(b"\n") {
+            corrupt_tail = true;
+            break;
+        }
+        let line = match std::str::from_utf8(&raw_line[..raw_line.len() - 1]) {
+            Ok(line) => line,
+            Err(_) => {
+                corrupt_tail = true;
+                break;
+            }
+        };
+        if line.trim().is_empty() {
+            valid_bytes += raw_line.len();
+            continue;
+        }
+        let parsed = serde_json::from_str::<JournalLine>(line);
+        let Ok(line) = parsed else {
+            warn!(path = %path.display(), line_number, "terminal journal has corrupt line; repairing segment tail");
+            corrupt_tail = true;
+            break;
+        };
+        if journal_line_checksum(line.entry.as_ref(), line.acknowledged_sequence)? != line.checksum
+        {
+            warn!(path = %path.display(), line_number, "terminal journal checksum mismatch; repairing segment tail");
+            corrupt_tail = true;
+            break;
+        }
+        match (line.entry, line.acknowledged_sequence) {
+            (Some(entry), None) => entries.push(entry),
+            (None, Some(sequence)) => {
+                acknowledged.insert(sequence);
+            }
+            _ => {
+                warn!(path = %path.display(), line_number, "terminal journal line has invalid event shape; repairing segment tail");
+                corrupt_tail = true;
+                break;
+            }
+        }
+        valid_bytes += raw_line.len();
+    }
+    if corrupt_tail {
+        repair_corrupt_segment_tail(path, &raw[..valid_bytes])?;
+    }
+    let Some(first) = entries.first() else {
+        return Ok((None, Vec::new()));
+    };
+    let last_sequence = entries
+        .last()
+        .map(|entry| entry.sequence)
+        .unwrap_or(first.sequence);
+    let sequences = entries
+        .iter()
+        .map(|entry| entry.sequence)
+        .collect::<HashSet<_>>();
+    Ok((
+        Some(JournalSegment {
+            path: path.to_path_buf(),
+            first_sequence: first.sequence,
+            last_sequence,
+            bytes: valid_bytes as u64,
+            sequences,
+            acknowledged,
+            current: false,
+        }),
+        entries,
+    ))
+}
+
+fn encode_entry_line(entry: &JournalTerminalRecord) -> Result<Vec<u8>> {
+    let line = JournalLine {
+        entry: Some(entry.clone()),
+        acknowledged_sequence: None,
+        checksum: journal_line_checksum(Some(entry), None)?,
+    };
+    let mut bytes = serde_json::to_vec(&line).context("failed to encode terminal journal line")?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn encode_acknowledgement_line(sequence: u64) -> Result<Vec<u8>> {
+    let line = JournalLine {
+        entry: None,
+        acknowledged_sequence: Some(sequence),
+        checksum: journal_line_checksum(None, Some(sequence))?,
+    };
+    let mut bytes =
+        serde_json::to_vec(&line).context("failed to encode terminal journal acknowledgement")?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn journal_line_checksum(
+    entry: Option<&JournalTerminalRecord>,
+    acknowledged_sequence: Option<u64>,
+) -> Result<String> {
+    let encoded = serde_json::to_vec(&(entry, acknowledged_sequence))
+        .context("failed to checksum terminal journal event")?;
+    Ok(format!("{:x}", Sha256::digest(encoded)))
+}
+
+fn repair_corrupt_segment_tail(path: &Path, valid_prefix: &[u8]) -> Result<()> {
+    let evidence_path = path.with_extension(format!(
+        "jsonl.corrupt-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+    fs::rename(path, &evidence_path).with_context(|| {
+        format!(
+            "failed to preserve corrupt terminal journal segment {}",
+            path.display()
+        )
+    })?;
+    fs::write(path, valid_prefix).with_context(|| {
+        format!(
+            "failed to rebuild terminal journal segment {} after corruption",
+            path.display()
+        )
+    })?;
+    warn!(
+        path = %path.display(),
+        evidence_path = %evidence_path.display(),
+        valid_prefix_bytes = valid_prefix.len(),
+        "repaired terminal journal corrupt tail while preserving evidence"
+    );
+    Ok(())
+}
+
+fn entry_key(entry: &JournalTerminalRecord) -> (String, String, bool) {
+    (
+        entry.record.invoke_id.clone(),
+        entry.record.occurred_at.clone(),
+        entry.raw_capture,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replays_unacknowledged_record_and_clears_pending_ack() {
+        let root = std::env::temp_dir().join(format!("terminal-journal-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let record = crate::tests::test_proxy_capture_record("journal-1", "2026-07-29T00:00:00Z");
+
+        let mut journal = TerminalJournal::open(&database_path).expect("open journal");
+        let capture_started = Instant::now()
+            .checked_sub(Duration::from_millis(50))
+            .expect("capture start should precede now");
+        let outcome = journal.append(&record, false, Some(capture_started));
+        assert_eq!(
+            outcome.durability_mode,
+            TerminalJournalDurabilityMode::Journal
+        );
+        assert_eq!(outcome.pending_records, 1);
+        journal.force_sync().expect("sync journal");
+        drop(journal);
+
+        let mut replayed = TerminalJournal::open(&database_path).expect("reopen journal");
+        assert_eq!(replayed.stats().replay_count, 1);
+        let replay = replayed.take_replay();
+        assert_eq!(replay.len(), 1);
+        let replayed_capture_started = replay[0]
+            .capture_started
+            .expect("replay should preserve raw capture timing");
+        assert!(replayed_capture_started.elapsed() >= Duration::from_millis(50));
+        replayed.acknowledge("journal-1", "2026-07-29T00:00:00Z", false);
+        replayed.force_sync().expect("sync acknowledgement");
+        assert_eq!(replayed.stats().pending_records, 0);
+        drop(replayed);
+
+        let replayed_after_ack =
+            TerminalJournal::open(&database_path).expect("reopen acknowledged journal");
+        assert_eq!(replayed_after_ack.stats().replay_count, 0);
+
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn repairs_corrupt_tail_before_accepting_new_records() {
+        let root =
+            std::env::temp_dir().join(format!("terminal-journal-corrupt-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let first =
+            crate::tests::test_proxy_capture_record("journal-corrupt-1", "2026-07-29T00:00:00Z");
+        let second =
+            crate::tests::test_proxy_capture_record("journal-corrupt-2", "2026-07-29T00:01:00Z");
+
+        let mut journal = TerminalJournal::open(&database_path).expect("open journal");
+        journal.append(&first, false, None);
+        journal.force_sync().expect("sync journal");
+        let segment_path = journal
+            .segments
+            .values()
+            .find(|segment| segment.current)
+            .expect("current segment")
+            .path
+            .clone();
+        drop(journal);
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&segment_path)
+            .expect("open journal for corruption")
+            .write_all(b"{torn")
+            .expect("append corrupt tail");
+
+        let mut repaired = TerminalJournal::open(&database_path).expect("repair journal tail");
+        assert_eq!(repaired.stats().replay_count, 1);
+        repaired.append(&second, false, None);
+        repaired.force_sync().expect("sync repaired journal");
+        drop(repaired);
+
+        let reopened = TerminalJournal::open(&database_path).expect("reopen repaired journal");
+        assert_eq!(reopened.stats().replay_count, 2);
+        let evidence_count = fs::read_dir(root.join("terminal_journal"))
+            .expect("read journal directory")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext != "jsonl"))
+            .count();
+        assert_eq!(evidence_count, 1);
+
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn rotation_open_failure_keeps_existing_segment_current() {
+        let root =
+            std::env::temp_dir().join(format!("terminal-journal-rotation-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let mut journal = TerminalJournal::open(&database_path).expect("open journal");
+        let current_start = journal
+            .segments
+            .iter()
+            .find_map(|(start, segment)| segment.current.then_some(*start))
+            .expect("current segment");
+        journal
+            .segments
+            .get_mut(&current_start)
+            .expect("current segment")
+            .bytes = TERMINAL_JOURNAL_SEGMENT_BYTES;
+        journal.directory = root.join("missing-journal-directory");
+
+        assert!(journal.rotate_if_needed(1).is_err());
+        assert!(
+            journal
+                .segments
+                .get(&current_start)
+                .is_some_and(|segment| segment.current)
+        );
+
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+}

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1094,6 +1094,7 @@ async fn startup_backfill_not_due_check_does_not_claim_background_gate() {
             zero_update_streak: 0,
             next_run_after: &next_run_after,
             status: STARTUP_BACKFILL_STATUS_OK,
+            suspension_reason: None,
         },
     )
     .await
@@ -2402,6 +2403,7 @@ async fn upstream_last_activity_archive_backfill_retries_after_failed_progress()
             zero_update_streak: 0,
             next_run_after: &retry_due,
             status: STARTUP_BACKFILL_STATUS_FAILED,
+            suspension_reason: None,
         },
     )
     .await


### PR DESCRIPTION
## Summary\n- Add a segmented terminal journal and P1 raw-terminal persistence path so derived writes cannot extend terminal lock windows.\n- Defer Dashboard open-range reconcile during writer pressure while serving last-good in-memory snapshots.\n- Suspend source-unavailable historical backfill jobs until an archive recovery event or bounded daily probe.\n\n## Validation\n- cargo fmt --check\n- cargo check\n- cd web && bunx tsc -b\n- cargo test -q terminal_journal\n- cargo test -q pressure_deferral_stops_after_five_minutes\n- cargo test -q startup_backfill\n- Commit hooks: format-markdown, fmt, typecheck-web, check, commitlint\n\n## References\n- Specs: docs/specs/5932d-sse-proxy-live-sync, docs/specs/z6ysw-dashboard-account-activity-tabs, docs/specs/gz5ns-dashboard-natural-day-kpi-semantics\n- Solutions: docs/solutions/performance/sqlite-write-pressure-backpressure.md, docs/solutions/performance/realtime-dashboard-reconcile-budget.md\n- Project Docs: -\n\n## Notes\n- The Codex review CLI failed to initialize twice before producing review output; the diff was manually reviewed and the local check gates passed.