### PR TITLE
feat(proxy): record Codex standalone search requests

### DIFF
--- a/docs/specs/z9h7v-invocation-log-observability/HISTORY.md
+++ b/docs/specs/z9h7v-invocation-log-observability/HISTORY.md
@@ -1,5 +1,7 @@
 # 请求日志可观测性增强（IP / Cache Tokens / 分阶段耗时 / Prompt Cache Key / Body Logging Toggles） - History
 
+- 2026-08-04: Implemented Codex standalone search recording as an exact `POST /v1/alpha/search` non-streaming capture target. It reuses pool and OAuth passthrough accounting, records one parent invocation per downstream request, and enters the existing source-level hourly rollup without inventing search usage or adding an endpoint rollup dimension.
+
 ## Account upstream attempt observability
 
 - 账号详情从最终调用记录切换为 7 天主库尝试请求表，修复失败账号事件链接到最终成功账号调用而无法定位的问题；每行只显示本次尝试请求的请求/响应模型、结果、代理、三段延迟和错误，不显示 endpoint，也不混入重试序号或最终调用 usage。

--- a/docs/specs/z9h7v-invocation-log-observability/IMPLEMENTATION.md
+++ b/docs/specs/z9h7v-invocation-log-observability/IMPLEMENTATION.md
@@ -4,6 +4,7 @@
 
 - Canonical spec: `docs/specs/z9h7v-invocation-log-observability/SPEC.md`
 - Implementation summary: 已完成，且已扩展 request/response body logging 双开关
+- Codex standalone search (`POST /v1/alpha/search`) 复用普通非流式 capture、OAuth passthrough、父 invocation 与 source-level hourly rollup；不新增 endpoint rollup 或搜索专属 usage 解析。
 - 号池尝试详情会将真实上游请求尝试与 `budget_exhausted_final` / `sameAccountRetryIndex <= 0` 合成终态记录分开展示；终态记录只展示未发起新请求的终态说明与上一失败账号上下文。
 - proxy settings 现在持久化 `request_body_logging_enabled` / `response_body_logging_enabled`；关闭后只阻止新的 raw body / response preview 留存，不影响结构化 payload、usage、timing、routing/account、prompt cache key 等字段。
 - response body logging 关闭时，运行态记录与终态持久化都会将 `raw_response` preview 置空，并跳过 `response_raw_path` 元数据。

--- a/docs/specs/z9h7v-invocation-log-observability/SPEC.md
+++ b/docs/specs/z9h7v-invocation-log-observability/SPEC.md
@@ -23,6 +23,8 @@
 - `/api/invocations` 与 SSE `records` 在不改 schema 的前提下额外返回 `compactionRequestKind` / `compactionResponseKind`，把原始 endpoint 与压缩语义解耦。
 - `/api/invocations`、SSE `records` 与 Prompt Cache / Dashboard preview 在不改 schema 的前提下额外返回 `imageIntent`，使图片请求语义脱离 endpoint 和历史 raw body 存活状态而独立存在。
 - `/api/invocations`、SSE `records`、Prompt Cache preview 与 Dashboard working conversations 在不改 schema 的前提下额外返回 `requestModel` / `responseModel`，用于区分请求模型与实际响应模型。
+- Codex standalone search 的 `POST /v1/alpha/search` 必须进入与其他代理请求相同的 invocation capture、attempt、实时展示与 source-level hourly rollup 链路。
+- Standalone search 记录沿用普通请求的 raw body logging 开关与状态/延迟字段；搜索响应中的 `output`、`results` 与 `encrypted_output` 不被推断为 usage、token 或 cost。
 - 复用 invocation preview wire shape 的 owner-facing 列表在需要稳定对话关联时，必须继续返回真实 `promptCacheKey`；Dashboard 上游账号活动 recent 行不得再把 `invokeId` 当成对话键替代。
 - Records 与 Dashboard 两个 owner-facing 列表同时显示独立“图片工具”徽标，避免同一条 invocation 在不同列表面出现语义漂移。
 - Live 展开详情与 Dashboard 调用详情抽屉必须共用同一套调用详情组件，并按“快速排障”组织信息：请求身份、路由与模型、失败信号、细节保留、阶段耗时分组展示。
@@ -50,6 +52,7 @@
 - 不改费用、token 明细和既有时序聚合的归集语义；本规格只定义 `modelPerformance` 的成功已计费完整周期口径，以及该口径在 Dashboard 性能明细入口中的展示语义，不再驱动顶部实时 KPI。
 - 不新增“总日志开关”。
 - 不对历史 `.gz` / raw 文件做立即删除、迁移或重压缩。
+- 不新增 endpoint 维度的 rollup、搜索 query/result 专属字段或搜索专属 Dashboard。
 
 ## 范围（Scope）
 
@@ -63,6 +66,7 @@
 - `proxy_model_settings` 单例新增 request/response body logging 持久化字段与 settings 页面双开关 UI。
 - request raw / response raw / response preview 按设置开关 fail-soft 退化，详情页与历史回填接受“新记录没有 raw body”为正常状态。
 - `GET /api/stats/dashboard-activity` 的全局与账号活动返回模型性能分组；Dashboard 总览与账号卡复用同一个桌面浮层/窄屏抽屉入口。
+- `POST /v1/alpha/search` 只按精确 method/path 接入；普通号池 capture 与 OAuth bridge 的普通/counted passthrough 都必须保留原始 path、query、body、headers 与响应状态。
 
 ### Out of scope
 
@@ -86,6 +90,10 @@
 - `requestBodyLoggingEnabled=false` 时，新请求不再写入 `request_raw_path` / request raw 文件；相关 size/truncation 字段维持空值或零值语义，不把该情况视为损坏。
 - `responseBodyLoggingEnabled=false` 时，新响应不再写入 `response_raw_path` / response raw 文件，同时 `raw_response` inline preview 也不再持久化。
 - `responseBodyLoggingEnabled=false` 时，调用详情读取响应 body、异常 drawer 与历史回填链路必须返回既有 unavailable/fallback 语义，而不是 500 或“缺文件即损坏”语义。
+- `POST /v1/alpha/search` 必须被识别为独立的非流式 capture target；不得退化为 `Responses` target，也不得启用 Responses SSE、fast-mode、自动 usage、图片或 compaction 专属逻辑。
+- Standalone search 必须记录请求 endpoint/model、终态 status、failure kind、timing 与既有 attempt 信息；缺少明确 usage 证据时 token/cost 保持空值。
+- 一个下游 standalone search 请求只能产生一个父 invocation；upstream retry/failover 只增加既有 attempt 记录，不重复增加 invocation rollup 请求量。
+- OAuth bridge 的普通与 counted passthrough 都必须允许 `/v1/alpha/search`，不得返回 `oauth_unsupported_route`。
 - `/v1/responses/compact` 继续视为 `Compact`；不把它改名成 `V1`，也不把 `/v1/responses` 内的 V2 语义挤占到 endpoint 字段。
 - `/v1/responses` 请求体含 `context_management[type=compaction][compact_threshold]` 时，运行态记录必须写入 `compactionRequestKind="remote_v2"`，且不依赖 request body raw logging。
 - `/v1/responses` 终态只有在响应中实际检测到 compaction item 时才写入 `compactionResponseKind="remote_v2"`；“请求启用了 V2 但响应未触发”不得在终态列表误显示为 `远程压缩V2`。
@@ -129,6 +137,9 @@
 ### Core flows
 
 - 请求进入 `/v1/chat/completions` 或 `/v1/responses` 采集路径时，后端提取 IP 与 prompt cache key，并随 payload 一并落库。
+- 请求进入 `POST /v1/alpha/search` 时，后端使用与其他非流式 capture target 相同的结构化 invocation、raw body、终态和 attempt 记录路径；搜索协议字段只作为原始请求/响应内容保留。
+- 号池 standalone search 的 hourly rollup 以父 invocation 终态增量计数；归档 replay 继续读取相同的 `codex_invocations` source，不创建搜索专用 rollup 维度。
+- OAuth bridge standalone search 在普通与 counted passthrough 中都保留 `/v1/alpha/search` 的 upstream path，并沿用当前 OAuth 请求 accounting/终态记录路径。
 - `/api/invocations` 通过 `json_extract(payload, ...)` 投影扩展字段，不依赖新增列。
 - Dashboard 活动快照从 retained live 调用按响应模型与思考程度聚合成功已计费性能样本，同时分别生成全局、账号、模型与账号+模型四级的墙钟并集与累计时长，并在全局和账号级 `modelPerformance` 响应里显式返回 `wallClockUsageDurationMs`、`cumulativeUsageDurationMs` 与 `parallelism`；原始费用、token 明细和调用列表聚合保持不变。
 - Dashboard 性能明细入口继续展示当前选择范围的完整周期总计；顶部实时 KPI 与账号标题实时指标改由 `z6ysw` 的最近完整 1 分钟 bucket 提供，不再把 `modelPerformance` 总计当作当前值。
@@ -155,6 +166,7 @@
 - 若阶段耗时缺失（旧记录），前端逐项显示 `—`。
 - 若号池达到不同账号尝试上限，前端应明确说明终态记录未发起新的上游请求，并可保留上一失败账号与上一错误状态作为诊断上下文。
 - 当 body logging 开关关闭导致新记录没有 raw 路径或 preview 时，详情页、回填与异常查看都要把它当作“未保留 body”，不是“raw 文件丢失”。
+- 上游返回 standalone search 的 HTTP 404/5xx 时，网关必须将其作为 upstream failure 记录并透传既有错误语义；不得把它误记为本地不支持路由。
 
 ## 接口契约（Interfaces & Contracts）
 
@@ -166,6 +178,14 @@
 - `endpoint?: string`
 - `failureKind?: string`
 - `costAudit?: { recorded?: { input?: number; cacheWrite?: number; cacheRead?: number; output?: number; reasoning?: number; total?: number }; local?: { input?: number; cacheWrite?: number; cacheRead?: number; output?: number; reasoning?: number; total?: number }; mismatch: boolean; reason?: string | null; absoluteDiffUsd?: number | null; recordedPriceVersion?: string | null; localPriceVersion?: string | null }`
+
+### Codex standalone search invocation
+
+- 入站合同为精确 `POST /v1/alpha/search`；`GET`、trailing slash 与其他 `/v1/alpha/*` 路径不属于本合同。
+- `endpoint` 对外保持 `/v1/alpha/search`；`model` 从既有请求字段提取，`requestModel` / `responseModel` 继续遵循现有通用投影。
+- 搜索响应不会因为包含 `output`、`results` 或 `encrypted_output` 而生成 token/cost/usage；没有明确 usage 证据时对应字段保持 unavailable。
+- request/response raw 文件与 inline preview 完全遵循 `requestBodyLoggingEnabled` / `responseBodyLoggingEnabled`。
+- 号池重试按一个父 invocation 和多个既有 upstream attempts 记录，source-level hourly rollup 只计一次父 invocation。
 
 ### `GET /api/invocations/{invokeId}/pool-attempts` 尝试对象
 
@@ -289,6 +309,11 @@
 - Given 一条调用的请求体使用 `zstd` 压缩而上游响应 `Content-Encoding` 为 `identity`，When owner 查看调用列表或展开详情，Then “响应耗时 / HTTP 请求压缩”和“HTTP 请求压缩”均显示 `zstd`；响应值明确标为“HTTP 响应压缩”。
 - Given 历史记录没有持久化 `requestCompressionAlgorithm`，When owner 查看调用列表或详情，Then 请求压缩显示 `—`，不得用响应 `Content-Encoding` 回退填充。
 - Given 调用发生重试，When owner 查看调用列表、Prompt Cache 会话展开、账号活动预览或对应的归档历史，Then 请求压缩显示最终 attempt 的真实请求压缩算法。
+- Given `POST /v1/alpha/search` 进入普通号池，When mock upstream 返回成功 JSON，Then upstream 收到原始 path/body，invocation 的 endpoint 为 `/v1/alpha/search`，记录包含 model/status/timing，并进入现有 hourly rollup。
+- Given standalone search 的 mock upstream 返回 404/5xx，When 请求终止，Then 响应按 upstream failure 透传并持久化失败 invocation，不返回本地 `oauth_unsupported_route` 或 generic unsupported capture 结果。
+- Given standalone search 触发 upstream retry/failover，When 最终请求完成，Then 只有一个父 invocation 进入 total/success/failure rollup，各次真实尝试分别出现在既有 attempt 记录中。
+- Given OAuth bridge 使用普通或 counted passthrough 处理 standalone search，When 请求发往 OAuth upstream，Then `/v1/alpha/search`、query、body、forwardable headers 与响应状态保持不变，且不被 route whitelist 拒绝。
+- Given standalone search 没有 usage 字段，When 查询 invocation、summary 与 rollup，Then token/cost 不被搜索输出内容伪造，通用调用量/成功率/延迟统计仍正确。
 
 ### Manual verification
 

--- a/src/api/slices/settings_models_and_cache.rs
+++ b/src/api/slices/settings_models_and_cache.rs
@@ -1575,6 +1575,7 @@ pub(crate) enum ProxyCaptureTarget {
     ChatCompletions,
     Responses,
     ResponsesCompact,
+    StandaloneSearch,
     ImageGenerations,
     ImageEdits,
 }
@@ -1585,6 +1586,7 @@ impl ProxyCaptureTarget {
             Self::ChatCompletions => "/v1/chat/completions",
             Self::Responses => "/v1/responses",
             Self::ResponsesCompact => "/v1/responses/compact",
+            Self::StandaloneSearch => "/v1/alpha/search",
             Self::ImageGenerations => "/v1/images/generations",
             Self::ImageEdits => "/v1/images/edits",
         }
@@ -1603,6 +1605,7 @@ impl ProxyCaptureTarget {
             "/v1/chat/completions" => Self::ChatCompletions,
             "/v1/responses/compact" => Self::ResponsesCompact,
             "/v1/responses" => Self::Responses,
+            "/v1/alpha/search" => Self::StandaloneSearch,
             "/v1/images/generations" => Self::ImageGenerations,
             "/v1/images/edits" => Self::ImageEdits,
             _ => Self::Responses,

--- a/src/oauth_bridge.rs
+++ b/src/oauth_bridge.rs
@@ -293,7 +293,7 @@ pub(crate) async fn send_oauth_upstream_request(
             )
             .await
         }
-        path if is_supported_oauth_passthrough_route(path) => {
+        path if is_supported_oauth_passthrough_route(&method, path) => {
             oauth_passthrough(
                 client,
                 method,
@@ -379,7 +379,7 @@ pub(crate) async fn send_counted_oauth_upstream_request(
             )
             .await
         }
-        path if is_supported_oauth_passthrough_route(path) => {
+        path if is_supported_oauth_passthrough_route(&method, path) => {
             counted_oauth_passthrough(
                 method,
                 original_uri,
@@ -989,8 +989,12 @@ async fn read_counted_oauth_upstream_bytes_with_timeout(
     }
 }
 
-fn is_supported_oauth_passthrough_route(path: &str) -> bool {
-    matches!(path, "/v1/responses/compact" | "/v1/chat/completions")
+fn is_supported_oauth_passthrough_route(method: &Method, path: &str) -> bool {
+    *method == Method::POST
+        && matches!(
+            path,
+            "/v1/responses/compact" | "/v1/chat/completions" | "/v1/alpha/search"
+        )
 }
 
 async fn oauth_models(
@@ -2073,11 +2077,132 @@ mod tests {
 
     #[test]
     fn unsupported_oauth_route_returns_explicit_error() {
-        assert!(!is_supported_oauth_passthrough_route("/v1/embeddings"));
+        assert!(!is_supported_oauth_passthrough_route(
+            &Method::POST,
+            "/v1/embeddings"
+        ));
         assert!(is_supported_oauth_passthrough_route(
+            &Method::POST,
             "/v1/responses/compact"
         ));
-        assert!(is_supported_oauth_passthrough_route("/v1/chat/completions"));
+        assert!(is_supported_oauth_passthrough_route(
+            &Method::POST,
+            "/v1/chat/completions"
+        ));
+        assert!(is_supported_oauth_passthrough_route(
+            &Method::POST,
+            "/v1/alpha/search"
+        ));
+        assert!(!is_supported_oauth_passthrough_route(
+            &Method::GET,
+            "/v1/alpha/search"
+        ));
+        assert!(!is_supported_oauth_passthrough_route(
+            &Method::PUT,
+            "/v1/alpha/search"
+        ));
+    }
+
+    #[tokio::test]
+    async fn standalone_search_passthrough_supports_ordinary_and_counted_requests() {
+        async fn search_upstream(request: axum::extract::Request) -> Response {
+            let body = to_bytes(request.into_body(), usize::MAX)
+                .await
+                .expect("read search request body");
+            (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "path": "/backend-api/codex/alpha/search",
+                    "query": "cursor=next",
+                    "body": String::from_utf8(body.to_vec()).expect("search body is utf8"),
+                })),
+            )
+                .into_response()
+        }
+
+        let _guard = TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK.lock().await;
+        let app = Router::new().route("/backend-api/codex/alpha/search", post(search_upstream));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind standalone search oauth upstream");
+        let addr = listener
+            .local_addr()
+            .expect("standalone search oauth upstream addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("standalone search oauth upstream should run");
+        });
+        set_test_oauth_codex_upstream_base_url(
+            Url::parse(&format!("http://{addr}/backend-api/codex"))
+                .expect("valid standalone search oauth base url"),
+        )
+        .await;
+
+        let headers = HeaderMap::from_iter([(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )]);
+        let request_body = Bytes::from_static(br#"{"model":"gpt-5.4","query":"hello"}"#);
+        let ordinary = send_oauth_upstream_request(
+            &Client::new(),
+            Method::POST,
+            &"/v1/alpha/search?cursor=next"
+                .parse()
+                .expect("valid search uri"),
+            &headers,
+            OauthUpstreamRequestBody::Bytes(request_body.clone()),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            Some(7),
+            "oauth-search-ordinary",
+            Some("org_search"),
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(ordinary.response.status(), StatusCode::ACCEPTED);
+        let ordinary_body = to_bytes(ordinary.response.into_body(), usize::MAX)
+            .await
+            .expect("read ordinary search response");
+        let ordinary_payload: Value =
+            serde_json::from_slice(&ordinary_body).expect("decode ordinary search response");
+        assert_eq!(ordinary_payload["path"], "/backend-api/codex/alpha/search");
+        assert_eq!(ordinary_payload["query"], "cursor=next");
+        assert_eq!(
+            ordinary_payload["body"],
+            "{\"model\":\"gpt-5.4\",\"query\":\"hello\"}"
+        );
+
+        let counted = send_counted_oauth_upstream_request(
+            Method::POST,
+            &"/v1/alpha/search?cursor=next"
+                .parse()
+                .expect("valid search uri"),
+            &headers,
+            CountedOauthUpstreamRequestBody::Bytes(request_body),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            Some(7),
+            "oauth-search-counted",
+            Some("org_search"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(counted.response.status(), StatusCode::ACCEPTED);
+        let counted_body = to_bytes(counted.response.into_body(), usize::MAX)
+            .await
+            .expect("read counted search response");
+        let counted_payload: Value =
+            serde_json::from_slice(&counted_body).expect("decode counted search response");
+        assert_eq!(counted_payload["path"], "/backend-api/codex/alpha/search");
+        assert_eq!(counted_payload["query"], "cursor=next");
+
+        handle.abort();
+        reset_test_oauth_codex_upstream_base_url().await;
     }
 
     #[test]

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -385,6 +385,7 @@ pub(crate) fn capture_target_for_request(
         "/v1/chat/completions" => Some(ProxyCaptureTarget::ChatCompletions),
         "/v1/responses" => Some(ProxyCaptureTarget::Responses),
         "/v1/responses/compact" => Some(ProxyCaptureTarget::ResponsesCompact),
+        "/v1/alpha/search" => Some(ProxyCaptureTarget::StandaloneSearch),
         "/v1/images/generations" => Some(ProxyCaptureTarget::ImageGenerations),
         "/v1/images/edits" => Some(ProxyCaptureTarget::ImageEdits),
         _ => None,
@@ -1996,11 +1997,12 @@ pub(crate) async fn proxy_openai_v1_capture_target(
     };
 
     let upstream_connection_scoped = connection_scoped_header_names(upstream_response.headers());
-    let response_is_event_stream = upstream_response
-        .headers()
-        .get(header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.starts_with("text/event-stream"));
+    let response_is_event_stream = capture_target != ProxyCaptureTarget::StandaloneSearch
+        && upstream_response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.starts_with("text/event-stream"));
     let upstream_content_encoding = upstream_response
         .headers()
         .get(header::CONTENT_ENCODING)
@@ -2156,7 +2158,8 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         // Capture the bytes once and attach the finalized payload to both records below.
         let attempt_response_capture_enabled = proxy_settings.response_body_logging_enabled
             && pending_pool_attempt_record_for_task.is_some();
-        let mut stream_response_parser = StreamResponsePayloadChunkParser::default();
+        let mut stream_response_parser =
+            StreamResponsePayloadChunkParser::for_target(capture_target);
         let mut stream_response_decoder =
             IncrementalResponsePayloadDecoder::new(upstream_content_encoding_for_task.as_deref());
         let mut first_token_ms: Option<f64> = None;
@@ -2779,9 +2782,10 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             &preview_bytes,
             upstream_content_encoding_for_task.as_deref(),
         );
-        let response_is_stream_hint = response_is_event_stream_for_task
-            || streamed_response_outcome.saw_stream_fields
-            || preview_looks_like_sse;
+        let response_is_stream_hint = capture_target != ProxyCaptureTarget::StandaloneSearch
+            && (response_is_event_stream_for_task
+                || streamed_response_outcome.saw_stream_fields
+                || preview_looks_like_sse);
         let resp_parse_started = Instant::now();
         let mut response_info = if response_is_stream_hint {
             if streamed_response_outcome.saw_stream_fields {
@@ -3854,7 +3858,9 @@ pub(crate) fn resolve_compaction_response_kind_for_payload(
     capture_target: ProxyCaptureTarget,
     parsed_kind: Option<CompactionKind>,
 ) -> Option<CompactionKind> {
-    if capture_target == ProxyCaptureTarget::ResponsesCompact {
+    if capture_target == ProxyCaptureTarget::StandaloneSearch {
+        None
+    } else if capture_target == ProxyCaptureTarget::ResponsesCompact {
         Some(CompactionKind::Compact)
     } else {
         parsed_kind

--- a/src/proxy/payload_utils.rs
+++ b/src/proxy/payload_utils.rs
@@ -586,7 +586,9 @@ fn infer_image_intent_from_request_body_with_codex_namespace(
         ProxyCaptureTarget::ImageGenerations | ProxyCaptureTarget::ImageEdits => {
             ImageIntent::DirectImage
         }
-        ProxyCaptureTarget::ChatCompletions => ImageIntent::Unknown,
+        ProxyCaptureTarget::ChatCompletions | ProxyCaptureTarget::StandaloneSearch => {
+            ImageIntent::Unknown
+        }
         ProxyCaptureTarget::Responses | ProxyCaptureTarget::ResponsesCompact => {
             if value
                 .get("model")

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -80,7 +80,7 @@ pub(crate) fn parse_target_response_payload_from_raw_file(
     is_stream_hint: bool,
     content_encoding: Option<&str>,
 ) -> std::result::Result<ResponseCaptureInfo, String> {
-    if is_stream_hint {
+    if is_stream_hint && target != ProxyCaptureTarget::StandaloneSearch {
         let reader = open_decoded_response_reader(path, content_encoding)?;
         parse_stream_response_payload_from_reader(reader).map_err(|err| err.to_string())
     } else {

--- a/src/proxy/stream_gate.rs
+++ b/src/proxy/stream_gate.rs
@@ -355,10 +355,14 @@ pub(crate) fn prepare_target_request_body(
         }
         _ => None,
     };
-    info.is_stream = value
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    info.is_stream = if target == ProxyCaptureTarget::StandaloneSearch {
+        false
+    } else {
+        value
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    };
     info.image_intent = Some(
         infer_image_intent_from_request_body(target, &value)
             .as_str()
@@ -447,7 +451,7 @@ pub(crate) fn proxy_capture_target_stream_timeout(
     match capture_target {
         ProxyCaptureTarget::Responses => Some(timeouts.responses_stream_timeout),
         ProxyCaptureTarget::ResponsesCompact => Some(timeouts.compact_stream_timeout),
-        ProxyCaptureTarget::ChatCompletions => None,
+        ProxyCaptureTarget::ChatCompletions | ProxyCaptureTarget::StandaloneSearch => None,
         ProxyCaptureTarget::ImageGenerations | ProxyCaptureTarget::ImageEdits => None,
     }
 }
@@ -770,7 +774,9 @@ pub(crate) fn extract_reasoning_effort_from_request_body(
         ProxyCaptureTarget::ChatCompletions => {
             value.get("reasoning_effort").and_then(|v| v.as_str())
         }
-        ProxyCaptureTarget::ImageGenerations | ProxyCaptureTarget::ImageEdits => None,
+        ProxyCaptureTarget::ImageGenerations
+        | ProxyCaptureTarget::ImageEdits
+        | ProxyCaptureTarget::StandaloneSearch => None,
     }?;
 
     let normalized = raw.trim();
@@ -785,6 +791,22 @@ pub(crate) fn build_response_capture_info_from_bytes(
     bytes: &[u8],
     request_is_stream: bool,
     decode_failure_reason: Option<String>,
+) -> ResponseCaptureInfo {
+    build_response_capture_info_from_bytes_with_sse_detection(
+        bytes,
+        request_is_stream,
+        decode_failure_reason,
+        true,
+        true,
+    )
+}
+
+fn build_response_capture_info_from_bytes_with_sse_detection(
+    bytes: &[u8],
+    request_is_stream: bool,
+    decode_failure_reason: Option<String>,
+    allow_sse_detection: bool,
+    allow_compaction_detection: bool,
 ) -> ResponseCaptureInfo {
     if bytes.is_empty() {
         return ResponseCaptureInfo {
@@ -801,7 +823,8 @@ pub(crate) fn build_response_capture_info_from_bytes(
         };
     }
 
-    let looks_like_stream = request_is_stream || response_payload_looks_like_sse(bytes);
+    let looks_like_stream =
+        request_is_stream || (allow_sse_detection && response_payload_looks_like_sse(bytes));
     let mut response_info = if looks_like_stream {
         parse_stream_response_payload(bytes)
     } else {
@@ -824,8 +847,11 @@ pub(crate) fn build_response_capture_info_from_bytes(
                     usage_missing_reason,
                     contains_encrypted_content: value_contains_encrypted_content(&value),
                     service_tier,
-                    compaction_response_kind: response_value_indicates_remote_v2_compaction(&value)
-                        .then_some(CompactionKind::RemoteV2),
+                    compaction_response_kind: allow_compaction_detection
+                        .then(|| response_value_indicates_remote_v2_compaction(&value))
+                        .and_then(|is_compaction| {
+                            is_compaction.then_some(CompactionKind::RemoteV2)
+                        }),
                     stream_terminal_event: None,
                     upstream_error_code: extract_upstream_error_code(&value),
                     upstream_error_message: extract_upstream_error_message(&value),
@@ -875,31 +901,35 @@ pub(crate) fn build_response_capture_info_from_bytes(
 }
 
 pub(crate) fn parse_target_response_payload(
-    _target: ProxyCaptureTarget,
+    target: ProxyCaptureTarget,
     bytes: &[u8],
     request_is_stream: bool,
     content_encoding: Option<&str>,
 ) -> ResponseCaptureInfo {
     let (decoded_bytes, decode_failure_reason) =
         decode_response_payload_for_parse(bytes, content_encoding);
-    build_response_capture_info_from_bytes(
+    build_response_capture_info_from_bytes_with_sse_detection(
         decoded_bytes.as_ref(),
-        request_is_stream,
+        request_is_stream && target != ProxyCaptureTarget::StandaloneSearch,
         decode_failure_reason,
+        target != ProxyCaptureTarget::StandaloneSearch,
+        target != ProxyCaptureTarget::StandaloneSearch,
     )
 }
 pub(crate) fn parse_target_response_preview_payload(
-    _target: ProxyCaptureTarget,
+    target: ProxyCaptureTarget,
     bytes: &[u8],
     request_is_stream: bool,
     content_encoding: Option<&str>,
 ) -> ResponseCaptureInfo {
     let (decoded_bytes, decode_failure_reason) =
         decode_response_payload_for_preview_parse(bytes, content_encoding);
-    build_response_capture_info_from_bytes(
+    build_response_capture_info_from_bytes_with_sse_detection(
         decoded_bytes.as_ref(),
-        request_is_stream,
+        request_is_stream && target != ProxyCaptureTarget::StandaloneSearch,
         decode_failure_reason,
+        target != ProxyCaptureTarget::StandaloneSearch,
+        target != ProxyCaptureTarget::StandaloneSearch,
     )
 }
 
@@ -1059,8 +1089,8 @@ pub(crate) fn decode_single_content_encoding_lossy(
     }
 }
 
-#[derive(Default)]
 pub(crate) struct StreamResponsePayloadParser {
+    stream_semantics_enabled: bool,
     model: Option<String>,
     usage: ParsedUsage,
     service_tier: Option<String>,
@@ -1079,8 +1109,35 @@ pub(crate) struct StreamResponsePayloadParser {
     first_token_observed: bool,
 }
 
+impl Default for StreamResponsePayloadParser {
+    fn default() -> Self {
+        Self {
+            stream_semantics_enabled: true,
+            model: None,
+            usage: ParsedUsage::default(),
+            service_tier: None,
+            service_tier_rank: 0,
+            contains_encrypted_content: false,
+            compaction_response_kind: None,
+            stream_terminal_event: None,
+            successful_terminal_seen: false,
+            upstream_error_code: None,
+            upstream_error_message: None,
+            upstream_request_id: None,
+            usage_found: false,
+            parse_error_seen: false,
+            pending_event_name: None,
+            saw_stream_fields: false,
+            first_token_observed: false,
+        }
+    }
+}
+
 impl StreamResponsePayloadParser {
     fn ingest_line(&mut self, line: &str) {
+        if !self.stream_semantics_enabled {
+            return;
+        }
         let trimmed = line.trim();
         if trimmed.starts_with("event:") {
             self.saw_stream_fields = true;
@@ -1432,6 +1489,12 @@ impl StreamResponsePayloadChunkParser {
         }
     }
 
+    pub(crate) fn for_target(target: ProxyCaptureTarget) -> Self {
+        let mut parser = Self::default();
+        parser.parser.stream_semantics_enabled = target != ProxyCaptureTarget::StandaloneSearch;
+        parser
+    }
+
     fn line_bytes_look_like_stream_field(line: &[u8]) -> bool {
         let decoded = String::from_utf8_lossy(line);
         let trimmed = decoded.trim_start();
@@ -1451,10 +1514,14 @@ impl StreamResponsePayloadChunkParser {
     }
 
     fn start_discarding_oversized_line(&mut self) {
-        if Self::line_bytes_look_like_stream_field(&self.line_buffer) {
+        if self.parser.stream_semantics_enabled
+            && Self::line_bytes_look_like_stream_field(&self.line_buffer)
+        {
             self.parser.saw_stream_fields = true;
         }
-        self.parser.parse_error_seen = true;
+        if self.parser.stream_semantics_enabled {
+            self.parser.parse_error_seen = true;
+        }
         self.discarded_oversized_line = true;
         self.line_buffer.clear();
         self.discarding_oversized_line = true;
@@ -1502,7 +1569,8 @@ impl StreamResponsePayloadChunkParser {
     }
 
     pub(crate) fn successful_terminal_seen(&self) -> bool {
-        self.parser.successful_terminal_seen || self.pending_line_is_successful_terminal()
+        self.parser.stream_semantics_enabled
+            && (self.parser.successful_terminal_seen || self.pending_line_is_successful_terminal())
     }
 
     fn pending_line_is_successful_terminal(&self) -> bool {
@@ -1526,7 +1594,9 @@ impl StreamResponsePayloadChunkParser {
     }
 
     pub(crate) fn flush_pending_line(&mut self) {
-        if self.discarding_oversized_line {
+        if !self.parser.stream_semantics_enabled {
+            self.line_buffer.clear();
+        } else if self.discarding_oversized_line {
             self.parser.parse_error_seen = true;
         } else {
             self.flush_line();

--- a/src/tests/lightweight/prompt_cache_attribution.rs
+++ b/src/tests/lightweight/prompt_cache_attribution.rs
@@ -265,6 +265,46 @@ fn compact_request_body_still_avoids_rewrite_and_usage_injection() {
     assert!(!ProxyCaptureTarget::ResponsesCompact.should_auto_include_usage());
 }
 
+#[test]
+fn standalone_search_has_exact_non_stream_capture_target() {
+    assert_eq!(
+        capture_target_for_request("/v1/alpha/search", &Method::POST),
+        Some(ProxyCaptureTarget::StandaloneSearch)
+    );
+    assert_eq!(
+        ProxyCaptureTarget::from_endpoint("/v1/alpha/search"),
+        ProxyCaptureTarget::StandaloneSearch
+    );
+    assert_eq!(
+        ProxyCaptureTarget::StandaloneSearch.endpoint(),
+        "/v1/alpha/search"
+    );
+    assert!(!ProxyCaptureTarget::StandaloneSearch.allows_fast_mode_rewrite());
+    assert!(!ProxyCaptureTarget::StandaloneSearch.should_auto_include_usage());
+    assert_eq!(
+        capture_target_for_request("/v1/alpha/search/", &Method::POST),
+        None
+    );
+    assert_eq!(
+        capture_target_for_request("/v1/alpha/other", &Method::POST),
+        None
+    );
+    assert_eq!(
+        capture_target_for_request("/v1/alpha/search", &Method::GET),
+        None
+    );
+
+    let request_body = br#"{"model":"gpt-5.4","stream":true,"query":"hello"}"#;
+    let (prepared_body, request_info, rewritten) = prepare_target_request_body(
+        ProxyCaptureTarget::StandaloneSearch,
+        request_body.to_vec(),
+        true,
+    );
+    assert_eq!(prepared_body, request_body);
+    assert!(!request_info.is_stream);
+    assert!(!rewritten);
+}
+
 #[tokio::test]
 async fn prompt_cache_recent_invocations_include_attributed_compact_preview() {
     let state = test_state_from_config(test_config(), true).await;

--- a/src/tests/stateful_sqlite/oauth_route_body_rewrite_and_timeout.rs
+++ b/src/tests/stateful_sqlite/oauth_route_body_rewrite_and_timeout.rs
@@ -169,6 +169,102 @@ async fn pool_route_oauth_body_sticky_binding_applies_before_first_send() {
 }
 
 #[tokio::test]
+async fn pool_route_oauth_standalone_search_is_forwarded_and_recorded() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct InvocationRow {
+        status: Option<String>,
+        input_tokens: Option<i64>,
+        output_tokens: Option<i64>,
+        total_tokens: Option<i64>,
+        payload: Option<String>,
+    }
+
+    let _upstream_lock = oauth_bridge::TEST_OAUTH_CODEX_UPSTREAM_BASE_URL_LOCK
+        .lock()
+        .await;
+    let (upstream_base, upstream_handle) = spawn_oauth_codex_capture_upstream().await;
+    oauth_bridge::set_test_oauth_codex_upstream_base_url(
+        Url::parse(&format!("{upstream_base}/backend-api/codex")).expect("valid oauth base url"),
+    )
+    .await;
+
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    let account_id =
+        insert_test_pool_oauth_account(&state, "Standalone Search OAuth", "oauth-search").await;
+    let request_body = br#"{"model":"gpt-5.4","query":"hello","results":[]}"#;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri(
+            "/v1/alpha/search?cursor=next"
+                .parse()
+                .expect("valid standalone search uri"),
+        ),
+        Method::POST,
+        HeaderMap::from_iter([
+            (
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            ),
+            (
+                http_header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+        ]),
+        Body::from(request_body.to_vec()),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let forwarded: Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read oauth standalone search response"),
+    )
+    .expect("decode oauth standalone search response");
+    assert_eq!(forwarded["path"], "/backend-api/codex/alpha/search");
+    assert_eq!(forwarded["query"], "cursor=next");
+    assert_eq!(
+        forwarded["body"],
+        String::from_utf8_lossy(request_body).as_ref()
+    );
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let invocation = sqlx::query_as::<_, InvocationRow>(
+        r#"
+        SELECT status, input_tokens, output_tokens, total_tokens, payload
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load oauth standalone search invocation");
+    assert_eq!(invocation.status.as_deref(), Some("success"));
+    assert!(invocation.input_tokens.is_none());
+    assert!(invocation.output_tokens.is_none());
+    assert!(invocation.total_tokens.is_none());
+    let payload: Value = serde_json::from_str(
+        invocation
+            .payload
+            .as_deref()
+            .expect("oauth standalone search payload should be present"),
+    )
+    .expect("decode oauth standalone search payload");
+    assert_eq!(payload["endpoint"], "/v1/alpha/search");
+    assert_eq!(payload["upstreamAccountId"], account_id);
+    assert_ne!(payload["failureKind"], "oauth_unsupported_route");
+
+    upstream_handle.abort();
+    oauth_bridge::reset_test_oauth_codex_upstream_base_url().await;
+}
+
+#[tokio::test]
 async fn pool_route_oauth_compact_passthrough_preserves_prompt_cache_headers() {
     #[derive(sqlx::FromRow)]
     struct PersistedRow {

--- a/src/tests/stateful_sqlite/proxy_pool_roundtrip_and_retry_servers.rs
+++ b/src/tests/stateful_sqlite/proxy_pool_roundtrip_and_retry_servers.rs
@@ -311,6 +311,7 @@ struct PoolHttpFailureUpstreamState {
 async fn pool_retry_upstream(
     State(state): State<PoolRetryUpstreamState>,
     headers: HeaderMap,
+    uri: Uri,
 ) -> Response {
     let authorization = headers
         .get(http_header::AUTHORIZATION)
@@ -349,6 +350,8 @@ async fn pool_retry_upstream(
             "ok": true,
             "authorization": authorization,
             "attempt": attempt,
+            "path": uri.path(),
+            "query": uri.query().unwrap_or_default(),
         })),
     )
         .into_response()
@@ -1173,6 +1176,7 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
         tokio::time::sleep(Duration::from_millis(350)).await;
     }
     let path = request.uri().path().to_string();
+    let request_uri_query = request.uri().query().unwrap_or_default().to_string();
     let mut forwarded_header_names = request
         .headers()
         .keys()
@@ -1246,6 +1250,7 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
         StatusCode::OK,
         Json(json!({
             "path": path,
+            "query": request_uri_query,
             "authorization": authorization,
             "chatgptAccountId": chatgpt_account_id,
             "stickyKeyHeader": sticky_key_header,
@@ -1260,6 +1265,7 @@ async fn oauth_codex_capture_upstream(request: axum::extract::Request) -> Respon
             "forwardedFor": forwarded_for,
             "forwardedHeaderNames": forwarded_header_names,
             "bodyLength": body.len(),
+            "body": String::from_utf8_lossy(&body),
         })),
     )
         .into_response()
@@ -1523,6 +1529,7 @@ pub(crate) async fn spawn_pool_retry_upstream(
         .route("/v1/responses", post(pool_retry_upstream))
         .route("/v1/responses/compact", post(pool_retry_upstream))
         .route("/v1/chat/completions", post(pool_retry_upstream))
+        .route("/v1/alpha/search", post(pool_retry_upstream))
         .with_state(PoolRetryUpstreamState {
             attempts: attempts.clone(),
             fail_before_success,
@@ -1590,6 +1597,10 @@ pub(crate) async fn spawn_pool_static_failure_responses_upstream(
     let app = Router::new()
         .route(
             "/v1/responses",
+            post(pool_static_failure_responses_upstream),
+        )
+        .route(
+            "/v1/alpha/search",
             post(pool_static_failure_responses_upstream),
         )
         .with_state(PoolStaticFailureResponsesUpstreamState {

--- a/src/tests/stateful_sqlite/request_preparation_and_handshake_failures.rs
+++ b/src/tests/stateful_sqlite/request_preparation_and_handshake_failures.rs
@@ -2118,6 +2118,70 @@ fn parse_target_response_payload_reads_service_tier_from_response_object() {
 }
 
 #[test]
+fn standalone_search_response_does_not_infer_usage_from_results() {
+    let parsed = parse_target_response_payload(
+        ProxyCaptureTarget::StandaloneSearch,
+        br#"{
+            "model": "gpt-5.4",
+            "results": [{"title": "result", "content": "hello"}]
+        }"#,
+        false,
+        None,
+    );
+
+    assert_eq!(parsed.model.as_deref(), Some("gpt-5.4"));
+    assert!(parsed.usage.input_tokens.is_none());
+    assert!(parsed.usage.output_tokens.is_none());
+    assert!(parsed.usage.total_tokens.is_none());
+    assert_eq!(
+        parsed.usage_missing_reason.as_deref(),
+        Some("usage_missing_in_response")
+    );
+
+    let sse_like = parse_target_response_payload(
+        ProxyCaptureTarget::StandaloneSearch,
+        b"event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n",
+        false,
+        None,
+    );
+    assert!(sse_like.stream_terminal_event.is_none());
+    assert_eq!(
+        sse_like.usage_missing_reason.as_deref(),
+        Some("response_not_json")
+    );
+
+    let mut search_stream_parser =
+        StreamResponsePayloadChunkParser::for_target(ProxyCaptureTarget::StandaloneSearch);
+    search_stream_parser.ingest_bytes(
+        b"event: response.failed\ndata: {\"type\":\"response.failed\",\"object\":\"response.compaction\"}\n\n",
+    );
+    let search_stream_outcome = search_stream_parser.finish();
+    assert!(!search_stream_outcome.saw_stream_fields);
+    assert!(!search_stream_outcome.successful_terminal_seen);
+    assert!(
+        search_stream_outcome
+            .response_info
+            .compaction_response_kind
+            .is_none()
+    );
+    assert!(
+        search_stream_outcome
+            .response_info
+            .stream_terminal_event
+            .is_none()
+    );
+
+    let forced_stream_hint = parse_target_response_payload(
+        ProxyCaptureTarget::StandaloneSearch,
+        br#"{"object":"response.compaction","results":[]}"#,
+        true,
+        None,
+    );
+    assert!(forced_stream_hint.compaction_response_kind.is_none());
+    assert!(forced_stream_hint.stream_terminal_event.is_none());
+}
+
+#[test]
 fn parse_target_response_payload_detects_remote_v2_compaction_stream_events() {
     let raw = [
         "event: response.output_item.added",

--- a/src/tests/stateful_sqlite/routing_failover_terminal_reasoning.rs
+++ b/src/tests/stateful_sqlite/routing_failover_terminal_reasoning.rs
@@ -1302,6 +1302,289 @@ async fn capture_target_pool_route_persists_attempt_rows_and_summary_fields() {
 }
 
 #[tokio::test]
+async fn capture_target_pool_standalone_search_records_one_invocation_and_rollup() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct InvocationRow {
+        model: Option<String>,
+        status: Option<String>,
+        input_tokens: Option<i64>,
+        output_tokens: Option<i64>,
+        total_tokens: Option<i64>,
+        cost: Option<f64>,
+        payload: Option<String>,
+        request_raw_path: Option<String>,
+        response_raw_path: Option<String>,
+        t_total_ms: Option<f64>,
+    }
+
+    let (upstream_base, attempts, upstream_handle) =
+        spawn_pool_retry_upstream(&[("Bearer upstream-primary", 2)]).await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri(
+            "/v1/alpha/search?cursor=next"
+                .parse()
+                .expect("valid standalone search uri"),
+        ),
+        Method::POST,
+        HeaderMap::from_iter([
+            (
+                http_header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer pool-live-key"),
+            ),
+            (
+                http_header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+        ]),
+        Body::from(br#"{"model":"gpt-5.4","query":"hello","results":[]}"#.to_vec()),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_payload: Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read standalone search response"),
+    )
+    .expect("decode standalone search response");
+    assert_eq!(response_payload["path"], "/v1/alpha/search");
+    assert_eq!(response_payload["query"], "cursor=next");
+    assert_eq!(response_payload["attempt"], 3);
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    wait_for_pool_attempt_row_count(&state.pool, 3).await;
+    let invocation_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM codex_invocations")
+        .fetch_one(&state.pool)
+        .await
+        .expect("count standalone search invocations");
+    assert_eq!(invocation_count, 1);
+
+    let invocation = sqlx::query_as::<_, InvocationRow>(
+        r#"
+        SELECT model, status, input_tokens, output_tokens, total_tokens, cost, payload,
+               request_raw_path, response_raw_path, t_total_ms
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load standalone search invocation");
+    assert_eq!(invocation.model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(invocation.status.as_deref(), Some("success"));
+    assert!(invocation.input_tokens.is_none());
+    assert!(invocation.output_tokens.is_none());
+    assert!(invocation.total_tokens.is_none());
+    assert!(invocation.cost.is_none());
+    assert!(invocation.t_total_ms.is_some_and(|value| value >= 0.0));
+    assert!(invocation.request_raw_path.is_some());
+    assert!(invocation.response_raw_path.is_some());
+    let payload: Value = serde_json::from_str(
+        invocation
+            .payload
+            .as_deref()
+            .expect("standalone search payload should be present"),
+    )
+    .expect("decode standalone search payload");
+    assert_eq!(payload["endpoint"], "/v1/alpha/search");
+    assert_eq!(payload["isStream"], false);
+    assert_eq!(payload["requestModel"], "gpt-5.4");
+    assert!(payload["inputTokens"].is_null());
+    assert!(payload["outputTokens"].is_null());
+    assert!(payload["totalTokens"].is_null());
+
+    backfill_invocation_rollup_hourly_from_sources(&state.pool)
+        .await
+        .expect("rebuild standalone search rollup");
+    backfill_invocation_rollup_hourly_from_sources(&state.pool)
+        .await
+        .expect("replay standalone search rollup without duplication");
+    let rollup = sqlx::query_as::<_, (i64, i64, i64, i64)>(
+        r#"
+        SELECT COALESCE(SUM(total_count), 0),
+               COALESCE(SUM(success_count), 0),
+               COALESCE(SUM(failure_count), 0),
+               COALESCE(SUM(terminal_count), 0)
+        FROM invocation_rollup_hourly
+        WHERE source = ?1
+        "#,
+    )
+    .bind(SOURCE_PROXY)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load standalone search rollup");
+    assert_eq!(rollup, (1, 1, 0, 1));
+
+    assert_eq!(
+        attempts
+            .lock()
+            .expect("lock standalone search attempts")
+            .get("Bearer upstream-primary")
+            .copied(),
+        Some(3)
+    );
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn capture_target_pool_standalone_search_records_upstream_404_as_failure() {
+    let (upstream_base, _attempts, upstream_handle) = spawn_pool_static_failure_responses_upstream(
+        &[("Bearer upstream-primary", StatusCode::NOT_FOUND)],
+    )
+    .await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri(
+            "/v1/alpha/search"
+                .parse()
+                .expect("valid standalone search uri"),
+        ),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(br#"{"model":"gpt-5.4","query":"hello"}"#.to_vec()),
+    )
+    .await;
+    assert!(!response.status().is_success());
+    let _ = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read standalone search upstream 404 response");
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let (status, failure_kind, error_message, payload): (
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        String,
+    ) = sqlx::query_as(
+        "SELECT status, failure_kind, error_message, payload FROM codex_invocations ORDER BY id DESC LIMIT 1",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load standalone search 404 invocation");
+    assert_ne!(status.as_deref(), Some("success"));
+    assert!(
+        failure_kind.is_some(),
+        "404 failure kind missing: {error_message:?}"
+    );
+    assert_ne!(failure_kind.as_deref(), Some("oauth_unsupported_route"));
+    assert!(
+        error_message
+            .as_deref()
+            .is_some_and(|message| message.to_ascii_lowercase().contains("upstream")),
+        "404 error message should identify upstream failure: {error_message:?}"
+    );
+    let payload: Value = payload
+        .parse()
+        .expect("decode standalone search 404 payload");
+    assert_eq!(payload["endpoint"], "/v1/alpha/search");
+    assert_ne!(payload["failureKind"], "oauth_unsupported_route");
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn capture_target_pool_standalone_search_keeps_structured_record_when_raw_logging_disabled() {
+    #[derive(Debug, sqlx::FromRow)]
+    struct InvocationRow {
+        status: Option<String>,
+        payload: Option<String>,
+        request_raw_path: Option<String>,
+        response_raw_path: Option<String>,
+        t_total_ms: Option<f64>,
+    }
+
+    let (upstream_base, _attempts, upstream_handle) = spawn_pool_retry_upstream(&[]).await;
+    let state =
+        test_state_with_openai_base(Url::parse(&upstream_base).expect("valid upstream base url"))
+            .await;
+    seed_pool_routing_api_key(&state, "pool-live-key").await;
+    insert_test_pool_api_key_account(&state, "Primary", "upstream-primary").await;
+    let _ = put_proxy_settings(
+        State(state.clone()),
+        HeaderMap::new(),
+        Json(ProxyModelSettingsUpdateRequest {
+            hijack_enabled: true,
+            merge_upstream_enabled: true,
+            fast_mode_rewrite_mode: None,
+            upstream_429_max_retries: None,
+            websocket_enabled: None,
+            upstream_websocket_default_enabled: None,
+            request_body_logging_enabled: Some(false),
+            response_body_logging_enabled: Some(false),
+            encrypted_session_owner_routing_enabled: None,
+            enabled_models: default_enabled_preset_models(),
+        }),
+    )
+    .await
+    .expect("disable standalone search raw logging");
+
+    let response = proxy_openai_v1(
+        State(state.clone()),
+        OriginalUri(
+            "/v1/alpha/search"
+                .parse()
+                .expect("valid standalone search uri"),
+        ),
+        Method::POST,
+        HeaderMap::from_iter([(
+            http_header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer pool-live-key"),
+        )]),
+        Body::from(br#"{"model":"gpt-5.4","query":"hello"}"#.to_vec()),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read standalone search no-raw response");
+
+    wait_for_codex_invocations(&state.pool, 1).await;
+    let invocation = sqlx::query_as::<_, InvocationRow>(
+        r#"
+        SELECT status, payload, request_raw_path, response_raw_path, t_total_ms
+        FROM codex_invocations
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load standalone search no-raw invocation");
+    assert_eq!(invocation.status.as_deref(), Some("success"));
+    assert!(invocation.request_raw_path.is_none());
+    assert!(invocation.response_raw_path.is_none());
+    assert!(invocation.t_total_ms.is_some_and(|value| value >= 0.0));
+    let payload: Value = serde_json::from_str(
+        invocation
+            .payload
+            .as_deref()
+            .expect("standalone search no-raw payload should be present"),
+    )
+    .expect("decode standalone search no-raw payload");
+    assert_eq!(payload["endpoint"], "/v1/alpha/search");
+    assert_eq!(payload["statusCode"], 200);
+
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn capture_target_pool_route_stops_after_three_distinct_accounts() {
     #[derive(Debug, sqlx::FromRow)]
     struct AttemptStatusRow {

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -682,6 +682,10 @@ fn write_backfill_request_payload_with_fields(
             }
             payload
         }
+        ProxyCaptureTarget::StandaloneSearch => json!({
+            "model": "gpt-5.3-codex",
+            "query": "hello",
+        }),
         ProxyCaptureTarget::ImageGenerations | ProxyCaptureTarget::ImageEdits => {
             let mut payload = json!({
                 "model": "gpt-image-1",


### PR DESCRIPTION
## Summary

- recognize exact `POST /v1/alpha/search` as a first-class captured proxy target
- preserve neutral non-stream semantics while recording invocation, attempts, raw payload metadata, failures, timings, and existing hourly rollups
- allow ordinary and counted OAuth passthrough for standalone search without changing query, body, headers, or response status
- add pool, OAuth, retry/failover, raw logging, filtering, and rollup regression coverage

## Tests

- `cargo fmt --all -- --check`
- `cargo check --tests`
- `cargo test standalone_search -- --nocapture`
- full `cargo test`: 1937 passed, 4 unrelated timing-sensitive failures; all 4 passed when rerun individually
- spec drift check: passed
- Codex review against `origin/main`: no actionable correctness findings

## Delivery

- Delivery role: direct
- Spec: `docs/specs/z9h7v-invocation-log-observability/SPEC.md`
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: n/a (no solution change)
- Project Docs Sync: n/a (no project-doc change)

## References

### Specs

- `docs/specs/z9h7v-invocation-log-observability/SPEC.md`

### Solutions

- `docs/solutions/performance/multi-granularity-long-term-usage-rollup.md`
- `docs/solutions/performance/proxy-capture-body-replay-safety.md`
- `docs/solutions/performance/rollup-backed-summary-window-consistency.md`
- `docs/solutions/performance/proxy-usage-billing-breakdown.md`

### Project Docs

-

<!-- codex:custom-notes:start -->
## Notes

- no database migration or historical backfill
- no Web UI changes or visual evidence required
- validation used local mock upstreams only; no real provider request was sent
<!-- codex:custom-notes:end -->