### PR TITLE
feat(runtime): add dashboard projection hub

### DIFF
--- a/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
+++ b/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
@@ -32,4 +32,12 @@
 
 ## Verification State
 
-Implementation and validation evidence are recorded as child pull requests are integrated. The aggregate branch is merge-ready only after full backend/web/Storybook tests, performance assertions, review convergence, and owner-approved browser viewport evidence complete.
+Runtime Projection is implemented through `RuntimeProjectionHub` and `DashboardLiveProjection`:
+
+- Runtime, phase, account metadata, network and terminal mutations feed one in-memory current-state projection.
+- Healthy Dashboard current-state rendering has no SQLite dependency; persistence is isolated to startup restore, the pressure-gated 60-second reconcile and explicit cold fallback.
+- Producer updates use a non-extending 250-millisecond deadline, retain last-good data on degraded paths and suppress unchanged revisions.
+- Runtime pressure health exposes projection mode/state, producer/subscriber state, live-path database reads, build count, revision, snapshot origin and last-good age without querying SQLite.
+- Tests cover 10,000 healthy mutations with zero live-path database reads, a current-state update p95 at or below 400 milliseconds, cold fallback and degraded last-good behavior.
+
+Aggregate validation remains responsible for full backend/web/Storybook coverage, controlled performance evidence, review convergence and owner-approved browser viewport evidence.

--- a/src/api/slices/error_distribution_and_sse.rs
+++ b/src/api/slices/error_distribution_and_sse.rs
@@ -2201,6 +2201,73 @@ mod tests {
         );
     }
 
+    #[test]
+    fn runtime_projection_preserves_restored_rows_across_later_mutations() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        hub.bind_dashboard_network_speed_cache(Arc::new(DashboardNetworkSpeedCache::new(
+            Utc::now(),
+        )))
+        .expect("bind dashboard network cache");
+        let restored = live_record("restored-only", Some(41), "running", Some("requesting"), 1);
+        let baseline_snapshot = build_dashboard_activity_live_snapshot(0, vec![restored.clone()]);
+        let baseline = DashboardRuntimeProjectionBaseline {
+            records: vec![DashboardRuntimeBaselineRecord {
+                key: RuntimeInvocationKey::new(
+                    restored.invoke_id.clone(),
+                    restored.occurred_at.clone(),
+                ),
+                upstream_account_id: restored.upstream_account_id,
+                upstream_account_name: restored.upstream_account_name.clone(),
+                is_retry: false,
+                live_phase: restored.live_phase.clone(),
+                wait_ms: restored.t_upstream_ttfb_ms,
+            }],
+            source_scope: InvocationSourceScope::All,
+        };
+        hub.install_persistence_baseline_if_generation(
+            baseline_snapshot,
+            baseline,
+            "startup_restore",
+            hub.dashboard_generation(),
+        )
+        .expect("install startup baseline")
+        .expect("baseline generation should match");
+
+        hub.upsert(live_record(
+            "runtime-only",
+            Some(42),
+            "running",
+            Some("responding"),
+            1,
+        ));
+        let capture = hub
+            .capture_memory_snapshot()
+            .expect("merged runtime projection snapshot");
+
+        assert_eq!(capture.snapshot.in_progress_invocation_count, 2);
+        assert_eq!(capture.snapshot.in_progress_phase_counts.requesting, 1);
+        assert_eq!(capture.snapshot.in_progress_phase_counts.responding, 1);
+        assert_eq!(hub.health_snapshot(1).live_path_db_read_count, 0);
+
+        let mut restored_update = restored.clone();
+        restored_update.live_phase = Some("responding".to_string());
+        hub.upsert(restored_update.clone());
+        let updated = hub
+            .capture_memory_snapshot()
+            .expect("runtime overlay should replace its restored row");
+        assert_eq!(updated.snapshot.in_progress_invocation_count, 2);
+        assert_eq!(updated.snapshot.in_progress_phase_counts.requesting, 0);
+        assert_eq!(updated.snapshot.in_progress_phase_counts.responding, 2);
+
+        restored_update.status = Some("completed".to_string());
+        hub.upsert_terminal(restored_update);
+        let terminal = hub
+            .capture_memory_snapshot()
+            .expect("terminal delta should remove its restored row");
+        assert_eq!(terminal.snapshot.in_progress_invocation_count, 1);
+        assert_eq!(terminal.snapshot.in_progress_phase_counts.responding, 1);
+    }
+
     #[tokio::test]
     async fn dashboard_runtime_projection_update_p95_stays_within_four_hundred_ms() {
         let state = crate::tests::test_state_with_openai_base(
@@ -2853,7 +2920,7 @@ async fn capture_dashboard_activity_live_snapshot_from_persistence(
         hub.record_live_path_db_read();
     }
     hub.record_build();
-    let snapshot = query_dashboard_activity_live_snapshot_from_runtime(
+    let (snapshot, baseline) = query_dashboard_activity_live_snapshot_with_baseline_from_runtime(
         pool,
         hub,
         dashboard_network_speed_cache,
@@ -2867,6 +2934,7 @@ async fn capture_dashboard_activity_live_snapshot_from_persistence(
     };
     if let Some(capture) = hub.install_persistence_baseline_if_generation(
         snapshot,
+        baseline,
         snapshot_origin,
         expected_generation,
     )? {
@@ -2995,18 +3063,21 @@ pub(crate) fn spawn_dashboard_runtime_projection_reconcile(state: Arc<AppState>)
     });
 }
 
-pub(crate) fn build_dashboard_activity_live_snapshot(
+#[derive(Debug, Clone)]
+struct DashboardProjectionInvocation {
+    upstream_account_id: Option<i64>,
+    upstream_account_name: Option<String>,
+    is_retry: bool,
+    live_phase: Option<String>,
+    wait_ms: Option<f64>,
+}
+
+fn build_dashboard_activity_live_snapshot_from_projection_records(
     revision: u64,
-    records: impl IntoIterator<Item = ApiInvocation>,
+    records: impl IntoIterator<Item = DashboardProjectionInvocation>,
 ) -> DashboardActivityLiveSnapshot {
     let mut accounts = HashMap::<Option<i64>, DashboardActivityLiveAccount>::new();
     for record in records {
-        if !matches!(
-            normalized_runtime_text(record.status.as_deref()).as_str(),
-            "running" | "pending"
-        ) {
-            continue;
-        }
         let account_id = record.upstream_account_id;
         let account = accounts
             .entry(account_id)
@@ -3032,17 +3103,13 @@ pub(crate) fn build_dashboard_activity_live_snapshot(
                 normalize_trimmed_optional_string_local(record.upstream_account_name.clone());
         }
         account.in_progress_invocation_count += 1;
-        let live_phase = record
-            .live_phase
-            .as_deref()
-            .or_else(|| runtime_invocation_live_phase(&record));
         account
             .in_progress_phase_counts
-            .increment_phase_name(live_phase);
-        if record.pool_attempt_count.unwrap_or_default() > 1 {
+            .increment_phase_name(record.live_phase.as_deref());
+        if record.is_retry {
             account.retry_invocation_count += 1;
         }
-        if let Some(wait_ms) = normalized_wait_ms(record.t_upstream_ttfb_ms) {
+        if let Some(wait_ms) = normalized_wait_ms(record.wait_ms) {
             account.in_progress_wait_sum_ms += wait_ms;
             account.in_progress_wait_sample_count += 1;
         }
@@ -3077,13 +3144,113 @@ pub(crate) fn build_dashboard_activity_live_snapshot(
     }
 }
 
-pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
+pub(crate) fn build_dashboard_activity_live_snapshot(
     revision: u64,
     records: impl IntoIterator<Item = ApiInvocation>,
+) -> DashboardActivityLiveSnapshot {
+    build_dashboard_activity_live_snapshot_from_projection_records(
+        revision,
+        records.into_iter().filter_map(|record| {
+            matches!(
+                normalized_runtime_text(record.status.as_deref()).as_str(),
+                "running" | "pending"
+            )
+            .then(|| {
+                let live_phase = record
+                    .live_phase
+                    .clone()
+                    .or_else(|| runtime_invocation_live_phase(&record).map(str::to_string));
+                DashboardProjectionInvocation {
+                    upstream_account_id: record.upstream_account_id,
+                    upstream_account_name: record.upstream_account_name,
+                    is_retry: record.pool_attempt_count.unwrap_or_default() > 1,
+                    live_phase,
+                    wait_ms: record.t_upstream_ttfb_ms,
+                }
+            })
+        }),
+    )
+}
+
+pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
+    revision: u64,
+    baseline: Option<DashboardRuntimeProjectionBaseline>,
+    runtime_records: impl IntoIterator<Item = ApiInvocation>,
+    terminal_tombstones: HashSet<RuntimeInvocationKey>,
     dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
 ) -> DashboardActivityLiveSnapshot {
     let now = Utc::now();
-    let mut snapshot = build_dashboard_activity_live_snapshot(revision, records);
+    let source_scope = baseline
+        .as_ref()
+        .map_or(InvocationSourceScope::All, |baseline| baseline.source_scope);
+    let mut projection_records = baseline
+        .map(|baseline| {
+            baseline
+                .records
+                .into_iter()
+                .map(|record| {
+                    (
+                        record.key,
+                        DashboardProjectionInvocation {
+                            upstream_account_id: record.upstream_account_id,
+                            upstream_account_name: record.upstream_account_name,
+                            is_retry: record.is_retry,
+                            live_phase: record.live_phase,
+                            wait_ms: record.wait_ms,
+                        },
+                    )
+                })
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+    for key in &terminal_tombstones {
+        projection_records.remove(key);
+    }
+    for record in runtime_records {
+        let key = RuntimeInvocationKey::new(record.invoke_id.clone(), record.occurred_at.clone());
+        if terminal_tombstones.contains(&key) {
+            projection_records.remove(&key);
+            continue;
+        }
+        if source_scope == InvocationSourceScope::ProxyOnly && record.source != SOURCE_PROXY {
+            continue;
+        }
+        if !matches!(
+            normalized_runtime_text(record.status.as_deref()).as_str(),
+            "running" | "pending"
+        ) {
+            projection_records.remove(&key);
+            continue;
+        }
+        let baseline_record = projection_records.get(&key);
+        let upstream_account_id = record
+            .upstream_account_id
+            .or_else(|| baseline_record.and_then(|record| record.upstream_account_id));
+        let upstream_account_name = normalize_trimmed_optional_string_local(
+            record.upstream_account_name.clone(),
+        )
+        .or_else(|| baseline_record.and_then(|record| record.upstream_account_name.clone()));
+        let is_retry = record.pool_attempt_count.unwrap_or_default() > 1
+            || baseline_record.is_some_and(|record| record.is_retry);
+        let live_phase = record
+            .live_phase
+            .clone()
+            .or_else(|| runtime_invocation_live_phase(&record).map(str::to_string));
+        projection_records.insert(
+            key,
+            DashboardProjectionInvocation {
+                upstream_account_id,
+                upstream_account_name,
+                is_retry,
+                live_phase,
+                wait_ms: record.t_upstream_ttfb_ms,
+            },
+        );
+    }
+    let mut snapshot = build_dashboard_activity_live_snapshot_from_projection_records(
+        revision,
+        projection_records.into_values(),
+    );
     let account_rates = dashboard_network_speed_cache.snapshot_account_rates(now);
     let mut existing_account_keys = HashSet::new();
     for account in &mut snapshot.accounts {
@@ -3179,6 +3346,18 @@ pub(crate) fn schedule_dashboard_activity_live_snapshot(state: &AppState) {
     state
         .proxy_runtime_invocations
         .mark_dashboard_dirty("dashboard_live_schedule");
+    ensure_dashboard_activity_live_snapshot_producer(state);
+}
+
+pub(crate) fn ensure_dashboard_activity_live_snapshot_producer(state: &AppState) {
+    if state.shutdown.is_cancelled()
+        || state
+            .proxy_runtime_invocations
+            .pending_dashboard_publish_window()
+            .is_none()
+    {
+        return;
+    }
     if !state
         .subscription_hub
         .has_active_dashboard_activity_live_topic_sync()

--- a/src/api/slices/error_distribution_and_sse.rs
+++ b/src/api/slices/error_distribution_and_sse.rs
@@ -2115,6 +2115,8 @@ mod tests {
         assert_eq!(snapshot.in_progress_phase_counts.queued, 0);
         assert_eq!(snapshot.in_progress_phase_counts.requesting, 1);
         assert_eq!(snapshot.in_progress_phase_counts.responding, 1);
+        assert_eq!(snapshot.in_progress_wait_sample_count, 1);
+        assert_eq!(snapshot.in_progress_wait_sum_ms, 12.0);
     }
 
     #[test]
@@ -2123,6 +2125,314 @@ mod tests {
         let second = reserve_dashboard_activity_live_revision();
 
         assert_eq!(second, first + 1);
+    }
+
+    #[test]
+    fn runtime_projection_mode_keeps_auto_default_and_legacy_kill_switch() {
+        assert_eq!(
+            RuntimeProjectionMode::parse(None).expect("default projection mode"),
+            RuntimeProjectionMode::Auto
+        );
+        assert_eq!(
+            RuntimeProjectionMode::parse(Some("legacy")).expect("legacy projection mode"),
+            RuntimeProjectionMode::Legacy
+        );
+        assert!(RuntimeProjectionMode::parse(Some("invalid")).is_err());
+    }
+
+    #[test]
+    fn runtime_projection_fixed_deadline_is_not_extended_by_later_mutations() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        let started_at = Instant::now();
+
+        hub.mark_dashboard_dirty_at("runtime_upsert", started_at);
+        let first_deadline = hub
+            .pending_dashboard_deadline()
+            .expect("first mutation should establish a deadline");
+        hub.mark_dashboard_dirty_at("network_delta", started_at + Duration::from_millis(200));
+
+        assert_eq!(
+            first_deadline.duration_since(started_at),
+            Duration::from_millis(250)
+        );
+        assert_eq!(hub.pending_dashboard_deadline(), Some(first_deadline));
+    }
+
+    #[test]
+    fn healthy_runtime_projection_renders_ten_thousand_mutations_without_sql() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        hub.bind_dashboard_network_speed_cache(Arc::new(DashboardNetworkSpeedCache::new(
+            Utc::now(),
+        )))
+        .expect("bind dashboard network cache");
+        let mut record = live_record("high-frequency", Some(42), "running", Some("queued"), 1);
+
+        for mutation in 0..10_000 {
+            record.live_phase = Some(if mutation % 2 == 0 {
+                "requesting".to_string()
+            } else {
+                "responding".to_string()
+            });
+            hub.upsert(record.clone());
+        }
+
+        let mut render_samples_ms = Vec::new();
+        let mut snapshot = None;
+        for _ in 0..20 {
+            let started_at = Instant::now();
+            snapshot = Some(
+                hub.dashboard_live_projection()
+                    .snapshot()
+                    .expect("healthy memory projection snapshot"),
+            );
+            render_samples_ms.push(started_at.elapsed().as_secs_f64() * 1_000.0);
+        }
+        render_samples_ms.sort_by(f64::total_cmp);
+        let p95_index = ((render_samples_ms.len() - 1) as f64 * 0.95).ceil() as usize;
+        let p95_ms = render_samples_ms[p95_index];
+        let snapshot = snapshot.expect("projection snapshot");
+        let health = hub.health_snapshot(0);
+
+        assert_eq!(snapshot.in_progress_invocation_count, 1);
+        assert_eq!(health.live_path_db_read_count, 0);
+        assert!(
+            p95_ms <= 400.0,
+            "projection p95 exceeded 400ms: {p95_ms:.2}ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn dashboard_runtime_projection_update_p95_stays_within_four_hundred_ms() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let _lease = state
+            .subscription_hub
+            .register_test_topic_name("dashboard.activity.current")
+            .await;
+        let mut receiver = state.broadcaster.subscribe();
+        let mut samples_ms = Vec::new();
+
+        for mutation in 0..20 {
+            let phase = if mutation % 2 == 0 {
+                "requesting"
+            } else {
+                "responding"
+            };
+            state.proxy_runtime_invocations.upsert(live_record(
+                "latency-contract",
+                Some(42),
+                "running",
+                Some(phase),
+                1,
+            ));
+            let started_at = Instant::now();
+            schedule_dashboard_activity_live_snapshot(state.as_ref());
+            let snapshot = tokio::time::timeout(Duration::from_millis(400), async {
+                loop {
+                    if let Ok(BroadcastPayload::DashboardActivityLive { snapshot }) =
+                        receiver.recv().await
+                    {
+                        return snapshot;
+                    }
+                }
+            })
+            .await
+            .expect("dashboard current update exceeded 400ms");
+            assert_eq!(snapshot.in_progress_invocation_count, 1);
+            samples_ms.push(started_at.elapsed().as_secs_f64() * 1_000.0);
+        }
+
+        samples_ms.sort_by(f64::total_cmp);
+        let p95_index = ((samples_ms.len() - 1) as f64 * 0.95).ceil() as usize;
+        let p95_ms = samples_ms[p95_index];
+        let health = state.proxy_runtime_invocations.health_snapshot(1);
+        assert_eq!(health.live_path_db_read_count, 0);
+        assert!(
+            p95_ms <= 400.0,
+            "dashboard current update p95 exceeded 400ms: {p95_ms:.2}ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn network_mutation_without_subscribers_is_dirty_for_first_snapshot() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        state.dashboard_network_speed_cache.record_request_bytes(
+            "network-first-snapshot",
+            "2026-08-04 12:00:00",
+            Some(42),
+            Some("api.openai.com"),
+            128,
+            Utc::now(),
+        );
+
+        schedule_dashboard_activity_live_snapshot(state.as_ref());
+        assert!(
+            state
+                .proxy_runtime_invocations
+                .pending_dashboard_deadline()
+                .is_some()
+        );
+        let snapshot = capture_dashboard_activity_live_snapshot(state.as_ref())
+            .await
+            .expect("first memory snapshot after subscriber-free network mutation");
+        let health = state.proxy_runtime_invocations.health_snapshot(0);
+
+        assert_eq!(
+            snapshot
+                .network_live_bucket
+                .expect("global live bucket")
+                .upload_bytes,
+            128
+        );
+        assert_eq!(health.live_path_db_read_count, 0);
+        assert!(
+            state
+                .proxy_runtime_invocations
+                .pending_dashboard_deadline()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn unchanged_runtime_projection_does_not_advance_revision() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        hub.bind_dashboard_network_speed_cache(Arc::new(DashboardNetworkSpeedCache::new(
+            Utc::now(),
+        )))
+        .expect("bind dashboard network cache");
+        hub.upsert(live_record(
+            "stable-revision",
+            Some(42),
+            "running",
+            Some("requesting"),
+            1,
+        ));
+
+        let first = hub
+            .capture_memory_snapshot()
+            .expect("first memory snapshot");
+        let second = hub
+            .capture_memory_snapshot()
+            .expect("unchanged memory snapshot");
+
+        assert!(first.changed);
+        assert!(!second.changed);
+        assert_eq!(second.snapshot.revision, first.snapshot.revision);
+    }
+
+    #[tokio::test]
+    async fn degraded_runtime_projection_reuses_last_good_without_database_read() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        state.proxy_runtime_invocations.upsert(live_record(
+            "last-good",
+            Some(42),
+            "running",
+            Some("requesting"),
+            1,
+        ));
+        let first = capture_dashboard_activity_live_snapshot(state.as_ref())
+            .await
+            .expect("healthy memory snapshot");
+        state
+            .proxy_runtime_invocations
+            .mark_degraded("test_health_gate");
+
+        let degraded = capture_dashboard_activity_live_snapshot(state.as_ref())
+            .await
+            .expect("degraded last-good snapshot");
+        let health = state.proxy_runtime_invocations.health_snapshot(1);
+
+        assert_eq!(degraded.revision, first.revision);
+        assert_eq!(health.live_path_db_read_count, 0);
+        assert_eq!(health.snapshot_origin, "last_good");
+        assert_eq!(health.state, "degraded");
+    }
+
+    #[test]
+    fn reconcile_failure_reports_degraded_health_without_freezing_memory_projection() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        hub.bind_dashboard_network_speed_cache(Arc::new(DashboardNetworkSpeedCache::new(
+            Utc::now(),
+        )))
+        .expect("bind dashboard network cache");
+        hub.upsert(live_record(
+            "reconcile-health",
+            Some(42),
+            "running",
+            Some("requesting"),
+            1,
+        ));
+        hub.record_reconcile_failure("reconcile_failed");
+
+        let snapshot = hub
+            .capture_memory_snapshot()
+            .expect("reconcile failure must not gate healthy memory projection");
+        let health = hub.health_snapshot(1);
+
+        assert_eq!(snapshot.snapshot.in_progress_invocation_count, 1);
+        assert!(hub.is_memory_ready());
+        assert_eq!(health.state, "degraded");
+        assert_eq!(health.degraded_reason.as_deref(), Some("reconcile_failed"));
+        assert_eq!(health.live_path_db_read_count, 0);
+    }
+
+    #[tokio::test]
+    async fn cold_runtime_projection_uses_exact_persistence_fallback_once() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+
+        let snapshot = capture_dashboard_activity_live_snapshot(state.as_ref())
+            .await
+            .expect("cold persistence fallback");
+        let health = state.proxy_runtime_invocations.health_snapshot(1);
+
+        assert_eq!(snapshot.in_progress_invocation_count, 0);
+        assert_eq!(health.live_path_db_read_count, 1);
+        assert_eq!(health.snapshot_origin, "cold_fallback");
+        assert_eq!(health.state, "healthy");
+    }
+
+    #[tokio::test]
+    async fn legacy_runtime_projection_kill_switch_keeps_persistence_path() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Legacy);
+        hub.bind_dashboard_network_speed_cache(state.dashboard_network_speed_cache.clone())
+            .expect("bind dashboard network cache");
+
+        let first = capture_dashboard_activity_live_snapshot_from_runtime(
+            &state.pool,
+            &hub,
+            state.dashboard_network_speed_cache.as_ref(),
+        )
+        .await
+        .expect("first legacy capture");
+        let second = capture_dashboard_activity_live_snapshot_from_runtime(
+            &state.pool,
+            &hub,
+            state.dashboard_network_speed_cache.as_ref(),
+        )
+        .await
+        .expect("second legacy capture");
+        let health = hub.health_snapshot(0);
+
+        assert!(first.changed);
+        assert!(!second.changed);
+        assert_eq!(second.snapshot.revision, first.snapshot.revision);
+        assert_eq!(health.mode, "legacy");
+        assert_eq!(health.live_path_db_read_count, 2);
     }
 
     #[test]
@@ -2381,13 +2691,16 @@ pub(crate) struct BroadcastStateCache {
 }
 
 static DASHBOARD_ACTIVITY_LIVE_REVISION: AtomicU64 = AtomicU64::new(0);
-const DASHBOARD_ACTIVITY_LIVE_BROADCAST_DEBOUNCE: Duration = Duration::from_millis(100);
+pub(crate) const DASHBOARD_RUNTIME_PROJECTION_RECONCILE_INTERVAL: Duration =
+    Duration::from_secs(60);
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DashboardActivityLiveAccount {
     pub(crate) account_key: String,
     pub(crate) upstream_account_id: Option<i64>,
+    #[serde(skip)]
+    pub(crate) upstream_account_name: Option<String>,
     pub(crate) in_progress_invocation_count: i64,
     pub(crate) in_progress_phase_counts: InvocationPhaseCountsResponse,
     pub(crate) retry_invocation_count: i64,
@@ -2424,13 +2737,31 @@ pub(crate) fn current_dashboard_activity_live_revision() -> u64 {
     DASHBOARD_ACTIVITY_LIVE_REVISION.load(Ordering::Acquire)
 }
 
-fn reserve_dashboard_activity_live_revision() -> u64 {
+pub(crate) fn reserve_dashboard_activity_live_revision() -> u64 {
     DASHBOARD_ACTIVITY_LIVE_REVISION.fetch_add(1, Ordering::AcqRel) + 1
 }
 
 pub(crate) async fn capture_dashboard_activity_live_snapshot(
     state: &AppState,
 ) -> Result<DashboardActivityLiveSnapshot, ApiError> {
+    let pending_window = state
+        .proxy_runtime_invocations
+        .pending_dashboard_publish_window();
+    let capture = capture_dashboard_activity_live_snapshot_with_outcome(state).await?;
+    if let Some(window) = pending_window {
+        state
+            .proxy_runtime_invocations
+            .complete_dashboard_publish_window(window);
+    }
+    Ok(capture.snapshot)
+}
+
+async fn capture_dashboard_activity_live_snapshot_with_outcome(
+    state: &AppState,
+) -> Result<DashboardProjectionCapture, ApiError> {
+    state
+        .proxy_runtime_invocations
+        .bind_dashboard_network_speed_cache(state.dashboard_network_speed_cache.clone())?;
     capture_dashboard_activity_live_snapshot_from_runtime(
         &state.pool,
         state.proxy_runtime_invocations.as_ref(),
@@ -2441,18 +2772,227 @@ pub(crate) async fn capture_dashboard_activity_live_snapshot(
 
 async fn capture_dashboard_activity_live_snapshot_from_runtime(
     pool: &Pool<Sqlite>,
-    proxy_runtime_invocations: &ProxyRuntimeInvocationStore,
+    hub: &RuntimeProjectionHub,
     dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
-) -> Result<DashboardActivityLiveSnapshot, ApiError> {
-    // Reserve before awaiting so concurrent captures cannot label an older read as newer.
-    let revision = reserve_dashboard_activity_live_revision();
-    query_dashboard_activity_live_snapshot_from_runtime(
+) -> Result<DashboardProjectionCapture, ApiError> {
+    let started_at = Instant::now();
+    let capture = match hub.mode() {
+        RuntimeProjectionMode::Legacy => {
+            capture_dashboard_activity_live_snapshot_from_persistence(
+                pool,
+                hub,
+                dashboard_network_speed_cache,
+                true,
+                "legacy",
+            )
+            .await?
+        }
+        RuntimeProjectionMode::Auto if hub.is_memory_ready() => {
+            match hub.capture_memory_snapshot() {
+                Ok(capture) => capture,
+                Err(err) => {
+                    hub.mark_degraded("memory_snapshot_failed");
+                    warn!(
+                        ?err,
+                        "dashboard runtime projection entered degraded last-good mode"
+                    );
+                    if let Some(capture) = hub.last_good_capture("last_good") {
+                        capture
+                    } else {
+                        capture_dashboard_activity_live_snapshot_from_persistence(
+                            pool,
+                            hub,
+                            dashboard_network_speed_cache,
+                            true,
+                            "cold_fallback",
+                        )
+                        .await?
+                    }
+                }
+            }
+        }
+        RuntimeProjectionMode::Auto => {
+            if let Some(capture) = hub.last_good_capture("last_good") {
+                capture
+            } else {
+                capture_dashboard_activity_live_snapshot_from_persistence(
+                    pool,
+                    hub,
+                    dashboard_network_speed_cache,
+                    true,
+                    "cold_fallback",
+                )
+                .await?
+            }
+        }
+    };
+    let health = hub.health_snapshot(0);
+    tracing::debug!(
+        projection = "dashboard_current",
+        trigger = "capture",
+        revision = capture.snapshot.revision,
+        render_elapsed_ms = started_at.elapsed().as_millis() as u64,
+        live_path_db_read_count = health.live_path_db_read_count,
+        snapshot_origin = capture.snapshot_origin,
+        last_good_age_ms = health.last_good_age_ms,
+        changed = capture.changed,
+        "captured dashboard runtime projection"
+    );
+    Ok(capture)
+}
+
+async fn capture_dashboard_activity_live_snapshot_from_persistence(
+    pool: &Pool<Sqlite>,
+    hub: &RuntimeProjectionHub,
+    dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
+    count_live_path_read: bool,
+    snapshot_origin: &'static str,
+) -> Result<DashboardProjectionCapture, ApiError> {
+    let expected_generation = hub.dashboard_generation();
+    if count_live_path_read {
+        hub.record_live_path_db_read();
+    }
+    hub.record_build();
+    let snapshot = query_dashboard_activity_live_snapshot_from_runtime(
         pool,
-        proxy_runtime_invocations,
+        hub,
         dashboard_network_speed_cache,
-        revision,
+        0,
+    )
+    .await?;
+    let expected_generation = if hub.mode() == RuntimeProjectionMode::Legacy {
+        hub.dashboard_generation()
+    } else {
+        expected_generation
+    };
+    if let Some(capture) = hub.install_persistence_baseline_if_generation(
+        snapshot,
+        snapshot_origin,
+        expected_generation,
+    )? {
+        return Ok(capture);
+    }
+    Ok(hub.capture_memory_snapshot()?)
+}
+
+pub(crate) async fn warm_dashboard_runtime_projection(state: &AppState) {
+    if state.proxy_runtime_invocations.mode() == RuntimeProjectionMode::Legacy {
+        return;
+    }
+    if let Err(err) = capture_dashboard_activity_live_snapshot_from_persistence(
+        &state.pool,
+        state.proxy_runtime_invocations.as_ref(),
+        state.dashboard_network_speed_cache.as_ref(),
+        false,
+        "startup_restore",
     )
     .await
+    {
+        state
+            .proxy_runtime_invocations
+            .mark_degraded("startup_restore_failed");
+        warn!(
+            ?err,
+            "failed to warm dashboard runtime projection from persistence"
+        );
+    }
+}
+
+pub(crate) async fn reconcile_dashboard_runtime_projection_once(
+    state: &AppState,
+) -> Result<DashboardProjectionCapture, ApiError> {
+    capture_dashboard_activity_live_snapshot_from_persistence(
+        &state.pool,
+        state.proxy_runtime_invocations.as_ref(),
+        state.dashboard_network_speed_cache.as_ref(),
+        false,
+        "reconcile",
+    )
+    .await
+}
+
+pub(crate) fn spawn_dashboard_runtime_projection_reconcile(state: Arc<AppState>) {
+    if state.proxy_runtime_invocations.mode() == RuntimeProjectionMode::Legacy {
+        return;
+    }
+    tokio::spawn(async move {
+        let mut cadence = tokio::time::interval(DASHBOARD_RUNTIME_PROJECTION_RECONCILE_INTERVAL);
+        cadence.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        cadence.tick().await;
+        loop {
+            tokio::select! {
+                _ = state.shutdown.cancelled() => return,
+                _ = cadence.tick() => {}
+            }
+            let pressure_gate = crate::db_pressure::global_db_pressure_gate();
+            let _pressure_permit = match pressure_gate
+                .try_begin_background("dashboard_runtime_projection_reconcile")
+            {
+                Ok(permit) => permit,
+                Err(reason) => {
+                    let reason = match reason {
+                        crate::db_pressure::DbPressureDenyReason::PressureCooldown { .. } => {
+                            "writer_pressure"
+                        }
+                        crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
+                            "background_busy"
+                        }
+                    };
+                    state
+                        .proxy_runtime_invocations
+                        .record_reconcile_deferred(reason);
+                    tracing::debug!(
+                        projection = "dashboard_current",
+                        defer_reason = reason,
+                        "deferred dashboard runtime projection reconcile"
+                    );
+                    continue;
+                }
+            };
+            match reconcile_dashboard_runtime_projection_once(state.as_ref()).await {
+                Ok(capture) => {
+                    tracing::debug!(
+                        projection = "dashboard_current",
+                        revision = capture.snapshot.revision,
+                        changed = capture.changed,
+                        snapshot_origin = capture.snapshot_origin,
+                        "reconciled dashboard runtime projection baseline"
+                    );
+                    if capture.changed
+                        && state
+                            .subscription_hub
+                            .has_active_dashboard_activity_live_topic()
+                            .await
+                    {
+                        let _ = state
+                            .broadcaster
+                            .send(BroadcastPayload::DashboardActivityLive {
+                                snapshot: Box::new(capture.snapshot),
+                            });
+                    }
+                }
+                Err(err) => {
+                    let pressure_error = match &err {
+                        ApiError::BadRequest(err) | ApiError::Internal(err) => pressure_gate
+                            .record_error("dashboard_runtime_projection_reconcile", err),
+                    };
+                    if pressure_error {
+                        state
+                            .proxy_runtime_invocations
+                            .record_reconcile_deferred("writer_pressure");
+                    } else {
+                        state
+                            .proxy_runtime_invocations
+                            .record_reconcile_failure("reconcile_failed");
+                    }
+                    warn!(
+                        ?err,
+                        pressure_error, "failed to reconcile dashboard runtime projection baseline"
+                    );
+                }
+            }
+        }
+    });
 }
 
 pub(crate) fn build_dashboard_activity_live_snapshot(
@@ -2475,6 +3015,9 @@ pub(crate) fn build_dashboard_activity_live_snapshot(
                     .map(|id| format!("upstream:{id}"))
                     .unwrap_or_else(|| "unassigned".to_string()),
                 upstream_account_id: account_id,
+                upstream_account_name: normalize_trimmed_optional_string_local(
+                    record.upstream_account_name.clone(),
+                ),
                 in_progress_invocation_count: 0,
                 in_progress_phase_counts: InvocationPhaseCountsResponse::default(),
                 retry_invocation_count: 0,
@@ -2484,6 +3027,10 @@ pub(crate) fn build_dashboard_activity_live_snapshot(
                 download_bytes_per_second: 0.0,
                 network_live_bucket: None,
             });
+        if account.upstream_account_name.is_none() {
+            account.upstream_account_name =
+                normalize_trimmed_optional_string_local(record.upstream_account_name.clone());
+        }
         account.in_progress_invocation_count += 1;
         let live_phase = record
             .live_phase
@@ -2494,6 +3041,10 @@ pub(crate) fn build_dashboard_activity_live_snapshot(
             .increment_phase_name(live_phase);
         if record.pool_attempt_count.unwrap_or_default() > 1 {
             account.retry_invocation_count += 1;
+        }
+        if let Some(wait_ms) = normalized_wait_ms(record.t_upstream_ttfb_ms) {
+            account.in_progress_wait_sum_ms += wait_ms;
+            account.in_progress_wait_sample_count += 1;
         }
     }
     let mut accounts = accounts.into_values().collect::<Vec<_>>();
@@ -2526,15 +3077,115 @@ pub(crate) fn build_dashboard_activity_live_snapshot(
     }
 }
 
+pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
+    revision: u64,
+    records: impl IntoIterator<Item = ApiInvocation>,
+    dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
+) -> DashboardActivityLiveSnapshot {
+    let now = Utc::now();
+    let mut snapshot = build_dashboard_activity_live_snapshot(revision, records);
+    let account_rates = dashboard_network_speed_cache.snapshot_account_rates(now);
+    let mut existing_account_keys = HashSet::new();
+    for account in &mut snapshot.accounts {
+        existing_account_keys.insert(account.account_key.clone());
+        let rate = account_rates
+            .get(&account.upstream_account_id)
+            .copied()
+            .unwrap_or_default();
+        account.upload_bytes_per_second = rate.upload_bytes_per_second;
+        account.download_bytes_per_second = rate.download_bytes_per_second;
+        account.network_live_bucket = Some(dashboard_network_live_bucket_from_memory(
+            dashboard_network_speed_cache,
+            DashboardNetworkScopeKey::account_scope(account.upstream_account_id),
+            now,
+        ));
+    }
+    for (upstream_account_id, rate) in account_rates {
+        let account_key = upstream_account_id
+            .map(|id| format!("upstream:{id}"))
+            .unwrap_or_else(|| "unassigned".to_string());
+        if existing_account_keys.contains(&account_key) {
+            continue;
+        }
+        snapshot.accounts.push(DashboardActivityLiveAccount {
+            account_key,
+            upstream_account_id,
+            upstream_account_name: None,
+            in_progress_invocation_count: 0,
+            in_progress_phase_counts: InvocationPhaseCountsResponse::default(),
+            retry_invocation_count: 0,
+            in_progress_wait_sum_ms: 0.0,
+            in_progress_wait_sample_count: 0,
+            upload_bytes_per_second: rate.upload_bytes_per_second,
+            download_bytes_per_second: rate.download_bytes_per_second,
+            network_live_bucket: Some(dashboard_network_live_bucket_from_memory(
+                dashboard_network_speed_cache,
+                DashboardNetworkScopeKey::account_scope(upstream_account_id),
+                now,
+            )),
+        });
+    }
+    snapshot
+        .accounts
+        .sort_by(|left, right| left.account_key.cmp(&right.account_key));
+    snapshot.network_live_bucket = Some(dashboard_network_live_bucket_from_memory(
+        dashboard_network_speed_cache,
+        DashboardNetworkScopeKey::Global,
+        now,
+    ));
+    snapshot.network_realtime_rate = Some(build_dashboard_network_realtime_rate_response(
+        dashboard_network_speed_cache
+            .snapshot_scope_realtime_bytes(DashboardNetworkScopeKey::Global, now),
+    ));
+    snapshot.generated_at = format_utc_iso(now);
+    snapshot
+}
+
+fn dashboard_network_live_bucket_from_memory(
+    dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
+    scope: DashboardNetworkScopeKey,
+    now: DateTime<Utc>,
+) -> DashboardNetworkTimeseriesPointResponse {
+    let snapshot = dashboard_network_speed_cache.snapshot_open_bucket(scope, now);
+    build_dashboard_network_timeseries_point_response(
+        snapshot.bucket_start,
+        snapshot.bucket_end,
+        snapshot.totals,
+        ExactUtcRange {
+            start: snapshot.bucket_start,
+            end: now.min(snapshot.bucket_end),
+        },
+        true,
+    )
+}
+
 pub(crate) fn schedule_dashboard_activity_live_snapshot(state: &AppState) {
-    if state.shutdown.is_cancelled()
-        || !state
-            .subscription_hub
-            .has_active_dashboard_activity_live_topic_sync()
+    if state.shutdown.is_cancelled() {
+        return;
+    }
+    if let Err(err) = state
+        .proxy_runtime_invocations
+        .bind_dashboard_network_speed_cache(state.dashboard_network_speed_cache.clone())
+    {
+        state
+            .proxy_runtime_invocations
+            .mark_degraded("network_cache_bind_failed");
+        warn!(
+            ?err,
+            "failed to bind dashboard network cache to runtime projection"
+        );
+        return;
+    }
+    state
+        .proxy_runtime_invocations
+        .mark_dashboard_dirty("dashboard_live_schedule");
+    if !state
+        .subscription_hub
+        .has_active_dashboard_activity_live_topic_sync()
     {
         return;
     }
-    let worker_start_seq = state
+    let _ = state
         .dashboard_activity_live_broadcast_seq
         .fetch_add(1, Ordering::Relaxed)
         + 1;
@@ -2545,6 +3196,7 @@ pub(crate) fn schedule_dashboard_activity_live_snapshot(state: &AppState) {
     {
         return;
     }
+    state.proxy_runtime_invocations.set_producer_running(true);
 
     let latest_seq = state.dashboard_activity_live_broadcast_seq.clone();
     let broadcast_running = state.dashboard_activity_live_broadcast_running.clone();
@@ -2555,22 +3207,37 @@ pub(crate) fn schedule_dashboard_activity_live_snapshot(state: &AppState) {
     let broadcaster = state.broadcaster.clone();
     let shutdown = state.shutdown.clone();
     tokio::spawn(async move {
-        let mut delivered_seq = worker_start_seq.saturating_sub(1);
-        let mut cadence = DASHBOARD_ACTIVITY_LIVE_BROADCAST_DEBOUNCE;
+        let mut delivered_seq = latest_seq.load(Ordering::Acquire).saturating_sub(1);
         loop {
+            let Some(window) = proxy_runtime_invocations.pending_dashboard_publish_window() else {
+                broadcast_running.store(false, Ordering::Release);
+                proxy_runtime_invocations.set_producer_running(false);
+                if proxy_runtime_invocations
+                    .pending_dashboard_publish_window()
+                    .is_some()
+                    && broadcast_running
+                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                {
+                    proxy_runtime_invocations.set_producer_running(true);
+                    continue;
+                }
+                return;
+            };
             tokio::select! {
                 _ = shutdown.cancelled() => {
                     broadcast_running.store(false, Ordering::Release);
+                    proxy_runtime_invocations.set_producer_running(false);
                     return;
                 }
-                _ = tokio::time::sleep(cadence) => {}
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(window.deadline)) => {}
             }
 
             let sent_seq = latest_seq.load(Ordering::Acquire);
-            if subscription_hub
+            let has_active_subscribers = subscription_hub
                 .has_active_dashboard_activity_live_topic()
-                .await
-            {
+                .await;
+            if has_active_subscribers {
                 let started = Instant::now();
                 match capture_dashboard_activity_live_snapshot_from_runtime(
                     &pool,
@@ -2579,11 +3246,11 @@ pub(crate) fn schedule_dashboard_activity_live_snapshot(state: &AppState) {
                 )
                 .await
                 {
-                    Ok(snapshot) => {
-                        let revision = snapshot.revision;
+                    Ok(capture) if capture.changed => {
+                        let revision = capture.snapshot.revision;
                         if let Err(err) =
                             broadcaster.send(BroadcastPayload::DashboardActivityLive {
-                                snapshot: Box::new(snapshot),
+                                snapshot: Box::new(capture.snapshot),
                             })
                         {
                             warn!(
@@ -2595,34 +3262,28 @@ pub(crate) fn schedule_dashboard_activity_live_snapshot(state: &AppState) {
                                 revision,
                                 coalesced_mutation_count = sent_seq.saturating_sub(delivered_seq),
                                 generated_to_sent_ms = started.elapsed().as_millis() as u64,
+                                snapshot_origin = capture.snapshot_origin,
                                 "broadcast dashboard activity live snapshot"
                             );
                         }
                     }
+                    Ok(capture) => tracing::debug!(
+                        revision = capture.snapshot.revision,
+                        snapshot_origin = capture.snapshot_origin,
+                        "suppressed unchanged dashboard activity live snapshot"
+                    ),
                     Err(err) => warn!(?err, "failed to capture dashboard activity live snapshot"),
                 }
             }
+            proxy_runtime_invocations.complete_dashboard_publish_window(window);
             delivered_seq = sent_seq;
 
-            if latest_seq.load(Ordering::Acquire) != sent_seq {
-                cadence = DASHBOARD_ACTIVITY_LIVE_BROADCAST_DEBOUNCE;
-                continue;
-            }
-            if dashboard_network_speed_cache.should_keep_dashboard_activity_live_stream(Utc::now())
+            if has_active_subscribers
+                && dashboard_network_speed_cache
+                    .should_keep_dashboard_activity_live_stream(Utc::now())
             {
-                cadence = Duration::from_secs(1);
-                continue;
+                proxy_runtime_invocations.mark_dashboard_dirty("network_visibility");
             }
-            broadcast_running.store(false, Ordering::Release);
-            if latest_seq.load(Ordering::Acquire) != sent_seq
-                && broadcast_running
-                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok()
-            {
-                cadence = DASHBOARD_ACTIVITY_LIVE_BROADCAST_DEBOUNCE;
-                continue;
-            }
-            return;
         }
     });
 }

--- a/src/api/slices/error_distribution_and_sse.rs
+++ b/src/api/slices/error_distribution_and_sse.rs
@@ -2159,6 +2159,20 @@ mod tests {
     }
 
     #[test]
+    fn terminal_rollback_marks_runtime_projection_dirty() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        let record = live_record("terminal-rollback", Some(42), "success", None, 1);
+        let invoke_id = record.invoke_id.clone();
+        let occurred_at = record.occurred_at.clone();
+
+        hub.upsert_terminal(record);
+        let generation_before_rollback = hub.dashboard_generation();
+
+        assert!(hub.clear_terminal_tombstone(&invoke_id, &occurred_at));
+        assert_eq!(hub.dashboard_generation(), generation_before_rollback + 1);
+    }
+
+    #[test]
     fn healthy_runtime_projection_renders_ten_thousand_mutations_without_sql() {
         let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
         hub.bind_dashboard_network_speed_cache(Arc::new(DashboardNetworkSpeedCache::new(

--- a/src/api/slices/error_distribution_and_sse.rs
+++ b/src/api/slices/error_distribution_and_sse.rs
@@ -2159,6 +2159,32 @@ mod tests {
     }
 
     #[test]
+    fn runtime_projection_build_does_not_extend_next_fixed_deadline() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        let started_at = Instant::now();
+        hub.mark_dashboard_dirty_at("runtime_upsert", started_at);
+        let pending = hub
+            .pending_dashboard_publish_window()
+            .expect("first mutation should establish a publish window");
+        let building = hub
+            .begin_dashboard_publish_window(pending)
+            .expect("pending window should begin building");
+        let mutation_during_build = started_at + Duration::from_millis(300);
+
+        hub.mark_dashboard_dirty_at("network_delta", mutation_during_build);
+        let next_deadline = hub
+            .pending_dashboard_deadline()
+            .expect("mutation during build should establish the next deadline");
+        hub.complete_dashboard_publish_window(building);
+
+        assert_eq!(
+            next_deadline,
+            mutation_during_build + DASHBOARD_RUNTIME_PROJECTION_COALESCE
+        );
+        assert_eq!(hub.pending_dashboard_deadline(), Some(next_deadline));
+    }
+
+    #[test]
     fn terminal_rollback_marks_runtime_projection_dirty() {
         let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
         let record = live_record("terminal-rollback", Some(42), "success", None, 1);
@@ -2170,6 +2196,19 @@ mod tests {
 
         assert!(hub.clear_terminal_tombstone(&invoke_id, &occurred_at));
         assert_eq!(hub.dashboard_generation(), generation_before_rollback + 1);
+    }
+
+    #[test]
+    fn persisted_terminal_tombstone_insert_and_refresh_mark_projection_dirty() {
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        let generation_before_insert = hub.dashboard_generation();
+
+        assert!(!hub.remove_persisted_terminal_overlay("persisted", "2026-08-04 12:00:00"));
+        assert_eq!(hub.dashboard_generation(), generation_before_insert + 1);
+
+        let generation_before_refresh = hub.dashboard_generation();
+        assert!(!hub.remove_persisted_terminal_overlay("persisted", "2026-08-04 12:00:00"));
+        assert_eq!(hub.dashboard_generation(), generation_before_refresh + 1);
     }
 
     #[test]
@@ -2237,6 +2276,7 @@ mod tests {
                 wait_ms: restored.t_upstream_ttfb_ms,
             }],
             source_scope: InvocationSourceScope::All,
+            network_open_buckets: HashMap::new(),
         };
         hub.install_persistence_baseline_if_generation(
             baseline_snapshot,
@@ -2280,6 +2320,128 @@ mod tests {
             .expect("terminal delta should remove its restored row");
         assert_eq!(terminal.snapshot.in_progress_invocation_count, 1);
         assert_eq!(terminal.snapshot.in_progress_phase_counts.responding, 1);
+    }
+
+    #[test]
+    fn runtime_projection_merges_restored_network_bucket_without_double_counting() {
+        let now = Utc::now();
+        let cache = Arc::new(DashboardNetworkSpeedCache::new(now));
+        let hub = RuntimeProjectionHub::new(RuntimeProjectionMode::Auto);
+        hub.bind_dashboard_network_speed_cache(cache.clone())
+            .expect("bind dashboard network cache");
+        let global_at_install = cache.snapshot_open_bucket(DashboardNetworkScopeKey::Global, now);
+        let account_at_install =
+            cache.snapshot_open_bucket(DashboardNetworkScopeKey::Account(42), now);
+        let global_baseline_totals = DashboardNetworkByteTotals {
+            upload_bytes: 120,
+            download_bytes: 240,
+        };
+        let account_baseline_totals = DashboardNetworkByteTotals {
+            upload_bytes: 80,
+            download_bytes: 160,
+        };
+        let mut baseline_snapshot = build_dashboard_activity_live_snapshot(0, Vec::new());
+        baseline_snapshot.network_live_bucket =
+            Some(build_dashboard_network_timeseries_point_response(
+                global_at_install.bucket_start,
+                global_at_install.bucket_end,
+                global_baseline_totals,
+                ExactUtcRange {
+                    start: global_at_install.bucket_start,
+                    end: now,
+                },
+                true,
+            ));
+        let baseline = DashboardRuntimeProjectionBaseline {
+            records: Vec::new(),
+            source_scope: InvocationSourceScope::All,
+            network_open_buckets: HashMap::from([
+                (
+                    DashboardNetworkScopeKey::Global,
+                    DashboardRuntimeNetworkOpenBucketBaseline {
+                        bucket_start: global_at_install.bucket_start,
+                        bucket_end: global_at_install.bucket_end,
+                        baseline_totals: global_baseline_totals,
+                        memory_totals_at_install: global_at_install.totals,
+                    },
+                ),
+                (
+                    DashboardNetworkScopeKey::Account(42),
+                    DashboardRuntimeNetworkOpenBucketBaseline {
+                        bucket_start: account_at_install.bucket_start,
+                        bucket_end: account_at_install.bucket_end,
+                        baseline_totals: account_baseline_totals,
+                        memory_totals_at_install: account_at_install.totals,
+                    },
+                ),
+            ]),
+        };
+        hub.install_persistence_baseline_if_generation(
+            baseline_snapshot,
+            baseline,
+            "startup_restore",
+            hub.dashboard_generation(),
+        )
+        .expect("install startup baseline")
+        .expect("baseline generation should match");
+
+        cache.record_request_bytes(
+            "network-delta",
+            "2026-08-04 12:00:00",
+            Some(42),
+            Some("api.openai.com"),
+            30,
+            now,
+        );
+        cache.record_response_chunk_bytes(
+            "network-delta",
+            "2026-08-04 12:00:00",
+            Some(42),
+            Some("api.openai.com"),
+            60,
+            now,
+        );
+        hub.mark_dashboard_dirty_at("network_delta", Instant::now());
+
+        let first = hub
+            .capture_memory_snapshot()
+            .expect("merged network projection snapshot");
+        let second = hub
+            .capture_memory_snapshot()
+            .expect("unchanged merged network projection snapshot");
+
+        let global = first
+            .snapshot
+            .network_live_bucket
+            .as_ref()
+            .expect("global live bucket");
+        assert_eq!(global.upload_bytes, 150);
+        assert_eq!(global.download_bytes, 300);
+        let account = first
+            .snapshot
+            .accounts
+            .iter()
+            .find(|account| account.upstream_account_id == Some(42))
+            .and_then(|account| account.network_live_bucket.as_ref())
+            .expect("account live bucket");
+        assert_eq!(account.upload_bytes, 110);
+        assert_eq!(account.download_bytes, 220);
+        let second_global = second
+            .snapshot
+            .network_live_bucket
+            .as_ref()
+            .expect("second global live bucket");
+        assert_eq!(second_global.upload_bytes, 150);
+        assert_eq!(second_global.download_bytes, 300);
+        let second_account = second
+            .snapshot
+            .accounts
+            .iter()
+            .find(|account| account.upstream_account_id == Some(42))
+            .and_then(|account| account.network_live_bucket.as_ref())
+            .expect("second account live bucket");
+        assert_eq!(second_account.upload_bytes, 110);
+        assert_eq!(second_account.download_bytes, 220);
     }
 
     #[tokio::test]
@@ -2827,7 +2989,12 @@ pub(crate) async fn capture_dashboard_activity_live_snapshot(
 ) -> Result<DashboardActivityLiveSnapshot, ApiError> {
     let pending_window = state
         .proxy_runtime_invocations
-        .pending_dashboard_publish_window();
+        .pending_dashboard_publish_window()
+        .and_then(|window| {
+            state
+                .proxy_runtime_invocations
+                .begin_dashboard_publish_window(window)
+        });
     let capture = capture_dashboard_activity_live_snapshot_with_outcome(state).await?;
     if let Some(window) = pending_window {
         state
@@ -3194,29 +3361,31 @@ pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
     dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
 ) -> DashboardActivityLiveSnapshot {
     let now = Utc::now();
-    let source_scope = baseline
-        .as_ref()
-        .map_or(InvocationSourceScope::All, |baseline| baseline.source_scope);
-    let mut projection_records = baseline
-        .map(|baseline| {
-            baseline
-                .records
-                .into_iter()
-                .map(|record| {
-                    (
-                        record.key,
-                        DashboardProjectionInvocation {
-                            upstream_account_id: record.upstream_account_id,
-                            upstream_account_name: record.upstream_account_name,
-                            is_retry: record.is_retry,
-                            live_phase: record.live_phase,
-                            wait_ms: record.wait_ms,
-                        },
-                    )
-                })
-                .collect::<HashMap<_, _>>()
+    let (source_scope, baseline_records, network_open_buckets) = baseline.map_or_else(
+        || (InvocationSourceScope::All, Vec::new(), HashMap::new()),
+        |baseline| {
+            (
+                baseline.source_scope,
+                baseline.records,
+                baseline.network_open_buckets,
+            )
+        },
+    );
+    let mut projection_records = baseline_records
+        .into_iter()
+        .map(|record| {
+            (
+                record.key,
+                DashboardProjectionInvocation {
+                    upstream_account_id: record.upstream_account_id,
+                    upstream_account_name: record.upstream_account_name,
+                    is_retry: record.is_retry,
+                    live_phase: record.live_phase,
+                    wait_ms: record.wait_ms,
+                },
+            )
         })
-        .unwrap_or_default();
+        .collect::<HashMap<_, _>>();
     for key in &terminal_tombstones {
         projection_records.remove(key);
     }
@@ -3277,6 +3446,7 @@ pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
         account.download_bytes_per_second = rate.download_bytes_per_second;
         account.network_live_bucket = Some(dashboard_network_live_bucket_from_memory(
             dashboard_network_speed_cache,
+            &network_open_buckets,
             DashboardNetworkScopeKey::account_scope(account.upstream_account_id),
             now,
         ));
@@ -3301,6 +3471,7 @@ pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
             download_bytes_per_second: rate.download_bytes_per_second,
             network_live_bucket: Some(dashboard_network_live_bucket_from_memory(
                 dashboard_network_speed_cache,
+                &network_open_buckets,
                 DashboardNetworkScopeKey::account_scope(upstream_account_id),
                 now,
             )),
@@ -3311,6 +3482,7 @@ pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
         .sort_by(|left, right| left.account_key.cmp(&right.account_key));
     snapshot.network_live_bucket = Some(dashboard_network_live_bucket_from_memory(
         dashboard_network_speed_cache,
+        &network_open_buckets,
         DashboardNetworkScopeKey::Global,
         now,
     ));
@@ -3324,14 +3496,39 @@ pub(crate) fn build_dashboard_activity_live_snapshot_from_memory(
 
 fn dashboard_network_live_bucket_from_memory(
     dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
+    network_open_buckets: &HashMap<
+        DashboardNetworkScopeKey,
+        DashboardRuntimeNetworkOpenBucketBaseline,
+    >,
     scope: DashboardNetworkScopeKey,
     now: DateTime<Utc>,
 ) -> DashboardNetworkTimeseriesPointResponse {
     let snapshot = dashboard_network_speed_cache.snapshot_open_bucket(scope, now);
+    let totals = network_open_buckets
+        .get(&scope)
+        .filter(|baseline| {
+            baseline.bucket_start == snapshot.bucket_start
+                && baseline.bucket_end == snapshot.bucket_end
+        })
+        .map(|baseline| {
+            let mut totals = baseline.baseline_totals;
+            totals.add_assign(DashboardNetworkByteTotals {
+                upload_bytes: snapshot
+                    .totals
+                    .upload_bytes
+                    .saturating_sub(baseline.memory_totals_at_install.upload_bytes),
+                download_bytes: snapshot
+                    .totals
+                    .download_bytes
+                    .saturating_sub(baseline.memory_totals_at_install.download_bytes),
+            });
+            totals
+        })
+        .unwrap_or(snapshot.totals);
     build_dashboard_network_timeseries_point_response(
         snapshot.bucket_start,
         snapshot.bucket_end,
-        snapshot.totals,
+        totals,
         ExactUtcRange {
             start: snapshot.bucket_start,
             end: now.min(snapshot.bucket_end),
@@ -3425,6 +3622,11 @@ pub(crate) fn ensure_dashboard_activity_live_snapshot_producer(state: &AppState)
                 }
                 _ = tokio::time::sleep_until(tokio::time::Instant::from_std(window.deadline)) => {}
             }
+
+            let Some(window) = proxy_runtime_invocations.begin_dashboard_publish_window(window)
+            else {
+                continue;
+            };
 
             let sent_seq = latest_seq.load(Ordering::Acquire);
             let has_active_subscribers = subscription_hub

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -11719,6 +11719,7 @@ pub(crate) async fn query_dashboard_runtime_projection_baseline(
             })
             .collect(),
         source_scope,
+        network_open_buckets: HashMap::new(),
     })
 }
 
@@ -11872,7 +11873,7 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_with_baseline_from_ru
     let now = Utc::now();
     let source_scope = resolve_default_source_scope(pool).await?;
     flush_dashboard_network_socket_minute_rollups(pool, dashboard_network_speed_cache, now).await?;
-    let baseline = query_dashboard_runtime_projection_baseline(pool, source_scope).await?;
+    let mut baseline = query_dashboard_runtime_projection_baseline(pool, source_scope).await?;
     let counts = query_upstream_account_in_progress_counts_with_baseline(
         pool,
         proxy_runtime_invocations,
@@ -11959,6 +11960,47 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_with_baseline_from_ru
     }
     accounts.sort_by(|left, right| left.account_key.cmp(&right.account_key));
 
+    let global_live_bucket = load_dashboard_network_live_bucket_point(
+        pool,
+        dashboard_network_speed_cache,
+        source_scope,
+        now,
+        DashboardNetworkScopeKey::Global,
+    )
+    .await?;
+    let mut network_open_buckets = HashMap::new();
+    for (upstream_account_id, live_bucket) in &live_buckets {
+        let scope = DashboardNetworkScopeKey::account_scope(*upstream_account_id);
+        let memory = dashboard_network_speed_cache.snapshot_open_bucket(scope, now);
+        network_open_buckets.insert(
+            scope,
+            DashboardRuntimeNetworkOpenBucketBaseline {
+                bucket_start: memory.bucket_start,
+                bucket_end: memory.bucket_end,
+                baseline_totals: DashboardNetworkByteTotals {
+                    upload_bytes: live_bucket.upload_bytes,
+                    download_bytes: live_bucket.download_bytes,
+                },
+                memory_totals_at_install: memory.totals,
+            },
+        );
+    }
+    let global_memory =
+        dashboard_network_speed_cache.snapshot_open_bucket(DashboardNetworkScopeKey::Global, now);
+    network_open_buckets.insert(
+        DashboardNetworkScopeKey::Global,
+        DashboardRuntimeNetworkOpenBucketBaseline {
+            bucket_start: global_memory.bucket_start,
+            bucket_end: global_memory.bucket_end,
+            baseline_totals: DashboardNetworkByteTotals {
+                upload_bytes: global_live_bucket.upload_bytes,
+                download_bytes: global_live_bucket.download_bytes,
+            },
+            memory_totals_at_install: global_memory.totals,
+        },
+    );
+    baseline.network_open_buckets = network_open_buckets;
+
     let mut in_progress_phase_counts = InvocationPhaseCountsResponse::default();
     let mut in_progress_invocation_count = 0;
     let mut retry_invocation_count = 0;
@@ -11983,16 +12025,7 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_with_baseline_from_ru
             retry_invocation_count,
             in_progress_wait_sum_ms,
             in_progress_wait_sample_count,
-            network_live_bucket: Some(
-                load_dashboard_network_live_bucket_point(
-                    pool,
-                    dashboard_network_speed_cache,
-                    source_scope,
-                    now,
-                    DashboardNetworkScopeKey::Global,
-                )
-                .await?,
-            ),
+            network_live_bucket: Some(global_live_bucket),
             network_realtime_rate: Some(global_realtime_rate),
             accounts,
         },

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7692,7 +7692,7 @@ impl UpstreamAccountInProgressSummary {
     }
 }
 
-fn normalized_wait_ms(value: Option<f64>) -> Option<f64> {
+pub(crate) fn normalized_wait_ms(value: Option<f64>) -> Option<f64> {
     value.filter(|value| value.is_finite() && *value >= 0.0)
 }
 
@@ -11859,6 +11859,7 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_from_runtime(
                     .map(|id| format!("upstream:{id}"))
                     .unwrap_or_else(|| "unassigned".to_string()),
                 upstream_account_id,
+                upstream_account_name: None,
                 in_progress_invocation_count: summary.in_progress_count,
                 in_progress_phase_counts: summary.phase_counts,
                 retry_invocation_count: summary.retry_count,
@@ -11884,6 +11885,7 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_from_runtime(
         accounts.push(DashboardActivityLiveAccount {
             account_key,
             upstream_account_id,
+            upstream_account_name: None,
             in_progress_invocation_count: 0,
             in_progress_phase_counts: InvocationPhaseCountsResponse::default(),
             retry_invocation_count: 0,
@@ -14215,14 +14217,17 @@ pub(crate) fn dashboard_activity_account_from_live(
 ) -> DashboardActivityAccountResponse {
     let status_fields =
         meta.map(|row| build_upstream_account_activity_status_fields(row, Utc::now()));
-    let display_name_hint = recent_invocations.iter().find_map(|invocation| {
-        invocation
-            .upstream_account_name
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-    });
+    let display_name_hint = recent_invocations
+        .iter()
+        .find_map(|invocation| {
+            invocation
+                .upstream_account_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        })
+        .or_else(|| live_account.upstream_account_name.clone());
     let plan_type_hint = recent_invocations.iter().find_map(|invocation| {
         invocation
             .upstream_account_plan_type
@@ -14642,6 +14647,7 @@ async fn overlay_dashboard_activity_live_accounts(
                         .map(|id| format!("upstream:{id}"))
                         .unwrap_or_else(|| "unassigned".to_string()),
                     upstream_account_id,
+                    upstream_account_name: None,
                     in_progress_invocation_count: 0,
                     in_progress_phase_counts: InvocationPhaseCountsResponse::default(),
                     retry_invocation_count: 0,
@@ -17337,7 +17343,7 @@ fn dashboard_network_bucket_rate(
     total_bytes.max(0) as f64 / (effective_millis as f64 / 1000.0)
 }
 
-fn build_dashboard_network_realtime_rate_response(
+pub(crate) fn build_dashboard_network_realtime_rate_response(
     snapshot: DashboardNetworkRealtimeByteSnapshot,
 ) -> DashboardNetworkRealtimeRateResponse {
     DashboardNetworkRealtimeRateResponse {
@@ -17411,7 +17417,7 @@ fn build_dashboard_recent_network_window_response(
     }
 }
 
-fn build_dashboard_network_timeseries_point_response(
+pub(crate) fn build_dashboard_network_timeseries_point_response(
     bucket_start: DateTime<Utc>,
     bucket_end: DateTime<Utc>,
     totals: DashboardNetworkByteTotals,

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -11653,6 +11653,20 @@ pub(crate) async fn query_upstream_account_in_progress_counts_from_runtime(
     proxy_runtime_invocations: &ProxyRuntimeInvocationStore,
     source_scope: InvocationSourceScope,
 ) -> Result<HashMap<Option<i64>, UpstreamAccountInProgressSummary>, ApiError> {
+    let baseline = query_dashboard_runtime_projection_baseline(pool, source_scope).await?;
+    query_upstream_account_in_progress_counts_with_baseline(
+        pool,
+        proxy_runtime_invocations,
+        source_scope,
+        &baseline,
+    )
+    .await
+}
+
+pub(crate) async fn query_dashboard_runtime_projection_baseline(
+    pool: &Pool<Sqlite>,
+    source_scope: InvocationSourceScope,
+) -> Result<DashboardRuntimeProjectionBaseline, ApiError> {
     #[derive(Debug, FromRow)]
     struct RuntimeKeyRow {
         invoke_id: String,
@@ -11692,24 +11706,47 @@ pub(crate) async fn query_upstream_account_in_progress_counts_from_runtime(
         .build_query_as::<RuntimeKeyRow>()
         .fetch_all(pool)
         .await?;
+    Ok(DashboardRuntimeProjectionBaseline {
+        records: db_rows
+            .into_iter()
+            .map(|row| DashboardRuntimeBaselineRecord {
+                key: RuntimeInvocationKey::new(row.invoke_id, row.occurred_at),
+                upstream_account_id: row.upstream_account_id,
+                upstream_account_name: None,
+                is_retry: row.retry_count > 0,
+                live_phase: row.live_phase,
+                wait_ms: row.upstream_ttfb_ms,
+            })
+            .collect(),
+        source_scope,
+    })
+}
+
+async fn query_upstream_account_in_progress_counts_with_baseline(
+    pool: &Pool<Sqlite>,
+    proxy_runtime_invocations: &ProxyRuntimeInvocationStore,
+    source_scope: InvocationSourceScope,
+    baseline: &DashboardRuntimeProjectionBaseline,
+) -> Result<HashMap<Option<i64>, UpstreamAccountInProgressSummary>, ApiError> {
     let mut counts = HashMap::<Option<i64>, UpstreamAccountInProgressSummary>::new();
-    for row in &db_rows {
+    for row in &baseline.records {
         counts.entry(row.upstream_account_id).or_default().add(
-            row.retry_count > 0,
+            row.is_retry,
             row.live_phase.as_deref(),
-            row.upstream_ttfb_ms,
+            row.wait_ms,
         );
     }
-    let db_runtime_keys = db_rows
-        .into_iter()
+    let db_runtime_keys = baseline
+        .records
+        .iter()
         .map(|row| {
             (
-                (row.invoke_id, row.occurred_at),
+                (row.key.invoke_id.clone(), row.key.occurred_at.clone()),
                 (
                     row.upstream_account_id,
-                    row.retry_count > 0,
-                    row.live_phase,
-                    row.upstream_ttfb_ms,
+                    row.is_retry,
+                    row.live_phase.clone(),
+                    row.wait_ms,
                 ),
             )
         })
@@ -11810,13 +11847,37 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_from_runtime(
     dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
     revision: u64,
 ) -> Result<DashboardActivityLiveSnapshot, ApiError> {
+    query_dashboard_activity_live_snapshot_with_baseline_from_runtime(
+        pool,
+        proxy_runtime_invocations,
+        dashboard_network_speed_cache,
+        revision,
+    )
+    .await
+    .map(|(snapshot, _)| snapshot)
+}
+
+pub(crate) async fn query_dashboard_activity_live_snapshot_with_baseline_from_runtime(
+    pool: &Pool<Sqlite>,
+    proxy_runtime_invocations: &ProxyRuntimeInvocationStore,
+    dashboard_network_speed_cache: &DashboardNetworkSpeedCache,
+    revision: u64,
+) -> Result<
+    (
+        DashboardActivityLiveSnapshot,
+        DashboardRuntimeProjectionBaseline,
+    ),
+    ApiError,
+> {
     let now = Utc::now();
     let source_scope = resolve_default_source_scope(pool).await?;
     flush_dashboard_network_socket_minute_rollups(pool, dashboard_network_speed_cache, now).await?;
-    let counts = query_upstream_account_in_progress_counts_from_runtime(
+    let baseline = query_dashboard_runtime_projection_baseline(pool, source_scope).await?;
+    let counts = query_upstream_account_in_progress_counts_with_baseline(
         pool,
         proxy_runtime_invocations,
         source_scope,
+        &baseline,
     )
     .await?;
     let account_rates = dashboard_network_speed_cache.snapshot_account_rates(now);
@@ -11913,27 +11974,30 @@ pub(crate) async fn query_dashboard_activity_live_snapshot_from_runtime(
         in_progress_phase_counts.responding += account.in_progress_phase_counts.responding;
     }
 
-    Ok(DashboardActivityLiveSnapshot {
-        revision,
-        generated_at: format_utc_iso(now),
-        in_progress_invocation_count,
-        in_progress_phase_counts,
-        retry_invocation_count,
-        in_progress_wait_sum_ms,
-        in_progress_wait_sample_count,
-        network_live_bucket: Some(
-            load_dashboard_network_live_bucket_point(
-                pool,
-                dashboard_network_speed_cache,
-                source_scope,
-                now,
-                DashboardNetworkScopeKey::Global,
-            )
-            .await?,
-        ),
-        network_realtime_rate: Some(global_realtime_rate),
-        accounts,
-    })
+    Ok((
+        DashboardActivityLiveSnapshot {
+            revision,
+            generated_at: format_utc_iso(now),
+            in_progress_invocation_count,
+            in_progress_phase_counts,
+            retry_invocation_count,
+            in_progress_wait_sum_ms,
+            in_progress_wait_sample_count,
+            network_live_bucket: Some(
+                load_dashboard_network_live_bucket_point(
+                    pool,
+                    dashboard_network_speed_cache,
+                    source_scope,
+                    now,
+                    DashboardNetworkScopeKey::Global,
+                )
+                .await?,
+            ),
+            network_realtime_rate: Some(global_realtime_rate),
+            accounts,
+        },
+        baseline,
+    ))
 }
 
 fn dashboard_live_snapshot_in_progress_counts(

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -565,6 +565,38 @@ impl SubscriptionHub {
         has_cached_live_topic
     }
 
+    pub(crate) async fn dashboard_activity_live_subscriber_count(&self) -> usize {
+        let guard = self.state.lock().await;
+        let cached_count = guard
+            .topics
+            .iter()
+            .filter(|(_, cached)| {
+                cached.topic.uses_dashboard_activity_live_overlay()
+                    || cached.topic.uses_summary_live_overlay()
+                    || cached.topic.uses_dashboard_network_live_snapshot()
+            })
+            .map(|(topic_key, _)| {
+                guard
+                    .active_subscribers
+                    .get(topic_key)
+                    .copied()
+                    .unwrap_or_default()
+            })
+            .sum::<usize>();
+        #[cfg(test)]
+        {
+            cached_count.max(
+                guard
+                    .active_topic_names
+                    .get("dashboard.activity.current")
+                    .copied()
+                    .unwrap_or_default(),
+            )
+        }
+        #[cfg(not(test))]
+        cached_count
+    }
+
     pub(crate) fn has_active_dashboard_activity_live_topic_sync(&self) -> bool {
         let Ok(guard) = self.state.try_lock() else {
             return true;

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -631,8 +631,14 @@ impl SubscriptionHub {
 
     async fn register_topic_subscribers(
         self: &Arc<Self>,
+        state: &AppState,
         topics: &[SubscriptionTopic],
     ) -> Result<TopicSubscriptionLease, ApiError> {
+        let owns_dashboard_live = topics.iter().any(|topic| {
+            topic.uses_dashboard_activity_live_overlay()
+                || topic.uses_summary_live_overlay()
+                || topic.uses_dashboard_network_live_snapshot()
+        });
         let topic_keys = topics
             .iter()
             .map(SubscriptionTopic::cache_key)
@@ -658,6 +664,10 @@ impl SubscriptionHub {
                 .active_topic_names
                 .entry(topic_name.clone())
                 .or_insert(0) += 1;
+        }
+        drop(guard);
+        if owns_dashboard_live {
+            ensure_dashboard_activity_live_snapshot_producer(state);
         }
         Ok(TopicSubscriptionLease {
             hub: self.clone(),
@@ -2331,7 +2341,7 @@ pub(crate) async fn topic_sse_stream(
         .collect::<Result<HashSet<_>, _>>()?;
     let topic_lease = state
         .subscription_hub
-        .register_topic_subscribers(&selected_topics)
+        .register_topic_subscribers(state.as_ref(), &selected_topics)
         .await?;
     let prepared = state
         .subscription_hub
@@ -3506,6 +3516,67 @@ mod tests {
             limit: Some(20),
             upstream_account_id: None,
         }
+    }
+
+    #[tokio::test]
+    async fn first_dashboard_owner_starts_pending_runtime_projection_producer() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let topic = SubscriptionTopic::DashboardActivityCurrent {
+            range: "today".to_string(),
+            time_zone: SUBSCRIPTION_DEFAULT_TIME_ZONE.to_string(),
+            recent_limit: 16,
+            include_accounts: true,
+            include_recent: true,
+        };
+        state
+            .subscription_hub
+            .prepare_connection(state.clone(), vec![topic.descriptor()], Vec::new())
+            .await
+            .expect("prime a disconnected dashboard topic");
+        state.dashboard_network_speed_cache.record_request_bytes(
+            "network-before-owner",
+            "2026-08-04 12:00:00",
+            Some(42),
+            Some("api.openai.com"),
+            128,
+            Utc::now(),
+        );
+        schedule_dashboard_activity_live_snapshot(state.as_ref());
+        assert!(
+            state
+                .proxy_runtime_invocations
+                .pending_dashboard_deadline()
+                .is_some()
+        );
+        let mut receiver = state.broadcaster.subscribe();
+
+        let _lease = state
+            .subscription_hub
+            .register_topic_subscribers(state.as_ref(), std::slice::from_ref(&topic))
+            .await
+            .expect("register first dashboard owner");
+        let snapshot = tokio::time::timeout(Duration::from_millis(600), async {
+            loop {
+                if let Ok(BroadcastPayload::DashboardActivityLive { snapshot }) =
+                    receiver.recv().await
+                {
+                    return snapshot;
+                }
+            }
+        })
+        .await
+        .expect("first owner should start pending projection producer");
+
+        assert_eq!(
+            snapshot
+                .network_live_bucket
+                .expect("global live bucket")
+                .upload_bytes,
+            128
+        );
     }
 
     #[tokio::test]

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -614,7 +614,15 @@ impl SubscriptionHub {
             .active_topic_names
             .entry(topic_name.to_string())
             .or_insert(0) += 1;
-        let dashboard_live_topic_count = usize::from(topic_name == "dashboard.activity.current");
+        let dashboard_live_topic_count = usize::from(
+            topic_name == "dashboard.activity.current"
+                || guard.topics.values().any(|cached| {
+                    cached.topic.name() == topic_name
+                        && (cached.topic.uses_dashboard_activity_live_overlay()
+                            || cached.topic.uses_summary_live_overlay()
+                            || cached.topic.uses_dashboard_network_live_snapshot())
+                }),
+        );
         guard.dashboard_live_subscriber_count = guard
             .dashboard_live_subscriber_count
             .saturating_add(dashboard_live_topic_count);

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -214,7 +214,7 @@ pub(crate) struct TopicSubscriptionLease {
     hub: Arc<SubscriptionHub>,
     topic_keys: Vec<String>,
     topic_names: Vec<String>,
-    dashboard_live_topic_count: usize,
+    owns_dashboard_live: bool,
 }
 
 impl Drop for TopicSubscriptionLease {
@@ -225,9 +225,9 @@ impl Drop for TopicSubscriptionLease {
         let hub = self.hub.clone();
         let topic_keys = std::mem::take(&mut self.topic_keys);
         let topic_names = std::mem::take(&mut self.topic_names);
-        let dashboard_live_topic_count = self.dashboard_live_topic_count;
+        let owns_dashboard_live = self.owns_dashboard_live;
         tokio::spawn(async move {
-            hub.release_topic_subscribers(topic_keys, topic_names, dashboard_live_topic_count)
+            hub.release_topic_subscribers(topic_keys, topic_names, owns_dashboard_live)
                 .await;
         });
     }
@@ -559,14 +559,11 @@ impl SubscriptionHub {
         self: &Arc<Self>,
         topics: &[SubscriptionTopic],
     ) -> Result<TopicSubscriptionLease, ApiError> {
-        let dashboard_live_topic_count = topics
-            .iter()
-            .filter(|topic| {
-                topic.uses_dashboard_activity_live_overlay()
-                    || topic.uses_summary_live_overlay()
-                    || topic.uses_dashboard_network_live_snapshot()
-            })
-            .count();
+        let owns_dashboard_live = topics.iter().any(|topic| {
+            topic.uses_dashboard_activity_live_overlay()
+                || topic.uses_summary_live_overlay()
+                || topic.uses_dashboard_network_live_snapshot()
+        });
         let topic_keys = topics
             .iter()
             .map(SubscriptionTopic::cache_key)
@@ -595,12 +592,12 @@ impl SubscriptionHub {
         }
         guard.dashboard_live_subscriber_count = guard
             .dashboard_live_subscriber_count
-            .saturating_add(dashboard_live_topic_count);
+            .saturating_add(usize::from(owns_dashboard_live));
         Ok(TopicSubscriptionLease {
             hub: self.clone(),
             topic_keys,
             topic_names,
-            dashboard_live_topic_count,
+            owns_dashboard_live,
         })
     }
 
@@ -614,18 +611,16 @@ impl SubscriptionHub {
             .active_topic_names
             .entry(topic_name.to_string())
             .or_insert(0) += 1;
-        let dashboard_live_topic_count = usize::from(
-            topic_name == "dashboard.activity.current"
-                || guard.topics.values().any(|cached| {
-                    cached.topic.name() == topic_name
-                        && (cached.topic.uses_dashboard_activity_live_overlay()
-                            || cached.topic.uses_summary_live_overlay()
-                            || cached.topic.uses_dashboard_network_live_snapshot())
-                }),
-        );
+        let owns_dashboard_live = topic_name == "dashboard.activity.current"
+            || guard.topics.values().any(|cached| {
+                cached.topic.name() == topic_name
+                    && (cached.topic.uses_dashboard_activity_live_overlay()
+                        || cached.topic.uses_summary_live_overlay()
+                        || cached.topic.uses_dashboard_network_live_snapshot())
+            });
         guard.dashboard_live_subscriber_count = guard
             .dashboard_live_subscriber_count
-            .saturating_add(dashboard_live_topic_count);
+            .saturating_add(usize::from(owns_dashboard_live));
         let topic_keys = guard
             .topics
             .iter()
@@ -642,7 +637,7 @@ impl SubscriptionHub {
             hub: self.clone(),
             topic_keys,
             topic_names: vec![topic_name.to_string()],
-            dashboard_live_topic_count,
+            owns_dashboard_live,
         }
     }
 
@@ -650,7 +645,7 @@ impl SubscriptionHub {
         &self,
         topic_keys: Vec<String>,
         topic_names: Vec<String>,
-        dashboard_live_topic_count: usize,
+        owns_dashboard_live: bool,
     ) {
         let mut guard = self.state.lock().await;
         for topic_key in topic_keys {
@@ -673,7 +668,7 @@ impl SubscriptionHub {
         }
         guard.dashboard_live_subscriber_count = guard
             .dashboard_live_subscriber_count
-            .saturating_sub(dashboard_live_topic_count);
+            .saturating_sub(usize::from(owns_dashboard_live));
     }
 
     async fn register_server_push_topics(
@@ -3487,6 +3482,7 @@ mod tests {
             include_accounts: true,
             include_recent: true,
         };
+        let selected_topics = vec![topic.clone(), summary_topic()];
         state.dashboard_network_speed_cache.record_request_bytes(
             "network-before-owner",
             "2026-08-04 12:00:00",
@@ -3504,7 +3500,7 @@ mod tests {
         );
         let _lease = state
             .subscription_hub
-            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .register_topic_subscribers(&selected_topics)
             .await
             .expect("register first dashboard owner");
         assert!(
@@ -3513,9 +3509,23 @@ mod tests {
                 .has_active_dashboard_activity_live_topic()
                 .await
         );
+        assert_eq!(
+            state
+                .subscription_hub
+                .dashboard_activity_live_subscriber_count()
+                .await,
+            1
+        );
         let prepared = state
             .subscription_hub
-            .prepare_connection(state.clone(), vec![topic.descriptor()], Vec::new())
+            .prepare_connection(
+                state.clone(),
+                selected_topics
+                    .iter()
+                    .map(SubscriptionTopic::descriptor)
+                    .collect(),
+                Vec::new(),
+            )
             .await
             .expect("prepare first dashboard owner connection");
         assert!(!prepared.initial.is_empty());

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -167,6 +167,7 @@ struct SubscriptionHubState {
     topics: HashMap<String, CachedSubscriptionTopic>,
     active_subscribers: HashMap<String, usize>,
     active_topic_names: HashMap<String, usize>,
+    dashboard_live_subscriber_count: usize,
     server_push_subscribers: HashMap<String, usize>,
     server_push_tasks: HashSet<String>,
 }
@@ -213,6 +214,7 @@ pub(crate) struct TopicSubscriptionLease {
     hub: Arc<SubscriptionHub>,
     topic_keys: Vec<String>,
     topic_names: Vec<String>,
+    dashboard_live_topic_count: usize,
 }
 
 impl Drop for TopicSubscriptionLease {
@@ -223,8 +225,10 @@ impl Drop for TopicSubscriptionLease {
         let hub = self.hub.clone();
         let topic_keys = std::mem::take(&mut self.topic_keys);
         let topic_names = std::mem::take(&mut self.topic_names);
+        let dashboard_live_topic_count = self.dashboard_live_topic_count;
         tokio::spawn(async move {
-            hub.release_topic_subscribers(topic_keys, topic_names).await;
+            hub.release_topic_subscribers(topic_keys, topic_names, dashboard_live_topic_count)
+                .await;
         });
     }
 }
@@ -537,108 +541,32 @@ impl SubscriptionHub {
 
     pub(crate) async fn has_active_dashboard_activity_live_topic(&self) -> bool {
         let guard = self.state.lock().await;
-        let has_cached_live_topic = guard.topics.iter().any(|(topic_key, cached)| {
-            (cached.topic.uses_dashboard_activity_live_overlay()
-                || cached.topic.uses_summary_live_overlay()
-                || cached.topic.uses_dashboard_network_live_snapshot())
-                && guard
-                    .active_subscribers
-                    .get(topic_key)
-                    .copied()
-                    .unwrap_or_default()
-                    > 0
-        });
-        #[cfg(test)]
-        if has_cached_live_topic {
-            return true;
-        }
-        #[cfg(test)]
-        if guard
-            .active_topic_names
-            .get("dashboard.activity.current")
-            .copied()
-            .unwrap_or_default()
-            > 0
-        {
-            return true;
-        }
-        has_cached_live_topic
+        guard.dashboard_live_subscriber_count > 0
     }
 
     pub(crate) async fn dashboard_activity_live_subscriber_count(&self) -> usize {
-        let guard = self.state.lock().await;
-        let cached_count = guard
-            .topics
-            .iter()
-            .filter(|(_, cached)| {
-                cached.topic.uses_dashboard_activity_live_overlay()
-                    || cached.topic.uses_summary_live_overlay()
-                    || cached.topic.uses_dashboard_network_live_snapshot()
-            })
-            .map(|(topic_key, _)| {
-                guard
-                    .active_subscribers
-                    .get(topic_key)
-                    .copied()
-                    .unwrap_or_default()
-            })
-            .sum::<usize>();
-        #[cfg(test)]
-        {
-            cached_count.max(
-                guard
-                    .active_topic_names
-                    .get("dashboard.activity.current")
-                    .copied()
-                    .unwrap_or_default(),
-            )
-        }
-        #[cfg(not(test))]
-        cached_count
+        self.state.lock().await.dashboard_live_subscriber_count
     }
 
     pub(crate) fn has_active_dashboard_activity_live_topic_sync(&self) -> bool {
         let Ok(guard) = self.state.try_lock() else {
             return true;
         };
-        let has_cached_live_topic = guard.topics.iter().any(|(topic_key, cached)| {
-            (cached.topic.uses_dashboard_activity_live_overlay()
-                || cached.topic.uses_summary_live_overlay()
-                || cached.topic.uses_dashboard_network_live_snapshot())
-                && guard
-                    .active_subscribers
-                    .get(topic_key)
-                    .copied()
-                    .unwrap_or_default()
-                    > 0
-        });
-        #[cfg(test)]
-        if has_cached_live_topic {
-            return true;
-        }
-        #[cfg(test)]
-        if guard
-            .active_topic_names
-            .get("dashboard.activity.current")
-            .copied()
-            .unwrap_or_default()
-            > 0
-        {
-            return true;
-        }
-        has_cached_live_topic
+        guard.dashboard_live_subscriber_count > 0
     }
 
     async fn register_topic_subscribers(
         self: &Arc<Self>,
-        state: &AppState,
         topics: &[SubscriptionTopic],
     ) -> Result<TopicSubscriptionLease, ApiError> {
-        let owns_dashboard_live = topics.iter().any(|topic| {
-            topic.uses_dashboard_activity_live_overlay()
-                || topic.uses_summary_live_overlay()
-                || topic.uses_dashboard_network_live_snapshot()
-        });
+        let dashboard_live_topic_count = topics
+            .iter()
+            .filter(|topic| {
+                topic.uses_dashboard_activity_live_overlay()
+                    || topic.uses_summary_live_overlay()
+                    || topic.uses_dashboard_network_live_snapshot()
+            })
+            .count();
         let topic_keys = topics
             .iter()
             .map(SubscriptionTopic::cache_key)
@@ -665,14 +593,14 @@ impl SubscriptionHub {
                 .entry(topic_name.clone())
                 .or_insert(0) += 1;
         }
-        drop(guard);
-        if owns_dashboard_live {
-            ensure_dashboard_activity_live_snapshot_producer(state);
-        }
+        guard.dashboard_live_subscriber_count = guard
+            .dashboard_live_subscriber_count
+            .saturating_add(dashboard_live_topic_count);
         Ok(TopicSubscriptionLease {
             hub: self.clone(),
             topic_keys,
             topic_names,
+            dashboard_live_topic_count,
         })
     }
 
@@ -686,6 +614,10 @@ impl SubscriptionHub {
             .active_topic_names
             .entry(topic_name.to_string())
             .or_insert(0) += 1;
+        let dashboard_live_topic_count = usize::from(topic_name == "dashboard.activity.current");
+        guard.dashboard_live_subscriber_count = guard
+            .dashboard_live_subscriber_count
+            .saturating_add(dashboard_live_topic_count);
         let topic_keys = guard
             .topics
             .iter()
@@ -702,10 +634,16 @@ impl SubscriptionHub {
             hub: self.clone(),
             topic_keys,
             topic_names: vec![topic_name.to_string()],
+            dashboard_live_topic_count,
         }
     }
 
-    async fn release_topic_subscribers(&self, topic_keys: Vec<String>, topic_names: Vec<String>) {
+    async fn release_topic_subscribers(
+        &self,
+        topic_keys: Vec<String>,
+        topic_names: Vec<String>,
+        dashboard_live_topic_count: usize,
+    ) {
         let mut guard = self.state.lock().await;
         for topic_key in topic_keys {
             match guard.active_subscribers.get_mut(&topic_key) {
@@ -725,6 +663,9 @@ impl SubscriptionHub {
                 None => {}
             }
         }
+        guard.dashboard_live_subscriber_count = guard
+            .dashboard_live_subscriber_count
+            .saturating_sub(dashboard_live_topic_count);
     }
 
     async fn register_server_push_topics(
@@ -2341,12 +2282,19 @@ pub(crate) async fn topic_sse_stream(
         .collect::<Result<HashSet<_>, _>>()?;
     let topic_lease = state
         .subscription_hub
-        .register_topic_subscribers(state.as_ref(), &selected_topics)
+        .register_topic_subscribers(&selected_topics)
         .await?;
     let prepared = state
         .subscription_hub
         .prepare_connection(state.clone(), descriptors, resume)
         .await?;
+    if selected_topics.iter().any(|topic| {
+        topic.uses_dashboard_activity_live_overlay()
+            || topic.uses_summary_live_overlay()
+            || topic.uses_dashboard_network_live_snapshot()
+    }) {
+        ensure_dashboard_activity_live_snapshot_producer(state.as_ref());
+    }
     tracing::info!(
         attempt = query.attempt,
         reason = query.reason.as_deref().unwrap_or("unknown"),
@@ -3531,11 +3479,6 @@ mod tests {
             include_accounts: true,
             include_recent: true,
         };
-        state
-            .subscription_hub
-            .prepare_connection(state.clone(), vec![topic.descriptor()], Vec::new())
-            .await
-            .expect("prime a disconnected dashboard topic");
         state.dashboard_network_speed_cache.record_request_bytes(
             "network-before-owner",
             "2026-08-04 12:00:00",
@@ -3551,32 +3494,24 @@ mod tests {
                 .pending_dashboard_deadline()
                 .is_some()
         );
-        let mut receiver = state.broadcaster.subscribe();
-
         let _lease = state
             .subscription_hub
-            .register_topic_subscribers(state.as_ref(), std::slice::from_ref(&topic))
+            .register_topic_subscribers(std::slice::from_ref(&topic))
             .await
             .expect("register first dashboard owner");
-        let snapshot = tokio::time::timeout(Duration::from_millis(600), async {
-            loop {
-                if let Ok(BroadcastPayload::DashboardActivityLive { snapshot }) =
-                    receiver.recv().await
-                {
-                    return snapshot;
-                }
-            }
-        })
-        .await
-        .expect("first owner should start pending projection producer");
-
-        assert_eq!(
-            snapshot
-                .network_live_bucket
-                .expect("global live bucket")
-                .upload_bytes,
-            128
+        assert!(
+            state
+                .subscription_hub
+                .has_active_dashboard_activity_live_topic()
+                .await
         );
+        let prepared = state
+            .subscription_hub
+            .prepare_connection(state.clone(), vec![topic.descriptor()], Vec::new())
+            .await
+            .expect("prepare first dashboard owner connection");
+        assert!(!prepared.initial.is_empty());
+        ensure_dashboard_activity_live_snapshot_producer(state.as_ref());
     }
 
     #[tokio::test]

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -74,6 +74,7 @@ pub(crate) struct SystemRuntimePressureHealth {
     pub(crate) process: SystemRuntimePressureProcess,
     pub(crate) allocator: SystemRuntimePressureAllocator,
     pub(crate) writer_accounting: PendingQueueAccountingSnapshot,
+    pub(crate) dashboard_projection: RuntimeProjectionHealthSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -99,7 +100,17 @@ pub(crate) struct SystemStatusResponse {
 pub(crate) async fn load_runtime_pressure_health(state: &AppState) -> SystemRuntimePressureHealth {
     let memory = state.memory_diagnostics.runtime_pressure_snapshot();
     let writer_accounting = state.sqlite_batch_writer.accounting_snapshot();
-    let state = if writer_accounting.state == "degraded" || memory.pressure_level != "normal" {
+    let active_subscriber_count = state
+        .subscription_hub
+        .dashboard_activity_live_subscriber_count()
+        .await;
+    let dashboard_projection = state
+        .proxy_runtime_invocations
+        .health_snapshot(active_subscriber_count);
+    let state = if writer_accounting.state == "degraded"
+        || memory.pressure_level != "normal"
+        || dashboard_projection.state == "degraded"
+    {
         "degraded".to_string()
     } else {
         "healthy".to_string()
@@ -120,6 +131,7 @@ pub(crate) async fn load_runtime_pressure_health(state: &AppState) -> SystemRunt
             malloc_arena_max: memory.malloc_arena_max,
         },
         writer_accounting,
+        dashboard_projection,
     }
 }
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -128,7 +128,24 @@ struct DashboardRuntimeProjectionState {
     degraded_reason: Option<&'static str>,
     reconcile_error: Option<&'static str>,
     last_reconcile_defer_reason: Option<&'static str>,
+    persistence_baseline: Option<DashboardRuntimeProjectionBaseline>,
     memory_ready: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DashboardRuntimeBaselineRecord {
+    pub(crate) key: RuntimeInvocationKey,
+    pub(crate) upstream_account_id: Option<i64>,
+    pub(crate) upstream_account_name: Option<String>,
+    pub(crate) is_retry: bool,
+    pub(crate) live_phase: Option<String>,
+    pub(crate) wait_ms: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DashboardRuntimeProjectionBaseline {
+    pub(crate) records: Vec<DashboardRuntimeBaselineRecord>,
+    pub(crate) source_scope: InvocationSourceScope,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -325,6 +342,7 @@ impl RuntimeProjectionHub {
     pub(crate) fn install_persistence_baseline_if_generation(
         &self,
         mut snapshot: DashboardActivityLiveSnapshot,
+        baseline: DashboardRuntimeProjectionBaseline,
         snapshot_origin: &'static str,
         expected_generation: u64,
     ) -> Result<Option<DashboardProjectionCapture>> {
@@ -354,6 +372,7 @@ impl RuntimeProjectionHub {
         dashboard.degraded_reason = None;
         dashboard.reconcile_error = None;
         dashboard.last_reconcile_defer_reason = None;
+        dashboard.persistence_baseline = Some(baseline);
         dashboard.memory_ready = false;
         Ok(Some(DashboardProjectionCapture {
             snapshot,
@@ -467,9 +486,19 @@ impl DashboardLiveProjection<'_> {
             .dashboard_network_speed_cache
             .get()
             .ok_or_else(|| anyhow!("dashboard network speed cache is not bound"))?;
+        let persistence_baseline = self
+            .hub
+            .dashboard
+            .lock()
+            .map_err(|_| anyhow!("runtime projection state lock is poisoned"))?
+            .persistence_baseline
+            .clone();
+        let (runtime_records, terminal_tombstones) = self.hub.dashboard_projection_inputs();
         Ok(build_dashboard_activity_live_snapshot_from_memory(
             0,
-            self.hub.snapshot(),
+            persistence_baseline,
+            runtime_records,
+            terminal_tombstones,
             dashboard_network_speed_cache.as_ref(),
         ))
     }
@@ -726,6 +755,23 @@ impl RuntimeProjectionHub {
             .values()
             .map(|entry| entry.record.clone())
             .collect()
+    }
+
+    pub(crate) fn dashboard_projection_inputs(
+        &self,
+    ) -> (Vec<ApiInvocation>, HashSet<RuntimeInvocationKey>) {
+        let Ok(mut guard) = self.inner.lock() else {
+            return (Vec::new(), HashSet::new());
+        };
+        let _ = prune_bounded_runtime_invocation_store_locked(&mut guard, Instant::now());
+        (
+            guard
+                .records
+                .values()
+                .map(|entry| entry.record.clone())
+                .collect(),
+            guard.terminal_tombstones.keys().cloned().collect(),
+        )
     }
 
     #[cfg(test)]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -650,10 +650,15 @@ impl RuntimeProjectionHub {
         let Ok(mut guard) = self.inner.lock() else {
             return false;
         };
-        guard
+        let removed = guard
             .terminal_tombstones
             .remove(&RuntimeInvocationKey::new(invoke_id, occurred_at))
-            .is_some()
+            .is_some();
+        drop(guard);
+        if removed {
+            self.mark_dashboard_dirty("terminal_rollback");
+        }
+        removed
     }
 
     pub(crate) fn contains_terminal(&self, invoke_id: &str, occurred_at: &str) -> bool {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -146,6 +146,16 @@ pub(crate) struct DashboardRuntimeBaselineRecord {
 pub(crate) struct DashboardRuntimeProjectionBaseline {
     pub(crate) records: Vec<DashboardRuntimeBaselineRecord>,
     pub(crate) source_scope: InvocationSourceScope,
+    pub(crate) network_open_buckets:
+        HashMap<DashboardNetworkScopeKey, DashboardRuntimeNetworkOpenBucketBaseline>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DashboardRuntimeNetworkOpenBucketBaseline {
+    pub(crate) bucket_start: DateTime<Utc>,
+    pub(crate) bucket_end: DateTime<Utc>,
+    pub(crate) baseline_totals: DashboardNetworkByteTotals,
+    pub(crate) memory_totals_at_install: DashboardNetworkByteTotals,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -270,18 +280,27 @@ impl RuntimeProjectionHub {
         })
     }
 
+    pub(crate) fn begin_dashboard_publish_window(
+        &self,
+        window: DashboardProjectionPublishWindow,
+    ) -> Option<DashboardProjectionPublishWindow> {
+        let mut dashboard = self.dashboard.lock().ok()?;
+        if dashboard.pending_deadline != Some(window.deadline) {
+            return None;
+        }
+        dashboard.pending_deadline = None;
+        Some(DashboardProjectionPublishWindow {
+            deadline: window.deadline,
+            generation: dashboard.dirty_generation,
+        })
+    }
+
     pub(crate) fn complete_dashboard_publish_window(
         &self,
         window: DashboardProjectionPublishWindow,
     ) {
-        let Ok(mut dashboard) = self.dashboard.lock() else {
-            return;
-        };
-        if dashboard.dirty_generation == window.generation {
-            dashboard.pending_deadline = None;
-        } else {
-            dashboard.pending_deadline =
-                Some(Instant::now() + DASHBOARD_RUNTIME_PROJECTION_COALESCE);
+        if let Ok(dashboard) = self.dashboard.lock() {
+            debug_assert!(dashboard.dirty_generation >= window.generation);
         }
     }
 
@@ -744,9 +763,7 @@ impl RuntimeProjectionHub {
         guard.terminal_tombstones.insert(key, now);
         let _ = prune_bounded_runtime_invocation_store_locked(&mut guard, now);
         drop(guard);
-        if removed {
-            self.mark_dashboard_dirty("terminal_persisted");
-        }
+        self.mark_dashboard_dirty("terminal_persisted");
         removed
     }
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -85,9 +85,407 @@ pub(crate) struct RuntimeInvocationStoreRemoveOutcome {
     pub(crate) already_terminal: bool,
 }
 
+pub(crate) const DASHBOARD_RUNTIME_PROJECTION_MODE_ENV: &str = "DASHBOARD_RUNTIME_PROJECTION_MODE";
+pub(crate) const DASHBOARD_RUNTIME_PROJECTION_COALESCE: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeProjectionMode {
+    Auto,
+    Legacy,
+}
+
+impl RuntimeProjectionMode {
+    pub(crate) fn parse(value: Option<&str>) -> Result<Self> {
+        match value.map(str::trim).filter(|value| !value.is_empty()) {
+            None | Some("auto") => Ok(Self::Auto),
+            Some("legacy") => Ok(Self::Legacy),
+            Some(value) => bail!(
+                "invalid {DASHBOARD_RUNTIME_PROJECTION_MODE_ENV} value `{value}`; expected `auto` or `legacy`"
+            ),
+        }
+    }
+
+    pub(crate) fn from_env() -> Result<Self> {
+        let value = std::env::var(DASHBOARD_RUNTIME_PROJECTION_MODE_ENV).ok();
+        Self::parse(value.as_deref())
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Legacy => "legacy",
+        }
+    }
+}
+
 #[derive(Debug, Default)]
-pub(crate) struct ProxyRuntimeInvocationStore {
+struct DashboardRuntimeProjectionState {
+    dirty_generation: u64,
+    pending_deadline: Option<Instant>,
+    last_good: Option<DashboardActivityLiveSnapshot>,
+    last_good_at: Option<Instant>,
+    last_snapshot_origin: Option<&'static str>,
+    degraded_reason: Option<&'static str>,
+    reconcile_error: Option<&'static str>,
+    last_reconcile_defer_reason: Option<&'static str>,
+    memory_ready: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DashboardProjectionPublishWindow {
+    pub(crate) deadline: Instant,
+    pub(crate) generation: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DashboardProjectionCapture {
+    pub(crate) snapshot: DashboardActivityLiveSnapshot,
+    pub(crate) changed: bool,
+    pub(crate) snapshot_origin: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RuntimeProjectionHealthSnapshot {
+    pub(crate) mode: String,
+    pub(crate) state: String,
+    pub(crate) producer_state: String,
+    pub(crate) active_subscriber_count: u64,
+    pub(crate) live_path_db_read_count: u64,
+    pub(crate) build_count: u64,
+    pub(crate) revision: u64,
+    pub(crate) snapshot_origin: String,
+    pub(crate) last_good_age_ms: Option<u64>,
+    pub(crate) degraded_reason: Option<String>,
+    pub(crate) last_defer_reason: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct RuntimeProjectionHub {
     pub(crate) inner: std::sync::Mutex<ProxyRuntimeInvocationStoreInner>,
+    mode: RuntimeProjectionMode,
+    dashboard_network_speed_cache: std::sync::OnceLock<Arc<DashboardNetworkSpeedCache>>,
+    dashboard: std::sync::Mutex<DashboardRuntimeProjectionState>,
+    live_path_db_read_count: AtomicU64,
+    build_count: AtomicU64,
+    producer_running: AtomicBool,
+}
+
+pub(crate) type ProxyRuntimeInvocationStore = RuntimeProjectionHub;
+
+impl Default for RuntimeProjectionHub {
+    fn default() -> Self {
+        Self::new(RuntimeProjectionMode::Auto)
+    }
+}
+
+impl RuntimeProjectionHub {
+    pub(crate) fn new(mode: RuntimeProjectionMode) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(ProxyRuntimeInvocationStoreInner::default()),
+            mode,
+            dashboard_network_speed_cache: std::sync::OnceLock::new(),
+            dashboard: std::sync::Mutex::new(DashboardRuntimeProjectionState::default()),
+            live_path_db_read_count: AtomicU64::new(0),
+            build_count: AtomicU64::new(0),
+            producer_running: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn mode(&self) -> RuntimeProjectionMode {
+        self.mode
+    }
+
+    pub(crate) fn bind_dashboard_network_speed_cache(
+        &self,
+        cache: Arc<DashboardNetworkSpeedCache>,
+    ) -> Result<()> {
+        if let Some(existing) = self.dashboard_network_speed_cache.get() {
+            return if Arc::ptr_eq(existing, &cache) {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "runtime projection hub is already bound to another dashboard network cache"
+                ))
+            };
+        }
+        self.dashboard_network_speed_cache
+            .set(cache)
+            .map_err(|_| anyhow!("dashboard network speed cache is already bound"))
+    }
+
+    pub(crate) fn dashboard_live_projection(&self) -> DashboardLiveProjection<'_> {
+        DashboardLiveProjection { hub: self }
+    }
+
+    pub(crate) fn mark_dashboard_dirty(&self, trigger: &'static str) {
+        self.mark_dashboard_dirty_at(trigger, Instant::now());
+    }
+
+    pub(crate) fn mark_dashboard_dirty_at(&self, _trigger: &'static str, now: Instant) {
+        let Ok(mut dashboard) = self.dashboard.lock() else {
+            return;
+        };
+        dashboard.dirty_generation = dashboard.dirty_generation.saturating_add(1);
+        dashboard.memory_ready = true;
+        if dashboard.pending_deadline.is_none() {
+            dashboard.pending_deadline = Some(now + DASHBOARD_RUNTIME_PROJECTION_COALESCE);
+        }
+    }
+
+    pub(crate) fn pending_dashboard_deadline(&self) -> Option<Instant> {
+        self.dashboard
+            .lock()
+            .ok()
+            .and_then(|dashboard| dashboard.pending_deadline)
+    }
+
+    pub(crate) fn pending_dashboard_publish_window(
+        &self,
+    ) -> Option<DashboardProjectionPublishWindow> {
+        self.dashboard.lock().ok().and_then(|dashboard| {
+            dashboard
+                .pending_deadline
+                .map(|deadline| DashboardProjectionPublishWindow {
+                    deadline,
+                    generation: dashboard.dirty_generation,
+                })
+        })
+    }
+
+    pub(crate) fn complete_dashboard_publish_window(
+        &self,
+        window: DashboardProjectionPublishWindow,
+    ) {
+        let Ok(mut dashboard) = self.dashboard.lock() else {
+            return;
+        };
+        if dashboard.dirty_generation == window.generation {
+            dashboard.pending_deadline = None;
+        } else {
+            dashboard.pending_deadline =
+                Some(Instant::now() + DASHBOARD_RUNTIME_PROJECTION_COALESCE);
+        }
+    }
+
+    pub(crate) fn is_memory_ready(&self) -> bool {
+        self.dashboard
+            .lock()
+            .map(|dashboard| dashboard.memory_ready && dashboard.degraded_reason.is_none())
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn dashboard_generation(&self) -> u64 {
+        self.dashboard
+            .lock()
+            .map(|dashboard| dashboard.dirty_generation)
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn capture_memory_snapshot(&self) -> Result<DashboardProjectionCapture> {
+        let candidate = self.dashboard_live_projection().snapshot()?;
+        self.build_count.fetch_add(1, Ordering::Relaxed);
+        let mut dashboard = self
+            .dashboard
+            .lock()
+            .map_err(|_| anyhow!("runtime projection state lock is poisoned"))?;
+        let changed = dashboard
+            .last_good
+            .as_ref()
+            .is_none_or(|current| !dashboard_live_snapshot_content_eq(current, &candidate));
+        if !changed {
+            let snapshot = dashboard
+                .last_good
+                .clone()
+                .expect("unchanged projection has a last-good snapshot");
+            dashboard.memory_ready = true;
+            dashboard.degraded_reason = None;
+            dashboard.last_snapshot_origin = Some("memory");
+            return Ok(DashboardProjectionCapture {
+                snapshot,
+                changed: false,
+                snapshot_origin: "memory",
+            });
+        }
+
+        let mut snapshot = candidate;
+        snapshot.revision = reserve_dashboard_activity_live_revision();
+        dashboard.last_good = Some(snapshot.clone());
+        dashboard.last_good_at = Some(Instant::now());
+        dashboard.last_snapshot_origin = Some("memory");
+        dashboard.degraded_reason = None;
+        dashboard.memory_ready = true;
+        Ok(DashboardProjectionCapture {
+            snapshot,
+            changed: true,
+            snapshot_origin: "memory",
+        })
+    }
+
+    pub(crate) fn install_persistence_baseline_if_generation(
+        &self,
+        mut snapshot: DashboardActivityLiveSnapshot,
+        snapshot_origin: &'static str,
+        expected_generation: u64,
+    ) -> Result<Option<DashboardProjectionCapture>> {
+        let mut dashboard = self
+            .dashboard
+            .lock()
+            .map_err(|_| anyhow!("runtime projection state lock is poisoned"))?;
+        if dashboard.dirty_generation != expected_generation {
+            return Ok(None);
+        }
+        let changed = dashboard
+            .last_good
+            .as_ref()
+            .is_none_or(|current| !dashboard_live_snapshot_content_eq(current, &snapshot));
+        let snapshot = if changed {
+            snapshot.revision = reserve_dashboard_activity_live_revision();
+            dashboard.last_good = Some(snapshot.clone());
+            dashboard.last_good_at = Some(Instant::now());
+            snapshot
+        } else {
+            dashboard
+                .last_good
+                .clone()
+                .expect("unchanged baseline has a last-good snapshot")
+        };
+        dashboard.last_snapshot_origin = Some(snapshot_origin);
+        dashboard.degraded_reason = None;
+        dashboard.reconcile_error = None;
+        dashboard.last_reconcile_defer_reason = None;
+        dashboard.memory_ready = false;
+        Ok(Some(DashboardProjectionCapture {
+            snapshot,
+            changed,
+            snapshot_origin,
+        }))
+    }
+
+    pub(crate) fn last_good_capture(
+        &self,
+        snapshot_origin: &'static str,
+    ) -> Option<DashboardProjectionCapture> {
+        let mut dashboard = self.dashboard.lock().ok()?;
+        let snapshot = dashboard.last_good.clone()?;
+        dashboard.last_snapshot_origin = Some(snapshot_origin);
+        Some(DashboardProjectionCapture {
+            snapshot,
+            changed: false,
+            snapshot_origin,
+        })
+    }
+
+    pub(crate) fn mark_degraded(&self, reason: &'static str) {
+        if let Ok(mut dashboard) = self.dashboard.lock() {
+            dashboard.degraded_reason = Some(reason);
+        }
+    }
+
+    pub(crate) fn record_reconcile_failure(&self, reason: &'static str) {
+        if let Ok(mut dashboard) = self.dashboard.lock() {
+            dashboard.reconcile_error = Some(reason);
+            dashboard.last_reconcile_defer_reason = None;
+        }
+    }
+
+    pub(crate) fn record_reconcile_deferred(&self, reason: &'static str) {
+        if let Ok(mut dashboard) = self.dashboard.lock() {
+            dashboard.last_reconcile_defer_reason = Some(reason);
+        }
+    }
+
+    pub(crate) fn record_live_path_db_read(&self) {
+        self.live_path_db_read_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_build(&self) {
+        self.build_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn set_producer_running(&self, running: bool) {
+        self.producer_running.store(running, Ordering::Release);
+    }
+
+    pub(crate) fn health_snapshot(
+        &self,
+        active_subscriber_count: usize,
+    ) -> RuntimeProjectionHealthSnapshot {
+        let dashboard = self.dashboard.lock().ok();
+        let last_good_age_ms = dashboard
+            .as_ref()
+            .and_then(|state| state.last_good_at)
+            .map(|captured_at| captured_at.elapsed().as_millis() as u64);
+        let state = match dashboard.as_ref() {
+            Some(state) if state.degraded_reason.is_some() || state.reconcile_error.is_some() => {
+                "degraded"
+            }
+            Some(state) if state.memory_ready || state.last_good.is_some() => "healthy",
+            _ => "cold",
+        };
+        RuntimeProjectionHealthSnapshot {
+            mode: self.mode.as_str().to_string(),
+            state: state.to_string(),
+            producer_state: if self.producer_running.load(Ordering::Acquire) {
+                "running".to_string()
+            } else {
+                "idle".to_string()
+            },
+            active_subscriber_count: active_subscriber_count as u64,
+            live_path_db_read_count: self.live_path_db_read_count.load(Ordering::Relaxed),
+            build_count: self.build_count.load(Ordering::Relaxed),
+            revision: dashboard
+                .as_ref()
+                .and_then(|state| state.last_good.as_ref())
+                .map_or(0, |snapshot| snapshot.revision),
+            snapshot_origin: dashboard
+                .as_ref()
+                .and_then(|state| state.last_snapshot_origin)
+                .unwrap_or("none")
+                .to_string(),
+            last_good_age_ms,
+            degraded_reason: dashboard
+                .as_ref()
+                .and_then(|state| state.degraded_reason.or(state.reconcile_error))
+                .map(str::to_string),
+            last_defer_reason: dashboard
+                .as_ref()
+                .and_then(|state| state.last_reconcile_defer_reason)
+                .map(str::to_string),
+        }
+    }
+}
+
+pub(crate) struct DashboardLiveProjection<'a> {
+    hub: &'a RuntimeProjectionHub,
+}
+
+impl DashboardLiveProjection<'_> {
+    pub(crate) fn snapshot(&self) -> Result<DashboardActivityLiveSnapshot> {
+        let dashboard_network_speed_cache = self
+            .hub
+            .dashboard_network_speed_cache
+            .get()
+            .ok_or_else(|| anyhow!("dashboard network speed cache is not bound"))?;
+        Ok(build_dashboard_activity_live_snapshot_from_memory(
+            0,
+            self.hub.snapshot(),
+            dashboard_network_speed_cache.as_ref(),
+        ))
+    }
+}
+
+fn dashboard_live_snapshot_content_eq(
+    left: &DashboardActivityLiveSnapshot,
+    right: &DashboardActivityLiveSnapshot,
+) -> bool {
+    let mut left = left.clone();
+    let mut right = right.clone();
+    left.revision = 0;
+    right.revision = 0;
+    left.generated_at.clear();
+    right.generated_at.clear();
+    left == right
 }
 
 #[derive(Debug, Default)]
@@ -101,7 +499,7 @@ pub(crate) const PROXY_RUNTIME_INVOCATION_STORE_MAX_AGE: Duration =
 pub(crate) const PROXY_RUNTIME_INVOCATION_STORE_MAX_RECORDS: usize = 10_000;
 pub(crate) const PROXY_RUNTIME_INVOCATION_TERMINAL_TOMBSTONE_MAX_RECORDS: usize = 50_000;
 
-impl ProxyRuntimeInvocationStore {
+impl RuntimeProjectionHub {
     pub(crate) fn runtime_record_count(&self) -> usize {
         self.inner
             .lock()
@@ -168,11 +566,14 @@ impl ProxyRuntimeInvocationStore {
         );
         let pruned_count =
             pruned_count + prune_bounded_runtime_invocation_store_locked(&mut guard, now);
-        RuntimeInvocationStoreUpsertOutcome {
+        let outcome = RuntimeInvocationStoreUpsertOutcome {
             running_count: guard.records.len(),
             pruned_count,
             skipped_terminal: false,
-        }
+        };
+        drop(guard);
+        self.mark_dashboard_dirty("runtime_upsert");
+        outcome
     }
 
     pub(crate) fn upsert_terminal(
@@ -207,10 +608,13 @@ impl ProxyRuntimeInvocationStore {
             .is_some();
         guard.terminal_tombstones.insert(key, now);
         let _ = prune_bounded_runtime_invocation_store_locked(&mut guard, now);
-        RuntimeInvocationStoreRemoveOutcome {
+        let outcome = RuntimeInvocationStoreRemoveOutcome {
             removed,
             already_terminal: false,
-        }
+        };
+        drop(guard);
+        self.mark_dashboard_dirty("terminal_delta");
+        outcome
     }
 
     pub(crate) fn clear_terminal_tombstone(&self, invoke_id: &str, occurred_at: &str) -> bool {
@@ -259,6 +663,10 @@ impl ProxyRuntimeInvocationStore {
         if removed.is_some() {
             let _ = prune_bounded_runtime_invocation_store_locked(&mut guard, Instant::now());
         }
+        drop(guard);
+        if removed.is_some() {
+            self.mark_dashboard_dirty("runtime_remove");
+        }
         removed
     }
 
@@ -281,6 +689,10 @@ impl ProxyRuntimeInvocationStore {
         if removed_count > 0 {
             let _ = prune_bounded_runtime_invocation_store_locked(&mut guard, Instant::now());
         }
+        drop(guard);
+        if removed_count > 0 {
+            self.mark_dashboard_dirty("runtime_remove");
+        }
         removed_count
     }
 
@@ -297,6 +709,10 @@ impl ProxyRuntimeInvocationStore {
         let removed = guard.records.remove(&key).is_some();
         guard.terminal_tombstones.insert(key, now);
         let _ = prune_bounded_runtime_invocation_store_locked(&mut guard, now);
+        drop(guard);
+        if removed {
+            self.mark_dashboard_dirty("terminal_persisted");
+        }
         removed
     }
 
@@ -480,7 +896,7 @@ pub(crate) struct AppState {
     pub(crate) process_started_at_utc: DateTime<Utc>,
     pub(crate) sqlite_batch_writer: Arc<SqliteBatchWriter>,
     pub(crate) pool_account_selection_runtime: Arc<PoolAccountSelectionRuntime>,
-    pub(crate) proxy_runtime_invocations: Arc<ProxyRuntimeInvocationStore>,
+    pub(crate) proxy_runtime_invocations: Arc<RuntimeProjectionHub>,
     pub(crate) dashboard_network_speed_cache: Arc<DashboardNetworkSpeedCache>,
     pub(crate) oauth_installation_seed: [u8; 32],
     pub(crate) hourly_rollup_sync_lock: Arc<Mutex<()>>,

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1355,6 +1355,9 @@ impl Drop for PoolViaRuntimeSnapshotCleanupGuard {
             .state
             .proxy_runtime_invocations
             .remove_non_terminal_by_invoke_id(&self.invoke_id);
+        if removed_count > 0 {
+            schedule_dashboard_activity_live_snapshot(self.state.as_ref());
+        }
         debug!(
             invoke_id = %self.invoke_id,
             removed_count,

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -1803,6 +1803,7 @@ pub(crate) async fn recover_guard_dropped_pool_early_phase_orphan(
             &pending_attempt_record.occurred_at,
             "drop_guard",
         );
+        schedule_dashboard_activity_live_snapshot(state);
     }
 
     if should_clean_up_route {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -123,9 +123,12 @@ pub(crate) async fn run() -> Result<()> {
 
     let prompt_cache_conversation_cache =
         Arc::new(Mutex::new(PromptCacheConversationsCacheState::default()));
-    let proxy_runtime_invocations = Arc::new(ProxyRuntimeInvocationStore::default());
+    let proxy_runtime_invocations =
+        Arc::new(RuntimeProjectionHub::new(RuntimeProjectionMode::from_env()?));
     let dashboard_network_speed_cache =
         Arc::new(DashboardNetworkSpeedCache::new(process_started_at_utc));
+    proxy_runtime_invocations
+        .bind_dashboard_network_speed_cache(dashboard_network_speed_cache.clone())?;
     let dashboard_activity_snapshot_cache =
         Arc::new(Mutex::new(DashboardActivitySnapshotCacheState::default()));
     let terminal_projection_hub = Arc::new(TerminalProjectionHub::default());
@@ -193,6 +196,8 @@ pub(crate) async fn run() -> Result<()> {
         pool_no_available_wait: PoolNoAvailableWaitSettings::default(),
         upstream_accounts,
     });
+    warm_dashboard_runtime_projection(state.as_ref()).await;
+    spawn_dashboard_runtime_projection_reconcile(state.clone());
     spawn_subscription_broadcast_listener(state.clone());
     spawn_system_raw_payload_metrics_inventory(state.clone(), state.shutdown.clone());
     spawn_memory_diagnostics(state.clone(), state.shutdown.clone());

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -15410,6 +15410,9 @@ async fn dashboard_activity_cached_snapshot_overlays_new_live_accounts() {
             },
             Utc::now(),
         );
+    reconcile_dashboard_runtime_projection_once(state.as_ref())
+        .await
+        .expect("reconcile dashboard runtime projection after direct database fixture writes");
 
     let Json(cached_response) = fetch_dashboard_activity(
         State(state.clone()),

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -366,6 +366,10 @@ async fn runtime_pressure_health_serializes_without_sql() {
     assert!(payload["process"]["unattributedAnonBytes"].is_u64());
     assert!(payload["allocator"]["mallocArenaMax"].is_string());
     assert_eq!(payload["writerAccounting"]["state"], "healthy");
+    assert_eq!(payload["dashboardProjection"]["mode"], "auto");
+    assert_eq!(payload["dashboardProjection"]["livePathDbReadCount"], 0);
+    assert!(payload["dashboardProjection"]["buildCount"].is_u64());
+    assert!(payload["dashboardProjection"]["activeSubscriberCount"].is_u64());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary\n- add the Dashboard RuntimeProjectionHub and memory-only live snapshot boundary\n- keep startup/cold fallback and 60-second reconcile behavior while preventing healthy live-path SQLite reads\n- add fixed 250ms coalescing, revision suppression, health telemetry, and stateful/performance coverage\n\nCloses #736\nParent: #733\n\n## Verification\n- cargo fmt --check\n- cargo check\n- targeted Dashboard runtime projection, SSE, stateful, and System Status tests\n- pre-commit hooks, including all-target Clippy and Web typecheck\n\n## References\n- Specs: docs/specs/high-frequency-runtime-data-plane\n- Solutions: docs/solutions/performance/realtime-dashboard-reconcile-budget.md\n- Project Docs: -\n\n## Notes\n- No owner-facing UI or wire-shape changes.\n- Aggregate documentation and full-stack validation remain tracked by #739.