### PR TITLE
perf(proxy): project request semantics once

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions},
 };
 use std::fs;
-use std::io::{self, BufRead, Read, Write};
+use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, TcpStream},

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -418,7 +418,7 @@ fn build_local_capture_error_resp_raw(envelope: &ProxyErrorResponseEnvelope) -> 
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn persist_pre_attempt_proxy_capture_error(
-    state: &AppState,
+    state: Arc<AppState>,
     proxy_request_id: u64,
     capture_started: Instant,
     invoke_id: &str,
@@ -430,7 +430,8 @@ pub(crate) async fn persist_pre_attempt_proxy_capture_error(
     sticky_key: Option<&str>,
     prompt_cache_key: Option<&str>,
     client_attribution_context: &ClientPromptCacheAttributionContext,
-    request_body_for_capture: Bytes,
+    request_body_for_capture: Option<Bytes>,
+    request_body_snapshot: PoolReplayBodySnapshot,
     request_body_logging_enabled: bool,
     t_req_read_ms: f64,
     t_req_parse_ms: f64,
@@ -446,13 +447,22 @@ pub(crate) async fn persist_pre_attempt_proxy_capture_error(
 ) -> bool {
     let response_envelope = response_envelope_override
         .unwrap_or_else(|| build_local_capture_error_envelope(invoke_id, status, error_message));
-    let req_raw = spawn_raw_payload_file_write(
-        state,
-        invoke_id,
-        "request",
-        request_body_for_capture,
-        request_body_logging_enabled,
-    )
+    let req_raw = match request_body_for_capture {
+        Some(bytes) => spawn_raw_payload_file_write(
+            state.as_ref(),
+            invoke_id,
+            "request",
+            bytes,
+            request_body_logging_enabled,
+        ),
+        None => spawn_raw_payload_snapshot_write(
+            state.clone(),
+            invoke_id,
+            "request",
+            request_body_snapshot,
+            request_body_logging_enabled,
+        ),
+    }
     .finish()
     .await;
     let usage = ParsedUsage::default();
@@ -582,7 +592,9 @@ pub(crate) async fn persist_pre_attempt_proxy_capture_error(
             t_persist_ms: 0.0,
         },
     };
-    if let Err(err) = persist_and_broadcast_proxy_capture(state, capture_started, record).await {
+    if let Err(err) =
+        persist_and_broadcast_proxy_capture(state.as_ref(), capture_started, record).await
+    {
         warn!(
             proxy_request_id,
             error = %err,
@@ -959,7 +971,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                 let status = StatusCode::BAD_GATEWAY;
                 let message = format!("failed to resolve prompt cache conversation binding: {err}");
                 let terminal_invocation_persisted = persist_pre_attempt_proxy_capture_error(
-                    state.as_ref(),
+                    state.clone(),
                     proxy_request_id,
                     capture_started,
                     &invoke_id,
@@ -971,10 +983,8 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     sticky_key.as_deref(),
                     prompt_cache_key.as_deref(),
                     &client_attribution_context,
-                    semantic_projection
-                        .request_body_for_capture
-                        .clone()
-                        .unwrap_or_default(),
+                    semantic_projection.request_body_for_capture.clone(),
+                    semantic_projection.upstream_snapshot.clone(),
                     proxy_settings.request_body_logging_enabled,
                     t_req_read_ms,
                     elapsed_ms(req_parse_started),
@@ -1011,7 +1021,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                 let message =
                     format!("failed to resolve prompt cache conversation overrides: {err}");
                 let terminal_invocation_persisted = persist_pre_attempt_proxy_capture_error(
-                    state.as_ref(),
+                    state.clone(),
                     proxy_request_id,
                     capture_started,
                     &invoke_id,
@@ -1023,10 +1033,8 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     sticky_key.as_deref(),
                     prompt_cache_key.as_deref(),
                     &client_attribution_context,
-                    semantic_projection
-                        .request_body_for_capture
-                        .clone()
-                        .unwrap_or_default(),
+                    semantic_projection.request_body_for_capture.clone(),
+                    semantic_projection.upstream_snapshot.clone(),
                     proxy_settings.request_body_logging_enabled,
                     t_req_read_ms,
                     elapsed_ms(req_parse_started),
@@ -1060,11 +1068,6 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         request_model: request_info.model.clone(),
     });
     let t_req_parse_ms = elapsed_ms(req_parse_started);
-    let upstream_body_bytes = semantic_projection
-        .request_body_for_capture
-        .clone()
-        .unwrap_or_default();
-    let base_request_bytes_for_capture = upstream_body_bytes.clone();
     let upstream_body_snapshot = semantic_projection.upstream_snapshot.clone();
 
     let initial_running_record = build_running_proxy_capture_record(
@@ -1111,6 +1114,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         pool_route_active.then(|| PoolAttemptRuntimeSnapshotContext {
             capture_target,
             request_info: request_info.clone(),
+            hosted_image_intent: Some(semantic_projection.hosted_image_intent),
             prompt_cache_key: prompt_cache_key.clone(),
             owner_auto_guard_active: encrypted_owner_auto_guard_active,
             t_req_read_ms,
@@ -1200,17 +1204,22 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     .requested_service_tier
                     .clone()
                     .or(request_info.requested_service_tier);
-                let request_body_for_capture = err
-                    .request_body_for_capture
-                    .clone()
-                    .unwrap_or_else(|| base_request_bytes_for_capture.clone());
-                let req_raw = spawn_raw_payload_file_write(
-                    state.as_ref(),
-                    &invoke_id,
-                    "request",
-                    request_body_for_capture,
-                    proxy_settings.request_body_logging_enabled,
-                )
+                let req_raw = match err.request_body_for_capture.clone() {
+                    Some(bytes) => spawn_raw_payload_file_write(
+                        state.as_ref(),
+                        &invoke_id,
+                        "request",
+                        bytes,
+                        proxy_settings.request_body_logging_enabled,
+                    ),
+                    None => spawn_raw_payload_snapshot_write(
+                        state.clone(),
+                        &invoke_id,
+                        "request",
+                        semantic_projection.upstream_snapshot.clone(),
+                        proxy_settings.request_body_logging_enabled,
+                    ),
+                }
                 .finish()
                 .await;
                 let usage = ParsedUsage::default();
@@ -1437,7 +1446,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             Method::POST,
             target_url,
             &upstream_headers,
-            Some(upstream_body_bytes.clone()),
+            Some(upstream_body_snapshot.clone()),
             Some(UpstreamTrafficReporter::new(
                 state.clone(),
                 invoke_id.as_str(),
@@ -1470,7 +1479,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                 Some(response.attempt_started_at),
                 None,
                 response.http_approx,
-                Some(base_request_bytes_for_capture.clone()),
+                semantic_projection.request_body_for_capture.clone(),
                 request_info.requested_service_tier.clone(),
                 None,
                 response.response,
@@ -1480,11 +1489,11 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                 let response_envelope =
                     build_local_capture_error_envelope(&invoke_id, err.status, &err.message);
                 drop(proxy_request_permit);
-                let req_raw = spawn_raw_payload_file_write(
-                    state.as_ref(),
+                let req_raw = spawn_raw_payload_snapshot_write(
+                    state.clone(),
                     &invoke_id,
                     "request",
-                    base_request_bytes_for_capture.clone(),
+                    semantic_projection.upstream_snapshot.clone(),
                     proxy_settings.request_body_logging_enabled,
                 )
                 .finish()
@@ -1681,7 +1690,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             state.clone(),
             &invoke_id,
             "request",
-            semantic_projection.snapshot.clone(),
+            semantic_projection.upstream_snapshot.clone(),
             proxy_settings.request_body_logging_enabled,
         ),
     });

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -887,151 +887,26 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             "openai proxy capture request body read completed"
         );
     }
-    let request_body_bytes = match request_body_snapshot.into_vec().await {
-        Ok(bytes) => bytes,
-        Err(err) => {
-            drop(proxy_request_permit);
-            let status = StatusCode::BAD_GATEWAY;
-            let message = format!("failed to materialize captured request body: {err}");
-            let response_envelope =
-                build_local_capture_error_envelope(&invoke_id, status, &message);
-            let request_info = RequestCaptureInfo::default();
-            let usage = ParsedUsage::default();
-            let (cost, cost_estimated, price_version) = estimate_proxy_cost_from_shared_catalog(
-                &state.pricing_catalog,
-                None,
-                &usage,
-                None,
-                ProxyPricingMode::ResponseTier,
-            )
-            .await;
-            let req_raw = RawPayloadMeta::default();
-            let record = ProxyCaptureRecord {
-                invoke_id,
-                occurred_at,
-                model: None,
-                usage,
-                cost,
-                cost_breakdown: None,
-                cost_estimated,
-                price_version,
-                status: "http_502".to_string(),
-                error_message: Some(message.clone()),
-                failure_kind: Some(PROXY_FAILURE_FAILED_CONTACT_UPSTREAM.to_string()),
-                payload: Some(build_proxy_payload_summary(ProxyPayloadSummary {
-                    target: capture_target,
-                    status,
-                    is_stream: request_info.is_stream,
-                    request_contains_encrypted_content: request_info.contains_encrypted_content,
-                    response_contains_encrypted_content: false,
-                    compaction_request_kind: request_info.compaction_request_kind,
-                    compaction_response_kind: None,
-                    image_intent: request_info.image_intent.as_deref(),
-                    request_model: request_info.model.as_deref(),
-                    requested_service_tier: request_info.requested_service_tier.as_deref(),
-                    billing_service_tier: None,
-                    reasoning_effort: request_info.reasoning_effort.as_deref(),
-                    response_model: None,
-                    usage_missing_reason: None,
-                    request_parse_error: Some("request_body_snapshot_materialize_failed"),
-                    request_compression_algorithm: None,
-                    request_compression_mode: None,
-                    request_compression_logical_body_bytes: None,
-                    request_compression_transmitted_body_bytes: None,
-                    request_compression_transmission_complete: None,
-                    failure_kind: Some(PROXY_FAILURE_FAILED_CONTACT_UPSTREAM),
-                    requester_ip: requester_ip.as_deref(),
-                    request_user_agent: request_chain_metadata.user_agent.as_deref(),
-                    request_x_forwarded_for: request_chain_metadata.x_forwarded_for.as_deref(),
-                    request_forwarded: request_chain_metadata.forwarded.as_deref(),
-                    request_x_real_ip: request_chain_metadata.x_real_ip.as_deref(),
-                    upstream_scope: INVOCATION_UPSTREAM_SCOPE_INTERNAL,
-                    route_mode: INVOCATION_ROUTE_MODE_POOL,
-                    sticky_key: header_sticky_key.as_deref(),
-                    prompt_cache_key: header_prompt_cache_key.as_deref(),
-                    prompt_cache_key_attribution_source: header_prompt_cache_key
-                        .as_ref()
-                        .map(|_| "request"),
-                    client_fingerprint: client_attribution_context.fingerprint.as_deref(),
-                    client_header_fingerprints: Some(
-                        &client_attribution_context.header_fingerprints,
-                    )
-                    .filter(|fingerprints| !fingerprints.is_empty()),
-                    upstream_account_id: None,
-                    upstream_account_name: None,
-                    upstream_account_kind: None,
-                    upstream_base_url_host: None,
-                    oauth_account_header_attached: None,
-                    oauth_account_id_shape: None,
-                    oauth_forwarded_header_count: None,
-                    oauth_forwarded_header_names: None,
-                    oauth_fingerprint_version: None,
-                    oauth_forwarded_header_fingerprints: None,
-                    oauth_prompt_cache_header_forwarded: None,
-                    oauth_request_body_prefix_fingerprint: None,
-                    oauth_request_body_prefix_bytes: None,
-                    oauth_request_body_snapshot_kind: Some(request_body_snapshot_kind),
-                    oauth_responses_body_mode: None,
-                    oauth_responses_rewrite: None,
-                    service_tier: None,
-                    stream_terminal_event: None,
-                    upstream_error_code: None,
-                    upstream_error_message: None,
-                    downstream_status_code: Some(status),
-                    downstream_error_message: Some(message.as_str()),
-                    upstream_request_id: None,
-                    response_content_encoding: None,
-                    stream_failure_origin: None,
-                    upstream_read_error_kind: None,
-                    content_encoding_chain: None,
-                    forwarded_chunk_count: None,
-                    forwarded_bytes: None,
-                    usage_observed: None,
-                    downstream_close_phase: None,
-                    downstream_write_error_kind: None,
-                    last_upstream_chunk_gap_ms: None,
-                    upstream_approx_upload_bytes: None,
-                    upstream_approx_download_bytes: None,
-                    proxy_display_name: None,
-                    proxy_weight_delta: None,
-                    pool_attempt_count: None,
-                    pool_distinct_account_count: None,
-                    pool_attempt_terminal_reason: None,
-                    blocked_binding: None,
-                })),
-                raw_response: response_envelope.body_text.clone(),
-                response_body_preview_enabled: true,
-                req_raw,
-                resp_raw: build_local_capture_error_resp_raw(&response_envelope),
-                timings: StageTimings {
-                    t_total_ms: 0.0,
-                    t_req_read_ms,
-                    t_req_parse_ms: 0.0,
-                    t_upstream_connect_ms: 0.0,
-                    t_upstream_ttfb_ms: 0.0,
-                    first_token_ms: None,
-                    t_upstream_stream_ms: 0.0,
-                    t_resp_parse_ms: 0.0,
-                    t_persist_ms: 0.0,
-                },
-            };
-            let terminal_invocation_persisted =
-                persist_and_broadcast_proxy_capture(state.as_ref(), capture_started, record)
-                    .await
-                    .is_ok();
-            if terminal_invocation_persisted {
-                disarm_pool_invocation_cleanup_guard(&mut pool_invocation_cleanup_guard);
-            }
-            return Err((status, message));
-        }
-    };
-
     let req_parse_started = Instant::now();
-    let (upstream_body, mut request_info, body_rewritten) = prepare_target_request_body(
+    let semantic_projection = project_request_semantics(
+        proxy_request_id,
+        request_body_snapshot.clone(),
         capture_target,
-        request_body_bytes,
         state.config.proxy_enforce_stream_include_usage,
+    )
+    .await;
+    debug!(
+        proxy_request_id,
+        pipeline_mode = ?request_semantic_pipeline_mode(),
+        json_parse_count = semantic_projection.json_parse_count,
+        whole_body_materialization_count = semantic_projection.whole_body_materialization_count,
+        materialization_bytes = semantic_projection.materialization_bytes,
+        peak_business_buffer_bytes = semantic_projection.peak_business_buffer_bytes,
+        parse_elapsed_ms = semantic_projection.parse_elapsed_ms,
+        "proxy request semantic projection completed"
     );
+    let mut request_info = semantic_projection.request_info.clone();
+    let body_rewritten = semantic_projection.body_rewritten;
     let mut prompt_cache_key = request_info
         .prompt_cache_key
         .clone()
@@ -1096,7 +971,10 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     sticky_key.as_deref(),
                     prompt_cache_key.as_deref(),
                     &client_attribution_context,
-                    Bytes::from(upstream_body.clone()),
+                    semantic_projection
+                        .request_body_for_capture
+                        .clone()
+                        .unwrap_or_default(),
                     proxy_settings.request_body_logging_enabled,
                     t_req_read_ms,
                     elapsed_ms(req_parse_started),
@@ -1145,7 +1023,10 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     sticky_key.as_deref(),
                     prompt_cache_key.as_deref(),
                     &client_attribution_context,
-                    Bytes::from(upstream_body.clone()),
+                    semantic_projection
+                        .request_body_for_capture
+                        .clone()
+                        .unwrap_or_default(),
                     proxy_settings.request_body_logging_enabled,
                     t_req_read_ms,
                     elapsed_ms(req_parse_started),
@@ -1179,10 +1060,12 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         request_model: request_info.model.clone(),
     });
     let t_req_parse_ms = elapsed_ms(req_parse_started);
-    let upstream_body_bytes = Bytes::from(upstream_body);
+    let upstream_body_bytes = semantic_projection
+        .request_body_for_capture
+        .clone()
+        .unwrap_or_default();
     let base_request_bytes_for_capture = upstream_body_bytes.clone();
-    let upstream_body_snapshot =
-        pool_replay_snapshot_from_bytes(proxy_request_id, upstream_body_bytes.clone()).await;
+    let upstream_body_snapshot = semantic_projection.upstream_snapshot.clone();
 
     let initial_running_record = build_running_proxy_capture_record(
         &invoke_id,
@@ -1786,15 +1669,22 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             account.image_tool_rewrite_mode,
         )
     });
-    let mut req_raw_pending = Some(spawn_raw_payload_file_write(
-        state.as_ref(),
-        &invoke_id,
-        "request",
-        final_request_body_for_capture
-            .clone()
-            .unwrap_or_else(|| base_request_bytes_for_capture.clone()),
-        proxy_settings.request_body_logging_enabled,
-    ));
+    let mut req_raw_pending = Some(match final_request_body_for_capture.clone() {
+        Some(bytes) => spawn_raw_payload_file_write(
+            state.as_ref(),
+            &invoke_id,
+            "request",
+            bytes,
+            proxy_settings.request_body_logging_enabled,
+        ),
+        None => spawn_raw_payload_snapshot_write(
+            state.clone(),
+            &invoke_id,
+            "request",
+            semantic_projection.snapshot.clone(),
+            proxy_settings.request_body_logging_enabled,
+        ),
+    });
 
     let upstream_status = upstream_response.status();
     let location_base_url = location_rewrite_upstream_base(

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -484,6 +484,7 @@ pub(crate) fn send_pool_request_with_failover_and_binding_constraint<'a>(
     Box::pin(async move {
         let capture_started = Instant::now();
         let state_for_terminal_capture = state.clone();
+        let body_for_terminal_capture = body.clone();
         let trace_for_terminal_capture = trace_context.clone();
         let runtime_context_for_terminal_capture = runtime_snapshot_context.clone();
         let result = send_pool_request_with_failover_and_binding_constraint_inner(
@@ -507,13 +508,14 @@ pub(crate) fn send_pool_request_with_failover_and_binding_constraint<'a>(
         .await;
         if persist_terminal_invocation && let Err(error) = &result {
             persist_pool_failover_terminal_invocation(
-                state_for_terminal_capture.as_ref(),
+                state_for_terminal_capture,
                 proxy_request_id,
                 capture_started,
                 original_uri,
                 headers,
                 trace_for_terminal_capture.as_ref(),
                 runtime_context_for_terminal_capture.as_ref(),
+                body_for_terminal_capture.unwrap_or(PoolReplayBodySnapshot::Empty),
                 error,
             )
             .await;
@@ -523,13 +525,14 @@ pub(crate) fn send_pool_request_with_failover_and_binding_constraint<'a>(
 }
 
 pub(crate) async fn persist_pool_failover_terminal_invocation(
-    state: &AppState,
+    state: Arc<AppState>,
     proxy_request_id: u64,
     capture_started: Instant,
     original_uri: &Uri,
     headers: &HeaderMap,
     trace_context: Option<&PoolUpstreamAttemptTraceContext>,
     runtime_snapshot_context: Option<&PoolAttemptRuntimeSnapshotContext>,
+    request_body_snapshot: PoolReplayBodySnapshot,
     error: &PoolUpstreamError,
 ) {
     let Some(trace) = trace_context else {
@@ -549,7 +552,7 @@ pub(crate) async fn persist_pool_failover_terminal_invocation(
     let requester_ip = extract_requester_ip(headers, None);
     let request_chain_metadata = request_chain_metadata_from_headers(headers);
     let client_attribution_context = client_prompt_cache_attribution_context_from_headers(headers);
-    let request_body = error.request_body_for_capture.clone().unwrap_or_default();
+    let request_body = error.request_body_for_capture.clone();
     let request_body_logging_enabled = state
         .proxy_model_settings
         .read()
@@ -566,7 +569,7 @@ pub(crate) async fn persist_pool_failover_terminal_invocation(
     let response_envelope =
         build_proxy_error_response_envelope(&downstream_error, &trace.invoke_id);
     let terminal_request_compression_algorithm = resolve_terminal_request_compression_algorithm(
-        latest_pool_attempt_request_compression_algorithm(state, trace)
+        latest_pool_attempt_request_compression_algorithm(state.as_ref(), trace)
             .await
             .ok()
             .flatten(),
@@ -586,6 +589,7 @@ pub(crate) async fn persist_pool_failover_terminal_invocation(
         prompt_cache_key,
         &client_attribution_context,
         request_body,
+        request_body_snapshot,
         request_body_logging_enabled,
         runtime_snapshot_context
             .map(|context| context.t_req_read_ms)
@@ -1713,6 +1717,12 @@ async fn send_pool_request_with_failover_and_binding_constraint_inner(
                 account.image_tool_rewrite_mode,
                 account.codex_imagegen_rewrite_mode,
                 codex_imagegen_protocol_from_headers(headers),
+                runtime_snapshot_context
+                    .as_ref()
+                    .map(|context| &context.request_info),
+                runtime_snapshot_context
+                    .as_ref()
+                    .and_then(|context| context.hosted_image_intent),
             )
             .await
             {

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -583,6 +583,89 @@ pub(crate) async fn store_raw_payload_file(
     meta
 }
 
+pub(crate) async fn store_raw_payload_snapshot_file(
+    config: &AppConfig,
+    invoke_id: &str,
+    kind: &str,
+    source_path: PathBuf,
+    source_size: usize,
+) -> RawPayloadMeta {
+    let started = Instant::now();
+    let file_bytes = config
+        .proxy_raw_max_bytes
+        .map_or(source_size, |limit| source_size.min(limit));
+    let mut meta = RawPayloadMeta {
+        path: None,
+        size_bytes: source_size as i64,
+        truncated: file_bytes < source_size,
+        truncated_reason: (file_bytes < source_size).then(|| "max_bytes_exceeded".to_string()),
+    };
+    let raw_dir = config.resolved_proxy_raw_dir();
+    let born_compressed = match config.proxy_raw_compression {
+        RawCompressionCodec::Zstd => true,
+        RawCompressionCodec::Gzip => config
+            .proxy_raw_immediate_compression_threshold()
+            .is_some_and(|threshold| file_bytes >= threshold),
+        RawCompressionCodec::None => false,
+    };
+    let codec = match (born_compressed, config.proxy_raw_compression) {
+        (true, RawCompressionCodec::Gzip) => RAW_CODEC_GZIP,
+        (true, RawCompressionCodec::Zstd) => RAW_CODEC_ZSTD,
+        _ => RAW_CODEC_IDENTITY,
+    };
+    let plain_path = raw_payload_path_for_kind(&raw_dir, invoke_id, kind, false);
+    let path = if codec == RAW_CODEC_ZSTD {
+        raw_payload_zstd_path(&plain_path)
+    } else if codec == RAW_CODEC_GZIP {
+        raw_payload_gzip_path(&plain_path)
+    } else {
+        plain_path
+    };
+    let write_path = path.clone();
+    let write_result = run_blocking_raw_writer_io(move || {
+        let mut source = std::io::BufReader::with_capacity(
+            REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES,
+            fs::File::open(source_path)?,
+        )
+        .take(file_bytes as u64);
+        if codec == RAW_CODEC_GZIP {
+            let mut encoder = create_gzip_streaming_raw_encoder(&write_path)?;
+            std::io::copy(&mut source, &mut encoder)?;
+            encoder.finish()?.flush()
+        } else if codec == RAW_CODEC_ZSTD {
+            let mut encoder = create_zstd_streaming_raw_encoder(&write_path)?;
+            std::io::copy(&mut source, &mut encoder)?;
+            encoder.finish()?.flush()
+        } else {
+            prepare_streaming_raw_parent(&write_path)?;
+            let mut writer = fs::File::create(&write_path)?;
+            std::io::copy(&mut source, &mut writer)?;
+            writer.flush()
+        }
+    })
+    .await;
+    match write_result {
+        Ok(()) => meta.path = Some(path.to_string_lossy().to_string()),
+        Err(err) => {
+            let _ = fs::remove_file(&path);
+            meta.truncated = true;
+            meta.truncated_reason = Some(format!("write_failed:{err}"));
+        }
+    }
+    debug!(
+        invoke_id,
+        raw_kind = kind,
+        codec,
+        file_bytes,
+        observed_bytes = meta.size_bytes,
+        truncated = meta.truncated,
+        has_path = meta.path.is_some(),
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "proxy raw replay snapshot write completed"
+    );
+    meta
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ProxyCaptureFollowUpBroadcastMode {
     ActiveSubscribers,

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1253,6 +1253,7 @@ pub(crate) struct PoolUpstreamAttemptTraceContext {
 pub(crate) struct PoolAttemptRuntimeSnapshotContext {
     pub(crate) capture_target: ProxyCaptureTarget,
     pub(crate) request_info: RequestCaptureInfo,
+    pub(crate) hosted_image_intent: Option<ImageIntent>,
     pub(crate) prompt_cache_key: Option<String>,
     pub(crate) owner_auto_guard_active: bool,
     pub(crate) t_req_read_ms: f64,
@@ -1631,6 +1632,7 @@ pub(crate) struct PoolReplayBodyKeyProbe {
 pub(crate) struct RequestSemanticProjection {
     pub(crate) snapshot: PoolReplayBodySnapshot,
     pub(crate) request_info: RequestCaptureInfo,
+    pub(crate) hosted_image_intent: ImageIntent,
     pub(crate) upstream_snapshot: PoolReplayBodySnapshot,
     pub(crate) request_body_for_capture: Option<Bytes>,
     pub(crate) body_rewritten: bool,
@@ -2699,7 +2701,7 @@ where
     Body::from_stream(stream)
 }
 
-fn counted_http_body_from_snapshot(
+pub(crate) fn counted_http_body_from_snapshot(
     snapshot: &PoolReplayBodySnapshot,
     counter: ObservedByteCounter,
 ) -> Body {
@@ -4079,6 +4081,8 @@ pub(crate) async fn prepare_pool_request_body_for_account(
     image_tool_rewrite_mode: crate::ImageToolRewriteMode,
     codex_imagegen_rewrite_mode: crate::CodexImagegenRewriteMode,
     codex_imagegen_protocol: Option<CodexImagegenProtocol>,
+    projected_request_info: Option<&RequestCaptureInfo>,
+    projected_hosted_image_intent: Option<ImageIntent>,
 ) -> Result<PreparedPoolRequestBody, PoolRequestBodyPreparationError> {
     let capture_target = capture_target_for_request(original_uri.path(), method);
     let default_image_intent = match capture_target {
@@ -4139,22 +4143,38 @@ pub(crate) async fn prepare_pool_request_body_for_account(
             ),
             PoolReplayBodySnapshot::Memory(bytes) => {
                 let (requested_service_tier, requested_image_intent, requested_hosted_image_intent) =
-                    serde_json::from_slice::<Value>(bytes)
-                        .ok()
-                        .map(|value| {
+                    projected_request_info
+                        .zip(projected_hosted_image_intent)
+                        .map(|(info, hosted_image_intent)| {
+                            let image_intent = info
+                                .image_intent
+                                .as_deref()
+                                .map(ImageIntent::from_str)
+                                .unwrap_or(default_image_intent);
                             (
-                                extract_requested_service_tier_from_request_body(&value),
-                                capture_target
-                                    .map(|target| {
-                                        infer_image_intent_from_request_body(target, &value)
-                                    })
-                                    .unwrap_or(ImageIntent::Unknown),
-                                capture_target
-                                    .map(|target| {
-                                        infer_hosted_image_intent_from_request_body(target, &value)
-                                    })
-                                    .unwrap_or(ImageIntent::Unknown),
+                                info.requested_service_tier.clone(),
+                                image_intent,
+                                hosted_image_intent,
                             )
+                        })
+                        .or_else(|| {
+                            serde_json::from_slice::<Value>(bytes).ok().map(|value| {
+                                (
+                                    extract_requested_service_tier_from_request_body(&value),
+                                    capture_target
+                                        .map(|target| {
+                                            infer_image_intent_from_request_body(target, &value)
+                                        })
+                                        .unwrap_or(ImageIntent::Unknown),
+                                    capture_target
+                                        .map(|target| {
+                                            infer_hosted_image_intent_from_request_body(
+                                                target, &value,
+                                            )
+                                        })
+                                        .unwrap_or(ImageIntent::Unknown),
+                                )
+                            })
                         })
                         .unwrap_or((None, default_image_intent, default_image_intent));
                 (
@@ -4165,7 +4185,18 @@ pub(crate) async fn prepare_pool_request_body_for_account(
                 )
             }
             PoolReplayBodySnapshot::File { .. } => {
-                (None, None, default_image_intent, default_image_intent)
+                let requested_service_tier =
+                    projected_request_info.and_then(|info| info.requested_service_tier.clone());
+                let image_intent = projected_request_info
+                    .and_then(|info| info.image_intent.as_deref())
+                    .map(ImageIntent::from_str)
+                    .unwrap_or(default_image_intent);
+                (
+                    None,
+                    requested_service_tier,
+                    image_intent,
+                    projected_hosted_image_intent.unwrap_or(default_image_intent),
+                )
             }
         };
         let codex_imagegen_rewrite = codex_imagegen_protocol
@@ -4189,6 +4220,14 @@ pub(crate) async fn prepare_pool_request_body_for_account(
             "failed to materialize pool request body for rewrite: {err}"
         ))
     })?;
+    info!(
+        proxy_request_id,
+        json_parse_count = 1_u8,
+        whole_body_materialization_count = 1_u8,
+        materialization_bytes = original_bytes.len(),
+        purpose = "account_specific_request_rewrite",
+        "pool request preparation materialized account-specific rewrite body"
+    );
     let downstream_encoding =
         resolve_request_body_content_encoding(&snapshot, content_encoding).await?;
     let decoded_original_bytes =
@@ -4288,6 +4327,332 @@ pub(crate) async fn prepare_pool_request_body_for_account(
 }
 
 const INCLUDE_USAGE_ROOT_INSERTION: &[u8] = br#","stream_options":{"include_usage":true}"#;
+const INCLUDE_USAGE_OBJECT_INSERTION: &[u8] = br#","include_usage":true"#;
+const INCLUDE_USAGE_EMPTY_OBJECT_INSERTION: &[u8] = br#""include_usage":true"#;
+const INCLUDE_USAGE_REPLACEMENT: &[u8] = br#"{"include_usage":true}"#;
+const INCLUDE_USAGE_COPY_BUFFER_BYTES: usize = 32 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+enum IncludeUsageRewritePlan {
+    InsertRoot {
+        offset: usize,
+    },
+    InsertObject {
+        start: usize,
+        offset: usize,
+        empty: bool,
+    },
+    ReplaceValue {
+        start: usize,
+        end: usize,
+    },
+    ReplaceIncludeUsageValue {
+        start: usize,
+        end: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ActiveStreamOptionsValue {
+    Object {
+        start: usize,
+        depth: usize,
+        has_content: bool,
+    },
+    Composite {
+        start: usize,
+        depth: usize,
+    },
+    Primitive {
+        start: usize,
+        last_non_whitespace: usize,
+    },
+    String {
+        start: usize,
+    },
+}
+
+fn locate_root_field_rewrite(
+    reader: impl Read,
+    target_key: &[u8],
+) -> io::Result<Option<IncludeUsageRewritePlan>> {
+    let mut reader = std::io::BufReader::with_capacity(INCLUDE_USAGE_COPY_BUFFER_BYTES, reader);
+    let mut depth = 0_usize;
+    let mut position = 0_usize;
+    let mut root_close = None;
+    let mut expect_root_key = false;
+    let mut pending_root_key_is_stream_options = false;
+    let mut awaiting_stream_options_value = false;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut string_is_root_key = false;
+    let mut string_is_target_value = false;
+    let mut root_key = Vec::with_capacity("stream_options".len());
+    let mut active = None;
+    let mut plan = None;
+    let mut buffer = [0_u8; 1];
+
+    while reader.read(&mut buffer)? != 0 {
+        let byte = buffer[0];
+        let current = position;
+        position += 1;
+
+        if in_string {
+            if escaped {
+                if string_is_root_key {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "escaped semantic key requires fail-open rewrite",
+                    ));
+                }
+                escaped = false;
+                continue;
+            }
+            if byte == b'\\' {
+                escaped = true;
+                continue;
+            }
+            if byte == b'"' {
+                in_string = false;
+                if string_is_root_key {
+                    pending_root_key_is_stream_options = root_key == target_key;
+                    string_is_root_key = false;
+                } else if string_is_target_value {
+                    if let Some(ActiveStreamOptionsValue::String { start }) = active.take() {
+                        plan = Some(IncludeUsageRewritePlan::ReplaceValue {
+                            start,
+                            end: current + 1,
+                        });
+                    }
+                    string_is_target_value = false;
+                }
+                continue;
+            }
+            if string_is_root_key && root_key.len() <= "stream_options".len() {
+                root_key.push(byte);
+            }
+            continue;
+        }
+
+        if awaiting_stream_options_value {
+            if byte.is_ascii_whitespace() {
+                continue;
+            }
+            awaiting_stream_options_value = false;
+            active = Some(match byte {
+                b'{' => ActiveStreamOptionsValue::Object {
+                    start: current,
+                    depth: depth + 1,
+                    has_content: false,
+                },
+                b'[' => ActiveStreamOptionsValue::Composite {
+                    start: current,
+                    depth: depth + 1,
+                },
+                b'"' => {
+                    in_string = true;
+                    string_is_target_value = true;
+                    ActiveStreamOptionsValue::String { start: current }
+                }
+                _ => ActiveStreamOptionsValue::Primitive {
+                    start: current,
+                    last_non_whitespace: current,
+                },
+            });
+            if byte == b'"' {
+                continue;
+            }
+        }
+
+        if let Some(ActiveStreamOptionsValue::Primitive {
+            start,
+            last_non_whitespace,
+        }) = active
+        {
+            if depth == 1 && matches!(byte, b',' | b'}') {
+                plan = Some(IncludeUsageRewritePlan::ReplaceValue {
+                    start,
+                    end: last_non_whitespace + 1,
+                });
+                active = None;
+            } else if !byte.is_ascii_whitespace() {
+                active = Some(ActiveStreamOptionsValue::Primitive {
+                    start,
+                    last_non_whitespace: current,
+                });
+            }
+        }
+
+        if byte == b'"' {
+            if let Some(ActiveStreamOptionsValue::Object {
+                start,
+                depth: target_depth,
+                ..
+            }) = active
+                && depth >= target_depth
+            {
+                active = Some(ActiveStreamOptionsValue::Object {
+                    start,
+                    depth: target_depth,
+                    has_content: true,
+                });
+            }
+            in_string = true;
+            string_is_root_key = depth == 1 && expect_root_key;
+            if string_is_root_key {
+                root_key.clear();
+                expect_root_key = false;
+            }
+            continue;
+        }
+
+        if let Some(ActiveStreamOptionsValue::Object {
+            start,
+            depth: target_depth,
+            has_content,
+        }) = active
+            && depth >= target_depth
+            && !byte.is_ascii_whitespace()
+            && !(byte == b'}' && depth == target_depth)
+        {
+            active = Some(ActiveStreamOptionsValue::Object {
+                start,
+                depth: target_depth,
+                has_content: has_content || byte != b'{',
+            });
+        }
+
+        match byte {
+            b':' if depth == 1 => {
+                awaiting_stream_options_value = pending_root_key_is_stream_options;
+                pending_root_key_is_stream_options = false;
+            }
+            b'{' | b'[' => {
+                depth += 1;
+                if depth == 1 {
+                    expect_root_key = byte == b'{';
+                }
+            }
+            b'}' | b']' => {
+                match active {
+                    Some(ActiveStreamOptionsValue::Object {
+                        start,
+                        depth: target_depth,
+                        has_content,
+                    }) if byte == b'}' && depth == target_depth => {
+                        plan = Some(IncludeUsageRewritePlan::InsertObject {
+                            start,
+                            offset: current,
+                            empty: !has_content,
+                        });
+                        active = None;
+                    }
+                    Some(ActiveStreamOptionsValue::Composite {
+                        start,
+                        depth: target_depth,
+                    }) if depth == target_depth => {
+                        plan = Some(IncludeUsageRewritePlan::ReplaceValue {
+                            start,
+                            end: current + 1,
+                        });
+                        active = None;
+                    }
+                    _ => {}
+                }
+                if depth == 0 {
+                    return Ok(None);
+                }
+                depth -= 1;
+                if depth == 0 && byte == b'}' {
+                    root_close = Some(current);
+                }
+            }
+            b',' if depth == 1 => expect_root_key = true,
+            _ => {}
+        }
+    }
+
+    Ok(plan.or_else(|| root_close.map(|offset| IncludeUsageRewritePlan::InsertRoot { offset })))
+}
+
+fn locate_include_usage_rewrite<R>(mut reader: R) -> io::Result<Option<IncludeUsageRewritePlan>>
+where
+    R: Read + Seek,
+{
+    let plan = locate_root_field_rewrite(&mut reader, b"stream_options")?;
+    let Some(IncludeUsageRewritePlan::InsertObject {
+        start,
+        offset,
+        empty,
+    }) = plan
+    else {
+        return Ok(plan);
+    };
+    reader.seek(SeekFrom::Start(start as u64))?;
+    let nested = locate_root_field_rewrite(
+        (&mut reader).take((offset - start + 1) as u64),
+        b"include_usage",
+    )?;
+    Ok(match nested {
+        Some(IncludeUsageRewritePlan::ReplaceValue {
+            start: nested_start,
+            end,
+        }) => Some(IncludeUsageRewritePlan::ReplaceIncludeUsageValue {
+            start: start + nested_start,
+            end: start + end,
+        }),
+        Some(IncludeUsageRewritePlan::InsertObject {
+            start: nested_start,
+            offset: nested_offset,
+            ..
+        }) => Some(IncludeUsageRewritePlan::ReplaceIncludeUsageValue {
+            start: start + nested_start,
+            end: start + nested_offset + 1,
+        }),
+        Some(IncludeUsageRewritePlan::ReplaceIncludeUsageValue { .. }) => {
+            unreachable!("nested locator only emits generic replacement plans")
+        }
+        Some(IncludeUsageRewritePlan::InsertRoot { .. }) | None => {
+            Some(IncludeUsageRewritePlan::InsertObject {
+                start,
+                offset,
+                empty,
+            })
+        }
+    })
+}
+
+fn copy_exact_bounded(
+    reader: &mut std::fs::File,
+    writer: &mut std::fs::File,
+    mut bytes: usize,
+) -> io::Result<()> {
+    let mut buffer = [0_u8; INCLUDE_USAGE_COPY_BUFFER_BYTES];
+    while bytes > 0 {
+        let capacity = buffer.len();
+        let read = reader.read(&mut buffer[..bytes.min(capacity)])?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "request snapshot ended during include_usage rewrite",
+            ));
+        }
+        writer.write_all(&buffer[..read])?;
+        bytes -= read;
+    }
+    Ok(())
+}
+
+fn copy_to_end_bounded(reader: &mut std::fs::File, writer: &mut std::fs::File) -> io::Result<()> {
+    let mut buffer = [0_u8; INCLUDE_USAGE_COPY_BUFFER_BYTES];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(());
+        }
+        writer.write_all(&buffer[..read])?;
+    }
+}
 
 async fn rewrite_snapshot_include_usage(
     proxy_request_id: u64,
@@ -4296,6 +4661,21 @@ async fn rewrite_snapshot_include_usage(
     match snapshot {
         PoolReplayBodySnapshot::Empty => Ok(None),
         PoolReplayBodySnapshot::Memory(bytes) => {
+            if bytes.len() > REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES {
+                let temp_file = Arc::new(PoolReplayTempFile {
+                    path: build_pool_replay_temp_path(proxy_request_id),
+                });
+                tokio::fs::write(&temp_file.path, bytes).await?;
+                let file_snapshot = PoolReplayBodySnapshot::File {
+                    temp_file,
+                    size: bytes.len(),
+                };
+                return Box::pin(rewrite_snapshot_include_usage(
+                    proxy_request_id,
+                    &file_snapshot,
+                ))
+                .await;
+            }
             let Some(close) = bytes.iter().rposition(|byte| !byte.is_ascii_whitespace()) else {
                 return Ok(None);
             };
@@ -4320,30 +4700,40 @@ async fn rewrite_snapshot_include_usage(
             let source_size = *size;
             let rewritten_size =
                 tokio::task::spawn_blocking(move || -> io::Result<Option<usize>> {
-                    let mut reader = std::fs::File::open(source)?;
-                    let tail_len = source_size.min(REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES);
-                    reader.seek(SeekFrom::End(-(tail_len as i64)))?;
-                    let mut tail = vec![0_u8; tail_len];
-                    reader.read_exact(&mut tail)?;
-                    let Some(tail_close) =
-                        tail.iter().rposition(|byte| !byte.is_ascii_whitespace())
-                    else {
+                    let plan = locate_include_usage_rewrite(std::fs::File::open(&source)?)?;
+                    let Some(plan) = plan else {
                         return Ok(None);
                     };
-                    if tail[tail_close] != b'}' {
-                        return Ok(None);
+                    let mut reader = std::fs::File::open(source)?;
+                    let mut writer = std::fs::File::create(&destination_for_worker.path)?;
+                    let (prefix_bytes, skipped_bytes, insertion) = match plan {
+                        IncludeUsageRewritePlan::InsertRoot { offset } => {
+                            (offset, 0, INCLUDE_USAGE_ROOT_INSERTION)
+                        }
+                        IncludeUsageRewritePlan::InsertObject { offset, empty, .. } => (
+                            offset,
+                            0,
+                            if empty {
+                                INCLUDE_USAGE_EMPTY_OBJECT_INSERTION
+                            } else {
+                                INCLUDE_USAGE_OBJECT_INSERTION
+                            },
+                        ),
+                        IncludeUsageRewritePlan::ReplaceValue { start, end } => {
+                            (start, end - start, INCLUDE_USAGE_REPLACEMENT)
+                        }
+                        IncludeUsageRewritePlan::ReplaceIncludeUsageValue { start, end } => {
+                            (start, end - start, b"true".as_slice())
+                        }
+                    };
+                    copy_exact_bounded(&mut reader, &mut writer, prefix_bytes)?;
+                    if skipped_bytes > 0 {
+                        reader.seek(SeekFrom::Current(skipped_bytes as i64))?;
                     }
-                    let close_offset = source_size - tail_len + tail_close;
-                    reader.seek(SeekFrom::Start(0))?;
-                    let mut writer = std::io::BufWriter::with_capacity(
-                        REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES,
-                        std::fs::File::create(&destination_for_worker.path)?,
-                    );
-                    std::io::copy(&mut (&mut reader).take(close_offset as u64), &mut writer)?;
-                    writer.write_all(INCLUDE_USAGE_ROOT_INSERTION)?;
-                    std::io::copy(&mut reader, &mut writer)?;
+                    writer.write_all(insertion)?;
+                    copy_to_end_bounded(&mut reader, &mut writer)?;
                     writer.flush()?;
-                    Ok(Some(source_size + INCLUDE_USAGE_ROOT_INSERTION.len()))
+                    Ok(Some(source_size - skipped_bytes + insertion.len()))
                 })
                 .await
                 .map_err(|err| io::Error::other(err.to_string()))??;
@@ -4370,6 +4760,7 @@ pub(crate) async fn project_request_semantics(
             return RequestSemanticProjection {
                 snapshot: snapshot.clone(),
                 request_info: RequestCaptureInfo::default(),
+                hosted_image_intent: ImageIntent::Unknown,
                 upstream_snapshot: snapshot,
                 request_body_for_capture: None,
                 body_rewritten: false,
@@ -4381,14 +4772,19 @@ pub(crate) async fn project_request_semantics(
                 peak_business_buffer_bytes: 0,
             };
         };
-        let (upstream, request_info, body_rewritten) =
-            prepare_target_request_body(target, original.to_vec(), auto_include_usage);
+        let (upstream, request_info, body_rewritten, hosted_image_intent) =
+            prepare_target_request_body_with_hosted_intent(
+                target,
+                original.to_vec(),
+                auto_include_usage,
+            );
         let json_parse_count = u8::from(!original.is_empty());
         let upstream_snapshot =
             pool_replay_snapshot_from_bytes(proxy_request_id, Bytes::from(upstream)).await;
         return RequestSemanticProjection {
             snapshot,
             request_info,
+            hosted_image_intent,
             upstream_snapshot,
             request_body_for_capture: Some(original),
             body_rewritten,
@@ -4400,88 +4796,120 @@ pub(crate) async fn project_request_semantics(
             peak_business_buffer_bytes: body_len,
         };
     }
-    let (request_info, upstream_snapshot, request_body_for_capture, body_rewritten, buffer_bytes) =
-        match &snapshot {
-            PoolReplayBodySnapshot::Empty => (
-                RequestCaptureInfo::default(),
-                PoolReplayBodySnapshot::Empty,
-                Some(Bytes::new()),
-                false,
-                0,
-            ),
-            PoolReplayBodySnapshot::Memory(bytes)
-                if bytes.len() <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES =>
-            {
-                let (upstream, info, rewritten) =
-                    prepare_target_request_body(target, bytes.to_vec(), auto_include_usage);
-                let capture = Some(bytes.clone());
-                let upstream_snapshot = if rewritten {
-                    pool_replay_snapshot_from_bytes(proxy_request_id, Bytes::from(upstream)).await
+    let mut projected_json_parse_count = u8::from(body_len > 0);
+    let mut semantic_parse_buffer_bytes = 0_usize;
+    let (
+        request_info,
+        hosted_image_intent,
+        upstream_snapshot,
+        request_body_for_capture,
+        body_rewritten,
+        rewrite_buffer_bytes,
+    ) = match &snapshot {
+        PoolReplayBodySnapshot::Empty => (
+            RequestCaptureInfo::default(),
+            ImageIntent::Unknown,
+            PoolReplayBodySnapshot::Empty,
+            Some(Bytes::new()),
+            false,
+            0,
+        ),
+        PoolReplayBodySnapshot::Memory(bytes)
+            if bytes.len() <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES =>
+        {
+            let (upstream, info, rewritten, hosted_image_intent) =
+                prepare_target_request_body_with_hosted_intent(
+                    target,
+                    bytes.to_vec(),
+                    auto_include_usage,
+                );
+            let capture = Some(bytes.clone());
+            let upstream_snapshot = if rewritten {
+                pool_replay_snapshot_from_bytes(proxy_request_id, Bytes::from(upstream)).await
+            } else {
+                snapshot.clone()
+            };
+            (
+                info,
+                hosted_image_intent,
+                upstream_snapshot,
+                capture,
+                rewritten,
+                bytes.len(),
+            )
+        }
+        _ => {
+            let analysis = analyze_replay_snapshot_for_pool_routing(
+                &snapshot,
+                Some(target),
+                proxy_request_id,
+                "request_semantic_projection",
+            )
+            .await;
+            projected_json_parse_count = analysis.json_parse_count;
+            semantic_parse_buffer_bytes = REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES.min(body_len);
+            let request_info = RequestCaptureInfo {
+                model: analysis.requested_model,
+                sticky_key: analysis.sticky_key,
+                prompt_cache_key: analysis.prompt_cache_key,
+                prompt_cache_key_attribution_source: None,
+                contains_encrypted_content: analysis.contains_encrypted_content,
+                image_intent: Some(analysis.image_intent.as_str().to_string()),
+                requested_service_tier: analysis.requested_service_tier,
+                reasoning_effort: analysis.reasoning_effort,
+                compaction_request_kind: analysis.compaction_kind,
+                is_stream: analysis.is_stream,
+                parse_error: (analysis.parse_outcome != "parsed")
+                    .then(|| format!("request_json_{}", analysis.parse_outcome)),
+            };
+            let should_rewrite =
+                target.should_auto_include_usage() && auto_include_usage && request_info.is_stream;
+            let rewritten_snapshot = if should_rewrite {
+                rewrite_snapshot_include_usage(proxy_request_id, &snapshot)
+                    .await
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+            let body_rewritten = rewritten_snapshot.is_some();
+            (
+                request_info,
+                analysis.hosted_image_intent,
+                rewritten_snapshot.unwrap_or_else(|| snapshot.clone()),
+                None,
+                body_rewritten,
+                if should_rewrite {
+                    INCLUDE_USAGE_COPY_BUFFER_BYTES.min(body_len)
                 } else {
-                    snapshot.clone()
-                };
-                (info, upstream_snapshot, capture, rewritten, bytes.len())
-            }
-            _ => {
-                let analysis = analyze_replay_snapshot_for_pool_routing(
-                    &snapshot,
-                    Some(target),
-                    proxy_request_id,
-                    "request_semantic_projection",
-                )
-                .await;
-                let request_info = RequestCaptureInfo {
-                    model: analysis.requested_model,
-                    sticky_key: analysis.sticky_key,
-                    prompt_cache_key: analysis.prompt_cache_key,
-                    prompt_cache_key_attribution_source: None,
-                    contains_encrypted_content: analysis.contains_encrypted_content,
-                    image_intent: Some(analysis.image_intent.as_str().to_string()),
-                    requested_service_tier: analysis.requested_service_tier,
-                    reasoning_effort: analysis.reasoning_effort,
-                    compaction_request_kind: analysis.compaction_kind,
-                    is_stream: analysis.is_stream,
-                    parse_error: (analysis.parse_outcome != "parsed")
-                        .then(|| format!("request_json_{}", analysis.parse_outcome)),
-                };
-                let should_rewrite = target.should_auto_include_usage()
-                    && auto_include_usage
-                    && request_info.is_stream
-                    && !analysis.stream_options_present;
-                let rewritten_snapshot = if should_rewrite {
-                    rewrite_snapshot_include_usage(proxy_request_id, &snapshot)
-                        .await
-                        .ok()
-                        .flatten()
-                } else {
-                    None
-                };
-                let body_rewritten = rewritten_snapshot.is_some();
-                (
-                    request_info,
-                    rewritten_snapshot.unwrap_or_else(|| snapshot.clone()),
-                    None,
-                    body_rewritten,
-                    if should_rewrite {
-                        REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES.min(body_len)
-                    } else {
-                        0
-                    },
-                )
-            }
-        };
+                    0
+                },
+            )
+        }
+    };
+    let buffer_bytes = rewrite_buffer_bytes.max(semantic_parse_buffer_bytes);
 
+    let whole_body_materialization_count = u8::from(matches!(
+        &snapshot,
+        PoolReplayBodySnapshot::Memory(bytes)
+            if !bytes.is_empty() && bytes.len() <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES
+    ));
     RequestSemanticProjection {
         snapshot,
         request_info,
+        hosted_image_intent,
         upstream_snapshot,
         request_body_for_capture,
         body_rewritten,
         parse_elapsed_ms: started.elapsed().as_millis() as u64,
-        materialization_bytes: 0,
+        materialization_bytes: if whole_body_materialization_count > 0 {
+            body_len
+        } else {
+            0
+        },
         buffer_bytes,
-        json_parse_count: u8::from(body_len > 0),
-        whole_body_materialization_count: 0,
+        json_parse_count: projected_json_parse_count,
+        whole_body_materialization_count,
         peak_business_buffer_bytes: buffer_bytes,
     }
 }
@@ -5423,6 +5851,8 @@ mod tests {
             crate::ImageToolRewriteMode::KeepOriginal,
             crate::CodexImagegenRewriteMode::KeepOriginal,
             Some(CodexImagegenProtocol::Full),
+            None,
+            None,
         )
         .await
         .expect("prepare keep-original Codex snapshot");
@@ -5481,6 +5911,8 @@ mod tests {
             crate::ImageToolRewriteMode::KeepOriginal,
             crate::CodexImagegenRewriteMode::ForceAdd,
             Some(CodexImagegenProtocol::Full),
+            None,
+            None,
         )
         .await
         .expect("rewrite gzip snapshot");
@@ -5526,6 +5958,8 @@ mod tests {
             crate::ImageToolRewriteMode::KeepOriginal,
             crate::CodexImagegenRewriteMode::ForceAdd,
             Some(CodexImagegenProtocol::Full),
+            None,
+            None,
         )
         .await
         .expect("rewrite file replay snapshot");
@@ -5679,6 +6113,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_semantic_projection_rewrites_medium_memory_snapshot_via_file() {
+        let prefix = br#"{"model":"gpt-5","stream":true,"stream_options":{"include_usage":false,"other_option":"preserved"},"padding":""#;
+        let mut body = Vec::with_capacity(512 * 1024);
+        body.extend_from_slice(prefix);
+        body.resize(512 * 1024 - 2, b'x');
+        body.extend_from_slice(br#""}"#);
+        let snapshot = pool_replay_snapshot_from_bytes(90_005, Bytes::from(body)).await;
+        assert!(matches!(&snapshot, PoolReplayBodySnapshot::Memory(_)));
+
+        let projection =
+            project_request_semantics(90_005, snapshot, ProxyCaptureTarget::ChatCompletions, true)
+                .await;
+
+        assert!(projection.body_rewritten);
+        assert!(matches!(
+            &projection.upstream_snapshot,
+            PoolReplayBodySnapshot::File { .. }
+        ));
+        let forwarded = projection
+            .upstream_snapshot
+            .to_bytes()
+            .await
+            .expect("read medium rewritten body");
+        assert_eq!(
+            forwarded
+                .windows(b"\"include_usage\"".len())
+                .filter(|window| *window == b"\"include_usage\"")
+                .count(),
+            1
+        );
+        let value: Value = serde_json::from_slice(&forwarded).expect("parse medium rewritten body");
+        assert_eq!(value["stream_options"]["include_usage"], true);
+        assert_eq!(value["stream_options"]["other_option"], "preserved");
+        assert_eq!(projection.whole_body_materialization_count, 0);
+        assert_eq!(projection.materialization_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn request_semantic_projection_keeps_codex_image_intent_out_of_hosted_routing() {
+        let prefix = br#"{"model":"gpt-5","input":[{"type":"additional_tools","tools":[{"type":"image_gen.imagegen"}]}],"padding":""#;
+        let mut body = Vec::with_capacity(512 * 1024);
+        body.extend_from_slice(prefix);
+        body.resize(512 * 1024 - 2, b'x');
+        body.extend_from_slice(br#""}"#);
+        let snapshot = pool_replay_snapshot_from_bytes(90_007, Bytes::from(body)).await;
+        let projection =
+            project_request_semantics(90_007, snapshot, ProxyCaptureTarget::Responses, true).await;
+
+        assert_eq!(projection.request_info.image_intent.as_deref(), Some("yes"));
+        assert_eq!(projection.hosted_image_intent, ImageIntent::No);
+        let prepared = prepare_pool_request_body_for_account(
+            90_007,
+            Some(&projection.upstream_snapshot),
+            &"/v1/responses".parse().expect("valid responses uri"),
+            &Method::POST,
+            None,
+            TagFastModeRewriteMode::KeepOriginal,
+            crate::ImageToolRewriteMode::KeepOriginal,
+            crate::CodexImagegenRewriteMode::KeepOriginal,
+            None,
+            Some(&projection.request_info),
+            Some(projection.hosted_image_intent),
+        )
+        .await
+        .expect("prepare projected Codex image request");
+        assert_eq!(prepared.requested_image_intent, ImageIntent::Yes);
+        assert_eq!(prepared.requested_hosted_image_intent, ImageIntent::No);
+    }
+
+    #[tokio::test]
     async fn request_semantic_projection_keeps_large_bodies_file_backed() {
         for (request_id, size, target) in [
             (
@@ -5689,8 +6193,8 @@ mod tests {
             (90_064, 64 * 1024 * 1024, ProxyCaptureTarget::Responses),
         ] {
             let prefix = match target {
-                ProxyCaptureTarget::ChatCompletions => br#"{"model":"gpt-5","stream":true,"metadata":{"sticky_key":"sticky-16","prompt_cache_key":"cache-16"},"service_tier":"priority","reasoning_effort":"high","nested":{"encrypted_content":"cipher"},"input":""#.as_slice(),
-                ProxyCaptureTarget::Responses => br#"{"model":"gpt-5","stream":true,"metadata":{"sticky_key":"sticky-64","prompt_cache_key":"cache-64"},"serviceTier":"priority","reasoning":{"effort":"medium"},"nested":{"type":"encrypted_content"},"tools":[{"type":"image_generation"}],"context_management":[{"type":"compaction","compact_threshold":1000}],"input":""#.as_slice(),
+                ProxyCaptureTarget::ChatCompletions => br#"{"model":"gpt-5","stream":true,"stream_options":{"include_usage":false,"other_option":"preserved"},"metadata":{"sticky_key":"sticky-16","prompt_cache_key":"cache-16"},"service_tier":"priority","reasoning_effort":"high","input":[{"encrypted_content":"cipher"}],"padding":""#.as_slice(),
+                ProxyCaptureTarget::Responses => br#"{"model":"gpt-5","stream":true,"metadata":{"sticky_key":"sticky-64","prompt_cache_key":"cache-64"},"serviceTier":"priority","reasoning":{"effort":"medium"},"nested":{"type":"encrypted\u005fcontent"},"tools":[{"type":"image_generation"}],"context_management":[{"type":"compaction","compact_threshold":1000}],"padding":""#.as_slice(),
                 _ => unreachable!(),
             };
             let suffix = br#""}"#;
@@ -5741,17 +6245,56 @@ mod tests {
             );
             if target == ProxyCaptureTarget::ChatCompletions {
                 assert!(projection.body_rewritten);
-                assert_eq!(
-                    projection.buffer_bytes,
-                    REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES
-                );
+                assert!(projection.buffer_bytes <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES);
                 assert_eq!(
                     projection.request_info.reasoning_effort.as_deref(),
                     Some("high")
                 );
+                let forwarded_bytes = projection
+                    .upstream_snapshot
+                    .to_bytes()
+                    .await
+                    .expect("read rewritten replay snapshot");
+                assert_eq!(
+                    forwarded_bytes
+                        .windows(b"\"include_usage\"".len())
+                        .filter(|window| *window == b"\"include_usage\"")
+                        .count(),
+                    1
+                );
+                let forwarded: Value = serde_json::from_slice(&forwarded_bytes)
+                    .expect("parse rewritten replay snapshot");
+                assert_eq!(forwarded["stream_options"]["include_usage"], true);
+                assert_eq!(forwarded["stream_options"]["other_option"], "preserved");
+                let PoolReplayBodySnapshot::File { temp_file, size } =
+                    &projection.upstream_snapshot
+                else {
+                    panic!("rewritten 16 MiB body must remain file-backed");
+                };
+                let mut config = crate::tests::test_config();
+                config.proxy_raw_dir = std::env::temp_dir().join(format!(
+                    "cvm-request-semantic-raw-{}",
+                    Utc::now().timestamp_nanos_opt().unwrap_or_default()
+                ));
+                config.proxy_raw_compression = RawCompressionCodec::None;
+                config.proxy_raw_max_bytes = None;
+                let raw = store_raw_payload_snapshot_file(
+                    &config,
+                    "request-semantic-16m",
+                    "request",
+                    temp_file.path.clone(),
+                    *size,
+                )
+                .await;
+                let raw_path = raw.path.expect("raw capture path");
+                assert_eq!(
+                    Sha256::digest(tokio::fs::read(&raw_path).await.expect("read raw capture")),
+                    Sha256::digest(&forwarded_bytes)
+                );
+                let _ = tokio::fs::remove_dir_all(&config.proxy_raw_dir).await;
             } else {
                 assert!(!projection.body_rewritten);
-                assert_eq!(projection.buffer_bytes, 0);
+                assert!(projection.buffer_bytes <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES);
                 assert_eq!(
                     projection.request_info.reasoning_effort.as_deref(),
                     Some("medium")
@@ -5771,6 +6314,20 @@ mod tests {
                     ),
                     original_digest
                 );
+                for _ in 0..2 {
+                    let replay = counted_http_body_from_snapshot(
+                        &projection.upstream_snapshot,
+                        ObservedByteCounter::default(),
+                    );
+                    assert_eq!(
+                        Sha256::digest(
+                            axum::body::to_bytes(replay, size + 1)
+                                .await
+                                .expect("read direct retry replay body")
+                        ),
+                        original_digest
+                    );
+                }
             }
             assert_eq!(projection.json_parse_count, 1);
             assert_eq!(projection.whole_body_materialization_count, 0);
@@ -5801,5 +6358,70 @@ mod tests {
         );
         assert_eq!(projection.whole_body_materialization_count, 0);
         assert_eq!(projection.materialization_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn request_semantic_projection_bounds_large_escaped_selected_string() {
+        for (request_id, size) in [(90_003, 512 * 1024), (90_004, 2 * 1024 * 1024)] {
+            let mut body = Vec::with_capacity(size);
+            body.extend_from_slice(br#"{"model":""#);
+            while body.len() < size {
+                body.extend_from_slice(br#"\u0061"#);
+            }
+            body.extend_from_slice(br#"","stream":true}"#);
+            let original = Bytes::from(body);
+            let snapshot = pool_replay_snapshot_from_bytes(request_id, original.clone()).await;
+
+            let projection = project_request_semantics(
+                request_id,
+                snapshot,
+                ProxyCaptureTarget::ChatCompletions,
+                true,
+            )
+            .await;
+
+            assert!(projection.request_info.parse_error.is_some());
+            assert!(!projection.body_rewritten);
+            assert_eq!(
+                projection
+                    .upstream_snapshot
+                    .to_bytes()
+                    .await
+                    .expect("read bounded fail-open body"),
+                original
+            );
+            assert_eq!(projection.whole_body_materialization_count, 0);
+            assert_eq!(projection.materialization_bytes, 0);
+            assert!(
+                projection.peak_business_buffer_bytes <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn request_semantic_projection_fails_open_for_escaped_rewrite_key() {
+        let prefix =
+            br#"{"model":"gpt-5","stream":true,"stream\u005foptions":{"include_usage":false},"padding":""#;
+        let mut body = Vec::with_capacity(512 * 1024);
+        body.extend_from_slice(prefix);
+        body.resize(512 * 1024 - 2, b'x');
+        body.extend_from_slice(br#""}"#);
+        let original = Bytes::from(body);
+        let snapshot = pool_replay_snapshot_from_bytes(90_006, original.clone()).await;
+
+        let projection =
+            project_request_semantics(90_006, snapshot, ProxyCaptureTarget::ChatCompletions, true)
+                .await;
+
+        assert!(!projection.body_rewritten);
+        assert_eq!(
+            projection
+                .upstream_snapshot
+                .to_bytes()
+                .await
+                .expect("read escaped-key fail-open body"),
+            original
+        );
+        assert_eq!(projection.whole_body_materialization_count, 0);
     }
 }

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1559,6 +1559,24 @@ pub(crate) fn disarm_pool_invocation_cleanup_guard(guard: &mut Option<PoolInvoca
 }
 pub(crate) const POOL_UPSTREAM_MAX_DISTINCT_ACCOUNTS: usize = 3;
 pub(crate) const POOL_UPSTREAM_RESPONSES_MAX_TIMEOUT_ROUTE_KEYS: usize = 3;
+pub(crate) const REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES: usize = 64 * 1024;
+pub(crate) const ENV_PROXY_REQUEST_SEMANTIC_PIPELINE_MODE: &str =
+    "PROXY_REQUEST_SEMANTIC_PIPELINE_MODE";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum RequestSemanticPipelineMode {
+    Projection,
+    Legacy,
+}
+
+pub(crate) fn request_semantic_pipeline_mode() -> RequestSemanticPipelineMode {
+    match std::env::var(ENV_PROXY_REQUEST_SEMANTIC_PIPELINE_MODE) {
+        Ok(value) if value.trim().eq_ignore_ascii_case("legacy") => {
+            RequestSemanticPipelineMode::Legacy
+        }
+        _ => RequestSemanticPipelineMode::Projection,
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct PoolReplayTempFile {
@@ -1602,6 +1620,26 @@ pub(crate) struct PoolReplayBodyKeyProbe {
     pub(crate) prompt_cache_key: Option<String>,
     pub(crate) model: Option<String>,
     pub(crate) contains_encrypted_content: bool,
+}
+
+/// Immutable request semantics derived from the single replay snapshot.
+///
+/// The snapshot remains the source of truth for forwarding and raw capture. The
+/// projection only owns bounded business metadata and an optional rewritten
+/// snapshot, so large request bodies never need to be copied into a `Vec`.
+#[derive(Debug, Clone)]
+pub(crate) struct RequestSemanticProjection {
+    pub(crate) snapshot: PoolReplayBodySnapshot,
+    pub(crate) request_info: RequestCaptureInfo,
+    pub(crate) upstream_snapshot: PoolReplayBodySnapshot,
+    pub(crate) request_body_for_capture: Option<Bytes>,
+    pub(crate) body_rewritten: bool,
+    pub(crate) parse_elapsed_ms: u64,
+    pub(crate) materialization_bytes: usize,
+    pub(crate) buffer_bytes: usize,
+    pub(crate) json_parse_count: u8,
+    pub(crate) whole_body_materialization_count: u8,
+    pub(crate) peak_business_buffer_bytes: usize,
 }
 
 pub(crate) struct PoolReplayBodyBuffer {
@@ -4249,6 +4287,205 @@ pub(crate) async fn prepare_pool_request_body_for_account(
     })
 }
 
+const INCLUDE_USAGE_ROOT_INSERTION: &[u8] = br#","stream_options":{"include_usage":true}"#;
+
+async fn rewrite_snapshot_include_usage(
+    proxy_request_id: u64,
+    snapshot: &PoolReplayBodySnapshot,
+) -> io::Result<Option<PoolReplayBodySnapshot>> {
+    match snapshot {
+        PoolReplayBodySnapshot::Empty => Ok(None),
+        PoolReplayBodySnapshot::Memory(bytes) => {
+            let Some(close) = bytes.iter().rposition(|byte| !byte.is_ascii_whitespace()) else {
+                return Ok(None);
+            };
+            if bytes[close] != b'}' {
+                return Ok(None);
+            }
+            let mut rewritten =
+                Vec::with_capacity(bytes.len() + INCLUDE_USAGE_ROOT_INSERTION.len());
+            rewritten.extend_from_slice(&bytes[..close]);
+            rewritten.extend_from_slice(INCLUDE_USAGE_ROOT_INSERTION);
+            rewritten.extend_from_slice(&bytes[close..]);
+            Ok(Some(
+                pool_replay_snapshot_from_bytes(proxy_request_id, Bytes::from(rewritten)).await,
+            ))
+        }
+        PoolReplayBodySnapshot::File { temp_file, size } => {
+            let source = temp_file.path.clone();
+            let destination = Arc::new(PoolReplayTempFile {
+                path: build_pool_replay_temp_path(proxy_request_id),
+            });
+            let destination_for_worker = destination.clone();
+            let source_size = *size;
+            let rewritten_size =
+                tokio::task::spawn_blocking(move || -> io::Result<Option<usize>> {
+                    let mut reader = std::fs::File::open(source)?;
+                    let tail_len = source_size.min(REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES);
+                    reader.seek(SeekFrom::End(-(tail_len as i64)))?;
+                    let mut tail = vec![0_u8; tail_len];
+                    reader.read_exact(&mut tail)?;
+                    let Some(tail_close) =
+                        tail.iter().rposition(|byte| !byte.is_ascii_whitespace())
+                    else {
+                        return Ok(None);
+                    };
+                    if tail[tail_close] != b'}' {
+                        return Ok(None);
+                    }
+                    let close_offset = source_size - tail_len + tail_close;
+                    reader.seek(SeekFrom::Start(0))?;
+                    let mut writer = std::io::BufWriter::with_capacity(
+                        REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES,
+                        std::fs::File::create(&destination_for_worker.path)?,
+                    );
+                    std::io::copy(&mut (&mut reader).take(close_offset as u64), &mut writer)?;
+                    writer.write_all(INCLUDE_USAGE_ROOT_INSERTION)?;
+                    std::io::copy(&mut reader, &mut writer)?;
+                    writer.flush()?;
+                    Ok(Some(source_size + INCLUDE_USAGE_ROOT_INSERTION.len()))
+                })
+                .await
+                .map_err(|err| io::Error::other(err.to_string()))??;
+            Ok(rewritten_size.map(|size| PoolReplayBodySnapshot::File {
+                temp_file: destination,
+                size,
+            }))
+        }
+    }
+}
+
+/// Build the semantic projection once, reusing the replay snapshot for routing,
+/// capture, and upstream preparation.
+pub(crate) async fn project_request_semantics(
+    proxy_request_id: u64,
+    snapshot: PoolReplayBodySnapshot,
+    target: ProxyCaptureTarget,
+    auto_include_usage: bool,
+) -> RequestSemanticProjection {
+    let started = Instant::now();
+    let body_len = pool_request_snapshot_body_bytes(&snapshot);
+    if request_semantic_pipeline_mode() == RequestSemanticPipelineMode::Legacy {
+        let Ok(original) = snapshot.to_bytes().await else {
+            return RequestSemanticProjection {
+                snapshot: snapshot.clone(),
+                request_info: RequestCaptureInfo::default(),
+                upstream_snapshot: snapshot,
+                request_body_for_capture: None,
+                body_rewritten: false,
+                parse_elapsed_ms: started.elapsed().as_millis() as u64,
+                materialization_bytes: 0,
+                buffer_bytes: 0,
+                json_parse_count: 0,
+                whole_body_materialization_count: 0,
+                peak_business_buffer_bytes: 0,
+            };
+        };
+        let (upstream, request_info, body_rewritten) =
+            prepare_target_request_body(target, original.to_vec(), auto_include_usage);
+        let json_parse_count = u8::from(!original.is_empty());
+        let upstream_snapshot =
+            pool_replay_snapshot_from_bytes(proxy_request_id, Bytes::from(upstream)).await;
+        return RequestSemanticProjection {
+            snapshot,
+            request_info,
+            upstream_snapshot,
+            request_body_for_capture: Some(original),
+            body_rewritten,
+            parse_elapsed_ms: started.elapsed().as_millis() as u64,
+            materialization_bytes: body_len,
+            buffer_bytes: body_len,
+            json_parse_count,
+            whole_body_materialization_count: u8::from(body_len > 0),
+            peak_business_buffer_bytes: body_len,
+        };
+    }
+    let (request_info, upstream_snapshot, request_body_for_capture, body_rewritten, buffer_bytes) =
+        match &snapshot {
+            PoolReplayBodySnapshot::Empty => (
+                RequestCaptureInfo::default(),
+                PoolReplayBodySnapshot::Empty,
+                Some(Bytes::new()),
+                false,
+                0,
+            ),
+            PoolReplayBodySnapshot::Memory(bytes)
+                if bytes.len() <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES =>
+            {
+                let (upstream, info, rewritten) =
+                    prepare_target_request_body(target, bytes.to_vec(), auto_include_usage);
+                let capture = Some(bytes.clone());
+                let upstream_snapshot = if rewritten {
+                    pool_replay_snapshot_from_bytes(proxy_request_id, Bytes::from(upstream)).await
+                } else {
+                    snapshot.clone()
+                };
+                (info, upstream_snapshot, capture, rewritten, bytes.len())
+            }
+            _ => {
+                let analysis = analyze_replay_snapshot_for_pool_routing(
+                    &snapshot,
+                    Some(target),
+                    proxy_request_id,
+                    "request_semantic_projection",
+                )
+                .await;
+                let request_info = RequestCaptureInfo {
+                    model: analysis.requested_model,
+                    sticky_key: analysis.sticky_key,
+                    prompt_cache_key: analysis.prompt_cache_key,
+                    prompt_cache_key_attribution_source: None,
+                    contains_encrypted_content: analysis.contains_encrypted_content,
+                    image_intent: Some(analysis.image_intent.as_str().to_string()),
+                    requested_service_tier: analysis.requested_service_tier,
+                    reasoning_effort: analysis.reasoning_effort,
+                    compaction_request_kind: analysis.compaction_kind,
+                    is_stream: analysis.is_stream,
+                    parse_error: (analysis.parse_outcome != "parsed")
+                        .then(|| format!("request_json_{}", analysis.parse_outcome)),
+                };
+                let should_rewrite = target.should_auto_include_usage()
+                    && auto_include_usage
+                    && request_info.is_stream
+                    && !analysis.stream_options_present;
+                let rewritten_snapshot = if should_rewrite {
+                    rewrite_snapshot_include_usage(proxy_request_id, &snapshot)
+                        .await
+                        .ok()
+                        .flatten()
+                } else {
+                    None
+                };
+                let body_rewritten = rewritten_snapshot.is_some();
+                (
+                    request_info,
+                    rewritten_snapshot.unwrap_or_else(|| snapshot.clone()),
+                    None,
+                    body_rewritten,
+                    if should_rewrite {
+                        REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES.min(body_len)
+                    } else {
+                        0
+                    },
+                )
+            }
+        };
+
+    RequestSemanticProjection {
+        snapshot,
+        request_info,
+        upstream_snapshot,
+        request_body_for_capture,
+        body_rewritten,
+        parse_elapsed_ms: started.elapsed().as_millis() as u64,
+        materialization_bytes: 0,
+        buffer_bytes,
+        json_parse_count: u8::from(body_len > 0),
+        whole_body_materialization_count: 0,
+        peak_business_buffer_bytes: buffer_bytes,
+    }
+}
+
 pub(crate) fn build_pool_replay_temp_path(proxy_request_id: u64) -> PathBuf {
     let mut path = env::temp_dir();
     let unique_id = NEXT_POOL_REPLAY_TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed);
@@ -5418,5 +5655,151 @@ mod tests {
             ),
             CapabilitySupport::Unsupported
         );
+    }
+
+    #[tokio::test]
+    async fn request_semantic_projection_rewrites_small_stream_body_without_changing_capture() {
+        let original = Bytes::from_static(br#"{"model":"gpt-5","stream":true}"#);
+        let snapshot = pool_replay_snapshot_from_bytes(90_001, original.clone()).await;
+
+        let projection =
+            project_request_semantics(90_001, snapshot, ProxyCaptureTarget::ChatCompletions, true)
+                .await;
+
+        assert!(projection.body_rewritten);
+        assert_eq!(projection.request_body_for_capture, Some(original));
+        let rewritten = projection
+            .upstream_snapshot
+            .to_bytes()
+            .await
+            .expect("read rewritten body");
+        let value: Value = serde_json::from_slice(&rewritten).expect("parse rewritten body");
+        assert_eq!(value["stream_options"]["include_usage"], true);
+        assert!(projection.buffer_bytes <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES);
+    }
+
+    #[tokio::test]
+    async fn request_semantic_projection_keeps_large_bodies_file_backed() {
+        for (request_id, size, target) in [
+            (
+                90_016,
+                16 * 1024 * 1024,
+                ProxyCaptureTarget::ChatCompletions,
+            ),
+            (90_064, 64 * 1024 * 1024, ProxyCaptureTarget::Responses),
+        ] {
+            let prefix = match target {
+                ProxyCaptureTarget::ChatCompletions => br#"{"model":"gpt-5","stream":true,"metadata":{"sticky_key":"sticky-16","prompt_cache_key":"cache-16"},"service_tier":"priority","reasoning_effort":"high","nested":{"encrypted_content":"cipher"},"input":""#.as_slice(),
+                ProxyCaptureTarget::Responses => br#"{"model":"gpt-5","stream":true,"metadata":{"sticky_key":"sticky-64","prompt_cache_key":"cache-64"},"serviceTier":"priority","reasoning":{"effort":"medium"},"nested":{"type":"encrypted_content"},"tools":[{"type":"image_generation"}],"context_management":[{"type":"compaction","compact_threshold":1000}],"input":""#.as_slice(),
+                _ => unreachable!(),
+            };
+            let suffix = br#""}"#;
+            let mut body = Vec::with_capacity(size);
+            body.extend_from_slice(prefix);
+            body.resize(size - suffix.len(), b'x');
+            body.extend_from_slice(suffix);
+            let original_digest = Sha256::digest(&body);
+            let snapshot = pool_replay_snapshot_from_bytes(request_id, Bytes::from(body)).await;
+            assert!(matches!(&snapshot, PoolReplayBodySnapshot::File { .. }));
+
+            let projection = project_request_semantics(request_id, snapshot, target, true).await;
+
+            assert!(matches!(
+                &projection.snapshot,
+                PoolReplayBodySnapshot::File { .. }
+            ));
+            assert!(matches!(
+                &projection.upstream_snapshot,
+                PoolReplayBodySnapshot::File { .. }
+            ));
+            assert_eq!(projection.request_info.model.as_deref(), Some("gpt-5"));
+            assert!(projection.request_info.is_stream);
+            assert!(projection.request_info.contains_encrypted_content);
+            assert_eq!(
+                projection.request_info.requested_service_tier.as_deref(),
+                Some("priority")
+            );
+            let suffix = if size == 16 * 1024 * 1024 { "16" } else { "64" };
+            assert_eq!(
+                projection.request_info.sticky_key.as_deref(),
+                Some(format!("sticky-{suffix}").as_str())
+            );
+            assert_eq!(
+                projection.request_info.prompt_cache_key.as_deref(),
+                Some(format!("cache-{suffix}").as_str())
+            );
+            assert_eq!(projection.request_body_for_capture, None);
+            assert_eq!(
+                Sha256::digest(
+                    projection
+                        .snapshot
+                        .to_bytes()
+                        .await
+                        .expect("read original replay snapshot")
+                ),
+                original_digest
+            );
+            if target == ProxyCaptureTarget::ChatCompletions {
+                assert!(projection.body_rewritten);
+                assert_eq!(
+                    projection.buffer_bytes,
+                    REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES
+                );
+                assert_eq!(
+                    projection.request_info.reasoning_effort.as_deref(),
+                    Some("high")
+                );
+            } else {
+                assert!(!projection.body_rewritten);
+                assert_eq!(projection.buffer_bytes, 0);
+                assert_eq!(
+                    projection.request_info.reasoning_effort.as_deref(),
+                    Some("medium")
+                );
+                assert_eq!(projection.request_info.image_intent.as_deref(), Some("yes"));
+                assert_eq!(
+                    projection.request_info.compaction_request_kind,
+                    Some(CompactionKind::RemoteV2)
+                );
+                assert_eq!(
+                    Sha256::digest(
+                        projection
+                            .upstream_snapshot
+                            .to_bytes()
+                            .await
+                            .expect("read forwarded replay snapshot")
+                    ),
+                    original_digest
+                );
+            }
+            assert_eq!(projection.json_parse_count, 1);
+            assert_eq!(projection.whole_body_materialization_count, 0);
+            assert_eq!(projection.materialization_bytes, 0);
+            assert!(
+                projection.peak_business_buffer_bytes <= REQUEST_SEMANTIC_BUSINESS_BUFFER_BYTES
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn request_semantic_projection_fails_open_for_invalid_large_json() {
+        let original = Bytes::from(vec![b'!'; 2 * 1024 * 1024]);
+        let snapshot = pool_replay_snapshot_from_bytes(90_002, original.clone()).await;
+        let projection =
+            project_request_semantics(90_002, snapshot, ProxyCaptureTarget::ChatCompletions, true)
+                .await;
+
+        assert!(!projection.body_rewritten);
+        assert!(projection.request_info.parse_error.is_some());
+        assert_eq!(
+            projection
+                .upstream_snapshot
+                .to_bytes()
+                .await
+                .expect("read fail-open body"),
+            original
+        );
+        assert_eq!(projection.whole_body_materialization_count, 0);
+        assert_eq!(projection.materialization_bytes, 0);
     }
 }

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -287,9 +287,207 @@ struct SelectiveRequestSemantics {
     nested_reasoning_effort: Option<String>,
     contains_encrypted_content: bool,
     contains_image_generation: bool,
+    contains_codex_image_generation: bool,
     declares_remote_v2_compaction: bool,
     stream_options_present: bool,
     invalid_sticky_projection: bool,
+}
+
+#[derive(Default)]
+struct SemanticMarkerScanner {
+    in_string: bool,
+    escaped: bool,
+    unicode_remaining: u8,
+    unicode_value: u16,
+    string_is_value: bool,
+    string_len: usize,
+    raw_string_bytes: usize,
+    string_overflow: bool,
+    string: [u8; 32],
+    candidate: Option<([u8; 32], usize)>,
+    value_key: Option<([u8; 32], usize)>,
+    contains_encrypted_content: bool,
+    contains_image_generation: bool,
+    contains_codex_image_generation: bool,
+    semantic_limit_exceeded: bool,
+}
+
+impl SemanticMarkerScanner {
+    fn scan(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            if self.in_string {
+                self.raw_string_bytes = self.raw_string_bytes.saturating_add(1);
+                let selected_value = self.string_is_value
+                    && self.value_key.is_some_and(|(key, len)| {
+                        matches!(
+                            &key[..len],
+                            b"model"
+                                | b"sticky_key"
+                                | b"stickyKey"
+                                | b"prompt_cache_key"
+                                | b"promptCacheKey"
+                                | b"service_tier"
+                                | b"serviceTier"
+                                | b"reasoning_effort"
+                                | b"effort"
+                                | b"type"
+                        )
+                    });
+                if selected_value && self.raw_string_bytes > REQUEST_SEMANTIC_STRING_MAX_BYTES {
+                    self.semantic_limit_exceeded = true;
+                }
+                if self.unicode_remaining > 0 {
+                    let Some(digit) = (byte as char).to_digit(16) else {
+                        self.string_overflow = true;
+                        self.unicode_remaining = 0;
+                        continue;
+                    };
+                    self.unicode_value = (self.unicode_value << 4) | digit as u16;
+                    self.unicode_remaining -= 1;
+                    if self.unicode_remaining == 0 {
+                        if self.unicode_value <= 0x7f && self.string_len < self.string.len() {
+                            self.string[self.string_len] = self.unicode_value as u8;
+                            self.string_len += 1;
+                        } else {
+                            self.string_overflow = true;
+                        }
+                    }
+                    continue;
+                }
+                if self.escaped {
+                    self.escaped = false;
+                    if byte == b'u' {
+                        self.unicode_remaining = 4;
+                        self.unicode_value = 0;
+                    } else {
+                        let decoded = match byte {
+                            b'"' | b'\\' | b'/' => byte,
+                            b'b' => 0x08,
+                            b'f' => 0x0c,
+                            b'n' => b'\n',
+                            b'r' => b'\r',
+                            b't' => b'\t',
+                            _ => {
+                                self.string_overflow = true;
+                                continue;
+                            }
+                        };
+                        if self.string_len < self.string.len() {
+                            self.string[self.string_len] = decoded;
+                            self.string_len += 1;
+                        } else {
+                            self.string_overflow = true;
+                        }
+                    }
+                    continue;
+                }
+                if byte == b'\\' {
+                    self.escaped = true;
+                    continue;
+                }
+                if byte == b'"' {
+                    self.in_string = false;
+                    if !self.string_overflow {
+                        let captured = (self.string, self.string_len);
+                        if self.string_is_value {
+                            if self
+                                .value_key
+                                .is_some_and(|(key, len)| &key[..len] == b"type")
+                            {
+                                let value = &captured.0[..captured.1];
+                                self.contains_encrypted_content |= value == b"encrypted_content";
+                                self.contains_image_generation |= value == b"image_generation";
+                                self.contains_codex_image_generation |=
+                                    value == b"image_gen.imagegen";
+                            }
+                            self.value_key = None;
+                        } else {
+                            self.candidate = Some(captured);
+                        }
+                    } else if self.string_is_value {
+                        self.value_key = None;
+                    }
+                    continue;
+                }
+                if self.string_len < self.string.len() {
+                    self.string[self.string_len] = byte;
+                    self.string_len += 1;
+                } else {
+                    self.string_overflow = true;
+                }
+                continue;
+            }
+
+            if byte == b'"' {
+                self.in_string = true;
+                self.escaped = false;
+                self.unicode_remaining = 0;
+                self.unicode_value = 0;
+                self.string_len = 0;
+                self.raw_string_bytes = 0;
+                self.string_overflow = false;
+                self.string_is_value = self.value_key.is_some();
+                continue;
+            }
+            if byte.is_ascii_whitespace() {
+                continue;
+            }
+            if byte == b':' {
+                self.value_key = self.candidate.take();
+                if self
+                    .value_key
+                    .is_some_and(|(key, len)| &key[..len] == b"encrypted_content")
+                {
+                    self.contains_encrypted_content = true;
+                }
+            } else if self.value_key.is_some() {
+                self.value_key = None;
+            }
+        }
+    }
+}
+
+struct SemanticMarkerReader<R> {
+    inner: R,
+    scanner: SemanticMarkerScanner,
+}
+
+impl<R> SemanticMarkerReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            scanner: SemanticMarkerScanner::default(),
+        }
+    }
+}
+
+impl<R: Read> Read for SemanticMarkerReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let read = self.inner.read(buffer)?;
+        self.scanner.scan(&buffer[..read]);
+        if self.scanner.semantic_limit_exceeded {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "request semantic string exceeds bounded projection limit",
+            ));
+        }
+        Ok(read)
+    }
+}
+
+fn parse_selective_request_semantics(
+    reader: impl Read,
+) -> Result<SelectiveRequestSemantics, &'static str> {
+    let mut reader = SemanticMarkerReader::new(reader);
+    let parsed = serde_json::from_reader::<_, SelectiveRequestSemantics>(std::io::BufReader::new(
+        &mut reader,
+    ))
+    .map_err(|_| "invalid_json")?;
+    let mut parsed = parsed;
+    parsed.contains_encrypted_content |= reader.scanner.contains_encrypted_content;
+    parsed.contains_image_generation |= reader.scanner.contains_image_generation;
+    parsed.contains_codex_image_generation |= reader.scanner.contains_codex_image_generation;
+    Ok(parsed)
 }
 
 #[derive(Clone, Copy)]
@@ -307,6 +505,8 @@ struct OptionalString {
     valid: bool,
 }
 
+const REQUEST_SEMANTIC_STRING_MAX_BYTES: usize = 256;
+
 impl<'de> Deserialize<'de> for OptionalString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -319,12 +519,24 @@ impl<'de> Deserialize<'de> for OptionalString {
                 formatter.write_str("a string or ignored JSON value")
             }
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+                if value.len() > REQUEST_SEMANTIC_STRING_MAX_BYTES {
+                    return Ok(OptionalString {
+                        value: None,
+                        valid: false,
+                    });
+                }
                 Ok(OptionalString {
                     value: Some(value.to_string()),
                     valid: true,
                 })
             }
             fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+                if value.len() > REQUEST_SEMANTIC_STRING_MAX_BYTES {
+                    return Ok(OptionalString {
+                        value: None,
+                        valid: false,
+                    });
+                }
                 Ok(OptionalString {
                     value: Some(value),
                     valid: true,
@@ -607,7 +819,11 @@ impl<'de> Visitor<'de> for SelectiveSemanticVisitor<'_> {
                     compact_threshold_present = true;
                     map.next_value::<serde::de::IgnoredAny>()?;
                 }
-                _ => map.next_value_seed(SelectiveSemanticSeed {
+                (
+                    _,
+                    "input" | "messages" | "content" | "items" | "tools" | "tool_choice"
+                    | "additional_tools" | "context",
+                ) => map.next_value_seed(SelectiveSemanticSeed {
                     projection: &mut *self.projection,
                     scope: if matches!(self.scope, SelectiveSemanticScope::ContextManagement) {
                         SelectiveSemanticScope::ContextManagement
@@ -615,6 +831,9 @@ impl<'de> Visitor<'de> for SelectiveSemanticVisitor<'_> {
                         SelectiveSemanticScope::Nested
                     },
                 })?,
+                _ => {
+                    map.next_value::<serde::de::IgnoredAny>()?;
+                }
             }
         }
         if object_type.as_deref() == Some("encrypted_content") {
@@ -622,6 +841,9 @@ impl<'de> Visitor<'de> for SelectiveSemanticVisitor<'_> {
         }
         if object_type.as_deref() == Some("image_generation") {
             self.projection.contains_image_generation = true;
+        }
+        if object_type.as_deref() == Some("image_gen.imagegen") {
+            self.projection.contains_codex_image_generation = true;
         }
         if matches!(self.scope, SelectiveSemanticScope::ContextManagement)
             && object_type.as_deref() == Some("compaction")
@@ -703,6 +925,7 @@ pub(crate) struct ReplaySnapshotRouteAnalysis {
     pub(crate) requested_model: Option<String>,
     pub(crate) contains_encrypted_content: bool,
     pub(crate) image_intent: ImageIntent,
+    pub(crate) hosted_image_intent: ImageIntent,
     pub(crate) compaction_kind: Option<CompactionKind>,
     pub(crate) is_stream: bool,
     pub(crate) requested_service_tier: Option<String>,
@@ -757,6 +980,24 @@ fn analyze_replay_snapshot_route_value(
                 .as_deref()
                 .is_some_and(is_openai_image_generation_model)
                 || value.contains_image_generation
+                || value.contains_codex_image_generation
+            {
+                ImageIntent::Yes
+            } else {
+                ImageIntent::No
+            }
+        }
+        Some(ProxyCaptureTarget::ChatCompletions) | None => ImageIntent::Unknown,
+    };
+    let hosted_image_intent = match capture_target {
+        Some(ProxyCaptureTarget::ImageGenerations | ProxyCaptureTarget::ImageEdits) => {
+            ImageIntent::DirectImage
+        }
+        Some(ProxyCaptureTarget::Responses | ProxyCaptureTarget::ResponsesCompact) => {
+            if requested_model
+                .as_deref()
+                .is_some_and(is_openai_image_generation_model)
+                || value.contains_image_generation
             {
                 ImageIntent::Yes
             } else {
@@ -788,6 +1029,7 @@ fn analyze_replay_snapshot_route_value(
         requested_model,
         contains_encrypted_content: value.contains_encrypted_content,
         image_intent,
+        hosted_image_intent,
         compaction_kind,
         is_stream: value.stream,
         requested_service_tier,
@@ -814,19 +1056,17 @@ pub(crate) async fn analyze_replay_snapshot_for_pool_routing(
     let snapshot_bytes = pool_request_snapshot_body_bytes(snapshot);
     let (value, parse_outcome, file_read_count, json_parse_count) = match snapshot {
         PoolReplayBodySnapshot::Empty => (None, "empty", 0_u8, 0_u8),
-        PoolReplayBodySnapshot::Memory(bytes) => match serde_json::from_slice(bytes.as_ref()) {
-            Ok(value) => (Some(value), "parsed", 0, 1),
-            Err(_) => (None, "invalid_json", 0, 1),
-        },
+        PoolReplayBodySnapshot::Memory(bytes) => {
+            match parse_selective_request_semantics(std::io::Cursor::new(bytes.as_ref())) {
+                Ok(value) => (Some(value), "parsed", 0, 1),
+                Err(_) => (None, "invalid_json", 0, 1),
+            }
+        }
         PoolReplayBodySnapshot::File { temp_file, .. } => {
             let path = temp_file.path.clone();
             match tokio::task::spawn_blocking(move || {
                 let file = std::fs::File::open(path).map_err(|_| "read_failed")?;
-                serde_json::from_reader::<_, SelectiveRequestSemantics>(std::io::BufReader::new(
-                    file,
-                ))
-                .map(Some)
-                .map_err(|_| "invalid_json")
+                parse_selective_request_semantics(file).map(Some)
             })
             .await
             {
@@ -2493,6 +2733,7 @@ pub(crate) async fn continue_or_retry_pool_live_request(
             model: requested_model.clone(),
             ..RequestCaptureInfo::default()
         },
+        hosted_image_intent: None,
         prompt_cache_key: prompt_cache_key.clone(),
         owner_auto_guard_active,
         t_req_read_ms: 0.0,
@@ -2521,14 +2762,19 @@ pub(crate) async fn continue_or_retry_pool_live_request(
     )
     .await;
     if let Err(error) = &result {
+        let request_body_snapshot = match replay_status_rx.borrow().clone() {
+            PoolReplayBodyStatus::Complete(snapshot) => snapshot,
+            _ => PoolReplayBodySnapshot::Empty,
+        };
         persist_pool_failover_terminal_invocation(
-            state.as_ref(),
+            state.clone(),
             proxy_request_id,
             capture_started,
             original_uri,
             headers,
             Some(&trace_context),
             Some(&runtime_snapshot_context),
+            request_body_snapshot,
             error,
         )
         .await;
@@ -2833,6 +3079,7 @@ async fn continue_or_retry_pool_live_request_inner(
                         compaction_request_kind: replay_request_compaction_kind,
                         ..RequestCaptureInfo::default()
                     },
+                    hosted_image_intent: None,
                     prompt_cache_key: replay_prompt_cache_key,
                     owner_auto_guard_active: replay_owner_auto_guard_active,
                     t_req_read_ms: 0.0,
@@ -3119,6 +3366,7 @@ pub(crate) fn proxy_openai_v1_via_pool(
                                     compaction_request_kind: request_compaction_kind,
                                     ..RequestCaptureInfo::default()
                                 },
+                                hosted_image_intent: None,
                                 prompt_cache_key: effective_prompt_cache_key.clone(),
                                 owner_auto_guard_active,
                                 t_req_read_ms: 0.0,
@@ -4705,6 +4953,7 @@ pub(crate) fn proxy_openai_v1_via_pool(
                                     compaction_request_kind: request_compaction_kind,
                                     ..RequestCaptureInfo::default()
                                 },
+                                hosted_image_intent: None,
                                 prompt_cache_key: body_prompt_cache_key.clone(),
                                 owner_auto_guard_active,
                                 t_req_read_ms: 0.0,
@@ -4768,6 +5017,7 @@ pub(crate) fn proxy_openai_v1_via_pool(
                         Some(PoolAttemptRuntimeSnapshotContext {
                             capture_target: header_capture_target,
                             request_info: RequestCaptureInfo::default(),
+                            hosted_image_intent: None,
                             prompt_cache_key: header_prompt_cache_key.clone(),
                             owner_auto_guard_active,
                             t_req_read_ms: 0.0,
@@ -5298,7 +5548,7 @@ pub(crate) async fn send_forward_proxy_request_with_429_retry(
     method: Method,
     target_url: Url,
     headers: &HeaderMap,
-    body: Option<Bytes>,
+    body: Option<PoolReplayBodySnapshot>,
     live_reporter: Option<UpstreamTrafficReporter>,
     handshake_timeout: Duration,
     capture_target: Option<ProxyCaptureTarget>,
@@ -5322,14 +5572,15 @@ pub(crate) async fn send_forward_proxy_request_with_429_retry(
     }
 
     let request_connection_scoped = connection_scoped_header_names(headers);
-    let request_body_len = body.as_ref().map(Bytes::len);
-    let request_compression = body.as_ref().and_then(|body_bytes| {
-        observe_request_compression_from_bytes(
-            body_bytes.as_ref(),
+    let request_body_len = body.as_ref().map(pool_request_snapshot_body_bytes);
+    let request_compression = body.as_ref().and_then(|snapshot| match snapshot {
+        PoolReplayBodySnapshot::Memory(body_bytes) => observe_request_compression_from_bytes(
+            body_bytes,
             headers
                 .get(header::CONTENT_ENCODING)
                 .and_then(|value| value.to_str().ok()),
-        )
+        ),
+        _ => None,
     });
     let mut approx_upload_bytes = 0usize;
     let mut approx_download_bytes_before_response_body = 0usize;
@@ -5357,10 +5608,14 @@ pub(crate) async fn send_forward_proxy_request_with_429_retry(
                 outbound_headers.append(name.clone(), value.clone());
             }
         }
-        let transmitted_body_bytes = body.as_ref().map(Bytes::len).unwrap_or_default();
-        if let Some(body_bytes) = body.clone()
+        let transmitted_body_bytes = body
+            .as_ref()
+            .map(pool_request_snapshot_body_bytes)
+            .unwrap_or_default();
+        if let Some(body_bytes) = body.as_ref()
             && !outbound_headers.contains_key(header::CONTENT_LENGTH)
-            && let Ok(content_length) = HeaderValue::from_str(&body_bytes.len().to_string())
+            && let Ok(content_length) =
+                HeaderValue::from_str(&pool_request_snapshot_body_bytes(body_bytes).to_string())
         {
             outbound_headers.insert(header::CONTENT_LENGTH, content_length.clone());
         }
@@ -5373,7 +5628,11 @@ pub(crate) async fn send_forward_proxy_request_with_429_retry(
                 method.clone(),
                 &target_url,
                 &outbound_headers,
-                body.clone().map(Body::from).unwrap_or_else(Body::empty),
+                body.as_ref()
+                    .map(|snapshot| {
+                        counted_http_body_from_snapshot(snapshot, ObservedByteCounter::default())
+                    })
+                    .unwrap_or_else(Body::empty),
                 selected_proxy.endpoint_url.as_ref(),
                 live_reporter.clone(),
             ),

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -269,6 +269,385 @@ impl<'de> Deserialize<'de> for ReplaySnapshotRouteValue {
     }
 }
 
+#[derive(Debug, Default)]
+struct SelectiveRequestSemantics {
+    root_sticky_key: Option<String>,
+    root_sticky_key_alias: Option<String>,
+    root_prompt_cache_key: Option<String>,
+    root_prompt_cache_key_alias: Option<String>,
+    metadata_sticky_key: Option<String>,
+    metadata_sticky_key_alias: Option<String>,
+    metadata_prompt_cache_key: Option<String>,
+    metadata_prompt_cache_key_alias: Option<String>,
+    model: Option<String>,
+    stream: bool,
+    service_tier: Option<String>,
+    service_tier_alias: Option<String>,
+    reasoning_effort: Option<String>,
+    nested_reasoning_effort: Option<String>,
+    contains_encrypted_content: bool,
+    contains_image_generation: bool,
+    declares_remote_v2_compaction: bool,
+    stream_options_present: bool,
+    invalid_sticky_projection: bool,
+}
+
+#[derive(Clone, Copy)]
+enum SelectiveSemanticScope {
+    Root,
+    Metadata,
+    Reasoning,
+    ContextManagement,
+    Nested,
+}
+
+#[derive(Default)]
+struct OptionalString {
+    value: Option<String>,
+    valid: bool,
+}
+
+impl<'de> Deserialize<'de> for OptionalString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct OptionalStringVisitor;
+        impl<'de> Visitor<'de> for OptionalStringVisitor {
+            type Value = OptionalString;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a string or ignored JSON value")
+            }
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: Some(value.to_string()),
+                    valid: true,
+                })
+            }
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: Some(value),
+                    valid: true,
+                })
+            }
+            fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: None,
+                    valid: false,
+                })
+            }
+            fn visit_i64<E>(self, _: i64) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: None,
+                    valid: false,
+                })
+            }
+            fn visit_u64<E>(self, _: u64) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: None,
+                    valid: false,
+                })
+            }
+            fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: None,
+                    valid: false,
+                })
+            }
+            fn visit_none<E>(self) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: None,
+                    valid: true,
+                })
+            }
+            fn visit_unit<E>(self) -> Result<Self::Value, E> {
+                Ok(OptionalString {
+                    value: None,
+                    valid: true,
+                })
+            }
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                Ok(OptionalString {
+                    value: None,
+                    valid: false,
+                })
+            }
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                while map
+                    .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+                    .is_some()
+                {}
+                Ok(OptionalString {
+                    value: None,
+                    valid: false,
+                })
+            }
+        }
+        deserializer.deserialize_any(OptionalStringVisitor)
+    }
+}
+
+struct SelectiveSemanticSeed<'a> {
+    projection: &'a mut SelectiveRequestSemantics,
+    scope: SelectiveSemanticScope,
+}
+
+impl<'de> DeserializeSeed<'de> for SelectiveSemanticSeed<'_> {
+    type Value = ();
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(SelectiveSemanticVisitor {
+            projection: self.projection,
+            scope: self.scope,
+        })
+    }
+}
+
+struct SelectiveSemanticVisitor<'a> {
+    projection: &'a mut SelectiveRequestSemantics,
+    scope: SelectiveSemanticScope,
+}
+
+impl<'de> Visitor<'de> for SelectiveSemanticVisitor<'_> {
+    type Value = ();
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a request JSON value")
+    }
+    fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_i64<E>(self, _: i64) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_u64<E>(self, _: u64) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_str<E>(self, _: &str) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_string<E>(self, _: String) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        Ok(())
+    }
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        if matches!(self.scope, SelectiveSemanticScope::Metadata) {
+            self.projection.invalid_sticky_projection = true;
+        }
+        let child_scope = if matches!(self.scope, SelectiveSemanticScope::ContextManagement) {
+            SelectiveSemanticScope::ContextManagement
+        } else {
+            SelectiveSemanticScope::Nested
+        };
+        while seq
+            .next_element_seed(SelectiveSemanticSeed {
+                projection: &mut *self.projection,
+                scope: child_scope,
+            })?
+            .is_some()
+        {}
+        Ok(())
+    }
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut object_type = None;
+        let mut compact_threshold_present = false;
+        let mut seen_sticky_projection_bits = 0_u16;
+        while let Some(key) = map.next_key::<String>()? {
+            let is_sticky_projection_field = matches!(
+                (self.scope, key.as_str()),
+                (
+                    SelectiveSemanticScope::Root | SelectiveSemanticScope::Metadata,
+                    "sticky_key" | "stickyKey" | "prompt_cache_key" | "promptCacheKey"
+                )
+            );
+            let sticky_projection_bit = match (self.scope, key.as_str()) {
+                (SelectiveSemanticScope::Root, "sticky_key") => Some(1 << 0),
+                (SelectiveSemanticScope::Root, "stickyKey") => Some(1 << 1),
+                (SelectiveSemanticScope::Root, "prompt_cache_key") => Some(1 << 2),
+                (SelectiveSemanticScope::Root, "promptCacheKey") => Some(1 << 3),
+                (SelectiveSemanticScope::Root, "metadata") => Some(1 << 4),
+                (SelectiveSemanticScope::Metadata, "sticky_key") => Some(1 << 5),
+                (SelectiveSemanticScope::Metadata, "stickyKey") => Some(1 << 6),
+                (SelectiveSemanticScope::Metadata, "prompt_cache_key") => Some(1 << 7),
+                (SelectiveSemanticScope::Metadata, "promptCacheKey") => Some(1 << 8),
+                _ => None,
+            };
+            if let Some(bit) = sticky_projection_bit {
+                if seen_sticky_projection_bits & bit != 0 {
+                    self.projection.invalid_sticky_projection = true;
+                }
+                seen_sticky_projection_bits |= bit;
+            }
+            let string_slot = match (self.scope, key.as_str()) {
+                (SelectiveSemanticScope::Root, "model") => Some(&mut self.projection.model),
+                (SelectiveSemanticScope::Root, "sticky_key") => {
+                    Some(&mut self.projection.root_sticky_key)
+                }
+                (SelectiveSemanticScope::Root, "stickyKey") => {
+                    Some(&mut self.projection.root_sticky_key_alias)
+                }
+                (SelectiveSemanticScope::Root, "prompt_cache_key") => {
+                    Some(&mut self.projection.root_prompt_cache_key)
+                }
+                (SelectiveSemanticScope::Root, "promptCacheKey") => {
+                    Some(&mut self.projection.root_prompt_cache_key_alias)
+                }
+                (SelectiveSemanticScope::Root, "service_tier") => {
+                    Some(&mut self.projection.service_tier)
+                }
+                (SelectiveSemanticScope::Root, "serviceTier") => {
+                    Some(&mut self.projection.service_tier_alias)
+                }
+                (SelectiveSemanticScope::Root, "reasoning_effort") => {
+                    Some(&mut self.projection.reasoning_effort)
+                }
+                (SelectiveSemanticScope::Metadata, "sticky_key") => {
+                    Some(&mut self.projection.metadata_sticky_key)
+                }
+                (SelectiveSemanticScope::Metadata, "stickyKey") => {
+                    Some(&mut self.projection.metadata_sticky_key_alias)
+                }
+                (SelectiveSemanticScope::Metadata, "prompt_cache_key") => {
+                    Some(&mut self.projection.metadata_prompt_cache_key)
+                }
+                (SelectiveSemanticScope::Metadata, "promptCacheKey") => {
+                    Some(&mut self.projection.metadata_prompt_cache_key_alias)
+                }
+                (SelectiveSemanticScope::Reasoning, "effort") => {
+                    Some(&mut self.projection.nested_reasoning_effort)
+                }
+                _ => None,
+            };
+            if let Some(slot) = string_slot {
+                let parsed = map.next_value::<OptionalString>()?;
+                if is_sticky_projection_field && !parsed.valid {
+                    self.projection.invalid_sticky_projection = true;
+                }
+                *slot = parsed.value;
+                continue;
+            }
+            match (self.scope, key.as_str()) {
+                (SelectiveSemanticScope::Root, "stream") => {
+                    self.projection.stream = map.next_value::<bool>().unwrap_or(false);
+                }
+                (SelectiveSemanticScope::Root, "stream_options") => {
+                    self.projection.stream_options_present = true;
+                    map.next_value::<serde::de::IgnoredAny>()?;
+                }
+                (SelectiveSemanticScope::Root, "metadata") => {
+                    map.next_value_seed(SelectiveSemanticSeed {
+                        projection: &mut *self.projection,
+                        scope: SelectiveSemanticScope::Metadata,
+                    })?
+                }
+                (SelectiveSemanticScope::Root, "reasoning") => {
+                    map.next_value_seed(SelectiveSemanticSeed {
+                        projection: &mut *self.projection,
+                        scope: SelectiveSemanticScope::Reasoning,
+                    })?
+                }
+                (SelectiveSemanticScope::Root, "context_management") => {
+                    map.next_value_seed(SelectiveSemanticSeed {
+                        projection: &mut *self.projection,
+                        scope: SelectiveSemanticScope::ContextManagement,
+                    })?
+                }
+                (_, "encrypted_content") => {
+                    self.projection.contains_encrypted_content = true;
+                    map.next_value::<serde::de::IgnoredAny>()?;
+                }
+                (_, "type") => object_type = map.next_value::<OptionalString>()?.value,
+                (SelectiveSemanticScope::ContextManagement, "compact_threshold") => {
+                    compact_threshold_present = true;
+                    map.next_value::<serde::de::IgnoredAny>()?;
+                }
+                _ => map.next_value_seed(SelectiveSemanticSeed {
+                    projection: &mut *self.projection,
+                    scope: if matches!(self.scope, SelectiveSemanticScope::ContextManagement) {
+                        SelectiveSemanticScope::ContextManagement
+                    } else {
+                        SelectiveSemanticScope::Nested
+                    },
+                })?,
+            }
+        }
+        if object_type.as_deref() == Some("encrypted_content") {
+            self.projection.contains_encrypted_content = true;
+        }
+        if object_type.as_deref() == Some("image_generation") {
+            self.projection.contains_image_generation = true;
+        }
+        if matches!(self.scope, SelectiveSemanticScope::ContextManagement)
+            && object_type.as_deref() == Some("compaction")
+            && compact_threshold_present
+        {
+            self.projection.declares_remote_v2_compaction = true;
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for SelectiveRequestSemantics {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut projection = Self::default();
+        SelectiveSemanticSeed {
+            projection: &mut projection,
+            scope: SelectiveSemanticScope::Root,
+        }
+        .deserialize(deserializer)?;
+        Ok(projection)
+    }
+}
+
 fn extract_sticky_key_from_request_value_projection_semantics(value: &Value) -> Option<String> {
     fn projection_field<'a>(
         object: &'a serde_json::Map<String, Value>,
@@ -325,35 +704,95 @@ pub(crate) struct ReplaySnapshotRouteAnalysis {
     pub(crate) contains_encrypted_content: bool,
     pub(crate) image_intent: ImageIntent,
     pub(crate) compaction_kind: Option<CompactionKind>,
+    pub(crate) is_stream: bool,
+    pub(crate) requested_service_tier: Option<String>,
+    pub(crate) reasoning_effort: Option<String>,
+    pub(crate) stream_options_present: bool,
     pub(crate) file_read_count: u8,
     pub(crate) json_parse_count: u8,
     pub(crate) parse_outcome: &'static str,
 }
 
 fn analyze_replay_snapshot_route_value(
-    parsed_value: Option<ReplaySnapshotRouteValue>,
+    parsed_value: Option<SelectiveRequestSemantics>,
     capture_target: Option<ProxyCaptureTarget>,
 ) -> ReplaySnapshotRouteAnalysis {
-    let sticky_projection_valid = parsed_value
-        .as_ref()
-        .is_none_or(|value| value.sticky_projection_valid);
-    let value = parsed_value.as_ref().map(|value| &value.value);
-    let image_intent = infer_request_image_intent(capture_target, value);
-    let compaction_kind = infer_request_compaction_kind(capture_target, value);
-    let sticky_key = sticky_projection_valid
-        .then(|| value.and_then(extract_sticky_key_from_request_value_projection_semantics))
+    let value = parsed_value.unwrap_or_default();
+    let normalize = |value: Option<String>| {
+        value
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    };
+    let sticky_key = (!value.invalid_sticky_projection)
+        .then(|| {
+            [
+                value.metadata_sticky_key,
+                value.metadata_sticky_key_alias,
+                value.metadata_prompt_cache_key.clone(),
+                value.metadata_prompt_cache_key_alias.clone(),
+                value.root_sticky_key,
+                value.root_sticky_key_alias,
+                value.root_prompt_cache_key.clone(),
+                value.root_prompt_cache_key_alias.clone(),
+            ]
+            .into_iter()
+            .find_map(normalize)
+        })
         .flatten();
-    let prompt_cache_key = value.and_then(extract_prompt_cache_key_from_request_body);
-    let requested_model = value.and_then(extract_model_from_payload);
-    let contains_encrypted_content = value.is_some_and(value_contains_encrypted_content);
+    let prompt_cache_key = [
+        value.metadata_prompt_cache_key,
+        value.metadata_prompt_cache_key_alias,
+        value.root_prompt_cache_key,
+        value.root_prompt_cache_key_alias,
+    ]
+    .into_iter()
+    .find_map(normalize);
+    let requested_model = normalize(value.model);
+    let image_intent = match capture_target {
+        Some(ProxyCaptureTarget::ImageGenerations | ProxyCaptureTarget::ImageEdits) => {
+            ImageIntent::DirectImage
+        }
+        Some(ProxyCaptureTarget::Responses | ProxyCaptureTarget::ResponsesCompact) => {
+            if requested_model
+                .as_deref()
+                .is_some_and(is_openai_image_generation_model)
+                || value.contains_image_generation
+            {
+                ImageIntent::Yes
+            } else {
+                ImageIntent::No
+            }
+        }
+        Some(ProxyCaptureTarget::ChatCompletions) | None => ImageIntent::Unknown,
+    };
+    let compaction_kind = match capture_target {
+        Some(ProxyCaptureTarget::ResponsesCompact) => Some(CompactionKind::Compact),
+        Some(ProxyCaptureTarget::Responses) if value.declares_remote_v2_compaction => {
+            Some(CompactionKind::RemoteV2)
+        }
+        _ => None,
+    };
+    let requested_service_tier = normalize(value.service_tier.or(value.service_tier_alias))
+        .and_then(|value| normalize_service_tier(&value));
+    let reasoning_effort = normalize(match capture_target {
+        Some(ProxyCaptureTarget::Responses | ProxyCaptureTarget::ResponsesCompact) => {
+            value.nested_reasoning_effort
+        }
+        Some(ProxyCaptureTarget::ChatCompletions) => value.reasoning_effort,
+        _ => None,
+    });
 
     ReplaySnapshotRouteAnalysis {
         sticky_key,
         prompt_cache_key,
         requested_model,
-        contains_encrypted_content,
+        contains_encrypted_content: value.contains_encrypted_content,
         image_intent,
         compaction_kind,
+        is_stream: value.stream,
+        requested_service_tier,
+        reasoning_effort,
+        stream_options_present: value.stream_options_present,
         file_read_count: 0,
         json_parse_count: 0,
         parse_outcome: "empty",
@@ -383,7 +822,7 @@ pub(crate) async fn analyze_replay_snapshot_for_pool_routing(
             let path = temp_file.path.clone();
             match tokio::task::spawn_blocking(move || {
                 let file = std::fs::File::open(path).map_err(|_| "read_failed")?;
-                serde_json::from_reader::<_, ReplaySnapshotRouteValue>(std::io::BufReader::new(
+                serde_json::from_reader::<_, SelectiveRequestSemantics>(std::io::BufReader::new(
                     file,
                 ))
                 .map(Some)

--- a/src/proxy/stream_gate.rs
+++ b/src/proxy/stream_gate.rs
@@ -302,6 +302,22 @@ pub(crate) fn prepare_target_request_body(
     body: Vec<u8>,
     auto_include_usage: bool,
 ) -> (Vec<u8>, RequestCaptureInfo, bool) {
+    let (body, info, rewritten, _) =
+        prepare_target_request_body_with_hosted_intent(target, body, auto_include_usage);
+    (body, info, rewritten)
+}
+
+pub(crate) fn prepare_target_request_body_with_hosted_intent(
+    target: ProxyCaptureTarget,
+    body: Vec<u8>,
+    auto_include_usage: bool,
+) -> (Vec<u8>, RequestCaptureInfo, bool, ImageIntent) {
+    let mut hosted_image_intent = match target {
+        ProxyCaptureTarget::ImageGenerations | ProxyCaptureTarget::ImageEdits => {
+            ImageIntent::DirectImage
+        }
+        _ => ImageIntent::Unknown,
+    };
     let mut info = RequestCaptureInfo {
         model: None,
         sticky_key: None,
@@ -326,14 +342,14 @@ pub(crate) fn prepare_target_request_body(
     };
 
     if body.is_empty() {
-        return (body, info, false);
+        return (body, info, false, hosted_image_intent);
     }
 
     let mut value: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
         Err(err) => {
             info.parse_error = Some(format!("request_json_parse_error:{err}"));
-            return (body, info, false);
+            return (body, info, false, hosted_image_intent);
         }
     };
 
@@ -364,6 +380,7 @@ pub(crate) fn prepare_target_request_body(
             .as_str()
             .to_string(),
     );
+    hosted_image_intent = infer_hosted_image_intent_from_request_body(target, &value);
 
     let mut rewritten = false;
     if target.should_auto_include_usage()
@@ -390,15 +407,15 @@ pub(crate) fn prepare_target_request_body(
 
     if rewritten {
         match serde_json::to_vec(&value) {
-            Ok(rewritten_body) => (rewritten_body, info, true),
+            Ok(rewritten_body) => (rewritten_body, info, true, hosted_image_intent),
             Err(err) => {
                 let mut fallback = info;
                 fallback.parse_error = Some(format!("request_json_rewrite_error:{err}"));
-                (body, fallback, false)
+                (body, fallback, false, hosted_image_intent)
             }
         }
     } else {
-        (body, info, false)
+        (body, info, false, hosted_image_intent)
     }
 }
 

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -4322,22 +4322,18 @@ pub(crate) fn spawn_raw_payload_snapshot_write(
                 truncated_reason: None,
             })
         }
-        snapshot @ PoolReplayBodySnapshot::File { .. } => {
+        PoolReplayBodySnapshot::File { temp_file, size } => {
+            let config = state.config.clone();
+            let semaphore = state.proxy_raw_async_semaphore.clone();
             let invoke_id = invoke_id.to_string();
+            let source_path = temp_file.path.clone();
             PendingRawPayloadWrite::Task(tokio::spawn(async move {
-                match snapshot.to_bytes().await {
-                    Ok(bytes) => {
-                        spawn_raw_payload_file_write(&state, &invoke_id, kind, bytes, true)
-                            .finish()
-                            .await
-                    }
-                    Err(err) => RawPayloadMeta {
-                        path: None,
-                        size_bytes: pool_request_snapshot_body_bytes(&snapshot) as i64,
-                        truncated: true,
-                        truncated_reason: Some(format!("write_failed:{err}")),
-                    },
-                }
+                let _temp_file_guard = temp_file;
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("raw writer semaphore is live");
+                store_raw_payload_snapshot_file(&config, &invoke_id, kind, source_path, size).await
             }))
         }
     }

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -4302,6 +4302,47 @@ pub(crate) fn spawn_raw_payload_file_write(
     }))
 }
 
+pub(crate) fn spawn_raw_payload_snapshot_write(
+    state: Arc<AppState>,
+    invoke_id: &str,
+    kind: &'static str,
+    snapshot: PoolReplayBodySnapshot,
+    enabled: bool,
+) -> PendingRawPayloadWrite {
+    match snapshot {
+        PoolReplayBodySnapshot::Empty => PendingRawPayloadWrite::Ready(RawPayloadMeta::default()),
+        PoolReplayBodySnapshot::Memory(bytes) => {
+            spawn_raw_payload_file_write(state.as_ref(), invoke_id, kind, bytes, enabled)
+        }
+        PoolReplayBodySnapshot::File { size, .. } if !enabled => {
+            PendingRawPayloadWrite::Ready(RawPayloadMeta {
+                path: None,
+                size_bytes: size as i64,
+                truncated: false,
+                truncated_reason: None,
+            })
+        }
+        snapshot @ PoolReplayBodySnapshot::File { .. } => {
+            let invoke_id = invoke_id.to_string();
+            PendingRawPayloadWrite::Task(tokio::spawn(async move {
+                match snapshot.to_bytes().await {
+                    Ok(bytes) => {
+                        spawn_raw_payload_file_write(&state, &invoke_id, kind, bytes, true)
+                            .finish()
+                            .await
+                    }
+                    Err(err) => RawPayloadMeta {
+                        path: None,
+                        size_bytes: pool_request_snapshot_body_bytes(&snapshot) as i64,
+                        truncated: true,
+                        truncated_reason: Some(format!("write_failed:{err}")),
+                    },
+                }
+            }))
+        }
+    }
+}
+
 pub(crate) fn raw_payload_path_for_kind(
     raw_dir: &Path,
     invoke_id: &str,

--- a/src/tests/archive_file_io/raw_payload_retention_and_compression.rs
+++ b/src/tests/archive_file_io/raw_payload_retention_and_compression.rs
@@ -5098,6 +5098,7 @@ async fn send_pool_request_with_failover_defers_armed_guard_when_pending_attempt
             is_stream: true,
             ..RequestCaptureInfo::default()
         },
+        hosted_image_intent: None,
         prompt_cache_key: Some("pck-guard-deferred".to_string()),
         owner_auto_guard_active: false,
         t_req_read_ms: 1.0,
@@ -5241,6 +5242,7 @@ async fn send_pool_request_with_failover_disarms_guard_after_streaming_phase_is_
             is_stream: true,
             ..RequestCaptureInfo::default()
         },
+        hosted_image_intent: None,
         prompt_cache_key: Some("pck-guard-streaming-phase-persisted".to_string()),
         owner_auto_guard_active: false,
         t_req_read_ms: 1.0,
@@ -5369,6 +5371,7 @@ async fn send_pool_request_with_failover_keeps_early_phase_guard_armed_when_stre
             is_stream: true,
             ..RequestCaptureInfo::default()
         },
+        hosted_image_intent: None,
         prompt_cache_key: Some("pck-guard-streaming-phase".to_string()),
         owner_auto_guard_active: false,
         t_req_read_ms: 1.0,
@@ -7188,6 +7191,7 @@ async fn send_pool_request_with_failover_returns_owner_unavailable_for_encrypted
                 contains_encrypted_content: true,
                 ..RequestCaptureInfo::default()
             },
+            hosted_image_intent: None,
             prompt_cache_key: Some("encrypted-owner-unavailable-prompt-cache-key".to_string()),
             owner_auto_guard_active: true,
             t_req_read_ms: 1.0,

--- a/src/tests/stateful_sqlite/request_preparation_and_handshake_failures.rs
+++ b/src/tests/stateful_sqlite/request_preparation_and_handshake_failures.rs
@@ -490,6 +490,8 @@ async fn prepare_pool_request_body_for_account_skips_fast_mode_rewrite_for_compa
         crate::ImageToolRewriteMode::KeepOriginal,
         crate::CodexImagegenRewriteMode::KeepOriginal,
         None,
+        None,
+        None,
     )
     .await
     .expect("prepare compact pool request body");
@@ -524,6 +526,8 @@ async fn prepare_pool_request_body_for_account_preserves_file_snapshot_when_rewr
         TagFastModeRewriteMode::KeepOriginal,
         crate::ImageToolRewriteMode::ForceRemove,
         crate::CodexImagegenRewriteMode::KeepOriginal,
+        None,
+        None,
         None,
     )
     .await
@@ -567,6 +571,8 @@ async fn prepare_pool_request_body_for_account_reports_rewritten_image_intent_af
         TagFastModeRewriteMode::KeepOriginal,
         crate::ImageToolRewriteMode::ForceRemove,
         crate::CodexImagegenRewriteMode::KeepOriginal,
+        None,
+        None,
         None,
     )
     .await
@@ -616,6 +622,8 @@ async fn prepare_pool_request_body_for_account_keeps_large_rewrite_file_backed()
         crate::ImageToolRewriteMode::ForceRemove,
         crate::CodexImagegenRewriteMode::KeepOriginal,
         None,
+        None,
+        None,
     )
     .await
     .expect("prepare responses pool request body");
@@ -662,6 +670,8 @@ async fn prepare_pool_request_body_for_account_keeps_responses_lite_body_when_co
         crate::ImageToolRewriteMode::KeepOriginal,
         crate::CodexImagegenRewriteMode::KeepOriginal,
         Some(CodexImagegenProtocol::Lite),
+        None,
+        None,
     )
     .await
     .expect("prepare Lite pool request body");
@@ -696,6 +706,8 @@ async fn prepare_pool_request_body_for_account_keeps_compressed_and_file_backed_
         crate::ImageToolRewriteMode::ForceRemove,
         crate::CodexImagegenRewriteMode::KeepOriginal,
         Some(CodexImagegenProtocol::Lite),
+        None,
+        None,
     )
     .await
     .expect("prepare file-backed Lite request body");
@@ -728,6 +740,8 @@ async fn prepare_pool_request_body_for_account_keeps_compressed_and_file_backed_
         crate::ImageToolRewriteMode::ForceAdd,
         crate::CodexImagegenRewriteMode::KeepOriginal,
         Some(CodexImagegenProtocol::Lite),
+        None,
+        None,
     )
     .await
     .expect("prepare compressed Lite request body");
@@ -766,6 +780,8 @@ async fn prepare_pool_request_body_for_account_decodes_gzip_before_rewrite() {
         TagFastModeRewriteMode::ForceAdd,
         crate::ImageToolRewriteMode::KeepOriginal,
         crate::CodexImagegenRewriteMode::KeepOriginal,
+        None,
+        None,
         None,
     )
     .await


### PR DESCRIPTION
## Summary
- derive one immutable request semantic projection from the replay snapshot and reuse it for routing, capture, and upstream preparation
- keep large requests file-backed through forwarding, failover, raw capture, and bounded include_usage rewriting
- add legacy pipeline mode plus parse, materialization, and buffer telemetry with 512 KiB, 16 MiB, and 64 MiB regressions

## Verification
- cargo test request_semantic_projection -- --nocapture
- cargo test analyze_large_file_backed_replay_snapshot_once_for_pool_routing -- --nocapture
- cargo test replay_route_analysis_preserves_sticky_projection_type_semantics -- --nocapture
- cargo test pool_replay_snapshot -- --nocapture
- cargo test request_preparation_and_handshake_failures -- --nocapture
- cargo fmt --all -- --check
- cargo check
- cargo clippy --all-targets -- -D warnings

## Delivery
- Role: child
- Initiative: #733
- Ticket: #735
- Integration branch: prd/high-frequency-runtime-data-plane
- Wave: 2
- Risk: wave-gated
- Stop condition: merge-ready; do not merge

## References
- Specs: docs/specs/high-frequency-runtime-data-plane/SPEC.md
- Spec disposition: link
- Spec sync: done; no drift
- Solutions: -
- Project Docs: -

Refs #735