### PR TITLE
fix(proxy): coordinate SQLite hot writes

### DIFF
--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -127,3 +127,10 @@
 - Terminal admission, projection updates, and persistence acknowledgements are separate ownership boundaries. P1 raw durability must not wait for P2 rollups, account touches, or maintenance writes; each consumer needs its own cursor and dirty-last-good state.
 - A fixed publish deadline must not invalidate a database snapshot on every terminal event. Publish current-state changes from memory, reconcile baselines on a longer cadence, and defer reconciliation during writer pressure with explicit last-good age and defer telemetry.
 - memory-first 只能排除数据库成本，不能自动排除 CPU 放大。projection snapshot、topic overlay 与 delivery frame 必须形成单向 typed 边界；完整业务对象广播、cached JSON 深拷贝和多 topic 重复序列化仍会在零 SQL 情况下制造高 CPU 与 subscription lag。
+
+## Proxy hot-write coordination
+
+- SQLite 的单 writer 约束要求代理 terminal、attempt、route/account 状态和派生统计共享同一个 admission 面；只给后台任务加 pressure gate 不能阻止前台 helper 相互争锁。
+- P1 batch 必须同时限定条数、估算字节和 admission 时间。锁冲突要保留完整未提交批次并指数退避；固定短 ticker 会把一次外部锁放大为稳定 CPU/日志风暴。
+- 同步 attempt/route 可以保留原返回语义，但应在事务前按优先级等待。P2 只有在 P1 与同步 waiter 为空时运行，并且 cursor replay 必须按 chunk 让出 writer。
+- 健康诊断必须展示 active write class、waiter、retry generation、下一次 retry、batch rows/bytes 与 direct bypass；否则“排队成功”仍可能掩盖未迁移的直写入口。

--- a/docs/specs/high-frequency-runtime-data-plane/HISTORY.md
+++ b/docs/specs/high-frequency-runtime-data-plane/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## Key Decisions
 
+- 统一代理 terminal、attempt、route 与派生写的 SQLite admission，删除 P1 retained batch 固定 250ms 重试语义，并限制 P2 rollup 单事务工作量。
+
 - 高频路径的边界由类型依赖和计数测试约束，不再仅依赖“memory-first”命名或日志字段。
 - request body 只允许一个 replay snapshot 和一个语义投影；file-backed body 不因 dispatch/rewrite 再变成完整内存副本。
 - Dashboard current-state 与 terminal totals 使用不同 cadence：前者 `250ms`，后者 `5s`；SQLite reconcile 保持 `60s`。

--- a/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
+++ b/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
@@ -1,5 +1,9 @@
 # High-Frequency Runtime Data Plane Implementation
 
+`ProxySqliteWriteCoordinator` 是代理热写的统一 admission 面。实现覆盖 terminal P1/P2 actor、attempt 生命周期和 route success/failure 汇聚路径，并通过 `runtimePressureHealth.proxySqliteWriteCoordinator` 暴露 active class、各优先级 waiter 与 legacy bypass 计数。
+
+P1 正常 admission 为 20ms，批次上限为 32 条或 4 MiB；失败后按 250ms 到 5s 退避。P2 hourly replay 每次只执行一个既有有界 chunk，未覆盖 derived work 保留到下一轮。
+
 ## Delivery Topology
 
 - Integration branch: `prd/dashboard-runtime-delivery-plane`

--- a/docs/specs/high-frequency-runtime-data-plane/SPEC.md
+++ b/docs/specs/high-frequency-runtime-data-plane/SPEC.md
@@ -47,6 +47,8 @@
 
 ### Persistence And Reconcile
 
+代理请求热写必须经过统一写协调器。P1 terminal、同步 attempt/route 与 P2 derived 的优先级固定，禁止同一代理生命周期内的多个 helper 独立争抢 SQLite writer。P1 采用有界短批次并在 commit 后 ACK；锁冲突保留完整批次并指数退避，新事件只能合并，不能重置 retry deadline。P2 不得在一个事务内无界追赶 rollup cursor。
+
 - SQLite 是 terminal durable source、projection warm restore、closed-range exact query 与 drift reconcile 的事实源，不是 Dashboard current-state 的请求内查询依赖。
 - terminal totals 使用 `5s` 内存发布，baseline reconcile 使用 `60s` cadence。压力或 last-good 状态机沿用既有退避与精确恢复语义。
 - `PendingQueueAccounting` 统一拥有 enqueue、coalesce、batch replacement、P1 -> P2 transfer 与 completion 的 byte/depth 变化；业务阶段不得直接执行裸 `fetch_sub`。

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
@@ -112,6 +112,8 @@ PR: none
 
 ## Runtime Data Plane Boundary
 
+代理热路径中的 attempt begin/progress/final、response capture 与 route/account 状态写保持同步结果语义，但必须通过统一 SQLite 写协调器排队。该约束不改变请求转发、failover 或 body 解析语义；大请求解析 CPU 只做 thread-clock 归因，达到独立门槛后另行优化。
+
 - 本 topic 的 request body 语义受 [`high-frequency-runtime-data-plane`](../high-frequency-runtime-data-plane/SPEC.md) 约束：每个请求只允许一份 replay snapshot 与一次 `RequestSemanticProjection`。
 - `>1 MiB` 的 file-backed snapshot 不得在 dispatch、routing、rewrite 或 raw capture 中整体 `into_vec()`；需要转换时使用至多 `64 KiB` 业务缓冲。
 - legacy 模式只用于运维回退，不得被视为健康路径或性能验收证据。

--- a/docs/specs/vmcs3-terminal-projection-materialization/SPEC.md
+++ b/docs/specs/vmcs3-terminal-projection-materialization/SPEC.md
@@ -32,6 +32,8 @@ Dashboard 已有受限的实时累计态，但长期统计仍可能由定时任�
 
 ## Runtime Data Plane Boundary
 
+Terminal journal 的 durable ACK 只能发生在 P1 SQLite 事务提交后。P1 锁冲突时保留完整未提交批次并指数退避；新 terminal 事件不得提前既有重试 deadline。P2 projection materialization 不参与 P1 ACK，也不得在单事务内无界追赶 cursor。
+
 - `TerminalProjectionHub` 继续拥有 terminal durable cursor；current-state 由 [`RuntimeProjectionHub`](../high-frequency-runtime-data-plane/SPEC.md) 承担，二者不得合并为一个共享可变缓存。
 - Dashboard live render 只消费 Runtime/Terminal Projection 的不可变 snapshot，不得从 Terminal Projection 的订阅回调反向调用 SQLite builder。
 - SQLite writer P1 -> P2 派生工作必须通过统一 accounting ownership transfer，不能以裸原子减法跨越队列阶段。

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -46,6 +46,9 @@ flowchart LR
 - `TerminalProjectionHub` 保存 terminal admission/P1 ACK 与消费者 cursor，供 Dashboard totals、长期统计和 timeseries 增量物化。
 - P1 只保障 raw terminal 与 journal ACK；派生 rollup 和 repair 通过 P2 并受 SQLite pressure gate 控制。
 - writer queue 的 depth/bytes 由单一 accounting owner 管理。P1 生成 P2 工作时必须转移 ownership，不得跨阶段裸减计数。
+- 代理热写由 `ProxySqliteWriteCoordinator` 单点仲裁，优先级为 P1 terminal、同步 attempt/route、P2 derived。同步写仍等待并返回原结果，但不得绕过协调器直接竞争 SQLite writer。
+- P1 使用 20ms admission、最多 32 条或 4 MiB 的短批次；busy/locked 批次完整保留并按 250ms、500ms、1s、2s、5s 退避。只有事务提交后才能推进 journal 与 projection ACK。
+- P2 仅在 P1 与同步等待者为空时运行；rollup cursor 每次只推进一个有界 chunk，剩余工作重新排队。
 
 ## 4. Dashboard 与 SSE
 
@@ -66,6 +69,7 @@ flowchart LR
 
 - `DASHBOARD_RUNTIME_PROJECTION_MODE=auto|legacy` 控制 Dashboard 投影路径；默认 `auto`。
 - `PROXY_REQUEST_SEMANTIC_PIPELINE_MODE=auto|legacy` 控制请求语义流水线；默认 `auto`。
+- `PROXY_SQLITE_WRITE_COORDINATOR_MODE=coordinated|legacy` 控制代理热写协调器；默认 `coordinated`，legacy 只保留一个发布周期用于显式回滚。
 - `GET /api/system/status` 的 additive `runtimePressureHealth` 展示 Dashboard producer、request parsing/materialization、RSS/Swap、allocator 与 writer accounting 健康。
 - accounting violation、live-path DB read、whole-body materialization、cadence miss、subscription lag/skipped 或重复 serialization 必须改变健康状态并可被结构化 telemetry 判责。
 - 运行镜像默认 `MALLOC_ARENA_MAX=8`，部署可显式覆盖；该设置只限制 glibc arena 保留，不改变业务并发。

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -74,6 +74,8 @@ pub(crate) struct SystemRuntimePressureHealth {
     pub(crate) process: SystemRuntimePressureProcess,
     pub(crate) allocator: SystemRuntimePressureAllocator,
     pub(crate) writer_accounting: PendingQueueAccountingSnapshot,
+    pub(crate) proxy_sqlite_write_coordinator:
+        crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinatorSnapshot,
     pub(crate) dashboard_projection: RuntimeProjectionHealthSnapshot,
     pub(crate) delivery: DashboardDeliveryTopologyCounterSnapshot,
     pub(crate) request_pipeline: RequestPipelineHealthSnapshot,
@@ -102,6 +104,10 @@ pub(crate) struct SystemStatusResponse {
 pub(crate) async fn load_runtime_pressure_health(state: &AppState) -> SystemRuntimePressureHealth {
     let memory = state.memory_diagnostics.runtime_pressure_snapshot();
     let writer_accounting = state.sqlite_batch_writer.accounting_snapshot();
+    let proxy_sqlite_write_coordinator =
+        crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+            .snapshot()
+            .await;
     let active_subscriber_count = state
         .subscription_hub
         .dashboard_activity_live_subscriber_count()
@@ -152,6 +158,7 @@ pub(crate) async fn load_runtime_pressure_health(state: &AppState) -> SystemRunt
             malloc_arena_max: memory.malloc_arena_max,
         },
         writer_accounting,
+        proxy_sqlite_write_coordinator,
         dashboard_projection,
         delivery,
         request_pipeline,

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,7 @@ mod memory_diagnostics;
 mod oauth_bridge;
 mod pricing;
 mod proxy;
+mod proxy_sqlite_write_coordinator;
 #[expect(
     clippy::too_many_arguments,
     reason = "Runtime shutdown coordination preserves established task handles."

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -1102,6 +1102,20 @@ pub(crate) async fn persist_proxy_capture_record(
 pub(crate) async fn persist_proxy_capture_record_core(
     pool: &Pool<Sqlite>,
     capture_started: Instant,
+    record: ProxyCaptureRecord,
+    write_derived_inline: bool,
+) -> Result<Option<ApiInvocation>> {
+    let mut tx = pool.begin().await?;
+    let persisted =
+        persist_proxy_capture_record_tx(tx.as_mut(), capture_started, record, write_derived_inline)
+            .await?;
+    tx.commit().await?;
+    Ok(persisted)
+}
+
+pub(crate) async fn persist_proxy_capture_record_tx(
+    tx: &mut SqliteConnection,
+    capture_started: Instant,
     mut record: ProxyCaptureRecord,
     write_derived_inline: bool,
 ) -> Result<Option<ApiInvocation>> {
@@ -1135,10 +1149,9 @@ pub(crate) async fn persist_proxy_capture_record_core(
     }
     let t_persist_ms = nullable_runtime_timing_value(record.timings.t_persist_ms);
 
-    let mut tx = pool.begin().await?;
     let mut core_write_path = "insert_missing";
     let existing_identity =
-        load_persisted_invocation_identity_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
+        load_persisted_invocation_identity_tx(&mut *tx, &record.invoke_id, &record.occurred_at)
             .await?;
 
     let invocation_id = if let Some(existing) = existing_identity {
@@ -1147,11 +1160,10 @@ pub(crate) async fn persist_proxy_capture_record_core(
             existing.failure_kind.as_deref(),
             &record.status,
         ) {
-            tx.commit().await?;
             return Ok(None);
         }
         let updated = update_existing_proxy_invocation_record_tx(
-            tx.as_mut(),
+            &mut *tx,
             existing.id,
             &record,
             &raw_response,
@@ -1171,7 +1183,6 @@ pub(crate) async fn persist_proxy_capture_record_core(
         )
         .await?;
         if !updated {
-            tx.commit().await?;
             return Ok(None);
         }
         core_write_path = "update_existing";
@@ -1276,19 +1287,18 @@ pub(crate) async fn persist_proxy_capture_record_core(
         .bind(record.timings.t_resp_parse_ms)
         .bind(t_persist_ms)
         .bind(created_at)
-        .execute(tx.as_mut())
+        .execute(&mut *tx)
         .await?;
         if insert_result.rows_affected() > 0 {
             insert_result.last_insert_rowid()
         } else {
             let Some(existing) = load_persisted_invocation_identity_tx(
-                tx.as_mut(),
+                &mut *tx,
                 &record.invoke_id,
                 &record.occurred_at,
             )
             .await?
             else {
-                tx.commit().await?;
                 return Ok(None);
             };
             if !persisted_invocation_allows_proxy_record_update(
@@ -1296,11 +1306,10 @@ pub(crate) async fn persist_proxy_capture_record_core(
                 existing.failure_kind.as_deref(),
                 &record.status,
             ) {
-                tx.commit().await?;
                 return Ok(None);
             }
             let updated = update_existing_proxy_invocation_record_tx(
-                tx.as_mut(),
+                &mut *tx,
                 existing.id,
                 &record,
                 &raw_response,
@@ -1320,7 +1329,6 @@ pub(crate) async fn persist_proxy_capture_record_core(
             )
             .await?;
             if !updated {
-                tx.commit().await?;
                 return Ok(None);
             }
             core_write_path = "update_race";
@@ -1330,7 +1338,7 @@ pub(crate) async fn persist_proxy_capture_record_core(
 
     if write_derived_inline {
         touch_invocation_upstream_account_last_activity_tx(
-            tx.as_mut(),
+            &mut *tx,
             &record.occurred_at,
             record.payload.as_deref(),
         )
@@ -1338,9 +1346,9 @@ pub(crate) async fn persist_proxy_capture_record_core(
     }
 
     if write_derived_inline {
-        recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &[invocation_id]).await?;
+        recompute_invocation_hourly_rollups_for_ids_tx(&mut *tx, &[invocation_id]).await?;
         save_hourly_rollup_live_progress_tx(
-            tx.as_mut(),
+            &mut *tx,
             HOURLY_ROLLUP_DATASET_INVOCATIONS,
             invocation_id,
         )
@@ -1357,13 +1365,11 @@ pub(crate) async fn persist_proxy_capture_record_core(
     )
     .bind(invocation_id)
     .bind(measured_t_persist_ms)
-    .execute(tx.as_mut())
+    .execute(&mut *tx)
     .await?;
 
     let persisted =
-        load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
-            .await?;
-    tx.commit().await?;
+        load_persisted_api_invocation_tx(&mut *tx, &record.invoke_id, &record.occurred_at).await?;
 
     let core_write_elapsed_ms = persist_started.elapsed().as_millis() as u64;
     if core_write_elapsed_ms >= 1_000 {

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -1096,6 +1096,9 @@ pub(crate) async fn persist_proxy_capture_record(
     capture_started: Instant,
     record: ProxyCaptureRecord,
 ) -> Result<Option<ApiInvocation>> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P1Terminal)
+        .await;
     persist_proxy_capture_record_core(pool, capture_started, record, true).await
 }
 

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -490,6 +490,73 @@ fn parse_selective_request_semantics(
     Ok(parsed)
 }
 
+#[cfg(target_os = "linux")]
+fn current_thread_cpu_time() -> Option<Duration> {
+    let mut value = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: clock_gettime writes to the valid timespec pointer and has no ownership effects.
+    let result = unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut value) };
+    (result == 0).then(|| {
+        Duration::from_secs(value.tv_sec as u64)
+            .saturating_add(Duration::from_nanos(value.tv_nsec as u64))
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_thread_cpu_time() -> Option<Duration> {
+    None
+}
+
+fn record_request_semantic_cpu_window(cpu_time: Option<Duration>, wall_time: Duration, bytes: u64) {
+    use std::sync::{Mutex as StdMutex, OnceLock};
+
+    #[derive(Default)]
+    struct Window {
+        started_at: Option<Instant>,
+        cpu_ns: u128,
+        wall_ns: u128,
+        bytes: u64,
+        count: u64,
+    }
+
+    static WINDOW: OnceLock<StdMutex<Window>> = OnceLock::new();
+    let Ok(mut window) = WINDOW
+        .get_or_init(|| StdMutex::new(Window::default()))
+        .lock()
+    else {
+        return;
+    };
+    let started_at = *window.started_at.get_or_insert_with(Instant::now);
+    window.cpu_ns = window
+        .cpu_ns
+        .saturating_add(cpu_time.map_or(0, |value| value.as_nanos()));
+    window.wall_ns = window.wall_ns.saturating_add(wall_time.as_nanos());
+    window.bytes = window.bytes.saturating_add(bytes);
+    window.count = window.count.saturating_add(1);
+    if started_at.elapsed() < Duration::from_secs(30) {
+        return;
+    }
+    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    debug!(
+        component = "request_semantic_projection",
+        window_elapsed_ms = elapsed_ms,
+        parse_count = window.count,
+        parse_cpu_ms = (window.cpu_ns / 1_000_000) as u64,
+        parse_wall_ms = (window.wall_ns / 1_000_000) as u64,
+        parse_bytes = window.bytes,
+        throughput_bytes_per_second = (u128::from(window.bytes) * 1_000_000_000)
+            .checked_div(window.wall_ns)
+            .unwrap_or_default() as u64,
+        "request semantic CPU attribution window"
+    );
+    *window = Window {
+        started_at: Some(Instant::now()),
+        ..Window::default()
+    };
+}
+
 #[derive(Clone, Copy)]
 enum SelectiveSemanticScope {
     Root,
@@ -1058,25 +1125,47 @@ pub(crate) async fn analyze_replay_snapshot_for_pool_routing(
     let started = Instant::now();
     let snapshot_kind = pool_request_snapshot_kind(snapshot);
     let snapshot_bytes = pool_request_snapshot_body_bytes(snapshot);
-    let (value, parse_outcome, file_read_count, json_parse_count) = match snapshot {
-        PoolReplayBodySnapshot::Empty => (None, "empty", 0_u8, 0_u8),
+    let (value, parse_outcome, file_read_count, json_parse_count, parse_cpu_time) = match snapshot {
+        PoolReplayBodySnapshot::Empty => (None, "empty", 0_u8, 0_u8, None),
         PoolReplayBodySnapshot::Memory(bytes) => {
+            let cpu_started = current_thread_cpu_time();
             match parse_selective_request_semantics(std::io::Cursor::new(bytes.as_ref())) {
-                Ok(value) => (Some(value), "parsed", 0, 1),
-                Err(_) => (None, "invalid_json", 0, 1),
+                Ok(value) => (
+                    Some(value),
+                    "parsed",
+                    0,
+                    1,
+                    cpu_started
+                        .zip(current_thread_cpu_time())
+                        .map(|(start, end)| end.saturating_sub(start)),
+                ),
+                Err(_) => (
+                    None,
+                    "invalid_json",
+                    0,
+                    1,
+                    cpu_started
+                        .zip(current_thread_cpu_time())
+                        .map(|(start, end)| end.saturating_sub(start)),
+                ),
             }
         }
         PoolReplayBodySnapshot::File { temp_file, .. } => {
             let path = temp_file.path.clone();
             match tokio::task::spawn_blocking(move || {
+                let cpu_started = current_thread_cpu_time();
                 let file = std::fs::File::open(path).map_err(|_| "read_failed")?;
-                parse_selective_request_semantics(file).map(Some)
+                let parsed = parse_selective_request_semantics(file).map(Some);
+                let cpu_time = cpu_started
+                    .zip(current_thread_cpu_time())
+                    .map(|(start, end)| end.saturating_sub(start));
+                parsed.map(|value| (value, cpu_time))
             })
             .await
             {
-                Ok(Ok(value)) => (value, "parsed", 1, 1),
-                Ok(Err(outcome)) => (None, outcome, 1, 1),
-                Err(_) => (None, "worker_failed", 1, 0),
+                Ok(Ok((value, cpu_time))) => (value, "parsed", 1, 1, cpu_time),
+                Ok(Err(outcome)) => (None, outcome, 1, 1, None),
+                Err(_) => (None, "worker_failed", 1, 0, None),
             }
         }
     };
@@ -1085,6 +1174,11 @@ pub(crate) async fn analyze_replay_snapshot_for_pool_routing(
     analysis.json_parse_count = json_parse_count;
     analysis.parse_outcome = parse_outcome;
     let analysis_elapsed_ms = elapsed_ms(started);
+    record_request_semantic_cpu_window(
+        parse_cpu_time,
+        started.elapsed(),
+        snapshot_bytes.min(u64::MAX as usize) as u64,
+    );
 
     if snapshot_kind == "file" {
         if analysis_elapsed_ms >= REPLAY_SNAPSHOT_ROUTE_ANALYSIS_SLOW_MS {

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -580,6 +580,9 @@ pub(crate) async fn begin_pool_upstream_request_attempt_with_scope_and_routing_s
     same_account_retry_index: i64,
     started_at: &str,
 ) -> PendingPoolAttemptRecord {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let routing_source_value = routing_source.map(PoolRoutingSelectionSource::as_persisted_str);
     let routing_selection_audit_json =
         routing_selection_audit.and_then(|audit| serde_json::to_string(audit).ok());
@@ -738,6 +741,9 @@ pub(crate) async fn persist_pool_upstream_request_attempt_response_capture(
     pool: &Pool<Sqlite>,
     pending: &PendingPoolAttemptRecord,
 ) -> Result<()> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let attempt_id = match pending.attempt_id {
         Some(attempt_id) => Some(attempt_id),
         None => sqlx::query_scalar::<_, Option<i64>>(
@@ -911,6 +917,9 @@ pub(crate) async fn update_pool_upstream_request_attempt_progress(
     compact_support_status: Option<&str>,
     compact_support_reason: Option<&str>,
 ) -> Result<bool> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let Some(attempt_id) = pending.attempt_id else {
         return Ok(false);
     };
@@ -963,6 +972,9 @@ pub(crate) async fn persist_pool_upstream_request_attempt_first_byte_progress(
     connect_latency_ms: f64,
     first_byte_latency_ms: f64,
 ) -> Result<bool> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let Some(attempt_id) = pending.attempt_id else {
         return Ok(false);
     };
@@ -2097,6 +2109,9 @@ pub(crate) async fn finalize_pool_upstream_request_attempt(
     compact_support_status: Option<&str>,
     compact_support_reason: Option<&str>,
 ) -> Result<()> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let terminal_phase = terminal_pool_upstream_request_attempt_phase(status);
     let compact_support_status =
         compact_support_status.or(pending.compact_support_status.as_deref());
@@ -3625,6 +3640,18 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
     record: ProxyCaptureRecord,
     write_derived_inline: bool,
 ) -> Result<Option<ApiInvocation>> {
+    let mut tx = pool.begin().await?;
+    let persisted =
+        persist_proxy_capture_runtime_record_tx(tx.as_mut(), record, write_derived_inline).await?;
+    tx.commit().await?;
+    Ok(persisted)
+}
+
+pub(crate) async fn persist_proxy_capture_runtime_record_tx(
+    tx: &mut SqliteConnection,
+    record: ProxyCaptureRecord,
+    write_derived_inline: bool,
+) -> Result<Option<ApiInvocation>> {
     let raw_response = if record.response_body_preview_enabled {
         record.raw_response.clone()
     } else {
@@ -3659,9 +3686,8 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
     let core_write_started = Instant::now();
     let created_at = format_utc_iso_millis(Utc::now());
     let mut core_write_path = "insert_missing";
-    let mut tx = pool.begin().await?;
     let existing_identity =
-        load_persisted_invocation_identity_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
+        load_persisted_invocation_identity_tx(&mut *tx, &record.invoke_id, &record.occurred_at)
             .await?;
     if let Some(existing) = existing_identity.as_ref()
         && !persisted_invocation_allows_proxy_record_update(
@@ -3670,13 +3696,12 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
             &record.status,
         )
     {
-        tx.commit().await?;
         return Ok(None);
     }
 
     if let Some(existing) = existing_identity.as_ref() {
         let updated = update_existing_proxy_invocation_record_tx(
-            tx.as_mut(),
+            &mut *tx,
             existing.id,
             &record,
             &raw_response,
@@ -3696,7 +3721,6 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
         )
         .await?;
         if !updated {
-            tx.commit().await?;
             return Ok(None);
         }
         core_write_path = "update_existing";
@@ -3800,17 +3824,16 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
         .bind(None::<f64>)
         .bind(None::<f64>)
         .bind(created_at)
-        .execute(tx.as_mut())
+        .execute(&mut *tx)
         .await?;
         if insert_result.rows_affected() == 0 {
             let Some(existing) = load_persisted_invocation_identity_tx(
-                tx.as_mut(),
+                &mut *tx,
                 &record.invoke_id,
                 &record.occurred_at,
             )
             .await?
             else {
-                tx.commit().await?;
                 return Ok(None);
             };
             if !persisted_invocation_allows_proxy_record_update(
@@ -3818,11 +3841,10 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
                 existing.failure_kind.as_deref(),
                 &record.status,
             ) {
-                tx.commit().await?;
                 return Ok(None);
             }
             let updated = update_existing_proxy_invocation_record_tx(
-                tx.as_mut(),
+                &mut *tx,
                 existing.id,
                 &record,
                 &raw_response,
@@ -3842,7 +3864,6 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
             )
             .await?;
             if !updated {
-                tx.commit().await?;
                 return Ok(None);
             }
             core_write_path = "update_race";
@@ -3850,14 +3871,14 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
     }
 
     let persisted_identity =
-        load_persisted_invocation_identity_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
+        load_persisted_invocation_identity_tx(&mut *tx, &record.invoke_id, &record.occurred_at)
             .await?
             .ok_or_else(|| {
                 anyhow!("persisted proxy runtime invocation row disappeared after upsert")
             })?;
     if write_derived_inline {
         upsert_invocation_hourly_rollups_tx(
-            tx.as_mut(),
+            &mut *tx,
             &[InvocationHourlySourceRecord {
                 id: persisted_identity.id,
                 occurred_at: record.occurred_at.clone(),
@@ -3897,13 +3918,13 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
         )
         .await?;
         save_hourly_rollup_live_progress_tx(
-            tx.as_mut(),
+            &mut *tx,
             HOURLY_ROLLUP_DATASET_INVOCATIONS,
             persisted_identity.id,
         )
         .await?;
         touch_invocation_upstream_account_last_activity_tx(
-            tx.as_mut(),
+            &mut *tx,
             &record.occurred_at,
             record.payload.as_deref(),
         )
@@ -3911,9 +3932,7 @@ pub(crate) async fn persist_proxy_capture_runtime_record_core(
     }
 
     let persisted =
-        load_persisted_api_invocation_tx(tx.as_mut(), &record.invoke_id, &record.occurred_at)
-            .await?;
-    tx.commit().await?;
+        load_persisted_api_invocation_tx(&mut *tx, &record.invoke_id, &record.occurred_at).await?;
 
     let core_write_elapsed_ms = core_write_started.elapsed().as_millis() as u64;
     if core_write_elapsed_ms >= 1_000 {

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -3632,6 +3632,9 @@ pub(crate) async fn persist_proxy_capture_runtime_record(
     pool: &Pool<Sqlite>,
     record: ProxyCaptureRecord,
 ) -> Result<Option<ApiInvocation>> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P1Terminal)
+        .await;
     persist_proxy_capture_runtime_record_core(pool, record, true).await
 }
 

--- a/src/proxy_sqlite_write_coordinator.rs
+++ b/src/proxy_sqlite_write_coordinator.rs
@@ -1,0 +1,232 @@
+use std::{
+    sync::{Arc, Mutex, OnceLock},
+    time::{Duration, Instant},
+};
+
+use serde::Serialize;
+use tokio::sync::Notify;
+
+pub(crate) const PROXY_SQLITE_WRITE_COORDINATOR_MODE_ENV: &str =
+    "PROXY_SQLITE_WRITE_COORDINATOR_MODE";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProxySqliteWriteClass {
+    P1Terminal,
+    InteractiveProxy,
+    P2Derived,
+}
+
+impl ProxySqliteWriteClass {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::P1Terminal => "p1_terminal",
+            Self::InteractiveProxy => "interactive_proxy",
+            Self::P2Derived => "p2_derived",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProxySqliteWriteCoordinatorSnapshot {
+    pub(crate) mode: String,
+    pub(crate) active_write_class: Option<String>,
+    pub(crate) p1_waiter_count: usize,
+    pub(crate) interactive_waiter_count: usize,
+    pub(crate) p2_waiter_count: usize,
+    pub(crate) direct_write_bypass_count: u64,
+}
+
+#[derive(Debug, Default)]
+struct CoordinatorState {
+    active: Option<ProxySqliteWriteClass>,
+    p1_waiters: usize,
+    interactive_waiters: usize,
+    p2_waiters: usize,
+    direct_write_bypass_count: u64,
+}
+
+impl CoordinatorState {
+    fn increment(&mut self, class: ProxySqliteWriteClass) {
+        match class {
+            ProxySqliteWriteClass::P1Terminal => self.p1_waiters += 1,
+            ProxySqliteWriteClass::InteractiveProxy => self.interactive_waiters += 1,
+            ProxySqliteWriteClass::P2Derived => self.p2_waiters += 1,
+        }
+    }
+
+    fn decrement(&mut self, class: ProxySqliteWriteClass) {
+        match class {
+            ProxySqliteWriteClass::P1Terminal => self.p1_waiters -= 1,
+            ProxySqliteWriteClass::InteractiveProxy => self.interactive_waiters -= 1,
+            ProxySqliteWriteClass::P2Derived => self.p2_waiters -= 1,
+        }
+    }
+
+    fn can_admit(&self, class: ProxySqliteWriteClass) -> bool {
+        if self.active.is_some() {
+            return false;
+        }
+        match class {
+            ProxySqliteWriteClass::P1Terminal => true,
+            ProxySqliteWriteClass::InteractiveProxy => self.p1_waiters == 0,
+            ProxySqliteWriteClass::P2Derived => {
+                self.p1_waiters == 0 && self.interactive_waiters == 0
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ProxySqliteWriteCoordinator {
+    coordinated: bool,
+    state: Mutex<CoordinatorState>,
+    notify: Notify,
+}
+
+impl ProxySqliteWriteCoordinator {
+    fn from_env() -> Self {
+        let coordinated = !matches!(
+            std::env::var(PROXY_SQLITE_WRITE_COORDINATOR_MODE_ENV),
+            Ok(value) if value.trim().eq_ignore_ascii_case("legacy")
+        );
+        Self {
+            coordinated,
+            state: Mutex::new(CoordinatorState::default()),
+            notify: Notify::new(),
+        }
+    }
+
+    pub(crate) async fn acquire(
+        self: &Arc<Self>,
+        class: ProxySqliteWriteClass,
+    ) -> ProxySqliteWritePermit {
+        if !self.coordinated {
+            let mut state = self.state.lock().expect("proxy sqlite coordinator state");
+            state.direct_write_bypass_count = state.direct_write_bypass_count.saturating_add(1);
+            return ProxySqliteWritePermit {
+                coordinator: self.clone(),
+                class,
+                coordinated: false,
+                admitted_at: Instant::now(),
+            };
+        }
+
+        {
+            let mut state = self.state.lock().expect("proxy sqlite coordinator state");
+            state.increment(class);
+        }
+        loop {
+            let notified = self.notify.notified();
+            {
+                let mut state = self.state.lock().expect("proxy sqlite coordinator state");
+                if state.can_admit(class) {
+                    state.decrement(class);
+                    state.active = Some(class);
+                    return ProxySqliteWritePermit {
+                        coordinator: self.clone(),
+                        class,
+                        coordinated: true,
+                        admitted_at: Instant::now(),
+                    };
+                }
+            }
+            notified.await;
+        }
+    }
+
+    pub(crate) async fn snapshot(&self) -> ProxySqliteWriteCoordinatorSnapshot {
+        let state = self.state.lock().expect("proxy sqlite coordinator state");
+        ProxySqliteWriteCoordinatorSnapshot {
+            mode: if self.coordinated {
+                "coordinated"
+            } else {
+                "legacy"
+            }
+            .to_string(),
+            active_write_class: state.active.map(|class| class.as_str().to_string()),
+            p1_waiter_count: state.p1_waiters,
+            interactive_waiter_count: state.interactive_waiters,
+            p2_waiter_count: state.p2_waiters,
+            direct_write_bypass_count: state.direct_write_bypass_count,
+        }
+    }
+}
+
+pub(crate) struct ProxySqliteWritePermit {
+    coordinator: Arc<ProxySqliteWriteCoordinator>,
+    class: ProxySqliteWriteClass,
+    coordinated: bool,
+    admitted_at: Instant,
+}
+
+impl ProxySqliteWritePermit {
+    pub(crate) fn lock_wait(&self) -> Duration {
+        self.admitted_at.elapsed()
+    }
+
+    pub(crate) fn write_class(&self) -> &'static str {
+        self.class.as_str()
+    }
+}
+
+impl Drop for ProxySqliteWritePermit {
+    fn drop(&mut self) {
+        if !self.coordinated {
+            return;
+        }
+        {
+            let mut state = self
+                .coordinator
+                .state
+                .lock()
+                .expect("proxy sqlite coordinator state");
+            state.active = None;
+        }
+        self.coordinator.notify.notify_waiters();
+    }
+}
+
+pub(crate) fn proxy_sqlite_write_coordinator() -> Arc<ProxySqliteWriteCoordinator> {
+    static COORDINATOR: OnceLock<Arc<ProxySqliteWriteCoordinator>> = OnceLock::new();
+    COORDINATOR
+        .get_or_init(|| Arc::new(ProxySqliteWriteCoordinator::from_env()))
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn p1_is_admitted_before_waiting_interactive_and_p2_work() {
+        let coordinator = Arc::new(ProxySqliteWriteCoordinator {
+            coordinated: true,
+            state: Mutex::new(CoordinatorState::default()),
+            notify: Notify::new(),
+        });
+        let active = coordinator
+            .acquire(ProxySqliteWriteClass::InteractiveProxy)
+            .await;
+        let p2 = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.acquire(ProxySqliteWriteClass::P2Derived).await }
+        });
+        let p1 = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.acquire(ProxySqliteWriteClass::P1Terminal).await }
+        });
+        tokio::task::yield_now().await;
+        drop(active);
+        let p1_permit = tokio::time::timeout(Duration::from_secs(1), p1)
+            .await
+            .expect("P1 admitted")
+            .expect("P1 task");
+        assert!(!p2.is_finished());
+        drop(p1_permit);
+        tokio::time::timeout(Duration::from_secs(1), p2)
+            .await
+            .expect("P2 admitted")
+            .expect("P2 task");
+    }
+}

--- a/src/proxy_sqlite_write_coordinator.rs
+++ b/src/proxy_sqlite_write_coordinator.rs
@@ -101,6 +101,7 @@ impl ProxySqliteWriteCoordinator {
         self: &Arc<Self>,
         class: ProxySqliteWriteClass,
     ) -> ProxySqliteWritePermit {
+        let requested_at = Instant::now();
         if !self.coordinated {
             let mut state = self.state.lock().expect("proxy sqlite coordinator state");
             state.direct_write_bypass_count = state.direct_write_bypass_count.saturating_add(1);
@@ -108,7 +109,7 @@ impl ProxySqliteWriteCoordinator {
                 coordinator: self.clone(),
                 class,
                 coordinated: false,
-                admitted_at: Instant::now(),
+                lock_wait: requested_at.elapsed(),
             };
         }
 
@@ -116,18 +117,24 @@ impl ProxySqliteWriteCoordinator {
             let mut state = self.state.lock().expect("proxy sqlite coordinator state");
             state.increment(class);
         }
+        let mut waiter = ProxySqliteWriteWaiter {
+            coordinator: self.clone(),
+            class,
+            registered: true,
+        };
         loop {
             let notified = self.notify.notified();
             {
                 let mut state = self.state.lock().expect("proxy sqlite coordinator state");
                 if state.can_admit(class) {
                     state.decrement(class);
+                    waiter.registered = false;
                     state.active = Some(class);
                     return ProxySqliteWritePermit {
                         coordinator: self.clone(),
                         class,
                         coordinated: true,
-                        admitted_at: Instant::now(),
+                        lock_wait: requested_at.elapsed(),
                     };
                 }
             }
@@ -157,16 +164,39 @@ pub(crate) struct ProxySqliteWritePermit {
     coordinator: Arc<ProxySqliteWriteCoordinator>,
     class: ProxySqliteWriteClass,
     coordinated: bool,
-    admitted_at: Instant,
+    lock_wait: Duration,
 }
 
 impl ProxySqliteWritePermit {
     pub(crate) fn lock_wait(&self) -> Duration {
-        self.admitted_at.elapsed()
+        self.lock_wait
     }
 
     pub(crate) fn write_class(&self) -> &'static str {
         self.class.as_str()
+    }
+}
+
+struct ProxySqliteWriteWaiter {
+    coordinator: Arc<ProxySqliteWriteCoordinator>,
+    class: ProxySqliteWriteClass,
+    registered: bool,
+}
+
+impl Drop for ProxySqliteWriteWaiter {
+    fn drop(&mut self) {
+        if !self.registered {
+            return;
+        }
+        {
+            let mut state = self
+                .coordinator
+                .state
+                .lock()
+                .expect("proxy sqlite coordinator state");
+            state.decrement(self.class);
+        }
+        self.coordinator.notify.notify_waiters();
     }
 }
 
@@ -228,5 +258,33 @@ mod tests {
             .await
             .expect("P2 admitted")
             .expect("P2 task");
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiter_releases_priority_registration() {
+        let coordinator = Arc::new(ProxySqliteWriteCoordinator {
+            coordinated: true,
+            state: Mutex::new(CoordinatorState::default()),
+            notify: Notify::new(),
+        });
+        let active = coordinator
+            .acquire(ProxySqliteWriteClass::InteractiveProxy)
+            .await;
+        let waiter = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.acquire(ProxySqliteWriteClass::P1Terminal).await }
+        });
+        tokio::task::yield_now().await;
+        waiter.abort();
+        let _ = waiter.await;
+        assert_eq!(coordinator.snapshot().await.p1_waiter_count, 0);
+        drop(active);
+        let p2 = tokio::time::timeout(
+            Duration::from_secs(1),
+            coordinator.acquire(ProxySqliteWriteClass::P2Derived),
+        )
+        .await
+        .expect("cancelled P1 waiter must not block P2");
+        drop(p2);
     }
 }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -24,11 +24,56 @@ use crate::terminal_journal::{
     TerminalJournalStats,
 };
 
-pub(crate) const SQLITE_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
-pub(crate) const SQLITE_BATCH_MAX_ROWS: usize = 100;
+pub(crate) const SQLITE_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(20);
+pub(crate) const SQLITE_BATCH_MAX_ROWS: usize = 32;
+pub(crate) const SQLITE_BATCH_MAX_BYTES: usize = 4 * 1024 * 1024;
 pub(crate) const SQLITE_BATCH_MAX_AGE: Duration = Duration::from_secs(5);
 pub(crate) const SQLITE_BATCH_STALE_WARN_AGE: Duration = Duration::from_secs(30);
 pub(crate) const SQLITE_BATCH_CHANNEL_CAPACITY: usize = 10_000;
+const SQLITE_P1_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+];
+
+#[derive(Debug, Default)]
+struct P1RetryState {
+    generation: usize,
+    due_at: Option<Instant>,
+}
+
+impl P1RetryState {
+    fn ready(&self, now: Instant) -> bool {
+        self.due_at.is_none_or(|due_at| now >= due_at)
+    }
+
+    fn failed(&mut self, transaction_seed: u64) -> Duration {
+        let base = SQLITE_P1_RETRY_DELAYS[self.generation.min(SQLITE_P1_RETRY_DELAYS.len() - 1)];
+        self.generation = self.generation.saturating_add(1);
+        let jitter_ceiling_ms = (base.as_millis() as u64 / 10).max(1);
+        let jitter_ms = transaction_seed % jitter_ceiling_ms;
+        let delay = base.saturating_add(Duration::from_millis(jitter_ms));
+        self.due_at = Some(Instant::now() + delay);
+        delay
+    }
+
+    fn succeeded(&mut self) {
+        self.generation = 0;
+        self.due_at = None;
+    }
+}
+
+fn is_sqlite_lock_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        let message = cause.to_string().to_ascii_lowercase();
+        message.contains("database is locked")
+            || message.contains("database is busy")
+            || message.contains("sqlite_busy")
+            || message.contains("sqlite_locked")
+    })
+}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -1273,6 +1318,8 @@ pub(crate) async fn run_sqlite_batch_writer(
     deferred_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut pending = PendingBatch::default();
     let mut control_closed = false;
+    let mut p1_retry = P1RetryState::default();
+    let mut transaction_sequence = 0_u64;
 
     loop {
         tokio::select! {
@@ -1436,7 +1483,9 @@ pub(crate) async fn run_sqlite_batch_writer(
                     return;
                 };
                 pending.push_accounted(write, &accounting);
-                if pending.logical_rows() >= SQLITE_BATCH_MAX_ROWS
+                if (pending.logical_rows() >= SQLITE_BATCH_MAX_ROWS
+                    || pending.estimated_memory_bytes() >= SQLITE_BATCH_MAX_BYTES)
+                    && (pending.terminal_invocations.is_empty() || p1_retry.ready(Instant::now()))
                     && let Some(retained) =
                         flush_pending_batch_accounted(
                             &accounting,
@@ -1452,11 +1501,26 @@ pub(crate) async fn run_sqlite_batch_writer(
                         )
                         .await
                     {
+                        if retained.failed && !retained.batch.terminal_invocations.is_empty() {
+                            transaction_sequence = transaction_sequence.saturating_add(1);
+                            let delay = p1_retry.failed(transaction_sequence);
+                            warn!(
+                                write_class = "p1_terminal",
+                                retry_generation = p1_retry.generation as u64,
+                                next_retry_delay_ms = delay.as_millis() as u64,
+                                "scheduled retained P1 batch with exponential backoff"
+                            );
+                        } else {
+                            p1_retry.succeeded();
+                        }
                         pending = retained.batch;
                     }
             }
             _ = ticker.tick() => {
                 if !pending.is_empty() {
+                    if !pending.terminal_invocations.is_empty() && !p1_retry.ready(Instant::now()) {
+                        continue;
+                    }
                     let flush_reason = if pending.age() >= SQLITE_BATCH_MAX_AGE {
                         if pending.age() >= SQLITE_BATCH_STALE_WARN_AGE {
                             warn!(
@@ -1481,6 +1545,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                     } else {
                         FlushReason::Interval
                     };
+                    let submitted_p1 = !pending.terminal_invocations.is_empty();
                     if let Some(retained) =
                         flush_pending_batch_accounted(
                             &accounting,
@@ -1496,7 +1561,21 @@ pub(crate) async fn run_sqlite_batch_writer(
                         )
                         .await
                     {
+                        if retained.failed && !retained.batch.terminal_invocations.is_empty() {
+                            transaction_sequence = transaction_sequence.saturating_add(1);
+                            let delay = p1_retry.failed(transaction_sequence);
+                            warn!(
+                                write_class = "p1_terminal",
+                                retry_generation = p1_retry.generation as u64,
+                                next_retry_delay_ms = delay.as_millis() as u64,
+                                "scheduled retained P1 batch with exponential backoff"
+                            );
+                        } else if submitted_p1 {
+                            p1_retry.succeeded();
+                        }
                         pending = retained.batch;
+                    } else if submitted_p1 {
+                        p1_retry.succeeded();
                     }
                 }
             }
@@ -1668,7 +1747,13 @@ pub(crate) async fn flush_pending_batch(
     let flush_reason = reason.as_str();
     let p1_batch = batch.take_p1_terminals();
     if !p1_batch.is_empty() {
-        match flush_pending_batch_inner(
+        let transaction_id = format!("p1-{}", started.elapsed().as_nanos());
+        let permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+            .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P1Terminal)
+            .await;
+        let lock_wait_ms = permit.lock_wait().as_millis() as u64;
+        let execute_started = Instant::now();
+        let initial_result = flush_pending_batch_inner(
             pool,
             &p1_batch,
             prompt_cache_conversation_cache,
@@ -1677,9 +1762,77 @@ pub(crate) async fn flush_pending_batch(
             terminal_projection_hub,
             dashboard_reconcile_gate,
         )
-        .await
-        {
+        .await;
+        let mut poison_record_count = 0_usize;
+        let p1_result = match initial_result {
+            Err(err) if !is_sqlite_lock_error(&err) => {
+                let mut deferred = PendingBatch::default();
+                let mut isolation_error = None;
+                for terminal in p1_batch.terminal_invocations.values() {
+                    let mut singleton = PendingBatch::default();
+                    singleton.push(SqliteBatchWrite::TerminalInvocation(terminal.clone()));
+                    match flush_pending_batch_inner(
+                        pool,
+                        &singleton,
+                        prompt_cache_conversation_cache,
+                        terminal_runtime_store,
+                        dashboard_activity_snapshot_cache,
+                        terminal_projection_hub,
+                        dashboard_reconcile_gate,
+                    )
+                    .await
+                    {
+                        Ok(singleton_deferred) => deferred.merge_p2(singleton_deferred),
+                        Err(singleton_err) if !is_sqlite_lock_error(&singleton_err) => {
+                            let quarantine_result = terminal_journal
+                                .lock()
+                                .ok()
+                                .and_then(|mut journal| {
+                                    journal.as_mut().map(|journal| {
+                                        journal.quarantine(terminal, &format!("{singleton_err:#}"))
+                                    })
+                                })
+                                .unwrap_or_else(|| {
+                                    Err(anyhow!("terminal journal unavailable for quarantine"))
+                                });
+                            if let Err(quarantine_err) = quarantine_result {
+                                isolation_error = Some(quarantine_err);
+                                break;
+                            }
+                            poison_record_count = poison_record_count.saturating_add(1);
+                            warn!(
+                                invoke_id = %terminal.record.invoke_id,
+                                occurred_at = %terminal.record.occurred_at,
+                                error = %singleton_err,
+                                poison_record_count,
+                                "quarantined deterministic P1 terminal record"
+                            );
+                        }
+                        Err(singleton_err) => {
+                            isolation_error = Some(singleton_err);
+                            break;
+                        }
+                    }
+                }
+                match isolation_error {
+                    Some(error) => Err(error),
+                    None => Ok(deferred),
+                }
+            }
+            result => result,
+        };
+        match p1_result {
             Ok(deferred) => {
+                debug!(
+                    write_class = permit.write_class(),
+                    transaction_id,
+                    batch_rows = p1_batch.logical_rows(),
+                    batch_bytes = p1_batch.estimated_memory_bytes(),
+                    lock_wait_ms,
+                    execute_ms = execute_started.elapsed().as_millis() as u64,
+                    poison_record_count,
+                    "proxy sqlite coordinated P1 batch committed"
+                );
                 accounting.transfer_p1_to_p2(deferred.estimated_memory_bytes());
                 if let Ok(mut journal) = terminal_journal.lock()
                     && let Some(journal) = journal.as_mut()
@@ -1704,6 +1857,12 @@ pub(crate) async fn flush_pending_batch(
                     oldest_age_ms,
                     elapsed_ms = started.elapsed().as_millis() as u64,
                     flush_reason,
+                    write_class = permit.write_class(),
+                    transaction_id,
+                    batch_rows = p1_batch.logical_rows(),
+                    batch_bytes = p1_batch.estimated_memory_bytes(),
+                    lock_wait_ms,
+                    execute_ms = execute_started.elapsed().as_millis() as u64,
                     "sqlite batch writer P1 terminal flush failed"
                 );
                 batch.terminal_invocations = p1_batch.terminal_invocations;
@@ -1735,6 +1894,10 @@ pub(crate) async fn flush_pending_batch(
         }
     };
 
+    let write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
+        .await;
+
     let deferred_batch = match flush_pending_batch_inner(
         pool,
         &batch,
@@ -1762,6 +1925,7 @@ pub(crate) async fn flush_pending_batch(
             return Some(RetainedBatch::new(batch, true));
         }
     };
+    drop(write_permit);
     drop(permit);
 
     let elapsed_ms = started.elapsed().as_millis() as u64;
@@ -1840,46 +2004,60 @@ pub(crate) async fn flush_pending_batch_inner(
     let mut deferred_batch = PendingBatch::default();
     let mut should_invalidate_prompt_cache_conversations = false;
     let _dashboard_reconcile_guard = dashboard_reconcile_gate.lock().await;
-    for terminal in batch.terminal_invocations.values() {
-        let persisted = if terminal.raw_capture {
-            let capture_started = terminal.capture_started.unwrap_or_else(Instant::now);
-            persist_proxy_capture_record_core(pool, capture_started, terminal.record.clone(), false)
+    let mut persisted_terminals = Vec::with_capacity(batch.terminal_invocations.len());
+    if !batch.terminal_invocations.is_empty() {
+        let mut terminal_tx = pool.begin().await?;
+        for terminal in batch.terminal_invocations.values() {
+            let persisted = if terminal.raw_capture {
+                let capture_started = terminal.capture_started.unwrap_or_else(Instant::now);
+                persist_proxy_capture_record_tx(
+                    terminal_tx.as_mut(),
+                    capture_started,
+                    terminal.record.clone(),
+                    false,
+                )
                 .await
                 .with_context(|| "flush terminal raw proxy invocation")?
-        } else {
-            persist_proxy_capture_runtime_record_core(pool, terminal.record.clone(), false)
+            } else {
+                persist_proxy_capture_runtime_record_tx(
+                    terminal_tx.as_mut(),
+                    terminal.record.clone(),
+                    false,
+                )
                 .await
                 .with_context(|| "flush terminal runtime proxy invocation")?
-        };
-        let derived_identity = if let Some(persisted) = persisted {
-            if persisted
-                .prompt_cache_key
-                .as_deref()
-                .is_some_and(|key| !key.trim().is_empty())
-            {
-                should_invalidate_prompt_cache_conversations = true;
-            }
-            Some((persisted.id, persisted.occurred_at))
-        } else {
-            // Terminal writes are committed before lower-priority derived work. If a later
-            // mixed-batch transaction fails, retry must still regenerate that derived work.
-            let mut lookup_tx = pool.begin().await?;
-            let identity = load_persisted_invocation_identity_tx(
-                lookup_tx.as_mut(),
-                &terminal.record.invoke_id,
-                &terminal.record.occurred_at,
-            )
-            .await?;
-            lookup_tx.commit().await?;
-            identity.map(|row| (row.id, terminal.record.occurred_at.clone()))
-        };
-        let (invocation_id, occurred_at) = derived_identity.ok_or_else(|| {
+            };
+            let derived_identity = if let Some(persisted) = persisted {
+                if persisted
+                    .prompt_cache_key
+                    .as_deref()
+                    .is_some_and(|key| !key.trim().is_empty())
+                {
+                    should_invalidate_prompt_cache_conversations = true;
+                }
+                Some((persisted.id, persisted.occurred_at))
+            } else {
+                let identity = load_persisted_invocation_identity_tx(
+                    terminal_tx.as_mut(),
+                    &terminal.record.invoke_id,
+                    &terminal.record.occurred_at,
+                )
+                .await?;
+                identity.map(|row| (row.id, terminal.record.occurred_at.clone()))
+            };
+            let (invocation_id, occurred_at) = derived_identity.ok_or_else(|| {
             anyhow!(
                 "terminal write completed without a persisted identity: invoke_id={} occurred_at={}",
                 terminal.record.invoke_id,
                 terminal.record.occurred_at
             )
         })?;
+            persisted_terminals.push((terminal, invocation_id, occurred_at));
+        }
+        terminal_tx.commit().await?;
+    }
+
+    for (terminal, invocation_id, occurred_at) in persisted_terminals {
         let dashboard_cache = dashboard_activity_snapshot_cache
             .lock()
             .ok()
@@ -1993,10 +2171,7 @@ pub(crate) async fn flush_pending_batch_inner(
     }
 
     let invocation_derived = batch.invocation_derived.clone();
-    let terminal_overlay_keys = invocation_derived
-        .values()
-        .filter_map(|derived| derived.terminal_overlay_key.clone())
-        .collect::<Vec<_>>();
+    let mut terminal_overlay_keys = Vec::new();
     if !invocation_derived.is_empty() {
         let target_invocation_id = invocation_derived
             .keys()
@@ -2007,6 +2182,9 @@ pub(crate) async fn flush_pending_batch_inner(
             load_hourly_rollup_live_progress_tx(tx.as_mut(), HOURLY_ROLLUP_DATASET_INVOCATIONS)
                 .await?;
         replay_live_invocation_hourly_rollups_until_tx(tx.as_mut(), target_invocation_id).await?;
+        let live_rollup_cursor_after =
+            load_hourly_rollup_live_progress_tx(tx.as_mut(), HOURLY_ROLLUP_DATASET_INVOCATIONS)
+                .await?;
         let skipped_terminal_ids = invocation_derived
             .keys()
             .filter(|invocation_id| **invocation_id <= live_rollup_cursor_before)
@@ -2017,6 +2195,13 @@ pub(crate) async fn flush_pending_batch_inner(
                 .await?;
         }
         for derived in invocation_derived.values() {
+            if derived.invocation_id > live_rollup_cursor_after {
+                deferred_batch.push(SqliteBatchWrite::InvocationDerived(derived.clone()));
+                continue;
+            }
+            if let Some(key) = derived.terminal_overlay_key.clone() {
+                terminal_overlay_keys.push(key);
+            }
             touch_invocation_upstream_account_last_activity_tx(
                 tx.as_mut(),
                 &derived.occurred_at,
@@ -2100,24 +2285,36 @@ pub(crate) async fn replay_live_invocation_hourly_rollups_until_tx(
     tx: &mut SqliteConnection,
     target_invocation_id: i64,
 ) -> Result<u64> {
-    let mut total_updated = 0;
-    loop {
-        let cursor =
-            load_hourly_rollup_live_progress_tx(tx, HOURLY_ROLLUP_DATASET_INVOCATIONS).await?;
-        if cursor >= target_invocation_id {
-            return Ok(total_updated);
-        }
-        let updated = replay_live_invocation_hourly_rollups_tx(tx).await?;
-        total_updated += updated;
-        if updated == 0 {
-            return Ok(total_updated);
-        }
+    let cursor = load_hourly_rollup_live_progress_tx(tx, HOURLY_ROLLUP_DATASET_INVOCATIONS).await?;
+    if cursor >= target_invocation_id {
+        return Ok(0);
     }
+    replay_live_invocation_hourly_rollups_tx(tx).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn p1_retry_backoff_is_bounded_and_new_work_does_not_reset_deadline() {
+        let mut retry = P1RetryState::default();
+        let expected = [250_u128, 500, 1_000, 2_000, 5_000, 5_000];
+        for (generation, expected_ms) in expected.into_iter().enumerate() {
+            let delay = retry.failed(0);
+            assert_eq!(delay.as_millis(), expected_ms, "generation {generation}");
+            let due_at = retry.due_at.expect("failed attempt sets deadline");
+            assert!(!retry.ready(Instant::now()));
+            assert_eq!(
+                retry.due_at,
+                Some(due_at),
+                "enqueue does not mutate retry state"
+            );
+        }
+        retry.succeeded();
+        assert!(retry.ready(Instant::now()));
+        assert_eq!(retry.generation, 0);
+    }
 
     #[test]
     fn pending_queue_accounting_clamps_underflow_and_degrades_health() {
@@ -2290,6 +2487,62 @@ mod tests {
             batch.estimated_memory_bytes()
         );
         assert_eq!(accounting.snapshot().pending_depth, batch.logical_rows());
+    }
+
+    #[tokio::test]
+    async fn p1_terminal_batch_rolls_back_the_committed_prefix_on_poison_record() {
+        let pool = test_pool().await;
+        sqlx::query(
+            r#"
+            CREATE TRIGGER reject_poison_terminal
+            BEFORE INSERT ON codex_invocations
+            WHEN NEW.invoke_id = 'poison-terminal'
+            BEGIN
+                SELECT RAISE(ABORT, 'poison terminal');
+            END
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("install poison trigger");
+
+        let mut batch = PendingBatch::default();
+        batch.push(SqliteBatchWrite::TerminalInvocation(
+            terminal_write_for_coalescing("valid-terminal", Some(1)),
+        ));
+        batch.push(SqliteBatchWrite::TerminalInvocation(
+            terminal_write_for_coalescing("poison-terminal", Some(2)),
+        ));
+        let runtime_store = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_cache = Arc::new(std::sync::Mutex::new(None));
+        let projection_hub = Arc::new(std::sync::Mutex::new(None));
+        let reconcile_gate = Arc::new(Mutex::new(()));
+
+        let error = flush_pending_batch_inner(
+            &pool,
+            &batch,
+            None,
+            &runtime_store,
+            &dashboard_cache,
+            &projection_hub,
+            &reconcile_gate,
+        )
+        .await
+        .expect_err("poison record aborts the complete P1 transaction");
+        assert!(
+            error
+                .chain()
+                .any(|cause| cause.to_string().contains("poison terminal")),
+            "unexpected error chain: {error:#}"
+        );
+
+        let persisted = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM codex_invocations WHERE invoke_id IN ('valid-terminal', 'poison-terminal')",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count terminal rows");
+        assert_eq!(persisted, 0, "P1 transaction must not commit a prefix");
     }
 
     #[tokio::test]

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -109,6 +109,41 @@ pub(crate) struct TerminalJournal {
 }
 
 impl TerminalJournal {
+    pub(crate) fn quarantine(
+        &mut self,
+        terminal: &BatchedTerminalInvocationWrite,
+        error: &str,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        struct QuarantineEntry<'a> {
+            invoke_id: &'a str,
+            occurred_at: &'a str,
+            raw_capture: bool,
+            error: &'a str,
+            record: &'a ProxyCaptureRecord,
+        }
+
+        let path = self.directory.join("quarantine.jsonl");
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("failed to open terminal quarantine {}", path.display()))?;
+        let entry = QuarantineEntry {
+            invoke_id: &terminal.record.invoke_id,
+            occurred_at: &terminal.record.occurred_at,
+            raw_capture: terminal.raw_capture,
+            error,
+            record: &terminal.record,
+        };
+        serde_json::to_writer(&mut file, &entry).context("failed to encode terminal quarantine")?;
+        file.write_all(b"\n")
+            .context("failed to append terminal quarantine delimiter")?;
+        file.sync_data()
+            .context("failed to sync terminal quarantine")?;
+        Ok(())
+    }
+
     pub(crate) fn open(database_path: &Path) -> Result<Self> {
         let directory = terminal_journal_directory(database_path);
         fs::create_dir_all(&directory).with_context(|| {

--- a/src/upstream_accounts/routing/failure_recording.rs
+++ b/src/upstream_accounts/routing/failure_recording.rs
@@ -178,6 +178,9 @@ async fn record_pool_route_success_inner(
     attempt_id: Option<i64>,
     sticky_affinity_generation: Option<i64>,
 ) -> Result<RuntimeStickyMutation> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let now_iso = format_utc_iso(Utc::now());
     let sticky_now_iso = format_utc_iso_precise(Utc::now());
     let request_started_at_iso = format_utc_iso(request_started_at_utc);
@@ -703,6 +706,9 @@ async fn record_pool_route_http_failure_with_image_intent_inner(
     sticky_affinity_generation: Option<i64>,
     prompt_cache_key: Option<&str>,
 ) -> Result<bool> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let requirements =
         RequestCapabilityRequirements::from_endpoint_and_image_intent(endpoint, image_intent);
     if requirements.response_endpoint
@@ -1136,6 +1142,9 @@ async fn record_pool_route_transport_failure_inner(
     invoke_id: Option<&str>,
     attempt_id: Option<i64>,
 ) -> Result<()> {
+    let _write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy)
+        .await;
     let account = load_upstream_account_row(pool, account_id)
         .await?
         .ok_or_else(|| anyhow!("account not found"))?;

--- a/web/src/lib/api/core-foundation.ts
+++ b/web/src/lib/api/core-foundation.ts
@@ -2168,6 +2168,15 @@ export interface RuntimePressureWriterAccountingHealth {
   degradedReason?: string;
 }
 
+export interface RuntimePressureProxySqliteWriteCoordinatorHealth {
+  mode: string;
+  activeWriteClass?: string;
+  p1WaiterCount: number;
+  interactiveWaiterCount: number;
+  p2WaiterCount: number;
+  directWriteBypassCount: number;
+}
+
 export interface RuntimePressureDashboardProjectionHealth {
   mode: string;
   state: string;
@@ -2227,6 +2236,7 @@ export interface RuntimePressureHealth {
   process: RuntimePressureProcessHealth;
   allocator: { mallocArenaMax: string };
   writerAccounting: RuntimePressureWriterAccountingHealth;
+  proxySqliteWriteCoordinator?: RuntimePressureProxySqliteWriteCoordinatorHealth;
   dashboardProjection: RuntimePressureDashboardProjectionHealth;
   delivery: RuntimePressureDeliveryHealth;
   requestPipeline?: RuntimePressureRequestPipelineHealth;
@@ -4096,6 +4106,9 @@ function normalizeRuntimePressureHealth(raw: unknown): RuntimePressureHealth | u
   const process = (payload.process ?? {}) as Record<string, unknown>;
   const allocator = (payload.allocator ?? {}) as Record<string, unknown>;
   const writer = (payload.writerAccounting ?? {}) as Record<string, unknown>;
+  const writeCoordinator = payload.proxySqliteWriteCoordinator as
+    | Record<string, unknown>
+    | undefined;
   const projection = (payload.dashboardProjection ?? {}) as Record<string, unknown>;
   const projectionSlices = (projection.sliceCounters ?? {}) as Record<string, unknown>;
   const delivery = (payload.delivery ?? {}) as Record<string, unknown>;
@@ -4145,6 +4158,16 @@ function normalizeRuntimePressureHealth(raw: unknown): RuntimePressureHealth | u
       invariantViolationCount: number(writer.invariantViolationCount),
       degradedReason: optionalString(writer.degradedReason),
     },
+    proxySqliteWriteCoordinator: writeCoordinator
+      ? {
+          mode: optionalString(writeCoordinator.mode) ?? "unknown",
+          activeWriteClass: optionalString(writeCoordinator.activeWriteClass),
+          p1WaiterCount: number(writeCoordinator.p1WaiterCount),
+          interactiveWaiterCount: number(writeCoordinator.interactiveWaiterCount),
+          p2WaiterCount: number(writeCoordinator.p2WaiterCount),
+          directWriteBypassCount: number(writeCoordinator.directWriteBypassCount),
+        }
+      : undefined,
     dashboardProjection: {
       mode: optionalString(projection.mode) ?? "unknown",
       state: optionalString(projection.state) ?? "unknown",


### PR DESCRIPTION
## Summary
- add a priority-aware proxy SQLite write coordinator for P1 terminal, interactive proxy, and P2 derived writes
- batch terminal persistence into short atomic transactions with commit-before-ack semantics, bounded exponential lock retry, and durable poison-record quarantine
- gate and bound P2 replay work, preserve synchronous attempt/route semantics, and expose additive coordinator and request-parse CPU telemetry
- update runtime data-plane, terminal projection, proxy stability, system design, and SQLite pressure documentation

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test -q proxy_sqlite_write_coordinator`
- `cargo test -q sqlite_batch_writer`
- `cargo test -q terminal_journal`
- `cargo test -q runtime_pressure_health_serializes_without_sql`
- `cargo test -q routing_failover_retry_budget`
- `cd web && bun run test`
- pre-commit Rust/Web/typecheck gates
- full `cargo test -q`: 2018 passed, 45 ignored; one timing-sensitive proxy test timed out under full-suite load and passed immediately in isolated rerun

## Contract
No public HTTP, SSE, Dashboard, statistics, or owner-facing UI changes. The legacy coordinator kill switch remains available for one release cycle.