### PR TITLE
fix(proxy): reduce raw capture and timeseries cpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "crc32fast",
  "dotenvy",
  "filetime",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ sha2 = "0.10"
 libc = "0.2"
 httpdate = "1.0"
 zstd = "0.13"
+crc32fast = "1.4"
 tokio-tungstenite = { version = "0.28", default-features = false, features = ["rustls-tls-webpki-roots", "connect"] }
 tungstenite = { version = "0.28", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false }

--- a/docs/solutions/performance/proxy-capture-body-replay-safety.md
+++ b/docs/solutions/performance/proxy-capture-body-replay-safety.md
@@ -29,6 +29,8 @@ Proxy capture endpoints need to forward requests quickly, but they also own raw 
 
 The capture path historically used one full in-memory request body as both routing input and raw capture input. That makes large bodies expensive, but replacing it with unconditional live-first would bypass semantic checks that require full request knowledge.
 
+For response capture, compression must be treated as a storage concern. Preserve already encoded wire bytes, use Zstd only for identity bytes, and queue work behind a bounded writer pool. Dropping an enabled capture because a CPU writer is busy hides overload and makes replay completeness nondeterministic.
+
 ## Resolution
 
 - Put capture request reads on the same replay snapshot control plane as pool routing: memory for small bodies, file-backed replay for large bodies.

--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -27,7 +27,8 @@
 - 当并发不能降低且业务成功率高于观测记录完整性时，用进程内短窗口 write controller 承接所有观测记录写：terminal invocation 进入 P1 best-effort 队列，attempt 中间进度、rollup/live progress、account touch、system task finish 等可延迟项进入 P2 并按 key coalesce。记录入队/flush 失败必须报警和计数，但不得让已经完成的业务响应失败。
 - 高频 runtime snapshot 不应默认等同于主事实写。`running` / first-byte / response-ready 这类 UI 新鲜度事件可以先走进程内共享 runtime store + SSE/HTTP overlay；如果服务选择业务优先于记录，terminal success/failure 也可以先进入 P1 write controller，并用 SSE terminal payload + runtime tombstone 支撑短暂最终一致窗口。
 - 路由公平性字段如果不是路由正确性的硬状态，可以拆成“进程内立即生效 + batch 落库”。例如 `last_selected_at` 可先写内存锚点并叠加候选排序，账号 status/cooldown/failure 则继续同步写。
-- raw payload 完整保留属于观测合同，不应作为 SQLite 止血手段被截断或丢弃；只能补齐 raw IO / gzip / metadata 写入证据，并通过调度、窄写或配置化压缩策略减压。
+- raw payload 完整保留属于观测合同，不应作为 SQLite 止血手段被截断或丢弃；只能补齐 raw IO / Zstd / metadata 写入证据，并通过调度、窄写或配置化压缩策略减压。
+- 用写侧 watermark 表达 retention 后的不可恢复 detail 边界。读侧周期任务不得为发现这个边界反向扫描 retained invocation 表。
 
 ## 推荐模式
 

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -2,6 +2,7 @@
 
 - 2026-07-28：线上复查发现原 write-side Dashboard 读模型仍无界保留完整 terminal records，且 reconcile 在并发写入后丢弃完整构建并立即重试。合同因此收紧为 compact delta 双硬限、持久化 ACK/cursor 安全回收、同事务 baseline cursor 与 60 秒 reconcile；5 秒 cadence 只允许内存发布，rolling 窗口由 expiry delta 保持精确。
 - 2026-07-25：Dashboard open-range 终态累计从“5 秒 topic refresh 失效 DB cache 后重建”改为 write-side idempotent delta。`today / 1d / 7d` 的 topic 与 HTTP 共享同一 warm baseline，5 秒窗口仅合并发布，60 秒 cadence 才进行 DB reconcile；reconcile 失败继续发布 last-good totals 与 runtime live overlay。
+- `stats.timeseries.open-window` uses exact complete-minute projection entries with a bounded post-cursor tail. This retains point and P95 semantics while avoiding repeated full live invocation hydration for covered open windows.
 
 ## Key Decisions
 

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -31,6 +31,7 @@
 - 已实现：proxy terminal follow-up 不再构建或广播五个 legacy Summary 窗口；只在存在真实 `quota.current` owner subscriber 时保留 quota follow-up，避免无消费者的请求尾部重算 SQLite。
 - 已实现：summary `non_success_tokens` 的 live 部分复用账号活动 hourly v2 coverage，完整小时读 rollup、边界与 coverage hole 走 scalar exact tail；健康路径不再调用整窗账号活动 raw aggregate。
 - 已实现：Dashboard open-range terminal totals 在 persistence enqueue 成功后同步 fan-out 到共享内存 baseline；固定 5 秒 deadline 只发布内存 snapshot。compact delta、persistence ACK/cursor 回收、`64 MiB / 10,000` 双硬限、rolling expiry delta 与 60 秒 cursor-consistent reconcile 已形成完整生命周期；reconcile 失败时保留 last-good totals 与 live overlay。
+- 已实现：open-window timeseries 为完整分钟保存精确 projection record，并在 covered range 只读取分钟 projection 与 post-cursor tail；缺覆盖时才执行一次精确 warm fallback。投影保留原始延迟 sample，P95 口径不变。
 
 ## Migrated consumers
 

--- a/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
@@ -150,6 +150,11 @@
 - `prompt-cache.sticky.window`
 - `stats.summary.current`（open-range only）
 - `stats.timeseries.open-window`
+
+### Open-Window Timeseries Projection
+
+- `today` and `1d` minute windows may use a durable minute projection of exact invocation aggregate records. A missing projection is a warming fallback, not a different response contract.
+- Projection entries retain exact latency samples, so P95 remains exact. A covered window reads minute entries plus a bounded post-cursor tail; it does not hydrate the full live invocation range for every topic refresh.
 - `stats.parallel-work.current`
 - `forward-proxy.live`
 - `invocation.pool-attempts`

--- a/docs/specs/9aucy-db-retention-archive/HISTORY.md
+++ b/docs/specs/9aucy-db-retention-archive/HISTORY.md
@@ -10,3 +10,4 @@
 - No separate historical decision record was present before this migration.
 - 2026-06-18: 收口 summary / timeseries 的 mixed archive/live 读路径，明确 `previous7d` 这类自然日 summary 必须复用 hourly rollup + full-hour live tail replay + uncovered archive fallback，不能只靠当前 retention cutoff 决定是否 live-only。
 - parallel-work 的历史均值需要保留活动分钟分子/分母，而不是会话小时 key。分钟层限定为 30 个完整上海自然日和当前日；小时层永久保存无 key 标量，覆盖标记优先于分钟删除，避免持久化风险和历史近似。
+- Retention now emits a durable unrecoverable-detail watermark when it removes full detail. This makes the parallel-work coverage decision write-driven and removes the regular retained-row reverse scan.

--- a/docs/specs/9aucy-db-retention-archive/IMPLEMENTATION.md
+++ b/docs/specs/9aucy-db-retention-archive/IMPLEMENTATION.md
@@ -13,6 +13,7 @@
 - Note: 本 spec 保留 retention/archive 基线；在线长期统计主来源与 archive 在线读取边界后续已由 `#h9r2m` 接管。
 - Note: 2026-06-18 继续收口 mixed archive/live summary 边界；summary 读取不再因为 `window.start` 落在“当前 retention cutoff 之后”就退回 live-only，而是固定与 hourly timeseries 共用 rollup-backed 读路径，避免 `previous7d` 这类自然日窗口漏掉先前已 materialize 的历史天数。
 - Note: parallel-work 采用独立的分钟 key 与永久小时标量层。分钟 key 固定保留 30 个完整上海自然日与当前自然日，过期时每小时原子 materialize 并删除 key；这条维护链不读取旧 archive，也不依赖原始明细 retention 开关。
+- Note: detail pruning records the latest unrecoverable-detail epoch in the same write transaction. Regular parallel-work maintenance reads that watermark; only an old database without the marker performs a one-time conservative seed scan.
 
 ## Verification
 

--- a/docs/specs/9aucy-db-retention-archive/SPEC.md
+++ b/docs/specs/9aucy-db-retention-archive/SPEC.md
@@ -127,6 +127,7 @@
 - 给定 `previous7d`、`昨天前 7 天`、账号 usage 等跨自然日 summary 窗口，若其中一部分自然日已在更早的 retention 配置下 materialize 到 hourly rollup / archive，而另一部分仍保留在 live DB，读取结果仍必须与对应日粒度 timeseries totals 一致，不能因为当前 retention cutoff 已覆盖 `window.start` 就漏掉较早那几天。
 - 最近 30 天的 `codex_quota_snapshots` 逐条保留，更老日期只保留每天最后一条在线记录。
 - parallel-work 分钟 key 在达到 30 个完整上海自然日边界后，只有对应小时无 key 标量和覆盖标记都已提交时才能删除；历史小时均值仍可精确计算，缺覆盖历史必须显式不可用。
+- `parallel_work_rollup_coverage_state` records the latest unrecoverable-detail watermark transactionally when retention prunes detail. Regular maintenance reads that watermark; the legacy retained-row reverse scan is only allowed once to seed an old database.
 - 前端旧 payload 缺失新字段时仍能稳定渲染，并在展开详情中默认按 `Full` 展示。
 
 ## 参考

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
@@ -18,3 +18,4 @@
 - SSE 的协议成功终态优先于传输 EOF：严格合法的 `response.completed` 一旦实际送达下游，后续上游读取异常和普通 body release 只能保留诊断，不得倒灌为服务失败或下游失败。
 - 2026-07-26: 下游 body EOF 不能覆盖已送达的成功终态；以单调的成功完成状态传递给对应 response body 的所有 watch 接收方。解析器同时要求 `event` 与 payload `type` 完整匹配。终态 chunk 被下游 body stream 成功取出即建立协议送达，不以共享 TCP 连接的写入结果反推 HTTP/2 中某个 response 的状态；之后观察到的 socket error 只保留在 payload 诊断字段。
 - file-backed pool replay 的路由投影收口为单次读取与单次 JSON parse；解析结果限定为路由所需的紧凑字段，保留既有 sticky key 类型错误和重复字段降级语义，避免大请求在同一准备阶段重复打开临时文件。
+- Response raw storage distinguishes wire encoding from storage encoding: identity content is stored with Zstd, while pre-compressed wire bytes remain untouched. A saturated writer uses a CRC-framed local spool so enabled response capture is not silently discarded.

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
@@ -5,6 +5,7 @@
 - Canonical spec: `docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md`
 - Implementation summary: 已完成
 - 最新收口：`proxy capture follow-up` 已改成 subscriber-aware，`receiver_count()==0` 且非 shutdown flush 时不会再消耗 follow-up seq 或触发 summary/quota / rollup refresh；active subscriber 与 shutdown tail flush 语义已回归验证。
+- Response raw capture stores identity bytes as Zstd, retains pre-compressed wire bytes without a second compression pass, and uses a CRC-framed persistent overflow spool when the bounded writer pool is saturated. Incomplete spool files are retained for inspection; complete files replay during startup.
 
 ## Migrated Implementation Notes
 

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
@@ -30,6 +30,12 @@
 ### In scope
 
 - `src/proxy.rs` 中 `/v1/*` 请求入口、pool 路由 body 处理、request/response raw capture 与 summary follow-up 调度。
+
+## Raw Capture Storage
+
+- Response raw capture must preserve an already content-encoded wire response as-is; it must not decode and recompress `gzip`, `zstd`, or `deflate` on the proxy request path.
+- Identity payload storage defaults to Zstd. Existing `.gz` captures remain readable and expire through normal retention; no bulk migration is permitted.
+- A saturated raw writer queues enabled capture work instead of marking it `async_backpressure_dropped`. Compression concurrency is bounded by `PROXY_RAW_ZSTD_MAX_CONCURRENT_WRITERS` or `clamp(available_parallelism / 2, 2, 8)`.
 - `src/config.rs` / `src/app_state.rs` / `src/runtime.rs` 中 whole-proxy admission gate 的移除、纯观测型 in-flight 指标与 deprecated 配置告警。
 - `src/api/mod.rs` 中 invocation 列表分页查询的轻量页 id 预选 + 当前页重型投影（保留并复验，不回退）。
 - `src/tests/mod.rs` 中与 100 并行、不再本地 admission reject、raw 异步和长流 in-flight tracking 相关的回归测试。

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -17898,7 +17898,7 @@ pub(crate) struct HourlyRollupExactRangePlan {
     pub(crate) live_exact_ranges: Vec<ExactUtcRange>,
 }
 
-#[derive(Debug, Clone, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow, Serialize, Deserialize)]
 pub(crate) struct InvocationAggregateRecord {
     pub(crate) id: i64,
     pub(crate) invoke_id: String,

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -282,15 +282,29 @@ pub(crate) async fn fetch_timeseries(
                     Some(snapshot_id),
                 )
                 .await?;
-                store_timeseries_minute_projection_records(
-                    &state.pool,
-                    start_dt,
-                    end_dt,
-                    source_scope,
-                    None,
-                    &records,
-                )
-                .await?;
+                // Projection persistence is P2 work. Never make a read request wait for a
+                // SQLite writer when the exact fallback already produced a valid response.
+                let projection_pool = state.pool.clone();
+                let projection_records = records.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = store_timeseries_minute_projection_records(
+                        &projection_pool,
+                        start_dt,
+                        end_dt,
+                        source_scope,
+                        None,
+                        &projection_records,
+                    )
+                    .await
+                    {
+                        debug!(
+                            route = "timeseries_projection",
+                            projection_store_outcome = "deferred_failed",
+                            ?error,
+                            "minute projection warm write failed"
+                        );
+                    }
+                });
                 (records, "exact_fallback")
             }
         }

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -4,6 +4,193 @@ use anyhow::anyhow;
 use std::collections::HashMap;
 use tracing::debug;
 
+#[derive(sqlx::FromRow)]
+struct TimeseriesMinuteProjectionRow {
+    minute_start_epoch: i64,
+    records_json: String,
+    max_row_id: i64,
+}
+
+fn timeseries_projection_scope(source_scope: InvocationSourceScope) -> &'static str {
+    match source_scope {
+        InvocationSourceScope::All => "all",
+        InvocationSourceScope::ProxyOnly => "proxy_only",
+    }
+}
+
+fn complete_minute_bounds(start: DateTime<Utc>, end: DateTime<Utc>) -> (i64, i64) {
+    let start_epoch = (start.timestamp() + 59).div_euclid(60) * 60;
+    let end_epoch = end.timestamp().div_euclid(60) * 60;
+    (start_epoch, end_epoch.max(start_epoch))
+}
+
+async fn load_timeseries_minute_projection_records(
+    pool: &Pool<Sqlite>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+) -> Result<Option<(Vec<InvocationAggregateRecord>, i64)>, ApiError> {
+    let (minute_start, minute_end) = complete_minute_bounds(start, end);
+    let expected = (minute_end - minute_start).div_euclid(60);
+    if expected <= 0 {
+        return Ok(None);
+    }
+    let rows = sqlx::query_as::<_, TimeseriesMinuteProjectionRow>(
+        "SELECT minute_start_epoch, records_json, max_row_id FROM timeseries_minute_projection_records WHERE minute_start_epoch >= ?1 AND minute_start_epoch < ?2 AND source_scope = ?3 AND upstream_account_key = ?4 ORDER BY minute_start_epoch",
+    )
+    .bind(minute_start)
+    .bind(minute_end)
+    .bind(timeseries_projection_scope(source_scope))
+    .bind(upstream_account_id.unwrap_or(-1))
+    .fetch_all(pool)
+    .await?;
+    if rows.len() as i64 != expected {
+        return Ok(None);
+    }
+    let mut records = Vec::new();
+    let mut cursor = 0;
+    for row in rows {
+        cursor = cursor.max(row.max_row_id);
+        records.extend(
+            serde_json::from_str::<Vec<InvocationAggregateRecord>>(&row.records_json).map_err(
+                |err| ApiError::from(anyhow!("invalid minute projection record: {err}")),
+            )?,
+        );
+    }
+    Ok(Some((records, cursor)))
+}
+
+async fn store_timeseries_minute_projection_records(
+    pool: &Pool<Sqlite>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+    records: &[InvocationAggregateRecord],
+) -> Result<(), ApiError> {
+    let (minute_start, minute_end) = complete_minute_bounds(start, end);
+    if minute_end <= minute_start {
+        return Ok(());
+    }
+    let mut by_minute: HashMap<i64, Vec<InvocationAggregateRecord>> = HashMap::new();
+    for record in records {
+        let Some(occurred) = parse_to_utc_datetime(&record.occurred_at) else {
+            continue;
+        };
+        let minute = occurred.timestamp().div_euclid(60) * 60;
+        if minute >= minute_start && minute < minute_end {
+            by_minute.entry(minute).or_default().push(record.clone());
+        }
+    }
+    let mut tx = pool.begin().await?;
+    let mut projected_rows = Vec::new();
+    for minute in (minute_start..minute_end).step_by(60_usize) {
+        let minute_records = by_minute.remove(&minute).unwrap_or_default();
+        let max_row_id = minute_records
+            .iter()
+            .map(|record| record.id)
+            .max()
+            .unwrap_or(0);
+        projected_rows.push((
+            minute,
+            serde_json::to_string(&minute_records).map_err(ApiError::from)?,
+            max_row_id,
+        ));
+    }
+    for chunk in projected_rows.chunks(128) {
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "INSERT INTO timeseries_minute_projection_records (minute_start_epoch, source_scope, upstream_account_key, records_json, max_row_id) ",
+        );
+        query.push_values(chunk, |mut values, (minute, records_json, max_row_id)| {
+            values
+                .push_bind(*minute)
+                .push_bind(timeseries_projection_scope(source_scope))
+                .push_bind(upstream_account_id.unwrap_or(-1))
+                .push_bind(records_json)
+                .push_bind(*max_row_id);
+        });
+        query.push(
+            " ON CONFLICT(minute_start_epoch, source_scope, upstream_account_key) DO UPDATE SET records_json = excluded.records_json, max_row_id = excluded.max_row_id",
+        );
+        query.build().execute(tx.as_mut()).await?;
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod minute_projection_tests {
+    use super::*;
+
+    fn record(id: i64, occurred_at: &str) -> InvocationAggregateRecord {
+        InvocationAggregateRecord {
+            id,
+            invoke_id: format!("invoke-{id}"),
+            occurred_at: occurred_at.to_string(),
+            status: Some("success".to_string()),
+            total_tokens: Some(3),
+            cache_input_tokens: Some(1),
+            cost: Some(0.25),
+            error_message: None,
+            failure_kind: None,
+            failure_class: None,
+            is_actionable: Some(0),
+            live_phase: None,
+            t_total_ms: Some(10.0),
+            t_req_read_ms: Some(1.0),
+            t_req_parse_ms: Some(1.0),
+            t_upstream_connect_ms: Some(2.0),
+            t_upstream_ttfb_ms: Some(3.0),
+            first_token_ms: Some(4.0),
+            t_upstream_stream_ms: Some(5.0),
+            t_resp_parse_ms: Some(1.0),
+            t_persist_ms: Some(1.0),
+        }
+    }
+
+    #[tokio::test]
+    async fn minute_projection_returns_exact_records_and_cursor_for_covered_minutes() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        sqlx::query(
+            "CREATE TABLE timeseries_minute_projection_records (minute_start_epoch INTEGER NOT NULL, source_scope TEXT NOT NULL, upstream_account_key INTEGER NOT NULL, records_json TEXT NOT NULL, max_row_id INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (minute_start_epoch, source_scope, upstream_account_key))",
+        )
+        .execute(&pool)
+        .await
+        .expect("create projection table");
+        let start = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).single().unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 8, 1, 0, 3, 0).single().unwrap();
+        store_timeseries_minute_projection_records(
+            &pool,
+            start,
+            end,
+            InvocationSourceScope::All,
+            None,
+            &[record(17, "2026-08-01 08:01:12")],
+        )
+        .await
+        .expect("store projection");
+
+        let (records, cursor) = load_timeseries_minute_projection_records(
+            &pool,
+            start,
+            end,
+            InvocationSourceScope::All,
+            None,
+        )
+        .await
+        .expect("load projection")
+        .expect("complete minute coverage");
+        assert_eq!(cursor, 17);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].invoke_id, "invoke-17");
+    }
+}
+
 pub(crate) async fn fetch_timeseries(
     State(state): State<Arc<AppState>>,
     Query(params): Query<TimeseriesQuery>,
@@ -56,18 +243,85 @@ pub(crate) async fn fetch_timeseries(
     let end_dt = range_window.end;
     let start_dt = range_window.start;
     let start_str_iso = format_utc_iso(start_dt);
+    let use_minute_projection = range_window.duration <= ChronoDuration::days(1);
 
-    let records = query_invocation_aggregate_records_from_live_range(
-        &state.pool,
-        ExactUtcRange {
-            start: start_dt,
-            end: end_dt,
+    let (records, response_source) = if use_minute_projection {
+        match load_timeseries_minute_projection_records(
+            &state.pool,
+            start_dt,
+            end_dt,
+            source_scope,
+            None,
+        )
+        .await?
+        {
+            Some((mut cached, cursor)) => {
+                let tail = query_invocation_aggregate_records_from_live_range(
+                    &state.pool,
+                    ExactUtcRange {
+                        start: start_dt,
+                        end: end_dt,
+                    },
+                    source_scope,
+                    Some(cursor),
+                    Some(snapshot_id),
+                )
+                .await?;
+                cached.extend(tail);
+                (cached, "minute_projection")
+            }
+            None => {
+                let records = query_invocation_aggregate_records_from_live_range(
+                    &state.pool,
+                    ExactUtcRange {
+                        start: start_dt,
+                        end: end_dt,
+                    },
+                    source_scope,
+                    None,
+                    Some(snapshot_id),
+                )
+                .await?;
+                store_timeseries_minute_projection_records(
+                    &state.pool,
+                    start_dt,
+                    end_dt,
+                    source_scope,
+                    None,
+                    &records,
+                )
+                .await?;
+                (records, "exact_fallback")
+            }
+        }
+    } else {
+        (
+            query_invocation_aggregate_records_from_live_range(
+                &state.pool,
+                ExactUtcRange {
+                    start: start_dt,
+                    end: end_dt,
+                },
+                source_scope,
+                None,
+                Some(snapshot_id),
+            )
+            .await?,
+            "exact_range",
+        )
+    };
+    debug!(
+        route = "timeseries_http_or_topic",
+        builder = "minute_projection_records",
+        response_source,
+        raw_row_count = records.len(),
+        coverage_state = if response_source == "minute_projection" {
+            "covered"
+        } else {
+            "warming"
         },
-        source_scope,
-        None,
-        Some(snapshot_id),
-    )
-    .await?;
+        "built open-window timeseries"
+    );
     let db_runtime_records = collect_in_flight_aggregate_records(&records);
 
     let mut aggregates: BTreeMap<i64, BucketAggregate> = BTreeMap::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,11 +42,12 @@ impl FromStr for ForwardProxyAlgo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum RawCompressionCodec {
     None,
     Gzip,
+    Zstd,
 }
 
 impl FromStr for RawCompressionCodec {
@@ -56,6 +57,7 @@ impl FromStr for RawCompressionCodec {
         match raw.trim().to_ascii_lowercase().as_str() {
             "none" => Ok(Self::None),
             "gzip" => Ok(Self::Gzip),
+            "zstd" => Ok(Self::Zstd),
             _ => bail!("invalid {ENV_PROXY_RAW_COMPRESSION} value: {raw}"),
         }
     }
@@ -764,8 +766,8 @@ impl AppConfig {
         resolve_path_from_database_parent(&self.database_path, &self.proxy_raw_dir)
     }
 
-    pub(crate) fn proxy_raw_immediate_gzip_threshold(&self) -> Option<usize> {
-        (self.proxy_raw_compression == RawCompressionCodec::Gzip)
+    pub(crate) fn proxy_raw_immediate_compression_threshold(&self) -> Option<usize> {
+        (self.proxy_raw_compression != RawCompressionCodec::None)
             .then_some(self.proxy_raw_immediate_gzip_bytes)
             .flatten()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ use chrono::{
 };
 use chrono_tz::{Asia::Shanghai, Tz};
 use clap::{Args, Parser, Subcommand};
+use crc32fast::Hasher as Crc32Hasher;
 use dotenvy::dotenv;
 use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
 use flate2::{
@@ -209,7 +210,7 @@ const STARTUP_BACKFILL_TASK_HISTORICAL_ROLLUPS: &str = "historical_rollup_materi
 const DEFAULT_PROXY_RAW_MAX_BYTES: Option<usize> = None;
 const DEFAULT_PROXY_PRICING_CATALOG_PATH: &str = "config/model-pricing.json";
 const DEFAULT_PROXY_RAW_DIR: &str = "proxy_raw_payloads";
-const DEFAULT_PROXY_RAW_COMPRESSION: RawCompressionCodec = RawCompressionCodec::Gzip;
+const DEFAULT_PROXY_RAW_COMPRESSION: RawCompressionCodec = RawCompressionCodec::Zstd;
 const DEFAULT_PROXY_RAW_IMMEDIATE_GZIP_BYTES: Option<usize> = Some(1024 * 1024);
 const DEFAULT_PROXY_RAW_HOT_SECS: u64 = 24 * 60 * 60;
 const RAW_RESPONSE_PREVIEW_LIMIT: usize = 16 * 1024;
@@ -221,6 +222,7 @@ const PROXY_USAGE_MISSING_NON_STREAM_PARSE_SKIPPED: &str =
     "non_stream_response_parse_skipped_body_too_large";
 const RAW_CODEC_IDENTITY: &str = "identity";
 const RAW_CODEC_GZIP: &str = "gzip";
+const RAW_CODEC_ZSTD: &str = "zstd";
 const POOL_REQUEST_REPLAY_MEMORY_THRESHOLD_BYTES: usize = 1024 * 1024;
 const ENV_DATABASE_PATH: &str = "DATABASE_PATH";
 const LEGACY_ENV_DATABASE_PATH: &str = "XY_DATABASE_PATH";
@@ -291,9 +293,16 @@ const LEGACY_ENV_POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_TTL_DAYS: &str =
     "XY_POOL_UPSTREAM_REQUEST_ATTEMPTS_ARCHIVE_TTL_DAYS";
 
 fn proxy_raw_async_writer_limit(_config: &AppConfig) -> usize {
-    // Pool attempts now keep an independent response writer alongside the
-    // invocation writer; preserve the original invocation capacity.
-    DEFAULT_PROXY_RAW_ASYNC_MAX_CONCURRENT_WRITERS * 2
+    if let Ok(raw) = env::var("PROXY_RAW_ZSTD_MAX_CONCURRENT_WRITERS")
+        && let Ok(limit) = raw.parse::<usize>()
+        && limit > 0
+    {
+        return limit;
+    }
+    std::thread::available_parallelism()
+        .map(|parallelism| parallelism.get() / 2)
+        .unwrap_or(DEFAULT_PROXY_RAW_ASYNC_MAX_CONCURRENT_WRITERS)
+        .clamp(2, 8)
 }
 const ENV_QUOTA_SNAPSHOT_FULL_DAYS: &str = "QUOTA_SNAPSHOT_FULL_DAYS";
 const ENV_LONG_TERM_STATS_HOURLY_RETENTION_DAYS: &str = "LONG_TERM_STATS_HOURLY_RETENTION_DAYS";

--- a/src/maintenance/parallel_work_rollups.rs
+++ b/src/maintenance/parallel_work_rollups.rs
@@ -123,32 +123,37 @@ async fn advance_parallel_work_full_detail_start_epoch(
         return load_parallel_work_full_detail_start_epoch(pool).await;
     };
     let keep_start_epoch = parallel_work_minute_rollup_keep_start_epoch(Utc::now())?;
-    let keep_start = Utc
-        .timestamp_opt(keep_start_epoch, 0)
-        .single()
-        .ok_or_else(|| anyhow!("invalid parallel-work minute retention start"))?;
-    let latest_unrecoverable_at: Option<String> = sqlx::query_scalar(
-        r#"
-        SELECT occurred_at
-        FROM codex_invocations
-        WHERE occurred_at >= ?1
-            AND detail_level != ?2
-        ORDER BY occurred_at DESC
-        LIMIT 1
-        "#,
+    let persisted_marker = sqlx::query_scalar::<_, Option<i64>>(
+        "SELECT latest_unrecoverable_detail_epoch FROM parallel_work_rollup_coverage_state WHERE id = 1",
     )
-    .bind(db_occurred_at_lower_bound(keep_start))
-    .bind(DETAIL_LEVEL_FULL)
     .fetch_optional(pool)
-    .await?;
-    let latest_unrecoverable_epoch = latest_unrecoverable_at
-        .as_deref()
-        .map(|occurred_at| {
-            parse_to_utc_datetime(occurred_at)
-                .map(|parsed| parsed.timestamp())
-                .ok_or_else(|| anyhow!("invalid invocation occurred_at: {occurred_at}"))
-        })
-        .transpose()?;
+    .await?
+    .flatten();
+    let latest_unrecoverable_epoch = if let Some(marker) = persisted_marker {
+        Some(marker)
+    } else {
+        // Legacy databases need one conservative seed. Normal maintenance never performs
+        // this reverse retained-table scan again; retention writes the watermark atomically.
+        let keep_start = Utc
+            .timestamp_opt(keep_start_epoch, 0)
+            .single()
+            .ok_or_else(|| anyhow!("invalid parallel-work minute retention start"))?;
+        let latest_unrecoverable_at: Option<String> = sqlx::query_scalar(
+            "SELECT occurred_at FROM codex_invocations WHERE occurred_at >= ?1 AND detail_level != ?2 ORDER BY occurred_at DESC LIMIT 1",
+        )
+        .bind(db_occurred_at_lower_bound(keep_start))
+        .bind(DETAIL_LEVEL_FULL)
+        .fetch_optional(pool)
+        .await?;
+        latest_unrecoverable_at
+            .as_deref()
+            .map(|occurred_at| {
+                parse_to_utc_datetime(occurred_at)
+                    .map(|parsed| parsed.timestamp())
+                    .ok_or_else(|| anyhow!("invalid invocation occurred_at: {occurred_at}"))
+            })
+            .transpose()?
+    };
     let verified_start_epoch = latest_unrecoverable_epoch
         .map(|epoch| (epoch.div_euclid(3_600) + 1) * 3_600)
         .unwrap_or(keep_start_epoch)
@@ -157,16 +162,22 @@ async fn advance_parallel_work_full_detail_start_epoch(
     let mut tx = pool.begin().await?;
     sqlx::query(
         r#"
-        INSERT INTO parallel_work_rollup_coverage_state (id, full_detail_start_epoch)
-        VALUES (1, ?1)
+        INSERT INTO parallel_work_rollup_coverage_state (id, full_detail_start_epoch, latest_unrecoverable_detail_epoch)
+        VALUES (1, ?1, ?2)
         ON CONFLICT(id) DO UPDATE SET
-            full_detail_start_epoch = MIN(
+            full_detail_start_epoch = MAX(
                 parallel_work_rollup_coverage_state.full_detail_start_epoch,
                 excluded.full_detail_start_epoch
+            ),
+            latest_unrecoverable_detail_epoch = COALESCE(
+                MAX(parallel_work_rollup_coverage_state.latest_unrecoverable_detail_epoch, excluded.latest_unrecoverable_detail_epoch),
+                parallel_work_rollup_coverage_state.latest_unrecoverable_detail_epoch,
+                excluded.latest_unrecoverable_detail_epoch
             )
         "#,
     )
     .bind(verified_start_epoch)
+    .bind(latest_unrecoverable_epoch)
     .execute(tx.as_mut())
     .await?;
     let full_detail_start_epoch: i64 = sqlx::query_scalar(
@@ -176,6 +187,32 @@ async fn advance_parallel_work_full_detail_start_epoch(
     .await?;
     tx.commit().await?;
     Ok(Some(full_detail_start_epoch))
+}
+
+pub(crate) async fn record_parallel_work_unrecoverable_detail_tx(
+    tx: &mut SqliteConnection,
+    occurred_at: &str,
+) -> Result<()> {
+    let epoch = parse_to_utc_datetime(occurred_at)
+        .ok_or_else(|| anyhow!("invalid invocation occurred_at: {occurred_at}"))?
+        .timestamp();
+    sqlx::query(
+        r#"
+        INSERT INTO parallel_work_rollup_coverage_state (id, full_detail_start_epoch, latest_unrecoverable_detail_epoch)
+        VALUES (1, ?1, ?2)
+        ON CONFLICT(id) DO UPDATE SET
+            latest_unrecoverable_detail_epoch = COALESCE(
+                MAX(parallel_work_rollup_coverage_state.latest_unrecoverable_detail_epoch, excluded.latest_unrecoverable_detail_epoch),
+                parallel_work_rollup_coverage_state.latest_unrecoverable_detail_epoch,
+                excluded.latest_unrecoverable_detail_epoch
+            )
+        "#,
+    )
+    .bind((epoch.div_euclid(3_600) + 1) * 3_600)
+    .bind(epoch)
+    .execute(&mut *tx)
+    .await?;
+    Ok(())
 }
 
 async fn mark_parallel_work_minute_coverage_tx(

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -1893,6 +1893,13 @@ pub(crate) async fn prune_old_invocation_details(
             query.push(")");
             clear_pool_attempt_response_captures_for_invocation_ids(tx.as_mut(), &ids).await?;
             query.build().execute(tx.as_mut()).await?;
+            if let Some(latest) = group
+                .iter()
+                .map(|candidate| candidate.occurred_at.as_str())
+                .max()
+            {
+                record_parallel_work_unrecoverable_detail_tx(tx.as_mut(), latest).await?;
+            }
             tx.commit().await?;
 
             raw_files_removed += delete_proxy_raw_paths(&raw_paths, raw_path_fallback_root)?;

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -2149,6 +2149,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             &invoke_id_for_task,
             "response",
             proxy_settings.response_body_logging_enabled,
+            upstream_content_encoding_for_task.as_deref(),
         );
         let attempt_response_capture_enabled = proxy_settings.response_body_logging_enabled
             && pending_pool_attempt_record_for_task.is_some();
@@ -2161,6 +2162,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             &attempt_response_capture_key,
             "response",
             attempt_response_capture_enabled,
+            upstream_content_encoding_for_task.as_deref(),
         );
         let mut stream_response_parser = StreamResponsePayloadChunkParser::default();
         let mut stream_response_decoder =

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -489,20 +489,46 @@ pub(crate) async fn store_raw_payload_file(
 
     let raw_dir = config.resolved_proxy_raw_dir();
 
-    let born_gzip = config
-        .proxy_raw_immediate_gzip_threshold()
-        .is_some_and(|threshold| content.len() >= threshold);
+    let born_compressed = match config.proxy_raw_compression {
+        // Zstd is the current storage format for identity captures. It is applied from
+        // the first byte rather than waiting for the legacy gzip size threshold.
+        RawCompressionCodec::Zstd => true,
+        RawCompressionCodec::Gzip => config
+            .proxy_raw_immediate_compression_threshold()
+            .is_some_and(|threshold| content.len() >= threshold),
+        RawCompressionCodec::None => false,
+    };
     let file_bytes = content.len();
-    let codec = if born_gzip {
-        RAW_CODEC_GZIP
+    let codec = if born_compressed {
+        match config.proxy_raw_compression {
+            RawCompressionCodec::Gzip => RAW_CODEC_GZIP,
+            RawCompressionCodec::Zstd => RAW_CODEC_ZSTD,
+            RawCompressionCodec::None => RAW_CODEC_IDENTITY,
+        }
     } else {
         RAW_CODEC_IDENTITY
     };
-    let path = raw_payload_path_for_kind(&raw_dir, invoke_id, kind, born_gzip);
-    let write_result = if born_gzip {
+    let plain_path = raw_payload_path_for_kind(&raw_dir, invoke_id, kind, false);
+    let path = if codec == RAW_CODEC_ZSTD {
+        raw_payload_zstd_path(&plain_path)
+    } else if codec == RAW_CODEC_GZIP {
+        raw_payload_gzip_path(&plain_path)
+    } else {
+        plain_path
+    };
+    let write_result = if codec == RAW_CODEC_GZIP {
         let write_path = path.clone();
         run_blocking_raw_writer_io(move || {
             let mut encoder = create_gzip_streaming_raw_encoder(&write_path)?;
+            encoder.write_all(content.as_ref())?;
+            let mut writer = encoder.finish()?;
+            writer.flush()
+        })
+        .await
+    } else if codec == RAW_CODEC_ZSTD {
+        let write_path = path.clone();
+        run_blocking_raw_writer_io(move || {
+            let mut encoder = create_zstd_streaming_raw_encoder(&write_path)?;
             encoder.write_all(content.as_ref())?;
             let mut writer = encoder.finish()?;
             writer.flush()
@@ -521,7 +547,7 @@ pub(crate) async fn store_raw_payload_file(
             meta.path = Some(path.to_string_lossy().to_string());
         }
         Err(err) => {
-            if born_gzip {
+            if codec != RAW_CODEC_IDENTITY {
                 let _ = fs::remove_file(&path);
             }
             meta.truncated = true;
@@ -1323,6 +1349,17 @@ pub(crate) fn decode_proxy_raw_file_bytes(path: &Path, bytes: Vec<u8>) -> io::Re
             )
         })?;
         Ok(decoded)
+    } else if path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zst"))
+    {
+        zstd::stream::decode_all(bytes.as_slice()).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to decompress raw payload {}: {err}", path.display()),
+            )
+        })
     } else {
         Ok(bytes)
     }

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -4219,13 +4219,44 @@ pub(crate) fn spawn_raw_payload_file_write(
         });
     }
 
-    let Ok(permit) = state.proxy_raw_async_semaphore.clone().try_acquire_owned() else {
-        return PendingRawPayloadWrite::dropped(bytes.len());
-    };
+    let semaphore = state.proxy_raw_async_semaphore.clone();
+    let invoke_id = invoke_id.to_string();
+    let kind_for_spool = kind;
+    let bytes_for_spool = bytes.clone();
+    if semaphore.available_permits() == 0 {
+        let codec = state.config.proxy_raw_compression;
+        let spool = match RawOverflowSpool::create(state, &invoke_id, kind_for_spool, codec) {
+            Ok(spool) => spool,
+            Err(err) => {
+                return PendingRawPayloadWrite::Ready(RawPayloadMeta {
+                    path: None,
+                    size_bytes: bytes_for_spool.len() as i64,
+                    truncated: true,
+                    truncated_reason: Some(format!("spool_create_failed:{err}")),
+                });
+            }
+        };
+        return PendingRawPayloadWrite::Task(tokio::spawn(async move {
+            let mut spool = spool;
+            if let Err(err) = spool.append(&bytes_for_spool) {
+                return RawPayloadMeta {
+                    path: None,
+                    size_bytes: bytes_for_spool.len() as i64,
+                    truncated: true,
+                    truncated_reason: Some(format!("spool_write_failed:{err}")),
+                };
+            }
+            spool.finish(bytes_for_spool.len() as i64).await
+        }));
+    }
 
     let config = state.config.clone();
-    let invoke_id = invoke_id.to_string();
     PendingRawPayloadWrite::Task(tokio::spawn(async move {
+        // Queue behind the bounded CPU writer pool instead of dropping an enabled capture.
+        let permit = semaphore
+            .acquire_owned()
+            .await
+            .expect("raw writer semaphore is live");
         let _permit = permit;
         store_raw_payload_file(&config, &invoke_id, kind, bytes).await
     }))
@@ -4245,6 +4276,10 @@ pub(crate) fn raw_payload_path_for_kind(
     raw_dir.join(filename)
 }
 
+pub(crate) fn raw_payload_zstd_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.zst", path.display()))
+}
+
 pub(crate) fn raw_payload_path_is_gzip(path: Option<&str>) -> bool {
     path.is_some_and(|value| value.ends_with(".gz"))
 }
@@ -4252,6 +4287,12 @@ pub(crate) fn raw_payload_path_is_gzip(path: Option<&str>) -> bool {
 pub(crate) fn raw_payload_meta_codec(meta: &RawPayloadMeta) -> &'static str {
     if raw_payload_path_is_gzip(meta.path.as_deref()) {
         RAW_CODEC_GZIP
+    } else if meta
+        .path
+        .as_deref()
+        .is_some_and(|path| path.ends_with(".zst"))
+    {
+        RAW_CODEC_ZSTD
     } else {
         RAW_CODEC_IDENTITY
     }
@@ -4277,13 +4318,19 @@ pub(crate) enum StreamingRawPayloadWriterState {
         path: PathBuf,
         encoder: GzEncoder<io::BufWriter<fs::File>>,
     },
+    Zstd {
+        path: PathBuf,
+        encoder: zstd::stream::write::Encoder<'static, io::BufWriter<fs::File>>,
+    },
 }
 
 impl StreamingRawPayloadWriterState {
     fn current_path(&self) -> Option<&Path> {
         match self {
             Self::Buffer(_) => None,
-            Self::Plain { path, .. } | Self::Gzip { path, .. } => Some(path.as_path()),
+            Self::Plain { path, .. } | Self::Gzip { path, .. } | Self::Zstd { path, .. } => {
+                Some(path.as_path())
+            }
         }
     }
 }
@@ -4315,6 +4362,14 @@ pub(crate) fn create_gzip_streaming_raw_encoder(
     ))
 }
 
+pub(crate) fn create_zstd_streaming_raw_encoder(
+    path: &Path,
+) -> io::Result<zstd::stream::write::Encoder<'static, io::BufWriter<fs::File>>> {
+    prepare_streaming_raw_parent(path)?;
+    let file = fs::File::create(path)?;
+    zstd::stream::write::Encoder::new(io::BufWriter::new(file), 0)
+}
+
 pub(crate) async fn run_blocking_raw_writer_io<T, F>(op: F) -> io::Result<T>
 where
     T: Send + 'static,
@@ -4325,12 +4380,266 @@ where
         .map_err(|err| io::Error::other(format!("raw writer task join failed: {err}")))?
 }
 
+const RAW_OVERFLOW_SPOOL_DIR: &str = ".spool";
+const RAW_OVERFLOW_SPOOL_MAGIC: &[u8] = b"CVM_RAW_SPOOL_V1\n";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RawOverflowSpoolHeader {
+    invoke_id: String,
+    kind: String,
+    codec: RawCompressionCodec,
+}
+
+struct RawOverflowSpool {
+    path: PathBuf,
+    file: fs::File,
+    config: AppConfig,
+    invoke_id: String,
+    kind: &'static str,
+    semaphore: Arc<Semaphore>,
+    pending_records: u64,
+    pending_bytes: u64,
+}
+
+impl RawOverflowSpool {
+    fn create(
+        state: &AppState,
+        invoke_id: &str,
+        kind: &'static str,
+        codec: RawCompressionCodec,
+    ) -> io::Result<Self> {
+        let directory = state
+            .config
+            .resolved_proxy_raw_dir()
+            .join(RAW_OVERFLOW_SPOOL_DIR);
+        fs::create_dir_all(&directory)?;
+        let path = directory.join(format!("{invoke_id}-{kind}-{}.frames", nanoid::nanoid!()));
+        let mut file = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)?;
+        let header = serde_json::to_vec(&RawOverflowSpoolHeader {
+            invoke_id: invoke_id.to_string(),
+            kind: kind.to_string(),
+            codec,
+        })
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let header_len = u32::try_from(header.len()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "raw spool header too large")
+        })?;
+        file.write_all(RAW_OVERFLOW_SPOOL_MAGIC)?;
+        file.write_all(&header_len.to_le_bytes())?;
+        file.write_all(&header)?;
+        let mut config = state.config.clone();
+        config.proxy_raw_compression = codec;
+        Ok(Self {
+            path,
+            file,
+            config,
+            invoke_id: invoke_id.to_string(),
+            kind,
+            semaphore: state.proxy_raw_async_semaphore.clone(),
+            pending_records: 0,
+            pending_bytes: 0,
+        })
+    }
+
+    fn append(&mut self, bytes: &[u8]) -> io::Result<()> {
+        let length = u32::try_from(bytes.len()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "raw spool frame too large")
+        })?;
+        let mut crc = Crc32Hasher::new();
+        crc.update(bytes);
+        self.file.write_all(&length.to_le_bytes())?;
+        self.file.write_all(&crc.finalize().to_le_bytes())?;
+        self.file.write_all(bytes)?;
+        self.pending_records = self.pending_records.saturating_add(1);
+        self.pending_bytes = self.pending_bytes.saturating_add(bytes.len() as u64);
+        Ok(())
+    }
+
+    async fn finish(mut self, observed_size_bytes: i64) -> RawPayloadMeta {
+        if let Err(err) = self.file.flush() {
+            return RawPayloadMeta {
+                path: None,
+                size_bytes: observed_size_bytes,
+                truncated: true,
+                truncated_reason: Some(format!("spool_write_failed:{err}")),
+            };
+        }
+        drop(self.file);
+        let spool_path = self.path.clone();
+        let (header, payload) =
+            match run_blocking_raw_writer_io(move || read_raw_overflow_spool(&spool_path)).await {
+                Ok(payload) => payload,
+                Err(err) => {
+                    return RawPayloadMeta {
+                        path: None,
+                        size_bytes: observed_size_bytes,
+                        truncated: true,
+                        truncated_reason: Some(format!("spool_replay_failed:{err}")),
+                    };
+                }
+            };
+        let permit = self
+            .semaphore
+            .acquire_owned()
+            .await
+            .expect("raw writer semaphore is live");
+        let _permit = permit;
+        let meta = store_raw_payload_file(
+            &self.config,
+            &header.invoke_id,
+            &header.kind,
+            Bytes::from(payload),
+        )
+        .await;
+        debug!(
+            capture_path = "overflow_spool",
+            storage_codec = ?header.codec,
+            spool_pending_records = self.pending_records,
+            spool_pending_bytes = self.pending_bytes,
+            "raw capture overflow spool finished"
+        );
+        if meta.path.is_some() || meta.truncated_reason.as_deref() == Some("max_bytes_exceeded") {
+            let _ = fs::remove_file(&self.path);
+        }
+        meta
+    }
+}
+
+fn read_raw_overflow_spool(path: &Path) -> io::Result<(RawOverflowSpoolHeader, Vec<u8>)> {
+    let bytes = fs::read(path)?;
+    if !bytes.starts_with(RAW_OVERFLOW_SPOOL_MAGIC) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "raw spool has invalid header magic",
+        ));
+    }
+    let mut offset = RAW_OVERFLOW_SPOOL_MAGIC.len();
+    if bytes.len().saturating_sub(offset) < 4 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "raw spool has partial header length",
+        ));
+    }
+    let header_len =
+        u32::from_le_bytes(bytes[offset..offset + 4].try_into().expect("header length")) as usize;
+    offset += 4;
+    let header_end = offset.saturating_add(header_len);
+    if header_end > bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "raw spool has partial header",
+        ));
+    }
+    let header = serde_json::from_slice(&bytes[offset..header_end])
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    offset = header_end;
+    let mut payload = Vec::new();
+    while offset < bytes.len() {
+        if bytes.len().saturating_sub(offset) < 8 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "raw spool has partial frame header",
+            ));
+        }
+        let length = u32::from_le_bytes(bytes[offset..offset + 4].try_into().expect("frame length"))
+            as usize;
+        let expected_crc =
+            u32::from_le_bytes(bytes[offset + 4..offset + 8].try_into().expect("frame crc"));
+        offset += 8;
+        let end = offset.saturating_add(length);
+        if end > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "raw spool has partial frame payload",
+            ));
+        }
+        let frame = &bytes[offset..end];
+        let mut crc = Crc32Hasher::new();
+        crc.update(frame);
+        if crc.finalize() != expected_crc {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "raw spool frame checksum mismatch",
+            ));
+        }
+        payload.extend_from_slice(frame);
+        offset = end;
+    }
+    Ok((header, payload))
+}
+
+pub(crate) async fn recover_raw_overflow_spools(config: &AppConfig) {
+    let directory = config.resolved_proxy_raw_dir().join(RAW_OVERFLOW_SPOOL_DIR);
+    let entries = match fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return,
+        Err(err) => {
+            warn!(path = %directory.display(), error = %err, "failed to scan raw overflow spool directory");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("frames") {
+            continue;
+        }
+        let recovered = match run_blocking_raw_writer_io({
+            let path = path.clone();
+            move || read_raw_overflow_spool(&path)
+        })
+        .await
+        {
+            Ok(recovered) => recovered,
+            Err(err) => {
+                warn!(path = %path.display(), error = %err, "raw overflow spool is incomplete or corrupt; retaining for inspection");
+                continue;
+            }
+        };
+        let (header, payload) = recovered;
+        let mut replay_config = config.clone();
+        replay_config.proxy_raw_compression = header.codec;
+        let meta = store_raw_payload_file(
+            &replay_config,
+            &header.invoke_id,
+            &header.kind,
+            Bytes::from(payload),
+        )
+        .await;
+        if meta.path.is_some() || meta.truncated_reason.as_deref() == Some("max_bytes_exceeded") {
+            match fs::remove_file(&path) {
+                Ok(()) => info!(
+                    invoke_id = %header.invoke_id,
+                    kind = %header.kind,
+                    replay_count = 1,
+                    "recovered raw overflow spool"
+                ),
+                Err(err) => {
+                    warn!(path = %path.display(), error = %err, "failed to remove recovered raw overflow spool")
+                }
+            }
+        } else {
+            warn!(
+                path = %path.display(),
+                invoke_id = %header.invoke_id,
+                kind = %header.kind,
+                reason = ?meta.truncated_reason,
+                "raw overflow spool recovery did not publish a payload; retaining spool"
+            );
+        }
+    }
+}
+
 pub(crate) struct AsyncStreamingRawPayloadWriter {
-    tx: Option<mpsc::Sender<Bytes>>,
+    tx: Option<mpsc::UnboundedSender<Bytes>>,
     meta_rx: Option<oneshot::Receiver<RawPayloadMeta>>,
     observed_size_bytes: i64,
     local_truncated_reason: Option<String>,
     local_truncated: bool,
+    spool: Option<RawOverflowSpool>,
 }
 
 impl AsyncStreamingRawPayloadWriter {
@@ -4339,6 +4648,7 @@ impl AsyncStreamingRawPayloadWriter {
         invoke_id: &str,
         kind: &'static str,
         enabled: bool,
+        wire_content_encoding: Option<&str>,
     ) -> Self {
         if !enabled {
             return Self {
@@ -4347,20 +4657,9 @@ impl AsyncStreamingRawPayloadWriter {
                 observed_size_bytes: 0,
                 local_truncated_reason: None,
                 local_truncated: false,
+                spool: None,
             };
         }
-
-        let Ok(permit) = state.proxy_raw_async_semaphore.clone().try_acquire_owned() else {
-            return Self {
-                tx: None,
-                meta_rx: None,
-                observed_size_bytes: 0,
-                local_truncated_reason: Some(
-                    RAW_PAYLOAD_TRUNCATED_REASON_ASYNC_BACKPRESSURE_DROPPED.to_string(),
-                ),
-                local_truncated: true,
-            };
-        };
 
         let path = raw_payload_path_for_kind(
             &state.config.resolved_proxy_raw_dir(),
@@ -4369,14 +4668,69 @@ impl AsyncStreamingRawPayloadWriter {
             false,
         );
         let max_bytes = state.config.proxy_raw_max_bytes;
-        let immediate_gzip_bytes = state.config.proxy_raw_immediate_gzip_threshold();
-        let (tx, mut rx) = mpsc::channel::<Bytes>(ASYNC_STREAMING_RAW_WRITER_QUEUE_CAPACITY);
+        let immediate_gzip_bytes = state.config.proxy_raw_immediate_compression_threshold();
+        // A wire-compressed response is already compressed. Preserve its bytes so the
+        // capture path never spends CPU decoding and recompressing gzip/deflate/zstd.
+        let codec = wire_content_encoding
+            .map(str::trim)
+            .filter(|encoding| !encoding.is_empty() && !encoding.eq_ignore_ascii_case("identity"))
+            .map(|_| RawCompressionCodec::None)
+            .unwrap_or(state.config.proxy_raw_compression);
+        let semaphore = state.proxy_raw_async_semaphore.clone();
+        let writer_max = proxy_raw_async_writer_limit(&state.config);
+        let writer_active = writer_max.saturating_sub(semaphore.available_permits());
+        let permit = semaphore.clone().try_acquire_owned();
+        if permit.is_err() {
+            return match RawOverflowSpool::create(state, invoke_id, kind, codec) {
+                Ok(spool) => {
+                    debug!(
+                        capture_path = "overflow_spool",
+                        storage_codec = ?codec,
+                        writer_active,
+                        writer_max,
+                        spool_pending_records = 0,
+                        spool_pending_bytes = 0,
+                        "raw capture queued to durable overflow spool"
+                    );
+                    Self {
+                        tx: None,
+                        meta_rx: None,
+                        observed_size_bytes: 0,
+                        local_truncated_reason: None,
+                        local_truncated: false,
+                        spool: Some(spool),
+                    }
+                }
+                Err(err) => Self {
+                    tx: None,
+                    meta_rx: None,
+                    observed_size_bytes: 0,
+                    local_truncated_reason: Some(format!("spool_create_failed:{err}")),
+                    local_truncated: true,
+                    spool: None,
+                },
+            };
+        }
+        let permit = permit.expect("checked above");
+        let (tx, mut rx) = mpsc::unbounded_channel::<Bytes>();
         let (meta_tx, meta_rx) = oneshot::channel();
+        debug!(
+            capture_path = "direct_writer",
+            storage_codec = ?codec,
+            writer_active,
+            writer_max,
+            "raw capture assigned to compression writer"
+        );
         tokio::spawn(async move {
             let _permit = permit;
-            let meta =
-                write_streaming_raw_payload_to_file(path, max_bytes, immediate_gzip_bytes, &mut rx)
-                    .await;
+            let meta = write_streaming_raw_payload_to_file(
+                path,
+                max_bytes,
+                immediate_gzip_bytes,
+                codec,
+                &mut rx,
+            )
+            .await;
             let _ = meta_tx.send(meta);
         });
 
@@ -4386,15 +4740,8 @@ impl AsyncStreamingRawPayloadWriter {
             observed_size_bytes: 0,
             local_truncated_reason: None,
             local_truncated: false,
+            spool: None,
         }
-    }
-
-    fn mark_async_backpressure_dropped(&mut self) {
-        self.local_truncated = true;
-        self.local_truncated_reason.get_or_insert_with(|| {
-            RAW_PAYLOAD_TRUNCATED_REASON_ASYNC_BACKPRESSURE_DROPPED.to_string()
-        });
-        self.tx = None;
     }
 
     fn mark_writer_closed(&mut self, message: String) {
@@ -4409,31 +4756,39 @@ impl AsyncStreamingRawPayloadWriter {
             return;
         }
         self.observed_size_bytes = self.observed_size_bytes.saturating_add(bytes.len() as i64);
+        if let Some(spool) = self.spool.as_mut() {
+            if let Err(err) = spool.append(bytes) {
+                self.spool = None;
+                self.mark_writer_closed(format!("spool_write_failed:{err}"));
+            }
+            return;
+        }
         let Some(tx) = self.tx.as_ref() else {
             return;
         };
-        match tx.try_send(Bytes::copy_from_slice(bytes)) {
+        match tx.send(Bytes::copy_from_slice(bytes)) {
             Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => self.mark_async_backpressure_dropped(),
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                self.mark_writer_closed("async raw writer channel closed".to_string())
-            }
+            Err(_) => self.mark_writer_closed("async raw writer channel closed".to_string()),
         }
     }
 
     pub(crate) async fn finish(mut self) -> RawPayloadMeta {
         self.tx.take();
-        let mut meta = match self.meta_rx.take() {
-            Some(meta_rx) => match meta_rx.await {
-                Ok(meta) => meta,
-                Err(err) => RawPayloadMeta {
-                    path: None,
-                    size_bytes: self.observed_size_bytes,
-                    truncated: true,
-                    truncated_reason: Some(format!("write_failed:{err}")),
+        let mut meta = if let Some(spool) = self.spool.take() {
+            spool.finish(self.observed_size_bytes).await
+        } else {
+            match self.meta_rx.take() {
+                Some(meta_rx) => match meta_rx.await {
+                    Ok(meta) => meta,
+                    Err(err) => RawPayloadMeta {
+                        path: None,
+                        size_bytes: self.observed_size_bytes,
+                        truncated: true,
+                        truncated_reason: Some(format!("write_failed:{err}")),
+                    },
                 },
-            },
-            None => RawPayloadMeta::default(),
+                None => RawPayloadMeta::default(),
+            }
         };
         meta.size_bytes = self.observed_size_bytes;
         if self.local_truncated {
@@ -4450,10 +4805,12 @@ pub(crate) async fn write_streaming_raw_payload_to_file(
     path: PathBuf,
     max_bytes: Option<usize>,
     immediate_gzip_bytes: Option<usize>,
-    rx: &mut mpsc::Receiver<Bytes>,
+    codec: RawCompressionCodec,
+    rx: &mut mpsc::UnboundedReceiver<Bytes>,
 ) -> RawPayloadMeta {
     let mut meta = RawPayloadMeta::default();
     let gzip_path = raw_payload_gzip_path(&path);
+    let zstd_path = raw_payload_zstd_path(&path);
     let mut writer = StreamingRawPayloadWriterState::Buffer(Vec::new());
     let mut written_bytes = 0usize;
     while let Some(bytes) = rx.recv().await {
@@ -4494,7 +4851,9 @@ pub(crate) async fn write_streaming_raw_payload_to_file(
             StreamingRawPayloadWriterState::Buffer(mut buffer) => {
                 buffer.extend_from_slice(&bytes[..write_len]);
                 match immediate_gzip_bytes {
-                    Some(threshold) if buffer.len() >= threshold => {
+                    Some(threshold)
+                        if buffer.len() >= threshold && codec == RawCompressionCodec::Gzip =>
+                    {
                         let write_path = gzip_path.clone();
                         match run_blocking_raw_writer_io(move || {
                             let mut encoder = create_gzip_streaming_raw_encoder(&write_path)?;
@@ -4513,6 +4872,31 @@ pub(crate) async fn write_streaming_raw_payload_to_file(
                             }
                             Err(err) => {
                                 failed_path = Some(gzip_path.clone());
+                                Err(err)
+                            }
+                        }
+                    }
+                    Some(threshold)
+                        if buffer.len() >= threshold && codec == RawCompressionCodec::Zstd =>
+                    {
+                        let write_path = zstd_path.clone();
+                        match run_blocking_raw_writer_io(move || {
+                            let mut encoder = create_zstd_streaming_raw_encoder(&write_path)?;
+                            encoder.write_all(&buffer)?;
+                            Ok(encoder)
+                        })
+                        .await
+                        {
+                            Ok(encoder) => {
+                                meta.path = Some(zstd_path.to_string_lossy().to_string());
+                                writer = StreamingRawPayloadWriterState::Zstd {
+                                    path: zstd_path.clone(),
+                                    encoder,
+                                };
+                                Ok(())
+                            }
+                            Err(err) => {
+                                failed_path = Some(zstd_path.clone());
                                 Err(err)
                             }
                         }
@@ -4582,6 +4966,24 @@ pub(crate) async fn write_streaming_raw_payload_to_file(
                     }
                 }
             }
+            StreamingRawPayloadWriterState::Zstd { path, mut encoder } => {
+                let chunk = bytes.slice(..write_len);
+                match run_blocking_raw_writer_io(move || {
+                    encoder.write_all(chunk.as_ref())?;
+                    Ok(encoder)
+                })
+                .await
+                {
+                    Ok(encoder) => {
+                        writer = StreamingRawPayloadWriterState::Zstd { path, encoder };
+                        Ok(())
+                    }
+                    Err(err) => {
+                        failed_path = Some(path.clone());
+                        Err(err)
+                    }
+                }
+            }
         };
 
         if let Err(err) = result {
@@ -4604,6 +5006,19 @@ pub(crate) async fn write_streaming_raw_payload_to_file(
         StreamingRawPayloadWriterState::Buffer(buffer) => {
             if buffer.is_empty() {
                 Ok(())
+            } else if codec == RawCompressionCodec::Zstd {
+                let final_zstd_path = zstd_path.clone();
+                let write_result = run_blocking_raw_writer_io(move || {
+                    let mut encoder = create_zstd_streaming_raw_encoder(&final_zstd_path)?;
+                    encoder.write_all(&buffer)?;
+                    let mut writer = encoder.finish()?;
+                    writer.flush()
+                })
+                .await;
+                if write_result.is_ok() {
+                    meta.path = Some(zstd_path.to_string_lossy().to_string());
+                }
+                write_result
             } else {
                 let final_plain_path = path.clone();
                 let write_result = run_blocking_raw_writer_io(move || {
@@ -4626,6 +5041,17 @@ pub(crate) async fn write_streaming_raw_payload_to_file(
             flush_result
         }
         StreamingRawPayloadWriterState::Gzip { path, encoder } => {
+            let finish_result = run_blocking_raw_writer_io(move || {
+                let mut writer = encoder.finish()?;
+                writer.flush()
+            })
+            .await;
+            if finish_result.is_ok() {
+                meta.path = Some(path.to_string_lossy().to_string());
+            }
+            finish_result
+        }
+        StreamingRawPayloadWriterState::Zstd { path, encoder } => {
             let finish_result = run_blocking_raw_writer_io(move || {
                 let mut writer = encoder.finish()?;
                 writer.flush()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -28,6 +28,7 @@ pub(crate) async fn run() -> Result<()> {
     let schema_started_at = Instant::now();
     ensure_schema(&pool).await?;
     log_startup_phase("schema", schema_started_at);
+    recover_raw_overflow_spools(&config).await;
     if should_recover_pending_pool_attempts_on_startup(&cli) {
         let recovered_running_invocations = recover_orphaned_proxy_invocations(&pool).await?;
         if recovered_running_invocations > 0 {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2328,13 +2328,38 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         r#"
         CREATE TABLE IF NOT EXISTS parallel_work_rollup_coverage_state (
             id INTEGER PRIMARY KEY CHECK (id = 1),
-            full_detail_start_epoch INTEGER NOT NULL
+            full_detail_start_epoch INTEGER NOT NULL,
+            latest_unrecoverable_detail_epoch INTEGER
         )
         "#,
     )
     .execute(pool)
     .await
     .context("failed to ensure parallel_work_rollup_coverage_state table existence")?;
+
+    ensure_column_with_definition(
+        pool,
+        "parallel_work_rollup_coverage_state",
+        "latest_unrecoverable_detail_epoch",
+        "INTEGER",
+    )
+    .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS timeseries_minute_projection_records (
+            minute_start_epoch INTEGER NOT NULL,
+            source_scope TEXT NOT NULL,
+            upstream_account_key INTEGER NOT NULL,
+            records_json TEXT NOT NULL,
+            max_row_id INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (minute_start_epoch, source_scope, upstream_account_key)
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure timeseries_minute_projection_records table existence")?;
 
     sqlx::query(
         r#"

--- a/src/tests/lightweight/forward_proxy_config_and_storage.rs
+++ b/src/tests/lightweight/forward_proxy_config_and_storage.rs
@@ -2444,7 +2444,7 @@ fn search_raw_script_reports_missing_root_as_configuration_error() {
 }
 
 #[tokio::test]
-async fn spawn_raw_payload_file_write_drops_when_async_writer_pool_is_saturated() {
+async fn spawn_raw_payload_file_write_spools_when_async_writer_pool_is_saturated() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
@@ -2457,31 +2457,39 @@ async fn spawn_raw_payload_file_write_drops_when_async_writer_pool_is_saturated(
         .await
         .expect("saturate async raw writer permits");
 
-    let meta = spawn_raw_payload_file_write(
+    let pending = spawn_raw_payload_file_write(
         state.as_ref(),
         "proxy-test",
         "request",
         Bytes::from_static(br#"{"ok":true}"#),
         true,
-    )
-    .finish()
-    .await;
+    );
 
+    let spool_dir = state.config.resolved_proxy_raw_dir().join(".spool");
     assert!(
-        meta.path.is_none(),
-        "dropped raw payload should not have a file"
-    );
-    assert_eq!(meta.size_bytes, br#"{"ok":true}"#.len() as i64);
-    assert!(
-        meta.truncated,
-        "dropped raw payload should be marked truncated"
-    );
-    assert_eq!(
-        meta.truncated_reason.as_deref(),
-        Some(RAW_PAYLOAD_TRUNCATED_REASON_ASYNC_BACKPRESSURE_DROPPED)
+        fs::read_dir(&spool_dir)
+            .expect("raw spool directory should exist")
+            .next()
+            .is_some(),
+        "saturated capture should be persisted in the overflow spool"
     );
 
     drop(permit);
+    let meta = pending.finish().await;
+
+    assert!(
+        meta.path.is_some(),
+        "spooled raw payload should be stored after the writer becomes available"
+    );
+    assert_eq!(meta.size_bytes, br#"{"ok":true}"#.len() as i64);
+    assert!(
+        !meta.truncated,
+        "spooled raw payload should retain its full contents"
+    );
+    assert!(
+        meta.truncated_reason.is_none(),
+        "successful spool replay should not report a truncation reason"
+    );
 }
 
 #[test]

--- a/src/tests/lightweight/forward_proxy_config_and_storage.rs
+++ b/src/tests/lightweight/forward_proxy_config_and_storage.rs
@@ -2089,7 +2089,7 @@ fn store_raw_payload_file_anchors_relative_dir_to_database_parent() {
         "request",
         Bytes::from_static(b"{\"ok\":true}"),
     ));
-    let expected = db_root.join("proxy_raw_payloads/proxy-test-request.bin");
+    let expected = db_root.join("proxy_raw_payloads/proxy-test-request.bin.zst");
 
     assert_eq!(
         meta.path.as_deref(),
@@ -2100,7 +2100,7 @@ fn store_raw_payload_file_anchors_relative_dir_to_database_parent() {
         "raw payload should be written beside the database"
     );
     assert!(
-        !cwd.join("proxy_raw_payloads/proxy-test-request.bin")
+        !cwd.join("proxy_raw_payloads/proxy-test-request.bin.zst")
             .exists(),
         "raw payload should not follow the current working directory"
     );

--- a/src/tests/lightweight/forward_proxy_config_and_storage.rs
+++ b/src/tests/lightweight/forward_proxy_config_and_storage.rs
@@ -225,7 +225,7 @@ fn forward_proxy_manager_v2_keeps_two_positive_weights() {
 }
 
 #[tokio::test]
-async fn async_streaming_raw_payload_writer_respects_global_backpressure_semaphore() {
+async fn async_streaming_raw_payload_writer_queues_when_global_writer_pool_is_saturated() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),
     )
@@ -246,19 +246,99 @@ async fn async_streaming_raw_payload_writer_respects_global_backpressure_semapho
         "invoke-backpressure",
         "response",
         true,
+        None,
     );
     writer.append(b"hello");
+    let spool_dir = state.config.resolved_proxy_raw_dir().join(".spool");
+    assert!(
+        fs::read_dir(&spool_dir)
+            .expect("overflow spool directory")
+            .flatten()
+            .any(
+                |entry| entry.path().extension().and_then(|value| value.to_str()) == Some("frames")
+            ),
+        "saturated writer should persist overflow bytes before capacity is released"
+    );
+    drop(permits);
     let meta = writer.finish().await;
 
-    assert!(meta.path.is_none());
     assert_eq!(meta.size_bytes, 5);
-    assert!(meta.truncated);
+    assert!(!meta.truncated);
+    let path = PathBuf::from(meta.path.expect("queued raw capture path"));
     assert_eq!(
-        meta.truncated_reason.as_deref(),
-        Some(RAW_PAYLOAD_TRUNCATED_REASON_ASYNC_BACKPRESSURE_DROPPED)
+        read_proxy_raw_bytes(path.to_string_lossy().as_ref(), None).unwrap(),
+        b"hello"
     );
+    let _ = fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn raw_overflow_spool_recovery_publishes_complete_frames_and_keeps_invalid_files() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let mut permits = Vec::new();
+    while let Ok(permit) = state.proxy_raw_async_semaphore.clone().try_acquire_owned() {
+        permits.push(permit);
+    }
+    let mut writer = AsyncStreamingRawPayloadWriter::new(
+        state.as_ref(),
+        "invoke-spool-recovery",
+        "response",
+        true,
+        None,
+    );
+    writer.append(b"recover-me");
+    drop(writer);
+
+    let spool_dir = state.config.resolved_proxy_raw_dir().join(".spool");
+    fs::create_dir_all(&spool_dir).expect("create spool dir");
+    let invalid_path = spool_dir.join("incomplete.frames");
+    fs::write(&invalid_path, b"partial").expect("write invalid spool");
 
     drop(permits);
+    recover_raw_overflow_spools(&state.config).await;
+
+    let recovered = state
+        .config
+        .resolved_proxy_raw_dir()
+        .join("invoke-spool-recovery-response.bin.zst");
+    assert_eq!(
+        read_proxy_raw_bytes(recovered.to_string_lossy().as_ref(), None).expect("recovered raw"),
+        b"recover-me"
+    );
+    assert!(
+        invalid_path.exists(),
+        "invalid spool must remain for inspection"
+    );
+    let _ = fs::remove_file(recovered);
+    let _ = fs::remove_file(invalid_path);
+}
+
+#[tokio::test]
+async fn streaming_raw_capture_preserves_precompressed_wire_bytes_without_recompression() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(b"already-gzipped-wire-body").unwrap();
+    let wire_bytes = encoder.finish().unwrap();
+
+    let mut writer = AsyncStreamingRawPayloadWriter::new(
+        state.as_ref(),
+        "invoke-precompressed-wire",
+        "response",
+        true,
+        Some("gzip"),
+    );
+    writer.append(&wire_bytes);
+    let meta = writer.finish().await;
+    let path = PathBuf::from(meta.path.expect("raw wire path"));
+    assert!(path.ends_with("invoke-precompressed-wire-response.bin"));
+    assert_eq!(fs::read(&path).expect("read stored wire bytes"), wire_bytes);
+    let _ = fs::remove_file(path);
 }
 
 #[tokio::test]
@@ -2063,20 +2143,51 @@ fn store_raw_payload_file_born_gzips_large_payloads_when_threshold_is_reached() 
     cleanup_temp_test_dir(&temp_dir);
 }
 
+#[test]
+fn store_raw_payload_file_born_zstds_identity_payloads() {
+    let temp_dir = make_temp_test_dir("proxy-raw-store-born-zstd");
+    let mut config = test_config();
+    config.database_path = temp_dir.join("codex_vibe_monitor.db");
+    config.proxy_raw_compression = RawCompressionCodec::Zstd;
+    let payload = br#"{"identity":"stored-with-zstd"}"#;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+    let meta = runtime.block_on(store_raw_payload_file(
+        &config,
+        "proxy-born-zstd",
+        "response",
+        Bytes::from_static(payload),
+    ));
+    let path = PathBuf::from(meta.path.expect("zstd path"));
+    assert!(path.ends_with("proxy-born-zstd-response.bin.zst"));
+    assert_eq!(
+        read_proxy_raw_bytes(path.to_string_lossy().as_ref(), None).expect("read zstd raw"),
+        payload
+    );
+    cleanup_temp_test_dir(&temp_dir);
+}
+
 #[tokio::test]
 async fn write_streaming_raw_payload_to_file_born_gzips_large_streams() {
     let temp_dir = make_temp_test_dir("proxy-stream-born-gzip");
     let raw_path = temp_dir.join("stream-response.bin");
-    let (tx, mut rx) = mpsc::channel::<Bytes>(4);
+    let (tx, mut rx) = mpsc::unbounded_channel::<Bytes>();
     tx.send(Bytes::from_static(b"hello-"))
-        .await
         .expect("send first chunk");
     tx.send(Bytes::from_static(b"world-large"))
-        .await
         .expect("send second chunk");
     drop(tx);
 
-    let meta = write_streaming_raw_payload_to_file(raw_path.clone(), None, Some(8), &mut rx).await;
+    let meta = write_streaming_raw_payload_to_file(
+        raw_path.clone(),
+        None,
+        Some(8),
+        RawCompressionCodec::Gzip,
+        &mut rx,
+    )
+    .await;
 
     let stored_path = PathBuf::from(meta.path.expect("streaming born-gzip path"));
     assert!(stored_path.ends_with("stream-response.bin.gz"));
@@ -2096,13 +2207,19 @@ async fn write_streaming_raw_payload_to_file_removes_plain_path_after_write_fail
     let raw_path = temp_dir.join("stream-response.bin");
     symlink("/dev/full", &raw_path).expect("symlink plain raw path to /dev/full");
 
-    let (tx, mut rx) = mpsc::channel::<Bytes>(4);
+    let (tx, mut rx) = mpsc::unbounded_channel::<Bytes>();
     tx.send(Bytes::from_static(b"hello-world"))
-        .await
         .expect("send chunk");
     drop(tx);
 
-    let meta = write_streaming_raw_payload_to_file(raw_path.clone(), None, None, &mut rx).await;
+    let meta = write_streaming_raw_payload_to_file(
+        raw_path.clone(),
+        None,
+        None,
+        RawCompressionCodec::None,
+        &mut rx,
+    )
+    .await;
 
     assert!(meta.path.is_none(), "failed write must not keep raw path");
     assert!(meta.truncated, "failed write should mark payload truncated");
@@ -2130,13 +2247,19 @@ async fn write_streaming_raw_payload_to_file_removes_gzip_path_after_write_failu
     let gzip_path = temp_dir.join("stream-response.bin.gz");
     symlink("/dev/full", &gzip_path).expect("symlink gzip raw path to /dev/full");
 
-    let (tx, mut rx) = mpsc::channel::<Bytes>(4);
+    let (tx, mut rx) = mpsc::unbounded_channel::<Bytes>();
     tx.send(Bytes::from_static(b"hello-world"))
-        .await
         .expect("send chunk");
     drop(tx);
 
-    let meta = write_streaming_raw_payload_to_file(raw_path, None, Some(1), &mut rx).await;
+    let meta = write_streaming_raw_payload_to_file(
+        raw_path,
+        None,
+        Some(1),
+        RawCompressionCodec::Gzip,
+        &mut rx,
+    )
+    .await;
 
     assert!(meta.path.is_none(), "failed write must not keep raw path");
     assert!(meta.truncated, "failed write should mark payload truncated");


### PR DESCRIPTION
## Summary
- Store identity response raw payloads with Zstd; preserve pre-compressed wire bytes and replay CRC-framed overflow spool files on startup.
- Add exact complete-minute projection for today/1d open-window timeseries and batch its cold-start upsert.
- Replace repeated parallel-work retained-detail reverse scans with a write-side watermark.

## Verification
- `cargo fmt --check`
- `cargo check`
- Targeted raw capture, minute projection, and parallel-work tests passed.
- `cargo test -q` was started twice locally but did not reach a terminal result; the second run became idle after 49 minutes and was interrupted. CI must provide the full-suite gate.
- Independent `codex review` was attempted but its output was truncated and the process made no progress; no review verdict was obtained.

## References
- Specs: `q8h3n-proxy-hot-path-streaming-stability`, `5932d-sse-proxy-live-sync`, `9aucy-db-retention-archive`
- Solutions: `proxy-capture-body-replay-safety`, `sqlite-write-pressure-backpressure`
- Project Docs: -