### PR TITLE
perf: coalesce P2 writes and prompt cache topics

### DIFF
--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -104,6 +104,8 @@
 ## Terminal Projection
 
 - P1 journal ACK 后可向多个 read-side consumer 发布紧凑 terminal event 与 durable row cursor；consumer cursor 必须独立，不能让 P2 rollup 成功阻塞 raw terminal durability。
+- P1 的高频 admission ticker 不能同时作为 P2 pressure retry ticker。P2 应由首事件固定 deadline、pressure cooldown 截止时间和 background-slot eligibility 事件唤醒，并把 gate defer 与真实 lock failure 分开统计；否则“没有执行 SQL”的 defer 也会形成 CPU 空转和误导 retry 指标。
+- SSE topic 的通用 mutation 广播不能自动等价为 full-window cache invalidation。对 Prompt Cache 这类可按 key 增量维护的读模型，应以 active-topic baseline + compact delta + bounded reconcile 代替每条 terminal 后的整窗 hydrate。
 - 用 cursor 与持久 interval segment 替代定时范围重算：正常窗口只 hydrate 新增 rowId 并 additive upsert 受影响 rollup key，明确 repair 才精确重建目标桶。压力期保持 last-good 并 defer，不得为了补账重新抢 P1 锁。
 - 对已持久化 terminal 的字段修正要在同一事务中写入 target bucket repair marker；只更新全局 materialization 状态会让 cursor 之后没有新 row 的投影永远看不到修正。
 - 目标桶 repair 的 archive source 不只包含 terminal archive，也包含补齐账号归属所需的 attempt archive。archive rewrite 要同时排入旧、新 coverage；单个文件不可读时只延后对应桶并保留 last-good，不能让最老的失败 marker 饿死整个 repair 队列。repair 查询必须按目标自然日绑定范围，避免每个桶都读出整份 archive 后再过滤。

--- a/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/HISTORY.md
@@ -6,6 +6,8 @@
 
 ## Key Decisions
 
+- 2026-08-08：Prompt Cache window/sticky topic 从任意 Records 整窗 hydrate 收敛为 active-owner 内存投影；500ms 固定合并发布，初始订阅和最多每 60 秒一次的 pressure-gated reconcile 保持精确 baseline。
+
 - 2026-08-03：Prompt Cache conversation detail joined the shared topic bus with four tab-scoped read models. The realtime Calls head remains bounded to 50 rows; the entire captured HTTP snapshot, including page 1, deliberately remains frozen across fresh topic snapshots. The overview additionally pins its summary and samples to one SQLite snapshot plus captured runtime overlay with a fixed accepted page width; its HTTP fallback reuses the first page snapshot for summary, samples, and full-range bounds, while cached binding fallbacks remain descriptor-local and configuration broadcasts only target binding/event subscribers.
 - 2026-07-24：线上复查确认 Summary topic 的主要残留压力来自 terminal follow-up 对 `all/30m/1h/1d/1mo` 五个 legacy 窗口的无关重建，以及 `today` summary 的 `non_success_tokens` 仍走整窗账号活动聚合。本轮删除生产 Summary follow-up，open-range topic 改为 live overlay + 固定 `500ms` totals coalescer；`non_success_tokens` 复用 hourly v2 rollup 与 boundary scalar tail。Dashboard 保留既有 `5s` TTL，仅改用真实 owner subscriber lease 门控，并以 dirty reconnect 保证失活期间不回放旧连续性。
 - 2026-07-24：补充闭区间防护：`yesterday` / `previous7d` 即使有遗留兼容 topic，也不再被 Records 或 live 广播触发重建；当前应用继续通过 HTTP exact path 获取闭区间结果。

--- a/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/IMPLEMENTATION.md
@@ -112,6 +112,7 @@
 - Terminal records are admitted through a local segmented journal before the asynchronous SQLite writer. The journal batches durable sync at a bounded interval and replays unacknowledged records on restart.
 - Dashboard open-range topic publishing continues to render the shared in-memory snapshot during writer pressure. A last-good baseline may defer a reconcile for up to five minutes; closed-range responses retain their exact database behavior.
 - P1 terminal persistence is isolated from P2 derived rollups, account touches, and system-task completion writes. P2 work waits for the pressure gate instead of extending the terminal lock window.
+- Prompt Cache window and sticky-window topics use an active-owner memory projection. Generic Records append deduplicated deltas and never invoke the HTTP/full-window builder; a fixed 500ms materializer updates the authoritative frame, with pressure-gated reconciliation capped at once per 60 seconds.
 
 ## Remaining gaps
 

--- a/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
+++ b/docs/specs/5932d-sse-proxy-live-sync/SPEC.md
@@ -181,6 +181,7 @@
   - 调试与手动读取
 - Detail drawer history is intentionally hybrid: `invocation-history.window` owns only the latest 50-record head while the entire captured HTTP snapshot, including page 1, stays bound to its first `snapshotId` and is never replayed through the topic stream.
 - Detail drawers subscribe only to the visible tab. `Records` invalidates scope-matching calls/overview topics; committed conversation configuration changes invalidate only scope-matching binding/operations topics.
+- Prompt Cache window topics do not treat generic `Records` as a database invalidation. Active topics coalesce compact runtime/terminal deltas for 500ms and publish one shared frame; initial subscription and bounded 60-second reconcile establish exact baselines, while an inactive topic reconnects with a fresh snapshot.
 - owner-facing summary 的边界固定为：`today / 1d / 7d` 等 open-range 继续走 topic，`yesterday / previous7d` 通过 `fetchSummary(...)` 走 exact HTTP。
 - closed-range Summary topic 即使保留兼容请求，也不因 Records 或 live 广播触发重建；后端保留 `summary_delivery_mode` 与 closed-window misuse telemetry 以识别遗留消费者。
 - 但主应用订阅类 UI 在健康态与恢复态都不能再依赖这些 HTTP 端点完成“当前态校准”。

--- a/docs/specs/high-frequency-runtime-data-plane/HISTORY.md
+++ b/docs/specs/high-frequency-runtime-data-plane/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## Key Decisions
 
+- P2 派生写从 P1 的 20ms ticker 中分离，使用 250ms 固定合并、pressure deadline 与分类 lock retry；Prompt Cache window topic 同步改为 500ms active projection，通用 Records 不再触发整窗 SQLite hydrate。
+
 - 统一代理 terminal、attempt、route 与派生写的 SQLite admission，删除 P1 retained batch 固定 250ms 重试语义，并限制 P2 rollup 单事务工作量。
 
 - 高频路径的边界由类型依赖和计数测试约束，不再仅依赖“memory-first”命名或日志字段。

--- a/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
+++ b/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
@@ -2,7 +2,9 @@
 
 `ProxySqliteWriteCoordinator` 是代理热写的统一 admission 面。实现覆盖 terminal P1/P2 actor、attempt 生命周期和 route success/failure 汇聚路径，并通过 `runtimePressureHealth.proxySqliteWriteCoordinator` 暴露 active class、各优先级 waiter 与 legacy bypass 计数。
 
-P1 正常 admission 为 20ms，批次上限为 32 条或 4 MiB；失败后按 250ms 到 5s 退避。P2 hourly replay 每次只执行一个既有有界 chunk，未覆盖 derived work 保留到下一轮。
+P1 正常 admission 为 20ms，批次上限为 32 条或 4 MiB；失败后按 250ms 到 5s 退避。P2 使用独立 250ms 固定 deadline，pressure defer、background busy 和实际 lock retry 分开调度与计数；hourly replay 每次只执行一个既有有界 chunk，未覆盖 derived work 保留到下一轮。
+
+Prompt Cache window topic 在首个 owner 订阅时建立精确 baseline。后续 Records 按调用 identity 去重并在 500ms 后直接更新 cached payload；完整 hydrate 仅用于初始 baseline、60 秒 reconcile 或 dirty recovery。最后一个 owner 释放时丢弃 pending delta 并要求重订阅 fresh baseline。
 
 ## Delivery Topology
 

--- a/docs/specs/high-frequency-runtime-data-plane/SPEC.md
+++ b/docs/specs/high-frequency-runtime-data-plane/SPEC.md
@@ -87,6 +87,8 @@
 - 同 topic 从 1 个增长到 N 个 subscriber 时，builder、serialization 与完整 payload clone 次数不增长；每个 revision 只有一个 frame。
 - Dashboard current-state 更新 p95 不超过 `400ms`，terminal totals 在 `5s` 内可见。
 - P1 -> P2、coalesce、retry 与 retained batch 后 accounting 与真实队列估算一致，不出现下溢。
+- P2 pressure defer 不是执行失败，不得增加 retry 计数。健康派生写采用固定 250ms 合并；cooldown 到期或 background eligibility generation 变化负责唤醒，P1 的 20ms admission ticker 不得轮询 P2。
+- 高频 Prompt Cache topic 必须使用 active-topic scoped projection。任意 Records 广播不得触发 full-window hydrate；topic delta 500ms 合并，last-good baseline 最多每 60 秒 pressure-gated reconcile 一次。
 - 生产受控 A/B 中新增 Dashboard tab 的 CPU 增量不超过 10 个百分点，subscription lag/skipped 为零；连续 12 小时 RSS p95 不超过 `2 GiB` 且 Swap 不持续增长。该 A/B 是架构完成门槛，不能由“零 SQL”或单 topic Arc 复用测试替代。
 
 ## Non-goals

--- a/docs/specs/vmcs3-terminal-projection-materialization/HISTORY.md
+++ b/docs/specs/vmcs3-terminal-projection-materialization/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## 关键决策
 
+- P2 pressure defer 与 SQLite retry 分离：派生写使用 250ms 固定合并并按 gate eligibility 唤醒，只有实际执行失败才推进 retry/backoff。
+
 - P1 journal 是 raw terminal durability 边界，不把投影完成当作 journal 回收条件。
 - Dashboard 与长期统计共享 terminal admission/ACK 事实，但各自持有 cursor，避免一个消费者的慢恢复阻塞另一个。
 - 增量物化持久化每个 rollup key 的 interval segment，并在内存维护规范化区间并集；因此无需把既有 `wall_time_ms` 直接相加，也无需为正常 terminal 流量重建整天。

--- a/docs/specs/vmcs3-terminal-projection-materialization/SPEC.md
+++ b/docs/specs/vmcs3-terminal-projection-materialization/SPEC.md
@@ -42,6 +42,7 @@ Terminal journal 的 durable ACK 只能发生在 P1 SQLite 事务提交后。P1 
 
 - 空闲期不再存在按 60 秒无条件扫描近两天 raw invocation 的长期统计生产任务。
 - terminal burst 下，每个长期 projection 最多一次固定 60 秒 P2 flush；P1 ACK 和 Dashboard terminal overlay 不依赖该 flush。
+- P2 admission 使用独立固定 250ms deadline。pressure gate 拒绝后按 eligibility/cooldown 事件唤醒，实际 SQLite busy/locked 才进入 250ms 到 5s 的失败退避；pressure defer 不属于 retry。
 - 重启、journal replay、重复 terminal、hard limit、跨自然日 interval、unassigned/model/reasoning 分组和 archive rewrite 与 exact builder 对账一致。
 - System Status 展示只读取内存 health，不增加 status route 的 SQLite 查询数；健康、deferred、dirty-last-good 均可读且详情可展开。
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -48,7 +48,8 @@ flowchart LR
 - writer queue 的 depth/bytes 由单一 accounting owner 管理。P1 生成 P2 工作时必须转移 ownership，不得跨阶段裸减计数。
 - 代理热写由 `ProxySqliteWriteCoordinator` 单点仲裁，优先级为 P1 terminal、同步 attempt/route、P2 derived。同步写仍等待并返回原结果，但不得绕过协调器直接竞争 SQLite writer。
 - P1 使用 20ms admission、最多 32 条或 4 MiB 的短批次；busy/locked 批次完整保留并按 250ms、500ms、1s、2s、5s 退避。只有事务提交后才能推进 journal 与 projection ACK。
-- P2 仅在 P1 与同步等待者为空时运行；rollup cursor 每次只推进一个有界 chunk，剩余工作重新排队。
+- P2 仅在 P1 与同步等待者为空时运行；首个派生事件建立固定 250ms 合并 deadline，后续事件不延长。pressure cooldown 按 gate 剩余时间休眠，background eligibility 变化或实际 SQLite 失败退避才再次唤醒，禁止复用 P1 的 20ms ticker 轮询。rollup cursor 每次只推进一个有界 chunk，剩余工作重新排队。
+- `prompt-cache.window` 与 `prompt-cache.sticky.window` 在 owner 订阅期间维护 topic-scoped 内存投影。通用 Records 只追加去重 delta，500ms 固定 deadline 从 last-good baseline 更新 lifetime、账号、recent 和 24h points；初始订阅、60 秒 pressure-gated reconcile 与 dirty 恢复才允许完整 hydrate。
 
 ## 4. Dashboard 与 SSE
 

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -397,6 +397,7 @@ pub(crate) struct SubscriptionHub {
 #[derive(Debug, Default)]
 struct SubscriptionHubState {
     topics: HashMap<String, CachedSubscriptionTopic>,
+    active_topics: HashMap<String, SubscriptionTopic>,
     active_subscribers: HashMap<String, usize>,
     active_topic_names: HashMap<String, usize>,
     dashboard_live_subscriber_count: usize,
@@ -405,6 +406,7 @@ struct SubscriptionHubState {
     dashboard_current_slice: Option<Arc<DashboardCurrentProjectionSlice>>,
     dashboard_network_slice: Option<Arc<DashboardNetworkProjectionSlice>>,
     dashboard_terminal_slice: Option<Arc<DashboardTerminalProjectionSlice>>,
+    prompt_cache_prebaseline_records: HashMap<String, BTreeMap<String, PromptCacheTopicDelta>>,
 }
 
 #[derive(Debug, Clone)]
@@ -425,9 +427,14 @@ struct CachedSubscriptionTopic {
     summary_retry_backoff_ms: u64,
     prompt_cache_refresh_scheduled: bool,
     prompt_cache_pending_records: BTreeMap<String, PromptCacheTopicDelta>,
+    prompt_cache_applied_terminal_ids: HashSet<String>,
     prompt_cache_coalesced_event_count: u64,
     prompt_cache_full_hydration_count: u64,
+    prompt_cache_bounded_key_hydration_count: u64,
     prompt_cache_baseline_at: Option<Instant>,
+    prompt_cache_baseline_row_id: i64,
+    prompt_cache_response_source: &'static str,
+    prompt_cache_reconcile_required: bool,
     latest_live_snapshot: Option<DashboardActivityLiveSnapshot>,
     calendar_anchor: Option<String>,
     continuity_reset_cursor: Option<u64>,
@@ -443,8 +450,10 @@ struct CachedSubscriptionTopic {
 
 #[derive(Debug, Clone)]
 struct PromptCacheTopicDelta {
+    row_id: i64,
     identity: String,
-    prompt_cache_key: String,
+    prompt_cache_key: Option<String>,
+    sticky_key: Option<String>,
     occurred_at: Value,
     status: String,
     is_terminal: bool,
@@ -456,20 +465,35 @@ struct PromptCacheTopicDelta {
     preview: Value,
 }
 
+struct PromptCacheBaselineBuild {
+    baseline_row_id: i64,
+    persisted_identities: HashSet<String>,
+}
+
 impl PromptCacheTopicDelta {
     fn from_record(record: &ApiInvocation) -> Result<Option<Self>, ApiError> {
-        let Some(prompt_cache_key) = record
+        let prompt_cache_key = record
             .prompt_cache_key
             .as_deref()
             .map(str::trim)
             .filter(|key| !key.is_empty())
-            .map(str::to_string)
-        else {
+            .map(str::to_string);
+        let sticky_key = record
+            .sticky_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .map(str::to_string);
+        if prompt_cache_key.is_none() && sticky_key.is_none() {
             return Ok(None);
-        };
+        }
+        let preview_key = prompt_cache_key
+            .clone()
+            .or_else(|| sticky_key.clone())
+            .expect("at least one prompt cache identity");
         let preview = serde_json::to_value(prompt_cache_invocation_preview_from_runtime_record(
             record,
-            prompt_cache_key.clone(),
+            preview_key,
         ))?;
         let occurred_at = preview
             .get("occurredAt")
@@ -480,8 +504,10 @@ impl PromptCacheTopicDelta {
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
         Ok(Some(Self {
+            row_id: record.id,
             identity: format!("{}\0{}", record.invoke_id, record.occurred_at),
             prompt_cache_key,
+            sticky_key,
             occurred_at,
             is_terminal: prompt_invocation_status_counts_toward_terminal_totals(Some(&status)),
             is_success: prompt_invocation_status_is_success_like(
@@ -1201,6 +1227,13 @@ impl SubscriptionHub {
             snapshot.full_hydration_count = snapshot
                 .full_hydration_count
                 .saturating_add(cached.prompt_cache_full_hydration_count);
+            snapshot.bounded_key_hydration_count = snapshot
+                .bounded_key_hydration_count
+                .saturating_add(cached.prompt_cache_bounded_key_hydration_count);
+            snapshot.live_path_db_read_count = snapshot
+                .live_path_db_read_count
+                .saturating_add(cached.prompt_cache_full_hydration_count.saturating_sub(1))
+                .saturating_add(cached.prompt_cache_bounded_key_hydration_count);
             snapshot.baseline_age_ms = snapshot.baseline_age_ms.max(
                 cached
                     .prompt_cache_baseline_at
@@ -1209,6 +1242,8 @@ impl SubscriptionHub {
             );
             if cached.dirty {
                 snapshot.response_source = "dirty_last_good".to_string();
+            } else if cached.prompt_cache_response_source != "memory" {
+                snapshot.response_source = cached.prompt_cache_response_source.to_string();
             }
         }
         snapshot
@@ -1393,6 +1428,10 @@ impl SubscriptionHub {
             .map(str::to_string)
             .collect::<Vec<_>>();
         let mut guard = self.state.lock().await;
+        for topic in topics {
+            let topic_key = topic.cache_key()?;
+            guard.active_topics.insert(topic_key, topic.clone());
+        }
         for topic_key in &topic_keys {
             *guard
                 .active_subscribers
@@ -1468,6 +1507,8 @@ impl SubscriptionHub {
                 Some(count) if *count > 1 => *count -= 1,
                 Some(_) => {
                     guard.active_subscribers.remove(&topic_key);
+                    guard.active_topics.remove(&topic_key);
+                    guard.prompt_cache_prebaseline_records.remove(&topic_key);
                     if let Some(cached) = guard.topics.get_mut(&topic_key)
                         && matches!(
                             cached.topic,
@@ -1476,6 +1517,7 @@ impl SubscriptionHub {
                         )
                     {
                         cached.prompt_cache_pending_records.clear();
+                        cached.prompt_cache_applied_terminal_ids.clear();
                         cached.prompt_cache_refresh_scheduled = false;
                         cached.prompt_cache_baseline_at = None;
                         cached.dirty = true;
@@ -1780,6 +1822,63 @@ impl SubscriptionHub {
             .await
     }
 
+    async fn build_prompt_cache_consistent_baseline(
+        &self,
+        state: Arc<AppState>,
+        topic: &SubscriptionTopic,
+    ) -> Result<(BuiltSubscriptionTopicPayload, PromptCacheBaselineBuild), ApiError> {
+        for _ in 0..3 {
+            let mut observer = state.pool.acquire().await?;
+            let version_before = sqlx::query_scalar::<_, i64>("PRAGMA data_version")
+                .fetch_one(&mut *observer)
+                .await?;
+            let baseline_row_id =
+                sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM codex_invocations")
+                    .fetch_one(&mut *observer)
+                    .await?;
+            let payload = topic.build_cached_payload(state.clone()).await?;
+            let candidate_identities = {
+                let guard = self.state.lock().await;
+                let topic_key = topic.cache_key()?;
+                guard
+                    .prompt_cache_prebaseline_records
+                    .get(&topic_key)
+                    .into_iter()
+                    .flat_map(|records| records.values())
+                    .chain(
+                        guard
+                            .topics
+                            .get(&topic_key)
+                            .into_iter()
+                            .flat_map(|cached| cached.prompt_cache_pending_records.values()),
+                    )
+                    .map(|delta| delta.identity.clone())
+                    .collect::<HashSet<_>>()
+            };
+            let persisted_identities = load_persisted_prompt_cache_identities(
+                &mut observer,
+                &candidate_identities,
+                baseline_row_id,
+            )
+            .await?;
+            let version_after = sqlx::query_scalar::<_, i64>("PRAGMA data_version")
+                .fetch_one(&mut *observer)
+                .await?;
+            if version_before == version_after {
+                return Ok((
+                    payload,
+                    PromptCacheBaselineBuild {
+                        baseline_row_id,
+                        persisted_identities,
+                    },
+                ));
+            }
+        }
+        Err(ApiError::from(anyhow!(
+            "prompt cache baseline changed during build"
+        )))
+    }
+
     async fn refresh_topic_inner(
         &self,
         state: Arc<AppState>,
@@ -1791,9 +1890,21 @@ impl SubscriptionHub {
         let schema_epoch = topic.schema_epoch();
         let descriptor = topic.descriptor();
         let started = Instant::now();
+        let is_prompt_cache_topic = matches!(
+            topic,
+            SubscriptionTopic::PromptCacheWindow { .. }
+                | SubscriptionTopic::PromptCacheStickyWindow { .. }
+        );
+        let (mut built_payload, prompt_cache_build) = if is_prompt_cache_topic {
+            let (payload, build) = self
+                .build_prompt_cache_consistent_baseline(state.clone(), &topic)
+                .await?;
+            (payload, Some(build))
+        } else {
+            (topic.build_cached_payload(state.clone()).await?, None)
+        };
         self.dashboard_topology_counters
             .record_materialization(topic.name());
-        let mut built_payload = topic.build_cached_payload(state.clone()).await?;
 
         let (cached, dispatch) = {
             let mut guard = self.state.lock().await;
@@ -1820,6 +1931,39 @@ impl SubscriptionHub {
                     .cloned()
             {
                 apply_topic_live_overlay_to_payload(state.as_ref(), &topic, payload, &live)?;
+            }
+            let mut prompt_cache_pending = guard
+                .prompt_cache_prebaseline_records
+                .remove(&topic_key)
+                .unwrap_or_default();
+            if let Some(existing) = guard.topics.get_mut(&topic_key) {
+                prompt_cache_pending.append(&mut existing.prompt_cache_pending_records);
+                existing.prompt_cache_refresh_scheduled = false;
+            }
+            let prompt_cache_replay = prompt_cache_build
+                .as_ref()
+                .map(|build| {
+                    prompt_cache_pending
+                        .into_values()
+                        .filter(|delta| {
+                            prompt_cache_delta_needs_replay(delta, &build.persisted_identities)
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let mut prompt_cache_applied_terminal_ids = HashSet::new();
+            if let BuiltSubscriptionTopicPayload::Json(payload) = &mut built_payload
+                && !prompt_cache_replay.is_empty()
+            {
+                apply_prompt_cache_records_to_payload(
+                    &topic,
+                    payload,
+                    &prompt_cache_replay,
+                    &mut prompt_cache_applied_terminal_ids,
+                    prompt_cache_build
+                        .as_ref()
+                        .map_or(0, |build| build.baseline_row_id),
+                )?;
             }
             let serialized_payload = built_payload.serialize(
                 guard.dashboard_current_slice.as_deref(),
@@ -1854,9 +1998,17 @@ impl SubscriptionHub {
                     existing.snapshot_payload = built_payload.snapshot_payload();
                     return Ok(Some(existing.clone()));
                 }
-                if let Some(existing) = reuse_unchanged_cached_topic(existing, &serialized_payload)
-                {
-                    return Ok(Some(existing));
+                if reuse_unchanged_cached_topic(existing, &serialized_payload).is_some() {
+                    if let Some(build) = &prompt_cache_build {
+                        existing.prompt_cache_full_hydration_count =
+                            existing.prompt_cache_full_hydration_count.saturating_add(1);
+                        existing.prompt_cache_baseline_at = Some(Instant::now());
+                        existing.prompt_cache_baseline_row_id = build.baseline_row_id;
+                        existing.prompt_cache_response_source = "database_reconcile";
+                        existing.prompt_cache_applied_terminal_ids =
+                            prompt_cache_applied_terminal_ids;
+                    }
+                    return Ok(Some(existing.clone()));
                 }
             }
             let current_cursor = guard.topics.get(&topic_key).map_or(0, |entry| entry.cursor);
@@ -1926,11 +2078,20 @@ impl SubscriptionHub {
                     .topics
                     .get(&topic_key)
                     .is_some_and(|entry| entry.prompt_cache_refresh_scheduled),
-                prompt_cache_pending_records: guard
-                    .topics
-                    .get(&topic_key)
-                    .map(|entry| entry.prompt_cache_pending_records.clone())
-                    .unwrap_or_default(),
+                prompt_cache_pending_records: BTreeMap::new(),
+                prompt_cache_applied_terminal_ids: if matches!(
+                    topic,
+                    SubscriptionTopic::PromptCacheWindow { .. }
+                        | SubscriptionTopic::PromptCacheStickyWindow { .. }
+                ) {
+                    prompt_cache_applied_terminal_ids
+                } else {
+                    guard
+                        .topics
+                        .get(&topic_key)
+                        .map(|entry| entry.prompt_cache_applied_terminal_ids.clone())
+                        .unwrap_or_default()
+                },
                 prompt_cache_coalesced_event_count: guard
                     .topics
                     .get(&topic_key)
@@ -1941,7 +2102,20 @@ impl SubscriptionHub {
                     .map_or(1, |entry| {
                         entry.prompt_cache_full_hydration_count.saturating_add(1)
                     }),
+                prompt_cache_bounded_key_hydration_count: guard
+                    .topics
+                    .get(&topic_key)
+                    .map_or(0, |entry| entry.prompt_cache_bounded_key_hydration_count),
                 prompt_cache_baseline_at: Some(Instant::now()),
+                prompt_cache_baseline_row_id: prompt_cache_build
+                    .as_ref()
+                    .map_or(0, |build| build.baseline_row_id),
+                prompt_cache_response_source: if guard.topics.contains_key(&topic_key) {
+                    "database_reconcile"
+                } else {
+                    "initial_baseline"
+                },
+                prompt_cache_reconcile_required: false,
                 latest_live_snapshot: guard
                     .topics
                     .get(&topic_key)
@@ -2211,6 +2385,42 @@ impl SubscriptionHub {
         {
             self.schedule_prompt_cache_topic_projection(state.clone(), records)
                 .await;
+        }
+        if prompt_cache_topic_projection_enabled() {
+            match &payload {
+                BroadcastPayload::PromptCacheConversationChanged { prompt_cache_key } => {
+                    if let Err(err) = self
+                        .apply_prompt_cache_binding_projection(state.as_ref(), prompt_cache_key)
+                        .await
+                    {
+                        warn!(
+                            ?err,
+                            prompt_cache_key,
+                            "failed to apply bounded prompt cache binding projection"
+                        );
+                    }
+                }
+                BroadcastPayload::PromptCacheConversationStickyRouteChanged {
+                    sticky_key,
+                    previous_upstream_account_id,
+                    upstream_account_id,
+                } => {
+                    if let Err(err) = self
+                        .apply_prompt_cache_sticky_route_projection(
+                            sticky_key,
+                            *previous_upstream_account_id,
+                            *upstream_account_id,
+                        )
+                        .await
+                    {
+                        warn!(
+                            ?err,
+                            sticky_key, "failed to apply prompt cache sticky route projection"
+                        );
+                    }
+                }
+                _ => {}
+            }
         }
         let affected = {
             let mut guard = self.state.lock().await;
@@ -2687,21 +2897,26 @@ impl SubscriptionHub {
 
         let scheduled = {
             let mut guard = self.state.lock().await;
-            let active_subscribers = guard.active_subscribers.clone();
+            let active_topics = guard.active_topics.clone();
             let mut scheduled = Vec::new();
-            for (topic_key, cached) in &mut guard.topics {
+            for (topic_key, topic) in active_topics {
                 if !matches!(
-                    cached.topic,
+                    topic,
                     SubscriptionTopic::PromptCacheWindow { .. }
                         | SubscriptionTopic::PromptCacheStickyWindow { .. }
-                ) || active_subscribers
-                    .get(topic_key)
-                    .copied()
-                    .unwrap_or_default()
-                    == 0
-                {
+                ) {
                     continue;
                 }
+                let Some(cached) = guard.topics.get_mut(&topic_key) else {
+                    let pending = guard
+                        .prompt_cache_prebaseline_records
+                        .entry(topic_key)
+                        .or_default();
+                    for record in &records {
+                        pending.insert(record.identity.clone(), record.clone());
+                    }
+                    continue;
+                };
                 let before = cached.prompt_cache_pending_records.len();
                 for record in &records {
                     cached
@@ -2719,7 +2934,7 @@ impl SubscriptionHub {
                     );
                 if !cached.prompt_cache_refresh_scheduled {
                     cached.prompt_cache_refresh_scheduled = true;
-                    scheduled.push(cached.topic.clone());
+                    scheduled.push(topic);
                 }
             }
             scheduled
@@ -2741,54 +2956,9 @@ impl SubscriptionHub {
                         "prompt cache in-memory topic materialization failed"
                     );
                     hub.mark_topic_dirty(&topic).await;
-                    return;
-                }
-                if hub.prompt_cache_topic_needs_reconcile(&topic).await {
-                    match crate::db_pressure::global_db_pressure_gate()
-                        .try_begin_background("prompt_cache_topic_reconcile")
-                    {
-                        Ok(_permit) => {
-                            match hub
-                                .refresh_topic_if_active(state.clone(), topic.clone(), true)
-                                .await
-                            {
-                                Ok(_) => tracing::debug!(
-                                    topic = topic.name(),
-                                    reconcile_outcome = "accepted_baseline",
-                                    response_source = "database_reconcile",
-                                    "prompt cache topic projection reconciled"
-                                ),
-                                Err(err) => warn!(
-                                    ?err,
-                                    topic = topic.name(),
-                                    reconcile_outcome = "retained_last_good",
-                                    "prompt cache topic reconcile failed"
-                                ),
-                            }
-                        }
-                        Err(reason) => tracing::debug!(
-                            topic = topic.name(),
-                            reconcile_outcome = "pressure_deferred",
-                            defer_reason = %reason,
-                            "prompt cache topic reconcile deferred"
-                        ),
-                    }
                 }
             });
         }
-    }
-
-    async fn prompt_cache_topic_needs_reconcile(&self, topic: &SubscriptionTopic) -> bool {
-        let Ok(topic_key) = topic.cache_key() else {
-            return false;
-        };
-        self.state
-            .lock()
-            .await
-            .topics
-            .get(&topic_key)
-            .and_then(|cached| cached.prompt_cache_baseline_at)
-            .is_none_or(|baseline| baseline.elapsed() >= PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL)
     }
 
     async fn materialize_prompt_cache_topic(
@@ -2820,6 +2990,8 @@ impl SubscriptionHub {
                     topic,
                     &mut cached.snapshot_payload,
                     &records,
+                    &mut cached.prompt_cache_applied_terminal_ids,
+                    cached.prompt_cache_baseline_row_id,
                 )?
             {
                 return Ok(());
@@ -2843,6 +3015,7 @@ impl SubscriptionHub {
                 emitted_at: Utc::now(),
             });
             cached.replay_bytes = cached.replay_bytes.saturating_add(retained_bytes);
+            cached.prompt_cache_response_source = "memory";
             prune_replay_window(&mut cached.replay_events, &mut cached.replay_bytes);
             tracing::debug!(
                 topic = topic.name(),
@@ -2858,6 +3031,272 @@ impl SubscriptionHub {
             SubscriptionDispatchEvent { frame }
         };
         let _ = self.broadcaster.send(dispatch);
+        Ok(())
+    }
+
+    async fn prompt_cache_reconcile_required(&self, topic_key: &str) -> bool {
+        self.state
+            .lock()
+            .await
+            .topics
+            .get(topic_key)
+            .is_some_and(|cached| {
+                cached.prompt_cache_reconcile_required
+                    || cached.dirty
+                    || !cached.prompt_cache_applied_terminal_ids.is_empty()
+            })
+    }
+
+    async fn expire_prompt_cache_topic_window(&self, topic_key: &str) -> Result<(), ApiError> {
+        let dispatch = {
+            let mut guard = self.state.lock().await;
+            let Some(cached) = guard.topics.get_mut(topic_key) else {
+                return Ok(());
+            };
+            let now = Utc::now();
+            let activity_cutoff = match cached.topic {
+                SubscriptionTopic::PromptCacheWindow {
+                    selection: PromptCacheConversationSelection::Count(_),
+                    ..
+                }
+                | SubscriptionTopic::PromptCacheStickyWindow {
+                    selection: AccountStickyKeySelection::Count(_),
+                    ..
+                } => Some(now - ChronoDuration::hours(24)),
+                SubscriptionTopic::PromptCacheWindow {
+                    selection: PromptCacheConversationSelection::ActivityWindowHours(hours),
+                    ..
+                } => Some(now - ChronoDuration::hours(hours)),
+                SubscriptionTopic::PromptCacheWindow {
+                    selection: PromptCacheConversationSelection::ActivityWindowMinutes(minutes),
+                    ..
+                } => Some(now - ChronoDuration::minutes(minutes)),
+                SubscriptionTopic::PromptCacheStickyWindow {
+                    selection: AccountStickyKeySelection::ActivityWindow(hours),
+                    ..
+                } => Some(now - ChronoDuration::hours(hours)),
+                _ => None,
+            };
+            let Some(conversations) = cached
+                .snapshot_payload
+                .get_mut("conversations")
+                .and_then(Value::as_array_mut)
+            else {
+                return Ok(());
+            };
+            let before = conversations.len();
+            if let Some(cutoff) = activity_cutoff {
+                conversations.retain(|conversation| {
+                    conversation
+                        .get("lastActivityAt")
+                        .and_then(Value::as_str)
+                        .and_then(parse_to_utc_datetime)
+                        .is_some_and(|last_activity| last_activity >= cutoff)
+                });
+            }
+            let mut changed = conversations.len() != before;
+            if changed {
+                cached.prompt_cache_reconcile_required = true;
+            }
+            let request_cutoff = now - ChronoDuration::hours(24);
+            for conversation in conversations {
+                let Some(points) = conversation
+                    .get_mut("last24hRequests")
+                    .and_then(Value::as_array_mut)
+                else {
+                    continue;
+                };
+                let before = points.len();
+                points.retain(|point| {
+                    point
+                        .get("occurredAt")
+                        .and_then(Value::as_str)
+                        .and_then(parse_to_utc_datetime)
+                        .is_some_and(|occurred_at| occurred_at >= request_cutoff)
+                });
+                changed |= points.len() != before;
+                let mut cumulative = 0_i64;
+                for point in points {
+                    cumulative = cumulative.saturating_add(
+                        point
+                            .get("requestTokens")
+                            .and_then(Value::as_i64)
+                            .unwrap_or_default(),
+                    );
+                    if let Some(point) = point.as_object_mut() {
+                        point.insert("cumulativeTokens".to_string(), Value::from(cumulative));
+                    }
+                }
+            }
+            if !changed {
+                return Ok(());
+            }
+            let next_cursor = cached.cursor.saturating_add(1);
+            let frame = Arc::new(self.serialize_frame(
+                cached.descriptor.clone(),
+                topic_key.to_string(),
+                cached.schema_epoch.clone(),
+                next_cursor,
+                serde_json::to_vec(&cached.snapshot_payload)?,
+            )?);
+            let retained_bytes = frame.retained_bytes();
+            cached.cursor = next_cursor;
+            cached.snapshot_frame = frame.clone();
+            cached.snapshot_bytes = frame.payload_bytes.len();
+            cached.replay_events.push_back(ReplayableTopicEvent {
+                frame: frame.clone(),
+                bytes: retained_bytes,
+                emitted_at: now,
+            });
+            cached.replay_bytes = cached.replay_bytes.saturating_add(retained_bytes);
+            prune_replay_window(&mut cached.replay_events, &mut cached.replay_bytes);
+            Some(SubscriptionDispatchEvent { frame })
+        };
+        if let Some(dispatch) = dispatch {
+            let _ = self.broadcaster.send(dispatch);
+        }
+        Ok(())
+    }
+
+    async fn apply_prompt_cache_binding_projection(
+        &self,
+        state: &AppState,
+        prompt_cache_key: &str,
+    ) -> Result<(), ApiError> {
+        let binding = serde_json::to_value(
+            load_prompt_cache_conversation_binding_response_for_key(
+                state,
+                prompt_cache_key.to_string(),
+            )
+            .await?,
+        )?;
+        let mut dispatches = Vec::new();
+        let mut guard = self.state.lock().await;
+        let active_subscribers = guard.active_subscribers.clone();
+        for (topic_key, cached) in &mut guard.topics {
+            if !matches!(cached.topic, SubscriptionTopic::PromptCacheWindow { .. })
+                || active_subscribers
+                    .get(topic_key)
+                    .copied()
+                    .unwrap_or_default()
+                    == 0
+            {
+                continue;
+            }
+            cached.prompt_cache_bounded_key_hydration_count = cached
+                .prompt_cache_bounded_key_hydration_count
+                .saturating_add(1);
+            let Some(changed) = patch_prompt_cache_binding_payload(
+                &mut cached.snapshot_payload,
+                prompt_cache_key,
+                &binding,
+            ) else {
+                cached.prompt_cache_reconcile_required = true;
+                continue;
+            };
+            if !changed {
+                continue;
+            }
+            let next_cursor = cached.cursor.saturating_add(1);
+            let frame = Arc::new(self.serialize_frame(
+                cached.descriptor.clone(),
+                topic_key.clone(),
+                cached.schema_epoch.clone(),
+                next_cursor,
+                serde_json::to_vec(&cached.snapshot_payload)?,
+            )?);
+            let retained_bytes = frame.retained_bytes();
+            cached.cursor = next_cursor;
+            cached.snapshot_frame = frame.clone();
+            cached.snapshot_bytes = frame.payload_bytes.len();
+            cached.replay_events.push_back(ReplayableTopicEvent {
+                frame: frame.clone(),
+                bytes: retained_bytes,
+                emitted_at: Utc::now(),
+            });
+            cached.replay_bytes = cached.replay_bytes.saturating_add(retained_bytes);
+            cached.prompt_cache_response_source = "memory";
+            prune_replay_window(&mut cached.replay_events, &mut cached.replay_bytes);
+            dispatches.push(SubscriptionDispatchEvent { frame });
+        }
+        drop(guard);
+        for dispatch in dispatches {
+            let _ = self.broadcaster.send(dispatch);
+        }
+        Ok(())
+    }
+
+    async fn apply_prompt_cache_sticky_route_projection(
+        &self,
+        sticky_key: &str,
+        previous_upstream_account_id: i64,
+        upstream_account_id: i64,
+    ) -> Result<(), ApiError> {
+        let mut dispatches = Vec::new();
+        let mut guard = self.state.lock().await;
+        let active_subscribers = guard.active_subscribers.clone();
+        for (topic_key, cached) in &mut guard.topics {
+            let SubscriptionTopic::PromptCacheStickyWindow { account_id, .. } = cached.topic else {
+                continue;
+            };
+            if active_subscribers
+                .get(topic_key)
+                .copied()
+                .unwrap_or_default()
+                == 0
+            {
+                continue;
+            }
+            let Some(conversations) = cached
+                .snapshot_payload
+                .get_mut("conversations")
+                .and_then(Value::as_array_mut)
+            else {
+                cached.prompt_cache_reconcile_required = true;
+                continue;
+            };
+            let before = conversations.len();
+            if account_id == previous_upstream_account_id && account_id != upstream_account_id {
+                conversations.retain(|conversation| {
+                    conversation.get("stickyKey").and_then(Value::as_str) != Some(sticky_key)
+                });
+            }
+            if account_id == upstream_account_id
+                && !conversations.iter().any(|conversation| {
+                    conversation.get("stickyKey").and_then(Value::as_str) == Some(sticky_key)
+                })
+            {
+                cached.prompt_cache_reconcile_required = true;
+            }
+            if conversations.len() == before {
+                continue;
+            }
+            let next_cursor = cached.cursor.saturating_add(1);
+            let frame = Arc::new(self.serialize_frame(
+                cached.descriptor.clone(),
+                topic_key.clone(),
+                cached.schema_epoch.clone(),
+                next_cursor,
+                serde_json::to_vec(&cached.snapshot_payload)?,
+            )?);
+            let retained_bytes = frame.retained_bytes();
+            cached.cursor = next_cursor;
+            cached.snapshot_frame = frame.clone();
+            cached.snapshot_bytes = frame.payload_bytes.len();
+            cached.replay_events.push_back(ReplayableTopicEvent {
+                frame: frame.clone(),
+                bytes: retained_bytes,
+                emitted_at: Utc::now(),
+            });
+            cached.replay_bytes = cached.replay_bytes.saturating_add(retained_bytes);
+            cached.prompt_cache_response_source = "memory";
+            prune_replay_window(&mut cached.replay_events, &mut cached.replay_bytes);
+            dispatches.push(SubscriptionDispatchEvent { frame });
+        }
+        drop(guard);
+        for dispatch in dispatches {
+            let _ = self.broadcaster.send(dispatch);
+        }
         Ok(())
     }
 
@@ -3469,10 +3908,118 @@ fn set_json_field(object: &mut serde_json::Map<String, Value>, key: &str, value:
     object.insert(key.to_string(), value);
 }
 
+async fn load_persisted_prompt_cache_identities(
+    conn: &mut sqlx::SqliteConnection,
+    identities: &HashSet<String>,
+    baseline_row_id: i64,
+) -> Result<HashSet<String>, ApiError> {
+    let selectors = identities
+        .iter()
+        .filter_map(|identity| identity.split_once('\0'))
+        .collect::<Vec<_>>();
+    let mut persisted = HashSet::new();
+    for chunk in selectors.chunks(300) {
+        let mut query = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "SELECT invoke_id, occurred_at FROM codex_invocations WHERE id <= ",
+        );
+        query.push_bind(baseline_row_id);
+        query.push(" AND (");
+        let mut separated = query.separated(" OR ");
+        for (invoke_id, occurred_at) in chunk {
+            separated
+                .push("(invoke_id = ")
+                .push_bind(*invoke_id)
+                .push(" AND occurred_at = ")
+                .push_bind(*occurred_at)
+                .push(")");
+        }
+        separated.push_unseparated(")");
+        for (invoke_id, occurred_at) in query
+            .build_query_as::<(String, String)>()
+            .fetch_all(&mut *conn)
+            .await?
+        {
+            persisted.insert(format!("{invoke_id}\0{occurred_at}"));
+        }
+    }
+    Ok(persisted)
+}
+
+fn patch_prompt_cache_binding_payload(
+    payload: &mut Value,
+    prompt_cache_key: &str,
+    binding: &Value,
+) -> Option<bool> {
+    let conversation = payload
+        .get_mut("conversations")?
+        .as_array_mut()?
+        .iter_mut()
+        .find(|conversation| {
+            conversation.get("promptCacheKey").and_then(Value::as_str) == Some(prompt_cache_key)
+        })?
+        .as_object_mut()?;
+    let binding_kind = binding.get("bindingKind").and_then(Value::as_str);
+    let manual_binding = binding_kind
+        .filter(|kind| *kind != "none")
+        .map(|kind| {
+            serde_json::json!({
+                "bindingKind": kind,
+                "groupName": binding.get("groupName").cloned().unwrap_or(Value::Null),
+                "upstreamAccountId": binding.get("upstreamAccountId").cloned().unwrap_or(Value::Null),
+                "upstreamAccountName": binding.get("upstreamAccountName").cloned().unwrap_or(Value::Null),
+            })
+        })
+        .unwrap_or(Value::Null);
+    let replacements = [
+        (
+            "hasEncryptedSessionOwner",
+            binding
+                .get("hasEncryptedSessionOwner")
+                .cloned()
+                .unwrap_or(Value::Bool(false)),
+        ),
+        (
+            "encryptedOwnerAccountId",
+            binding
+                .get("encryptedOwnerAccountId")
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        (
+            "encryptedOwnerAccountName",
+            binding
+                .get("encryptedOwnerAccountName")
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        (
+            "encryptedOwnerGroupName",
+            binding
+                .get("encryptedOwnerGroupName")
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        ("manualBinding", manual_binding),
+    ];
+    let changed = replacements
+        .iter()
+        .any(|(field, value)| conversation.get(*field) != Some(value));
+    for (field, value) in replacements {
+        if value.is_null() {
+            conversation.remove(field);
+        } else {
+            conversation.insert(field.to_string(), value);
+        }
+    }
+    Some(changed)
+}
+
 fn apply_prompt_cache_records_to_payload(
     topic: &SubscriptionTopic,
     payload: &mut Value,
     records: &[PromptCacheTopicDelta],
+    applied_terminal_ids: &mut HashSet<String>,
+    baseline_row_id: i64,
 ) -> Result<bool, ApiError> {
     let Some(conversations) = payload
         .as_object_mut()
@@ -3483,7 +4030,14 @@ fn apply_prompt_cache_records_to_payload(
     };
     let mut changed = false;
     for record in records {
-        let key = record.prompt_cache_key.as_str();
+        let key = match topic {
+            SubscriptionTopic::PromptCacheWindow { .. } => record.prompt_cache_key.as_deref(),
+            SubscriptionTopic::PromptCacheStickyWindow { .. } => record.sticky_key.as_deref(),
+            _ => None,
+        };
+        let Some(key) = key else {
+            continue;
+        };
         if let SubscriptionTopic::PromptCacheStickyWindow { account_id, .. } = topic
             && record.upstream_account_id != Some(*account_id)
         {
@@ -3536,14 +4090,8 @@ fn apply_prompt_cache_records_to_payload(
                 == preview.get("invokeId").and_then(Value::as_str)
                 && item.get("occurredAt") == Some(&occurred_at)
         });
-        let already_terminal = existing_index.is_some_and(|index| {
-            recent[index]
-                .get("status")
-                .and_then(Value::as_str)
-                .is_some_and(|status| {
-                    prompt_invocation_status_counts_toward_terminal_totals(Some(status))
-                })
-        });
+        let already_terminal = applied_terminal_ids.contains(&record.identity)
+            || (record.row_id > 0 && record.row_id <= baseline_row_id);
         if let Some(index) = existing_index {
             recent[index] = preview.clone();
         } else {
@@ -3565,13 +4113,33 @@ fn apply_prompt_cache_records_to_payload(
         };
         recent.truncate(recent_limit);
 
-        conversation.insert("lastActivityAt".to_string(), occurred_at.clone());
+        if conversation
+            .get("lastActivityAt")
+            .and_then(Value::as_str)
+            .is_none_or(|current| occurred_at.as_str().is_some_and(|next| next > current))
+        {
+            conversation.insert("lastActivityAt".to_string(), occurred_at.clone());
+        }
+        if conversation
+            .get("createdAt")
+            .and_then(Value::as_str)
+            .is_none_or(|current| occurred_at.as_str().is_some_and(|next| next < current))
+        {
+            conversation.insert("createdAt".to_string(), occurred_at.clone());
+        }
         if is_terminal && !already_terminal {
+            applied_terminal_ids.insert(record.identity.clone());
             increment_json_i64(conversation, "requestCount", 1);
             increment_json_i64(conversation, "totalTokens", request_tokens);
             increment_json_f64(conversation, "totalCost", record.cost);
             if matches!(topic, SubscriptionTopic::PromptCacheWindow { .. }) {
-                conversation.insert("lastTerminalAt".to_string(), occurred_at.clone());
+                if conversation
+                    .get("lastTerminalAt")
+                    .and_then(Value::as_str)
+                    .is_none_or(|current| occurred_at.as_str().is_some_and(|next| next > current))
+                {
+                    conversation.insert("lastTerminalAt".to_string(), occurred_at.clone());
+                }
                 apply_prompt_cache_account_delta(conversation, record, &occurred_at);
             }
             let points = conversation
@@ -3583,14 +4151,22 @@ fn apply_prompt_cache_records_to_payload(
                 point.get("occurredAt") == Some(&occurred_at)
                     && point.get("requestTokens").and_then(Value::as_i64) == Some(request_tokens)
             }) {
-                points.push(serde_json::json!({
+                let mut point = serde_json::json!({
                     "occurredAt": occurred_at,
                     "status": status,
                     "isSuccess": is_success,
-                    "outcome": if is_success { "success" } else { "failure" },
                     "requestTokens": request_tokens,
                     "cumulativeTokens": 0,
-                }));
+                });
+                if matches!(topic, SubscriptionTopic::PromptCacheWindow { .. })
+                    && let Some(point) = point.as_object_mut()
+                {
+                    point.insert(
+                        "outcome".to_string(),
+                        Value::String(if is_success { "success" } else { "failure" }.to_string()),
+                    );
+                }
+                points.push(point);
                 points.sort_by(|left, right| {
                     left.get("occurredAt")
                         .and_then(Value::as_str)
@@ -3639,6 +4215,13 @@ fn increment_json_i64(object: &mut serde_json::Map<String, Value>, field: &str, 
     );
 }
 
+fn prompt_cache_delta_needs_replay(
+    delta: &PromptCacheTopicDelta,
+    persisted_identities: &HashSet<String>,
+) -> bool {
+    !persisted_identities.contains(&delta.identity)
+}
+
 fn increment_json_f64(object: &mut serde_json::Map<String, Value>, field: &str, delta: f64) {
     let current = object
         .get(field)
@@ -3675,7 +4258,13 @@ fn apply_prompt_cache_account_delta(
         increment_json_i64(account, "requestCount", 1);
         increment_json_i64(account, "totalTokens", record.request_tokens);
         increment_json_f64(account, "totalCost", record.cost);
-        account.insert("lastActivityAt".to_string(), occurred_at.clone());
+        if account
+            .get("lastActivityAt")
+            .and_then(Value::as_str)
+            .is_none_or(|current| occurred_at.as_str().is_some_and(|next| next > current))
+        {
+            account.insert("lastActivityAt".to_string(), occurred_at.clone());
+        }
     }
 }
 
@@ -4268,6 +4857,55 @@ async fn run_server_push_topic_loop(
     topic_key: String,
     topic: SubscriptionTopic,
 ) {
+    if prompt_cache_topic_projection_enabled()
+        && matches!(
+            topic,
+            SubscriptionTopic::PromptCacheWindow { .. }
+                | SubscriptionTopic::PromptCacheStickyWindow { .. }
+        )
+    {
+        let mut interval = tokio::time::interval(PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                _ = state.shutdown.cancelled() => {
+                    hub.clear_server_push_task(&topic_key).await;
+                    break;
+                }
+                _ = interval.tick() => {
+                    if hub.stop_server_push_task_if_idle(&topic_key).await {
+                        break;
+                    }
+                    if let Err(err) = hub.expire_prompt_cache_topic_window(&topic_key).await {
+                        warn!(?err, topic = %topic.name(), "failed to expire prompt cache topic window");
+                    }
+                    if !hub.prompt_cache_reconcile_required(&topic_key).await {
+                        continue;
+                    }
+                    match crate::db_pressure::global_db_pressure_gate()
+                        .try_begin_background("prompt_cache_topic_reconcile")
+                    {
+                        Ok(_permit) => {
+                            if let Err(err) = hub
+                                .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                                .await
+                            {
+                                warn!(?err, topic = %topic.name(), reconcile_outcome = "retained_last_good", "prompt cache topic reconcile failed");
+                            }
+                        }
+                        Err(reason) => tracing::debug!(
+                            topic = %topic.name(),
+                            reconcile_outcome = "pressure_deferred",
+                            defer_reason = %reason,
+                            "prompt cache topic reconcile deferred"
+                        ),
+                    }
+                }
+            }
+        }
+        return;
+    }
     if !topic.is_closed_summary_topic() {
         let mut interval = tokio::time::interval(DASHBOARD_NETWORK_RECENT_TOPIC_PUSH_INTERVAL);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -4467,6 +5105,11 @@ pub(crate) async fn topic_sse_stream(
 impl SubscriptionTopic {
     fn uses_server_push_cadence(&self, mode: RuntimeProjectionMode) -> bool {
         self.is_closed_summary_topic()
+            || (prompt_cache_topic_projection_enabled()
+                && matches!(
+                    self,
+                    Self::PromptCacheWindow { .. } | Self::PromptCacheStickyWindow { .. }
+                ))
             || (mode == RuntimeProjectionMode::Legacy
                 && matches!(self, Self::DashboardNetworkRecentCurrent))
     }
@@ -4959,7 +5602,7 @@ impl SubscriptionTopic {
                 | Self::PromptCacheConversationOperationsWindow { scope, .. } => {
                     scope.binding_key() == prompt_cache_key
                 }
-                Self::PromptCacheWindow { .. } => true,
+                Self::PromptCacheWindow { .. } => !prompt_cache_topic_projection_enabled(),
                 _ => false,
             },
             BroadcastPayload::PromptCacheConversationStickyRouteChanged {
@@ -4973,10 +5616,11 @@ impl SubscriptionTopic {
                     *previous_upstream_account_id,
                     *upstream_account_id,
                 ),
-                Self::PromptCacheWindow { .. } => true,
+                Self::PromptCacheWindow { .. } => !prompt_cache_topic_projection_enabled(),
                 Self::PromptCacheStickyWindow { account_id, .. } => {
-                    *previous_upstream_account_id == *account_id
-                        || *upstream_account_id == *account_id
+                    !prompt_cache_topic_projection_enabled()
+                        && (*previous_upstream_account_id == *account_id
+                            || *upstream_account_id == *account_id)
                 }
                 _ => false,
             },
@@ -7782,9 +8426,14 @@ mod tests {
             summary_retry_backoff_ms: 0,
             prompt_cache_refresh_scheduled: false,
             prompt_cache_pending_records: BTreeMap::new(),
+            prompt_cache_applied_terminal_ids: HashSet::new(),
             prompt_cache_coalesced_event_count: 0,
             prompt_cache_full_hydration_count: 0,
+            prompt_cache_bounded_key_hydration_count: 0,
             prompt_cache_baseline_at: None,
+            prompt_cache_baseline_row_id: 0,
+            prompt_cache_response_source: "memory",
+            prompt_cache_reconcile_required: false,
             latest_live_snapshot: None,
             calendar_anchor: None,
             continuity_reset_cursor: None,
@@ -8374,11 +9023,14 @@ mod tests {
         let delta = PromptCacheTopicDelta::from_record(&record)
             .expect("build compact delta")
             .expect("prompt cache delta");
+        let mut applied_terminal_ids = HashSet::new();
         assert!(
             apply_prompt_cache_records_to_payload(
                 &topic,
                 &mut payload,
                 std::slice::from_ref(&delta),
+                &mut applied_terminal_ids,
+                0,
             )
             .expect("apply terminal delta")
         );
@@ -8392,9 +9044,252 @@ mod tests {
         );
         assert_eq!(conversation["last24hRequests"].as_array().unwrap().len(), 1);
 
-        apply_prompt_cache_records_to_payload(&topic, &mut payload, &[delta])
-            .expect("deduplicate repeated terminal delta");
+        apply_prompt_cache_records_to_payload(
+            &topic,
+            &mut payload,
+            &[delta],
+            &mut applied_terminal_ids,
+            0,
+        )
+        .expect("deduplicate repeated terminal delta");
         assert_eq!(payload["conversations"][0]["requestCount"], 1);
+    }
+
+    #[test]
+    fn prompt_cache_sticky_projection_uses_sticky_key_without_prompt_outcome() {
+        let topic = SubscriptionTopic::PromptCacheStickyWindow {
+            account_id: 9,
+            selection: AccountStickyKeySelection::Count(20),
+        };
+        let mut payload = serde_json::json!({ "conversations": [] });
+        let mut record = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        record.invoke_id = "sticky-terminal".to_string();
+        record.status = Some("success".to_string());
+        record.live_phase = None;
+        record.prompt_cache_key = Some("prompt-key".to_string());
+        record.sticky_key = Some("sticky-key".to_string());
+        record.upstream_account_id = Some(9);
+        let delta = PromptCacheTopicDelta::from_record(&record)
+            .expect("build compact delta")
+            .expect("sticky delta");
+        let mut applied_terminal_ids = HashSet::new();
+
+        assert!(
+            apply_prompt_cache_records_to_payload(
+                &topic,
+                &mut payload,
+                &[delta],
+                &mut applied_terminal_ids,
+                0,
+            )
+            .expect("apply sticky delta")
+        );
+        let conversation = &payload["conversations"][0];
+        assert_eq!(conversation["stickyKey"], "sticky-key");
+        assert!(conversation["last24hRequests"][0].get("outcome").is_none());
+    }
+
+    #[test]
+    fn prompt_cache_terminal_dedup_survives_recent_truncation() {
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(1),
+        };
+        let mut payload = serde_json::json!({ "conversations": [] });
+        let mut first = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        first.invoke_id = "first-terminal".to_string();
+        first.status = Some("success".to_string());
+        first.live_phase = None;
+        first.prompt_cache_key = Some("cache-key".to_string());
+        let first = PromptCacheTopicDelta::from_record(&first)
+            .expect("build first delta")
+            .expect("first delta");
+        let mut second = dashboard_runtime_topology_live_record("2026-08-08 10:01:00");
+        second.invoke_id = "second-terminal".to_string();
+        second.status = Some("success".to_string());
+        second.live_phase = None;
+        second.prompt_cache_key = Some("cache-key".to_string());
+        let second = PromptCacheTopicDelta::from_record(&second)
+            .expect("build second delta")
+            .expect("second delta");
+        let mut applied_terminal_ids = HashSet::new();
+
+        apply_prompt_cache_records_to_payload(
+            &topic,
+            &mut payload,
+            &[first.clone(), second],
+            &mut applied_terminal_ids,
+            0,
+        )
+        .expect("apply terminal deltas");
+        apply_prompt_cache_records_to_payload(
+            &topic,
+            &mut payload,
+            &[first],
+            &mut applied_terminal_ids,
+            0,
+        )
+        .expect("replay truncated terminal");
+
+        assert_eq!(payload["conversations"][0]["requestCount"], 2);
+        assert_eq!(
+            payload["conversations"][0]["recentInvocations"]
+                .as_array()
+                .expect("recent invocations")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn prompt_cache_baseline_cursor_skips_recovered_terminal_totals() {
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let mut payload = serde_json::json!({ "conversations": [] });
+        let mut record = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        record.id = 7;
+        record.invoke_id = "recovered-terminal".to_string();
+        record.status = Some("success".to_string());
+        record.live_phase = None;
+        record.prompt_cache_key = Some("cache-key".to_string());
+        let delta = PromptCacheTopicDelta::from_record(&record)
+            .expect("build recovered delta")
+            .expect("recovered delta");
+        let mut applied_terminal_ids = HashSet::new();
+
+        apply_prompt_cache_records_to_payload(
+            &topic,
+            &mut payload,
+            &[delta],
+            &mut applied_terminal_ids,
+            7,
+        )
+        .expect("apply recovered delta");
+
+        assert_eq!(payload["conversations"][0]["requestCount"], 0);
+        assert!(applied_terminal_ids.is_empty());
+        assert_eq!(
+            payload["conversations"][0]["recentInvocations"]
+                .as_array()
+                .expect("recent invocations")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn prompt_cache_baseline_does_not_replay_an_identity_already_in_payload() {
+        let mut record = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        record.id = 0;
+        record.invoke_id = "persisted-during-baseline".to_string();
+        record.status = Some("success".to_string());
+        record.live_phase = None;
+        record.prompt_cache_key = Some("cache-key".to_string());
+        let delta = PromptCacheTopicDelta::from_record(&record)
+            .expect("build concurrent delta")
+            .expect("prompt cache delta");
+
+        assert!(prompt_cache_delta_needs_replay(&delta, &HashSet::new()));
+        assert!(!prompt_cache_delta_needs_replay(
+            &delta,
+            &HashSet::from([delta.identity.clone()]),
+        ));
+    }
+
+    #[test]
+    fn prompt_cache_projection_keeps_latest_activity_for_out_of_order_records() {
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let mut payload = serde_json::json!({ "conversations": [] });
+        let mut newer = dashboard_runtime_topology_live_record("2026-08-08 10:01:00");
+        newer.invoke_id = "newer".to_string();
+        newer.prompt_cache_key = Some("cache-key".to_string());
+        newer.status = Some("success".to_string());
+        newer.live_phase = None;
+        newer.upstream_account_id = Some(9);
+        let newer = PromptCacheTopicDelta::from_record(&newer)
+            .expect("build newer delta")
+            .expect("newer delta");
+        let mut older = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        older.invoke_id = "older".to_string();
+        older.prompt_cache_key = Some("cache-key".to_string());
+        older.status = Some("success".to_string());
+        older.live_phase = None;
+        older.upstream_account_id = Some(9);
+        let older = PromptCacheTopicDelta::from_record(&older)
+            .expect("build older delta")
+            .expect("older delta");
+        let mut applied_terminal_ids = HashSet::new();
+
+        apply_prompt_cache_records_to_payload(
+            &topic,
+            &mut payload,
+            &[newer, older],
+            &mut applied_terminal_ids,
+            0,
+        )
+        .expect("apply out-of-order deltas");
+
+        assert_eq!(
+            payload["conversations"][0]["lastActivityAt"],
+            "2026-08-08T02:01:00Z"
+        );
+        assert_eq!(
+            payload["conversations"][0]["createdAt"],
+            "2026-08-08T02:00:00Z"
+        );
+        assert_eq!(
+            payload["conversations"][0]["lastTerminalAt"],
+            "2026-08-08T02:01:00Z"
+        );
+        assert_eq!(
+            payload["conversations"][0]["upstreamAccounts"][0]["lastActivityAt"],
+            "2026-08-08T02:01:00Z"
+        );
+    }
+
+    #[test]
+    fn prompt_cache_binding_patch_updates_only_the_selected_conversation() {
+        let mut payload = serde_json::json!({
+            "conversations": [
+                { "promptCacheKey": "selected", "hasEncryptedSessionOwner": false },
+                { "promptCacheKey": "other", "hasEncryptedSessionOwner": false }
+            ]
+        });
+        let binding = serde_json::json!({
+            "bindingKind": "account",
+            "groupName": "primary",
+            "upstreamAccountId": 9,
+            "upstreamAccountName": "Account 9",
+            "hasEncryptedSessionOwner": true,
+            "encryptedOwnerAccountId": 8,
+            "encryptedOwnerAccountName": "Account 8",
+            "encryptedOwnerGroupName": "owners"
+        });
+
+        assert_eq!(
+            patch_prompt_cache_binding_payload(&mut payload, "selected", &binding),
+            Some(true)
+        );
+        assert_eq!(
+            payload["conversations"][0]["manualBinding"]["upstreamAccountId"],
+            9
+        );
+        assert_eq!(
+            payload["conversations"][0]["hasEncryptedSessionOwner"],
+            true
+        );
+        assert_eq!(
+            payload["conversations"][1]["hasEncryptedSessionOwner"],
+            false
+        );
     }
 
     #[test]

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -6,7 +6,7 @@ use serde::ser::{SerializeSeq, SerializeStruct};
 use serde_json::json;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{
-    Mutex as StdMutex,
+    Mutex as StdMutex, OnceLock,
     atomic::{AtomicU64, Ordering},
 };
 
@@ -34,6 +34,17 @@ const DASHBOARD_ACTIVITY_TOPIC_REFRESH_TTL: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const DASHBOARD_ACTIVITY_TOPIC_REFRESH_TTL: Duration = Duration::from_millis(500);
 const SUMMARY_TOPIC_REFRESH_DEBOUNCE: Duration = Duration::from_millis(500);
+const PROMPT_CACHE_TOPIC_REFRESH_DEBOUNCE: Duration = Duration::from_millis(500);
+const PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
+
+fn prompt_cache_topic_projection_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        !std::env::var("PROMPT_CACHE_TOPIC_PROJECTION_MODE")
+            .ok()
+            .is_some_and(|value| value.trim().eq_ignore_ascii_case("legacy"))
+    })
+}
 #[cfg(test)]
 const DASHBOARD_RUNTIME_TOPOLOGY_CONTRACT_REASON: &str = "dashboard-runtime-topology-contract";
 #[cfg(not(test))]
@@ -354,6 +365,20 @@ pub(crate) struct SubscriptionDispatchEvent {
     pub(crate) frame: Arc<SerializedTopicFrame>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PromptCacheTopicProjectionHealthSnapshot {
+    pub(crate) mode: String,
+    pub(crate) active_topic_count: u64,
+    pub(crate) dirty_key_count: u64,
+    pub(crate) coalesced_event_count: u64,
+    pub(crate) full_hydration_count: u64,
+    pub(crate) bounded_key_hydration_count: u64,
+    pub(crate) live_path_db_read_count: u64,
+    pub(crate) baseline_age_ms: u64,
+    pub(crate) response_source: String,
+}
+
 #[cfg(test)]
 type DashboardTopologyFramesByTopic = BTreeMap<String, Vec<Arc<SerializedTopicFrame>>>;
 #[cfg(test)]
@@ -398,6 +423,11 @@ struct CachedSubscriptionTopic {
     summary_refresh_in_flight: bool,
     summary_pending_event_count: u64,
     summary_retry_backoff_ms: u64,
+    prompt_cache_refresh_scheduled: bool,
+    prompt_cache_pending_records: BTreeMap<String, PromptCacheTopicDelta>,
+    prompt_cache_coalesced_event_count: u64,
+    prompt_cache_full_hydration_count: u64,
+    prompt_cache_baseline_at: Option<Instant>,
     latest_live_snapshot: Option<DashboardActivityLiveSnapshot>,
     calendar_anchor: Option<String>,
     continuity_reset_cursor: Option<u64>,
@@ -409,6 +439,63 @@ struct CachedSubscriptionTopic {
     snapshot_bytes: usize,
     replay_events: VecDeque<ReplayableTopicEvent>,
     replay_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct PromptCacheTopicDelta {
+    identity: String,
+    prompt_cache_key: String,
+    occurred_at: Value,
+    status: String,
+    is_terminal: bool,
+    is_success: bool,
+    request_tokens: i64,
+    cost: f64,
+    upstream_account_id: Option<i64>,
+    upstream_account_name: Option<String>,
+    preview: Value,
+}
+
+impl PromptCacheTopicDelta {
+    fn from_record(record: &ApiInvocation) -> Result<Option<Self>, ApiError> {
+        let Some(prompt_cache_key) = record
+            .prompt_cache_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .map(str::to_string)
+        else {
+            return Ok(None);
+        };
+        let preview = serde_json::to_value(prompt_cache_invocation_preview_from_runtime_record(
+            record,
+            prompt_cache_key.clone(),
+        ))?;
+        let occurred_at = preview
+            .get("occurredAt")
+            .cloned()
+            .unwrap_or_else(|| Value::String(record.occurred_at.clone()));
+        let status = record
+            .status
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+        Ok(Some(Self {
+            identity: format!("{}\0{}", record.invoke_id, record.occurred_at),
+            prompt_cache_key,
+            occurred_at,
+            is_terminal: prompt_invocation_status_counts_toward_terminal_totals(Some(&status)),
+            is_success: prompt_invocation_status_is_success_like(
+                Some(&status),
+                record.error_message.as_deref(),
+            ),
+            status,
+            request_tokens: record.total_tokens.unwrap_or_default().max(0),
+            cost: record.cost.unwrap_or_default(),
+            upstream_account_id: record.upstream_account_id,
+            upstream_account_name: record.upstream_account_name.clone(),
+            preview,
+        }))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1076,6 +1163,57 @@ impl ConversationSubscriptionScope {
 }
 
 impl SubscriptionHub {
+    pub(crate) async fn prompt_cache_projection_health(
+        &self,
+    ) -> PromptCacheTopicProjectionHealthSnapshot {
+        let guard = self.state.lock().await;
+        let prompt_topics = guard.topics.iter().filter(|(_, cached)| {
+            matches!(
+                cached.topic,
+                SubscriptionTopic::PromptCacheWindow { .. }
+                    | SubscriptionTopic::PromptCacheStickyWindow { .. }
+            )
+        });
+        let mut snapshot = PromptCacheTopicProjectionHealthSnapshot {
+            mode: if prompt_cache_topic_projection_enabled() {
+                "memory".to_string()
+            } else {
+                "legacy".to_string()
+            },
+            response_source: "memory".to_string(),
+            ..PromptCacheTopicProjectionHealthSnapshot::default()
+        };
+        for (topic_key, cached) in prompt_topics {
+            snapshot.active_topic_count = snapshot.active_topic_count.saturating_add(u64::from(
+                guard
+                    .active_subscribers
+                    .get(topic_key)
+                    .copied()
+                    .unwrap_or_default()
+                    > 0,
+            ));
+            snapshot.dirty_key_count = snapshot
+                .dirty_key_count
+                .saturating_add(cached.prompt_cache_pending_records.len() as u64);
+            snapshot.coalesced_event_count = snapshot
+                .coalesced_event_count
+                .saturating_add(cached.prompt_cache_coalesced_event_count);
+            snapshot.full_hydration_count = snapshot
+                .full_hydration_count
+                .saturating_add(cached.prompt_cache_full_hydration_count);
+            snapshot.baseline_age_ms = snapshot.baseline_age_ms.max(
+                cached
+                    .prompt_cache_baseline_at
+                    .map(|started| started.elapsed().as_millis() as u64)
+                    .unwrap_or_default(),
+            );
+            if cached.dirty {
+                snapshot.response_source = "dirty_last_good".to_string();
+            }
+        }
+        snapshot
+    }
+
     pub(crate) fn new() -> Self {
         let (broadcaster, _) = broadcast::channel(1_024);
         Self {
@@ -1330,6 +1468,18 @@ impl SubscriptionHub {
                 Some(count) if *count > 1 => *count -= 1,
                 Some(_) => {
                     guard.active_subscribers.remove(&topic_key);
+                    if let Some(cached) = guard.topics.get_mut(&topic_key)
+                        && matches!(
+                            cached.topic,
+                            SubscriptionTopic::PromptCacheWindow { .. }
+                                | SubscriptionTopic::PromptCacheStickyWindow { .. }
+                        )
+                    {
+                        cached.prompt_cache_pending_records.clear();
+                        cached.prompt_cache_refresh_scheduled = false;
+                        cached.prompt_cache_baseline_at = None;
+                        cached.dirty = true;
+                    }
                 }
                 None => {}
             }
@@ -1772,6 +1922,26 @@ impl SubscriptionHub {
                     .topics
                     .get(&topic_key)
                     .map_or(0, |entry| entry.summary_retry_backoff_ms),
+                prompt_cache_refresh_scheduled: guard
+                    .topics
+                    .get(&topic_key)
+                    .is_some_and(|entry| entry.prompt_cache_refresh_scheduled),
+                prompt_cache_pending_records: guard
+                    .topics
+                    .get(&topic_key)
+                    .map(|entry| entry.prompt_cache_pending_records.clone())
+                    .unwrap_or_default(),
+                prompt_cache_coalesced_event_count: guard
+                    .topics
+                    .get(&topic_key)
+                    .map_or(0, |entry| entry.prompt_cache_coalesced_event_count),
+                prompt_cache_full_hydration_count: guard
+                    .topics
+                    .get(&topic_key)
+                    .map_or(1, |entry| {
+                        entry.prompt_cache_full_hydration_count.saturating_add(1)
+                    }),
+                prompt_cache_baseline_at: Some(Instant::now()),
                 latest_live_snapshot: guard
                     .topics
                     .get(&topic_key)
@@ -2035,6 +2205,12 @@ impl SubscriptionHub {
                 return;
             }
             _ => {}
+        }
+        if let BroadcastPayload::Records { records } = &payload
+            && prompt_cache_topic_projection_enabled()
+        {
+            self.schedule_prompt_cache_topic_projection(state.clone(), records)
+                .await;
         }
         let affected = {
             let mut guard = self.state.lock().await;
@@ -2488,6 +2664,200 @@ impl SubscriptionHub {
                 delay = CONVERSATION_OVERVIEW_TOPIC_REFRESH_DEBOUNCE;
             }
         });
+        Ok(())
+    }
+
+    async fn schedule_prompt_cache_topic_projection(
+        &self,
+        state: Arc<AppState>,
+        records: &[ApiInvocation],
+    ) {
+        let records = records
+            .iter()
+            .map(PromptCacheTopicDelta::from_record)
+            .collect::<Result<Vec<_>, _>>()
+            .map(|records| records.into_iter().flatten().collect::<Vec<_>>());
+        let Ok(records) = records else {
+            warn!("failed to build compact prompt cache topic delta");
+            return;
+        };
+        if records.is_empty() {
+            return;
+        }
+
+        let scheduled = {
+            let mut guard = self.state.lock().await;
+            let active_subscribers = guard.active_subscribers.clone();
+            let mut scheduled = Vec::new();
+            for (topic_key, cached) in &mut guard.topics {
+                if !matches!(
+                    cached.topic,
+                    SubscriptionTopic::PromptCacheWindow { .. }
+                        | SubscriptionTopic::PromptCacheStickyWindow { .. }
+                ) || active_subscribers
+                    .get(topic_key)
+                    .copied()
+                    .unwrap_or_default()
+                    == 0
+                {
+                    continue;
+                }
+                let before = cached.prompt_cache_pending_records.len();
+                for record in &records {
+                    cached
+                        .prompt_cache_pending_records
+                        .insert(record.identity.clone(), record.clone());
+                }
+                cached.prompt_cache_coalesced_event_count =
+                    cached.prompt_cache_coalesced_event_count.saturating_add(
+                        records.len().saturating_sub(
+                            cached
+                                .prompt_cache_pending_records
+                                .len()
+                                .saturating_sub(before),
+                        ) as u64,
+                    );
+                if !cached.prompt_cache_refresh_scheduled {
+                    cached.prompt_cache_refresh_scheduled = true;
+                    scheduled.push(cached.topic.clone());
+                }
+            }
+            scheduled
+        };
+
+        for topic in scheduled {
+            let hub = state.subscription_hub.clone();
+            let state = state.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(PROMPT_CACHE_TOPIC_REFRESH_DEBOUNCE).await;
+                if let Err(err) = hub
+                    .materialize_prompt_cache_topic(state.clone(), &topic)
+                    .await
+                {
+                    warn!(
+                        ?err,
+                        topic = topic.name(),
+                        response_source = "last_good",
+                        "prompt cache in-memory topic materialization failed"
+                    );
+                    hub.mark_topic_dirty(&topic).await;
+                    return;
+                }
+                if hub.prompt_cache_topic_needs_reconcile(&topic).await {
+                    match crate::db_pressure::global_db_pressure_gate()
+                        .try_begin_background("prompt_cache_topic_reconcile")
+                    {
+                        Ok(_permit) => {
+                            match hub
+                                .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                                .await
+                            {
+                                Ok(_) => tracing::debug!(
+                                    topic = topic.name(),
+                                    reconcile_outcome = "accepted_baseline",
+                                    response_source = "database_reconcile",
+                                    "prompt cache topic projection reconciled"
+                                ),
+                                Err(err) => warn!(
+                                    ?err,
+                                    topic = topic.name(),
+                                    reconcile_outcome = "retained_last_good",
+                                    "prompt cache topic reconcile failed"
+                                ),
+                            }
+                        }
+                        Err(reason) => tracing::debug!(
+                            topic = topic.name(),
+                            reconcile_outcome = "pressure_deferred",
+                            defer_reason = %reason,
+                            "prompt cache topic reconcile deferred"
+                        ),
+                    }
+                }
+            });
+        }
+    }
+
+    async fn prompt_cache_topic_needs_reconcile(&self, topic: &SubscriptionTopic) -> bool {
+        let Ok(topic_key) = topic.cache_key() else {
+            return false;
+        };
+        self.state
+            .lock()
+            .await
+            .topics
+            .get(&topic_key)
+            .and_then(|cached| cached.prompt_cache_baseline_at)
+            .is_none_or(|baseline| baseline.elapsed() >= PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL)
+    }
+
+    async fn materialize_prompt_cache_topic(
+        &self,
+        _state: Arc<AppState>,
+        topic: &SubscriptionTopic,
+    ) -> Result<(), ApiError> {
+        let topic_key = topic.cache_key()?;
+        let dispatch = {
+            let mut guard = self.state.lock().await;
+            let active = guard
+                .active_subscribers
+                .get(&topic_key)
+                .copied()
+                .unwrap_or_default();
+            let Some(cached) = guard.topics.get_mut(&topic_key) else {
+                return Ok(());
+            };
+            cached.prompt_cache_refresh_scheduled = false;
+            if active == 0 {
+                cached.prompt_cache_pending_records.clear();
+                return Ok(());
+            }
+            let records = std::mem::take(&mut cached.prompt_cache_pending_records)
+                .into_values()
+                .collect::<Vec<_>>();
+            if records.is_empty()
+                || !apply_prompt_cache_records_to_payload(
+                    topic,
+                    &mut cached.snapshot_payload,
+                    &records,
+                )?
+            {
+                return Ok(());
+            }
+            let next_cursor = cached.cursor.saturating_add(1);
+            let serialized_payload = serde_json::to_vec(&cached.snapshot_payload)?;
+            let frame = Arc::new(self.serialize_frame(
+                cached.descriptor.clone(),
+                topic_key.clone(),
+                cached.schema_epoch.clone(),
+                next_cursor,
+                serialized_payload,
+            )?);
+            let retained_bytes = frame.retained_bytes();
+            cached.cursor = next_cursor;
+            cached.snapshot_frame = frame.clone();
+            cached.snapshot_bytes = frame.payload_bytes.len();
+            cached.replay_events.push_back(ReplayableTopicEvent {
+                frame: frame.clone(),
+                bytes: retained_bytes,
+                emitted_at: Utc::now(),
+            });
+            cached.replay_bytes = cached.replay_bytes.saturating_add(retained_bytes);
+            prune_replay_window(&mut cached.replay_events, &mut cached.replay_bytes);
+            tracing::debug!(
+                topic = topic.name(),
+                response_source = "memory",
+                coalesced_event_count = records.len(),
+                live_path_db_read_count = 0_u64,
+                baseline_age_ms = cached
+                    .prompt_cache_baseline_at
+                    .map(|started| started.elapsed().as_millis() as u64)
+                    .unwrap_or_default(),
+                "prompt cache topic materialized from active projection"
+            );
+            SubscriptionDispatchEvent { frame }
+        };
+        let _ = self.broadcaster.send(dispatch);
         Ok(())
     }
 
@@ -3097,6 +3467,216 @@ fn apply_topic_live_overlay_to_payload(
 
 fn set_json_field(object: &mut serde_json::Map<String, Value>, key: &str, value: Value) {
     object.insert(key.to_string(), value);
+}
+
+fn apply_prompt_cache_records_to_payload(
+    topic: &SubscriptionTopic,
+    payload: &mut Value,
+    records: &[PromptCacheTopicDelta],
+) -> Result<bool, ApiError> {
+    let Some(conversations) = payload
+        .as_object_mut()
+        .and_then(|object| object.get_mut("conversations"))
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(false);
+    };
+    let mut changed = false;
+    for record in records {
+        let key = record.prompt_cache_key.as_str();
+        if let SubscriptionTopic::PromptCacheStickyWindow { account_id, .. } = topic
+            && record.upstream_account_id != Some(*account_id)
+        {
+            continue;
+        }
+        let key_field = match topic {
+            SubscriptionTopic::PromptCacheWindow { .. } => "promptCacheKey",
+            SubscriptionTopic::PromptCacheStickyWindow { .. } => "stickyKey",
+            _ => return Ok(false),
+        };
+        let preview = record.preview.clone();
+        let occurred_at = record.occurred_at.clone();
+        let status = record.status.as_str();
+        let is_terminal = record.is_terminal;
+        let is_success = record.is_success;
+        let request_tokens = record.request_tokens;
+        let conversation_index = conversations.iter().position(|conversation| {
+            conversation.get(key_field).and_then(Value::as_str) == Some(key)
+        });
+        let index = match conversation_index {
+            Some(index) => index,
+            None => {
+                let mut conversation = serde_json::Map::new();
+                conversation.insert(key_field.to_string(), Value::String(key.to_string()));
+                conversation.insert("requestCount".to_string(), Value::from(0));
+                conversation.insert("totalTokens".to_string(), Value::from(0));
+                conversation.insert("totalCost".to_string(), Value::from(0.0));
+                conversation.insert("createdAt".to_string(), occurred_at.clone());
+                conversation.insert("lastActivityAt".to_string(), occurred_at.clone());
+                conversation.insert("recentInvocations".to_string(), Value::Array(Vec::new()));
+                conversation.insert("last24hRequests".to_string(), Value::Array(Vec::new()));
+                if matches!(topic, SubscriptionTopic::PromptCacheWindow { .. }) {
+                    conversation.insert("hasEncryptedSessionOwner".to_string(), Value::Bool(false));
+                    conversation.insert("upstreamAccounts".to_string(), Value::Array(Vec::new()));
+                }
+                conversations.push(Value::Object(conversation));
+                conversations.len() - 1
+            }
+        };
+        let Some(conversation) = conversations[index].as_object_mut() else {
+            continue;
+        };
+        let recent = conversation
+            .entry("recentInvocations")
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+            .expect("prompt cache recentInvocations is an array");
+        let existing_index = recent.iter().position(|item| {
+            item.get("invokeId").and_then(Value::as_str)
+                == preview.get("invokeId").and_then(Value::as_str)
+                && item.get("occurredAt") == Some(&occurred_at)
+        });
+        let already_terminal = existing_index.is_some_and(|index| {
+            recent[index]
+                .get("status")
+                .and_then(Value::as_str)
+                .is_some_and(|status| {
+                    prompt_invocation_status_counts_toward_terminal_totals(Some(status))
+                })
+        });
+        if let Some(index) = existing_index {
+            recent[index] = preview.clone();
+        } else {
+            recent.push(preview.clone());
+        }
+        recent.sort_by(|left, right| {
+            right
+                .get("occurredAt")
+                .and_then(Value::as_str)
+                .cmp(&left.get("occurredAt").and_then(Value::as_str))
+        });
+        let recent_limit = match topic {
+            SubscriptionTopic::PromptCacheWindow {
+                recent_invocation_limit,
+                ..
+            } => recent_invocation_limit.unwrap_or(16).max(0) as usize,
+            SubscriptionTopic::PromptCacheStickyWindow { .. } => 5,
+            _ => 0,
+        };
+        recent.truncate(recent_limit);
+
+        conversation.insert("lastActivityAt".to_string(), occurred_at.clone());
+        if is_terminal && !already_terminal {
+            increment_json_i64(conversation, "requestCount", 1);
+            increment_json_i64(conversation, "totalTokens", request_tokens);
+            increment_json_f64(conversation, "totalCost", record.cost);
+            if matches!(topic, SubscriptionTopic::PromptCacheWindow { .. }) {
+                conversation.insert("lastTerminalAt".to_string(), occurred_at.clone());
+                apply_prompt_cache_account_delta(conversation, record, &occurred_at);
+            }
+            let points = conversation
+                .entry("last24hRequests")
+                .or_insert_with(|| Value::Array(Vec::new()))
+                .as_array_mut()
+                .expect("prompt cache last24hRequests is an array");
+            if !points.iter().any(|point| {
+                point.get("occurredAt") == Some(&occurred_at)
+                    && point.get("requestTokens").and_then(Value::as_i64) == Some(request_tokens)
+            }) {
+                points.push(serde_json::json!({
+                    "occurredAt": occurred_at,
+                    "status": status,
+                    "isSuccess": is_success,
+                    "outcome": if is_success { "success" } else { "failure" },
+                    "requestTokens": request_tokens,
+                    "cumulativeTokens": 0,
+                }));
+                points.sort_by(|left, right| {
+                    left.get("occurredAt")
+                        .and_then(Value::as_str)
+                        .cmp(&right.get("occurredAt").and_then(Value::as_str))
+                });
+                let mut cumulative = 0_i64;
+                for point in points {
+                    cumulative = cumulative.saturating_add(
+                        point
+                            .get("requestTokens")
+                            .and_then(Value::as_i64)
+                            .unwrap_or_default(),
+                    );
+                    if let Some(point) = point.as_object_mut() {
+                        point.insert("cumulativeTokens".to_string(), Value::from(cumulative));
+                    }
+                }
+            }
+        }
+        changed = true;
+    }
+
+    conversations.sort_by(|left, right| {
+        right
+            .get("lastActivityAt")
+            .and_then(Value::as_str)
+            .cmp(&left.get("lastActivityAt").and_then(Value::as_str))
+    });
+    let display_limit = match topic {
+        SubscriptionTopic::PromptCacheWindow { selection, .. } => selection.display_limit(),
+        SubscriptionTopic::PromptCacheStickyWindow { selection, .. } => selection.display_limit(),
+        _ => 0,
+    };
+    conversations.truncate(display_limit.max(0) as usize);
+    Ok(changed)
+}
+
+fn increment_json_i64(object: &mut serde_json::Map<String, Value>, field: &str, delta: i64) {
+    let current = object
+        .get(field)
+        .and_then(Value::as_i64)
+        .unwrap_or_default();
+    object.insert(
+        field.to_string(),
+        Value::from(current.saturating_add(delta)),
+    );
+}
+
+fn increment_json_f64(object: &mut serde_json::Map<String, Value>, field: &str, delta: f64) {
+    let current = object
+        .get(field)
+        .and_then(Value::as_f64)
+        .unwrap_or_default();
+    object.insert(field.to_string(), Value::from(current + delta));
+}
+
+fn apply_prompt_cache_account_delta(
+    conversation: &mut serde_json::Map<String, Value>,
+    record: &PromptCacheTopicDelta,
+    occurred_at: &Value,
+) {
+    let accounts = conversation
+        .entry("upstreamAccounts")
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .expect("prompt cache upstreamAccounts is an array");
+    let index = accounts.iter().position(|account| {
+        account.get("upstreamAccountId").and_then(Value::as_i64) == record.upstream_account_id
+    });
+    let index = index.unwrap_or_else(|| {
+        accounts.push(serde_json::json!({
+            "upstreamAccountId": record.upstream_account_id,
+            "upstreamAccountName": record.upstream_account_name,
+            "requestCount": 0,
+            "totalTokens": 0,
+            "totalCost": 0.0,
+            "lastActivityAt": occurred_at,
+        }));
+        accounts.len() - 1
+    });
+    if let Some(account) = accounts[index].as_object_mut() {
+        increment_json_i64(account, "requestCount", 1);
+        increment_json_i64(account, "totalTokens", record.request_tokens);
+        increment_json_f64(account, "totalCost", record.cost);
+        account.insert("lastActivityAt".to_string(), occurred_at.clone());
+    }
 }
 
 fn set_json_optional_field(
@@ -4365,12 +4945,13 @@ impl SubscriptionTopic {
                 | Self::DashboardNetworkRecentCurrent
                 | Self::DashboardWorkingConversationsCurrent { .. }
                 | Self::InvocationWindow { .. }
-                | Self::PromptCacheWindow { .. }
-                | Self::PromptCacheStickyWindow { .. }
                 | Self::SummaryCurrent { .. }
                 | Self::TimeseriesOpenWindow { .. }
                 | Self::ParallelWorkCurrent { .. }
                 | Self::ForwardProxyLive => true,
+                Self::PromptCacheWindow { .. } | Self::PromptCacheStickyWindow { .. } => {
+                    !prompt_cache_topic_projection_enabled()
+                }
                 _ => false,
             },
             BroadcastPayload::PromptCacheConversationChanged { prompt_cache_key } => match self {
@@ -4378,6 +4959,7 @@ impl SubscriptionTopic {
                 | Self::PromptCacheConversationOperationsWindow { scope, .. } => {
                     scope.binding_key() == prompt_cache_key
                 }
+                Self::PromptCacheWindow { .. } => true,
                 _ => false,
             },
             BroadcastPayload::PromptCacheConversationStickyRouteChanged {
@@ -4391,6 +4973,11 @@ impl SubscriptionTopic {
                     *previous_upstream_account_id,
                     *upstream_account_id,
                 ),
+                Self::PromptCacheWindow { .. } => true,
+                Self::PromptCacheStickyWindow { account_id, .. } => {
+                    *previous_upstream_account_id == *account_id
+                        || *upstream_account_id == *account_id
+                }
                 _ => false,
             },
             BroadcastPayload::DashboardActivityLive { .. } => {
@@ -7193,6 +7780,11 @@ mod tests {
             summary_refresh_in_flight: false,
             summary_pending_event_count: 0,
             summary_retry_backoff_ms: 0,
+            prompt_cache_refresh_scheduled: false,
+            prompt_cache_pending_records: BTreeMap::new(),
+            prompt_cache_coalesced_event_count: 0,
+            prompt_cache_full_hydration_count: 0,
+            prompt_cache_baseline_at: None,
             latest_live_snapshot: None,
             calendar_anchor: None,
             continuity_reset_cursor: None,
@@ -7755,6 +8347,54 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events.front().map(|event| event.frame.cursor), Some(2));
         assert_eq!(total_bytes, 32);
+    }
+
+    #[test]
+    fn prompt_cache_projection_applies_terminal_delta_without_full_hydration() {
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let mut payload = serde_json::json!({
+            "rangeStart": "2026-08-07T00:00:00Z",
+            "rangeEnd": "2026-08-08T00:00:00Z",
+            "conversations": []
+        });
+        let mut record = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        record.id = 7;
+        record.invoke_id = "projection-terminal".to_string();
+        record.status = Some("success".to_string());
+        record.live_phase = None;
+        record.prompt_cache_key = Some("cache-key".to_string());
+        record.total_tokens = Some(42);
+        record.cost = Some(0.25);
+        record.failure_class = Some("none".to_string());
+
+        let delta = PromptCacheTopicDelta::from_record(&record)
+            .expect("build compact delta")
+            .expect("prompt cache delta");
+        assert!(
+            apply_prompt_cache_records_to_payload(
+                &topic,
+                &mut payload,
+                std::slice::from_ref(&delta),
+            )
+            .expect("apply terminal delta")
+        );
+        let conversation = &payload["conversations"][0];
+        assert_eq!(conversation["promptCacheKey"], "cache-key");
+        assert_eq!(conversation["requestCount"], 1);
+        assert_eq!(conversation["totalTokens"], 42);
+        assert_eq!(
+            conversation["recentInvocations"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(conversation["last24hRequests"].as_array().unwrap().len(), 1);
+
+        apply_prompt_cache_records_to_payload(&topic, &mut payload, &[delta])
+            .expect("deduplicate repeated terminal delta");
+        assert_eq!(payload["conversations"][0]["requestCount"], 1);
     }
 
     #[test]

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -79,6 +79,7 @@ pub(crate) struct SystemRuntimePressureHealth {
     pub(crate) dashboard_projection: RuntimeProjectionHealthSnapshot,
     pub(crate) delivery: DashboardDeliveryTopologyCounterSnapshot,
     pub(crate) request_pipeline: RequestPipelineHealthSnapshot,
+    pub(crate) prompt_cache_projection: PromptCacheTopicProjectionHealthSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -119,6 +120,10 @@ pub(crate) async fn load_runtime_pressure_health(state: &AppState) -> SystemRunt
     let request_pipeline = state
         .proxy_runtime_invocations
         .request_pipeline_health_snapshot();
+    let prompt_cache_projection = state
+        .subscription_hub
+        .prompt_cache_projection_health()
+        .await;
     let projection_cadence_missed = [
         dashboard_projection.slice_counters.current,
         dashboard_projection.slice_counters.network,
@@ -162,6 +167,7 @@ pub(crate) async fn load_runtime_pressure_health(state: &AppState) -> SystemRunt
         dashboard_projection,
         delivery,
         request_pipeline,
+        prompt_cache_projection,
     }
 }
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -482,6 +482,10 @@ pub(crate) struct RequestPipelineHealthSnapshot {
     pub(crate) whole_body_materialization_count: u64,
     pub(crate) rewrite_buffer_peak_bytes: u64,
     pub(crate) last_fallback_reason: Option<String>,
+    pub(crate) parse_window_count: u64,
+    pub(crate) parse_window_cpu_ms: u64,
+    pub(crate) parse_window_wall_ms: u64,
+    pub(crate) parse_window_bytes: u64,
 }
 
 #[derive(Debug, Default)]
@@ -1303,6 +1307,7 @@ impl RuntimeProjectionHub {
 
     pub(crate) fn request_pipeline_health_snapshot(&self) -> RequestPipelineHealthSnapshot {
         let last = self.request_pipeline_last.lock().ok();
+        let parse_window = crate::proxy::request_semantic_cpu_attribution_snapshot();
         RequestPipelineHealthSnapshot {
             mode: request_semantic_pipeline_mode().as_str().to_string(),
             last_snapshot_kind: last
@@ -1319,6 +1324,10 @@ impl RuntimeProjectionHub {
                 .request_rewrite_buffer_peak_bytes
                 .load(Ordering::Relaxed),
             last_fallback_reason: last.and_then(|last| last.fallback_reason.clone()),
+            parse_window_count: parse_window.count,
+            parse_window_cpu_ms: parse_window.cpu_ms,
+            parse_window_wall_ms: parse_window.wall_ms,
+            parse_window_bytes: parse_window.bytes,
         }
     }
 

--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::Error;
 use once_cell::sync::Lazy;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tracing::warn;
 
 const DEFAULT_BACKGROUND_DB_SLOTS: usize = 1;
@@ -31,8 +31,15 @@ pub(crate) struct DbPressureGate {
     pressure_until_epoch_ms: AtomicU64,
     pressure_events: AtomicU64,
     background_skips: AtomicU64,
+    eligibility: Arc<DbPressureEligibility>,
     #[cfg(test)]
     bypass_for_test_global: bool,
+}
+
+#[derive(Debug, Default)]
+struct DbPressureEligibility {
+    generation: AtomicU64,
+    notify: Notify,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,6 +63,17 @@ impl fmt::Display for DbPressureDenyReason {
 pub(crate) struct DbBackgroundPermit {
     _permit: Option<OwnedSemaphorePermit>,
     started_at: Instant,
+    eligibility: Option<Arc<DbPressureEligibility>>,
+}
+
+impl Drop for DbBackgroundPermit {
+    fn drop(&mut self) {
+        self._permit.take();
+        if let Some(eligibility) = &self.eligibility {
+            eligibility.generation.fetch_add(1, Ordering::AcqRel);
+            eligibility.notify.notify_waiters();
+        }
+    }
 }
 
 impl DbBackgroundPermit {
@@ -81,6 +99,7 @@ impl DbPressureGate {
             pressure_until_epoch_ms: AtomicU64::new(0),
             pressure_events: AtomicU64::new(0),
             background_skips: AtomicU64::new(0),
+            eligibility: Arc::new(DbPressureEligibility::default()),
             #[cfg(test)]
             bypass_for_test_global: false,
         }
@@ -110,6 +129,7 @@ impl DbPressureGate {
             return Ok(DbBackgroundPermit {
                 _permit: None,
                 started_at: Instant::now(),
+                eligibility: None,
             });
         }
 
@@ -134,6 +154,7 @@ impl DbPressureGate {
         Ok(DbBackgroundPermit {
             _permit: Some(permit),
             started_at: Instant::now(),
+            eligibility: Some(self.eligibility.clone()),
         })
     }
 
@@ -147,6 +168,7 @@ impl DbPressureGate {
             return Ok(DbBackgroundPermit {
                 _permit: None,
                 started_at: Instant::now(),
+                eligibility: None,
             });
         }
 
@@ -165,6 +187,7 @@ impl DbPressureGate {
                 return Ok(DbBackgroundPermit {
                     _permit: Some(permit),
                     started_at: Instant::now(),
+                    eligibility: Some(self.eligibility.clone()),
                 });
             }
 
@@ -192,6 +215,8 @@ impl DbPressureGate {
         let until_ms = now_ms.saturating_add(cooldown_ms);
         update_atomic_max(&self.pressure_until_epoch_ms, until_ms);
         let events = self.pressure_events.fetch_add(1, Ordering::Relaxed) + 1;
+        self.eligibility.generation.fetch_add(1, Ordering::AcqRel);
+        self.eligibility.notify.notify_waiters();
         warn!(
             task,
             reason,
@@ -199,6 +224,20 @@ impl DbPressureGate {
             cooldown_ms,
             "database pressure detected; background database work will back off"
         );
+    }
+
+    pub(crate) fn eligibility_generation(&self) -> u64 {
+        self.eligibility.generation.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn wait_for_eligibility_change(&self, observed: u64) {
+        loop {
+            let notified = self.eligibility.notify.notified();
+            if self.eligibility_generation() != observed {
+                return;
+            }
+            notified.await;
+        }
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -309,6 +348,29 @@ mod tests {
             .expect("waiter task should not panic")
             .expect("second background permit");
         drop(second);
+    }
+
+    #[tokio::test]
+    async fn gate_notifies_eligibility_generation_when_slot_is_released() {
+        let gate = Arc::new(DbPressureGate::new(1, Duration::from_secs(1)));
+        let permit = gate
+            .try_begin_background("first")
+            .expect("first background permit");
+        let observed = gate.eligibility_generation();
+        let waiter_gate = gate.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_gate.wait_for_eligibility_change(observed).await;
+            waiter_gate.eligibility_generation()
+        });
+
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+        drop(permit);
+        let next_generation = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("eligibility waiter should wake")
+            .expect("eligibility waiter should not panic");
+        assert!(next_generation > observed);
     }
 
     #[tokio::test]

--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -230,6 +230,11 @@ impl DbPressureGate {
         self.eligibility.generation.load(Ordering::Acquire)
     }
 
+    pub(crate) fn notify_background_eligibility(&self) {
+        self.eligibility.generation.fetch_add(1, Ordering::AcqRel);
+        self.eligibility.notify.notify_waiters();
+    }
+
     pub(crate) async fn wait_for_eligibility_change(&self, observed: u64) {
         loop {
             let notified = self.eligibility.notify.notified();
@@ -371,6 +376,28 @@ mod tests {
             .expect("eligibility waiter should wake")
             .expect("eligibility waiter should not panic");
         assert!(next_generation > observed);
+    }
+
+    #[tokio::test]
+    async fn eligibility_wait_observes_release_that_precedes_wait_registration() {
+        let gate = DbPressureGate::new(1, Duration::from_secs(1));
+        let permit = gate
+            .try_begin_background("first")
+            .expect("first background permit");
+        let observed = gate.eligibility_generation();
+        assert_eq!(
+            gate.try_begin_background("second").unwrap_err(),
+            DbPressureDenyReason::BackgroundBusy
+        );
+
+        drop(permit);
+
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            gate.wait_for_eligibility_change(observed),
+        )
+        .await
+        .expect("release before waiter registration must still be observed");
     }
 
     #[tokio::test]

--- a/src/proxy/route_selection.rs
+++ b/src/proxy/route_selection.rs
@@ -509,6 +509,28 @@ fn current_thread_cpu_time() -> Option<Duration> {
     None
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct RequestSemanticCpuAttributionSnapshot {
+    pub(crate) count: u64,
+    pub(crate) cpu_ms: u64,
+    pub(crate) wall_ms: u64,
+    pub(crate) bytes: u64,
+}
+
+static REQUEST_SEMANTIC_CPU_COUNT: AtomicU64 = AtomicU64::new(0);
+static REQUEST_SEMANTIC_CPU_MS: AtomicU64 = AtomicU64::new(0);
+static REQUEST_SEMANTIC_WALL_MS: AtomicU64 = AtomicU64::new(0);
+static REQUEST_SEMANTIC_BYTES: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn request_semantic_cpu_attribution_snapshot() -> RequestSemanticCpuAttributionSnapshot {
+    RequestSemanticCpuAttributionSnapshot {
+        count: REQUEST_SEMANTIC_CPU_COUNT.load(Ordering::Relaxed),
+        cpu_ms: REQUEST_SEMANTIC_CPU_MS.load(Ordering::Relaxed),
+        wall_ms: REQUEST_SEMANTIC_WALL_MS.load(Ordering::Relaxed),
+        bytes: REQUEST_SEMANTIC_BYTES.load(Ordering::Relaxed),
+    }
+}
+
 fn record_request_semantic_cpu_window(cpu_time: Option<Duration>, wall_time: Duration, bytes: u64) {
     use std::sync::{Mutex as StdMutex, OnceLock};
 
@@ -539,6 +561,10 @@ fn record_request_semantic_cpu_window(cpu_time: Option<Duration>, wall_time: Dur
         return;
     }
     let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    REQUEST_SEMANTIC_CPU_COUNT.store(window.count, Ordering::Relaxed);
+    REQUEST_SEMANTIC_CPU_MS.store((window.cpu_ns / 1_000_000) as u64, Ordering::Relaxed);
+    REQUEST_SEMANTIC_WALL_MS.store((window.wall_ns / 1_000_000) as u64, Ordering::Relaxed);
+    REQUEST_SEMANTIC_BYTES.store(window.bytes, Ordering::Relaxed);
     debug!(
         component = "request_semantic_projection",
         window_elapsed_ms = elapsed_ms,

--- a/src/proxy_sqlite_write_coordinator.rs
+++ b/src/proxy_sqlite_write_coordinator.rs
@@ -142,6 +142,34 @@ impl ProxySqliteWriteCoordinator {
         }
     }
 
+    pub(crate) fn try_acquire(
+        self: &Arc<Self>,
+        class: ProxySqliteWriteClass,
+    ) -> Option<ProxySqliteWritePermit> {
+        let requested_at = Instant::now();
+        if !self.coordinated {
+            let mut state = self.state.lock().expect("proxy sqlite coordinator state");
+            state.direct_write_bypass_count = state.direct_write_bypass_count.saturating_add(1);
+            return Some(ProxySqliteWritePermit {
+                coordinator: self.clone(),
+                class,
+                coordinated: false,
+                lock_wait: requested_at.elapsed(),
+            });
+        }
+        let mut state = self.state.lock().expect("proxy sqlite coordinator state");
+        if !state.can_admit(class) {
+            return None;
+        }
+        state.active = Some(class);
+        Some(ProxySqliteWritePermit {
+            coordinator: self.clone(),
+            class,
+            coordinated: true,
+            lock_wait: requested_at.elapsed(),
+        })
+    }
+
     pub(crate) async fn snapshot(&self) -> ProxySqliteWriteCoordinatorSnapshot {
         let state = self.state.lock().expect("proxy sqlite coordinator state");
         ProxySqliteWriteCoordinatorSnapshot {
@@ -214,6 +242,7 @@ impl Drop for ProxySqliteWritePermit {
             state.active = None;
         }
         self.coordinator.notify.notify_waiters();
+        crate::db_pressure::global_db_pressure_gate().notify_background_eligibility();
     }
 }
 
@@ -286,5 +315,36 @@ mod tests {
         .await
         .expect("cancelled P1 waiter must not block P2");
         drop(p2);
+    }
+
+    #[tokio::test]
+    async fn p2_try_acquire_defers_without_registering_a_waiter_or_blocking_p1() {
+        let coordinator = Arc::new(ProxySqliteWriteCoordinator {
+            coordinated: true,
+            state: Mutex::new(CoordinatorState::default()),
+            notify: Notify::new(),
+        });
+        let active = coordinator
+            .acquire(ProxySqliteWriteClass::InteractiveProxy)
+            .await;
+
+        assert!(
+            coordinator
+                .try_acquire(ProxySqliteWriteClass::P2Derived)
+                .is_none()
+        );
+        assert_eq!(coordinator.snapshot().await.p2_waiter_count, 0);
+
+        let p1 = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.acquire(ProxySqliteWriteClass::P1Terminal).await }
+        });
+        tokio::task::yield_now().await;
+        drop(active);
+        let permit = tokio::time::timeout(Duration::from_secs(1), p1)
+            .await
+            .expect("P1 admitted after active writer releases")
+            .expect("P1 task");
+        drop(permit);
     }
 }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -25,6 +25,7 @@ use crate::terminal_journal::{
 };
 
 pub(crate) const SQLITE_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(20);
+pub(crate) const SQLITE_P2_COALESCE_INTERVAL: Duration = Duration::from_millis(250);
 pub(crate) const SQLITE_BATCH_MAX_ROWS: usize = 32;
 pub(crate) const SQLITE_BATCH_MAX_BYTES: usize = 4 * 1024 * 1024;
 pub(crate) const SQLITE_BATCH_MAX_AGE: Duration = Duration::from_secs(5);
@@ -42,6 +43,86 @@ const SQLITE_P1_RETRY_DELAYS: [Duration; 5] = [
 struct P1RetryState {
     generation: usize,
     due_at: Option<Instant>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum P2WakeReason {
+    CoalescedDeadline,
+    PressureCooldownElapsed,
+    BackgroundEligible,
+    LockRetry,
+}
+
+impl P2WakeReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CoalescedDeadline => "coalesced_deadline",
+            Self::PressureCooldownElapsed => "pressure_cooldown_elapsed",
+            Self::BackgroundEligible => "background_eligible",
+            Self::LockRetry => "lock_retry",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct P2ScheduleState {
+    generation: usize,
+    due_at: Option<Instant>,
+    wake_reason: Option<P2WakeReason>,
+    deferred_since: Option<Instant>,
+}
+
+impl P2ScheduleState {
+    fn arm_if_idle(&mut self, now: Instant) {
+        if self.due_at.is_none() {
+            self.due_at = Some(now + SQLITE_P2_COALESCE_INTERVAL);
+            self.wake_reason = Some(P2WakeReason::CoalescedDeadline);
+            self.deferred_since.get_or_insert(now);
+        }
+    }
+
+    fn ready(&self, now: Instant) -> bool {
+        self.due_at.is_some_and(|due_at| now >= due_at)
+    }
+
+    fn defer_pressure(&mut self, delay: Duration, reason: P2WakeReason) {
+        self.due_at = Some(Instant::now() + delay.max(Duration::from_millis(1)));
+        self.wake_reason = Some(reason);
+        self.deferred_since.get_or_insert_with(Instant::now);
+    }
+
+    fn wake_background_eligible(&mut self) {
+        self.due_at = Some(Instant::now());
+        self.wake_reason = Some(P2WakeReason::BackgroundEligible);
+    }
+
+    fn failed(&mut self, transaction_seed: u64) -> Duration {
+        let base = SQLITE_P1_RETRY_DELAYS[self.generation.min(SQLITE_P1_RETRY_DELAYS.len() - 1)];
+        self.generation = self.generation.saturating_add(1);
+        let jitter_ceiling_ms = (base.as_millis() as u64 / 10).max(1);
+        let delay =
+            base.saturating_add(Duration::from_millis(transaction_seed % jitter_ceiling_ms));
+        self.due_at = Some(Instant::now() + delay);
+        self.wake_reason = Some(P2WakeReason::LockRetry);
+        self.deferred_since.get_or_insert_with(Instant::now);
+        delay
+    }
+
+    fn succeeded(&mut self) {
+        *self = Self::default();
+    }
+
+    fn next_attempt_in_ms(&self) -> u64 {
+        self.due_at
+            .map(|due_at| due_at.saturating_duration_since(Instant::now()).as_millis() as u64)
+            .unwrap_or_default()
+    }
+
+    fn deferred_age_ms(&self) -> u64 {
+        self.deferred_since
+            .map(|started| started.elapsed().as_millis() as u64)
+            .unwrap_or_default()
+    }
 }
 
 impl P1RetryState {
@@ -96,6 +177,13 @@ pub(crate) struct PendingQueueAccountingSnapshot {
     pub(crate) pending_bytes: usize,
     pub(crate) transfer_bytes: usize,
     pub(crate) retry_count: u64,
+    pub(crate) p2_flush_attempt_count: u64,
+    pub(crate) p2_pressure_defer_count: u64,
+    pub(crate) p2_lock_retry_count: u64,
+    pub(crate) p2_next_attempt_in_ms: u64,
+    pub(crate) p2_deferred_age_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) p2_wake_reason: Option<String>,
     pub(crate) invariant_violation_count: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) degraded_reason: Option<String>,
@@ -109,6 +197,12 @@ pub(crate) struct PendingQueueAccounting {
     pending_bytes: AtomicUsize,
     transfer_bytes: AtomicUsize,
     retry_count: AtomicU64,
+    p2_flush_attempt_count: AtomicU64,
+    p2_pressure_defer_count: AtomicU64,
+    p2_lock_retry_count: AtomicU64,
+    p2_next_attempt_in_ms: AtomicU64,
+    p2_deferred_age_ms: AtomicU64,
+    p2_wake_reason: std::sync::Mutex<Option<String>>,
     invariant_violation_count: AtomicU64,
     last_invariant_violation: std::sync::Mutex<Option<PendingQueueInvariantViolation>>,
 }
@@ -163,6 +257,30 @@ impl PendingQueueAccounting {
         self.retry_count.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn p2_attempted(&self) {
+        self.p2_flush_attempt_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn p2_pressure_deferred(&self) {
+        self.p2_pressure_defer_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn p2_lock_retried(&self) {
+        self.p2_lock_retry_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn update_p2_schedule(&self, schedule: &P2ScheduleState) {
+        self.p2_next_attempt_in_ms
+            .store(schedule.next_attempt_in_ms(), Ordering::Relaxed);
+        self.p2_deferred_age_ms
+            .store(schedule.deferred_age_ms(), Ordering::Relaxed);
+        if let Ok(mut wake_reason) = self.p2_wake_reason.lock() {
+            *wake_reason = schedule
+                .wake_reason
+                .map(|reason| reason.as_str().to_string());
+        }
+    }
+
     pub(crate) fn complete(
         &self,
         submitted_depth: usize,
@@ -205,6 +323,16 @@ impl PendingQueueAccounting {
             pending_bytes: self.pending_bytes.load(Ordering::Relaxed),
             transfer_bytes: self.transfer_bytes.load(Ordering::Relaxed),
             retry_count: self.retry_count.load(Ordering::Relaxed),
+            p2_flush_attempt_count: self.p2_flush_attempt_count.load(Ordering::Relaxed),
+            p2_pressure_defer_count: self.p2_pressure_defer_count.load(Ordering::Relaxed),
+            p2_lock_retry_count: self.p2_lock_retry_count.load(Ordering::Relaxed),
+            p2_next_attempt_in_ms: self.p2_next_attempt_in_ms.load(Ordering::Relaxed),
+            p2_deferred_age_ms: self.p2_deferred_age_ms.load(Ordering::Relaxed),
+            p2_wake_reason: self
+                .p2_wake_reason
+                .lock()
+                .ok()
+                .and_then(|value| value.clone()),
             invariant_violation_count,
             degraded_reason,
             last_invariant_violation,
@@ -510,6 +638,13 @@ impl PendingBatch {
             && self.system_task_finishes.is_empty()
     }
 
+    fn has_p2(&self) -> bool {
+        !self.attempt_progress.is_empty()
+            || !self.invocation_derived.is_empty()
+            || !self.account_selected_touches.is_empty()
+            || !self.system_task_finishes.is_empty()
+    }
+
     fn logical_rows(&self) -> usize {
         self.terminal_invocations.len()
             + self.attempt_progress.len()
@@ -715,13 +850,33 @@ impl PendingBatch {
 pub(crate) struct RetainedBatch {
     batch: PendingBatch,
     failed: bool,
+    p2_defer: Option<P2DeferReason>,
 }
 
 impl RetainedBatch {
     fn new(mut batch: PendingBatch, failed: bool) -> Self {
         batch.retained_for_retry = true;
-        Self { batch, failed }
+        Self {
+            batch,
+            failed,
+            p2_defer: None,
+        }
     }
+
+    fn p2_deferred(mut batch: PendingBatch, reason: P2DeferReason) -> Self {
+        batch.retained_for_retry = true;
+        Self {
+            batch,
+            failed: false,
+            p2_defer: Some(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum P2DeferReason {
+    PressureCooldown(u64),
+    BackgroundBusy,
 }
 
 fn estimated_option_string_bytes(value: &Option<String>) -> usize {
@@ -1319,11 +1474,24 @@ pub(crate) async fn run_sqlite_batch_writer(
     let mut pending = PendingBatch::default();
     let mut control_closed = false;
     let mut p1_retry = P1RetryState::default();
+    let mut p2_schedule = P2ScheduleState::default();
+    let mut p2_eligibility_generation =
+        crate::db_pressure::global_db_pressure_gate().eligibility_generation();
     let mut transaction_sequence = 0_u64;
 
     loop {
         tokio::select! {
             biased;
+            _ = crate::db_pressure::global_db_pressure_gate()
+                .wait_for_eligibility_change(p2_eligibility_generation),
+                if pending.has_p2()
+                    && p2_schedule.wake_reason == Some(P2WakeReason::BackgroundEligible) =>
+            {
+                p2_eligibility_generation = crate::db_pressure::global_db_pressure_gate()
+                    .eligibility_generation();
+                p2_schedule.wake_background_eligible();
+                accounting.update_p2_schedule(&p2_schedule);
+            }
             maybe_control = control_receiver.recv(), if !control_closed => {
                 if let Some(control) = maybe_control {
                     match control {
@@ -1483,14 +1651,32 @@ pub(crate) async fn run_sqlite_batch_writer(
                     return;
                 };
                 pending.push_accounted(write, &accounting);
+                if pending.has_p2() {
+                    p2_schedule.arm_if_idle(Instant::now());
+                    accounting.update_p2_schedule(&p2_schedule);
+                }
                 if (pending.logical_rows() >= SQLITE_BATCH_MAX_ROWS
                     || pending.estimated_memory_bytes() >= SQLITE_BATCH_MAX_BYTES)
                     && (pending.terminal_invocations.is_empty() || p1_retry.ready(Instant::now()))
-                    && let Some(retained) =
+                    && (!pending.terminal_invocations.is_empty()
+                        || p2_schedule.ready(Instant::now()))
+                {
+                    let p2_ready = p2_schedule.ready(Instant::now());
+                    let flush_batch = if !pending.terminal_invocations.is_empty()
+                        && pending.has_p2()
+                        && !p2_ready
+                    {
+                        pending.take_p1_terminals()
+                    } else {
+                        pending.take()
+                    };
+                    let submitted_p1 = !flush_batch.terminal_invocations.is_empty();
+                    let submitted_p2 = flush_batch.has_p2();
+                    if let Some(retained) =
                         flush_pending_batch_accounted(
                             &accounting,
                             &pool,
-                            pending.take(),
+                            flush_batch,
                             FlushReason::RowLimit,
                             prompt_cache_conversation_cache.as_ref(),
                             &terminal_runtime_store,
@@ -1513,12 +1699,58 @@ pub(crate) async fn run_sqlite_batch_writer(
                         } else {
                             p1_retry.succeeded();
                         }
-                        pending = retained.batch;
+                        match retained.p2_defer {
+                            Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                                p2_schedule.defer_pressure(
+                                    Duration::from_millis(remaining_ms),
+                                    P2WakeReason::PressureCooldownElapsed,
+                                );
+                            }
+                            Some(P2DeferReason::BackgroundBusy) => {
+                                p2_eligibility_generation = crate::db_pressure::global_db_pressure_gate()
+                                    .eligibility_generation();
+                                p2_schedule.defer_pressure(
+                                    SQLITE_P2_COALESCE_INTERVAL,
+                                    P2WakeReason::BackgroundEligible,
+                                );
+                            }
+                            None if retained.failed && retained.batch.has_p2()
+                                && retained.batch.terminal_invocations.is_empty() => {
+                                transaction_sequence = transaction_sequence.saturating_add(1);
+                                p2_schedule.failed(transaction_sequence);
+                                accounting.p2_lock_retried();
+                            }
+                            None if retained.batch.has_p2() => {
+                                p2_schedule.arm_if_idle(Instant::now());
+                            }
+                            None => p2_schedule.succeeded(),
+                        }
+                        accounting.update_p2_schedule(&p2_schedule);
+                        if retained.batch.terminal_invocations.is_empty() {
+                            pending.merge_p2(retained.batch);
+                        } else {
+                            let mut retained_batch = retained.batch;
+                            retained_batch.merge_p2(pending.take());
+                            pending = retained_batch;
+                        }
+                    } else {
+                        if submitted_p1 {
+                            p1_retry.succeeded();
+                        }
+                        if submitted_p2 {
+                            p2_schedule.succeeded();
+                            accounting.update_p2_schedule(&p2_schedule);
+                        }
                     }
+                }
             }
             _ = ticker.tick() => {
                 if !pending.is_empty() {
                     if !pending.terminal_invocations.is_empty() && !p1_retry.ready(Instant::now()) {
+                        continue;
+                    }
+                    let p2_ready = p2_schedule.ready(Instant::now());
+                    if pending.terminal_invocations.is_empty() && !p2_ready {
                         continue;
                     }
                     let flush_reason = if pending.age() >= SQLITE_BATCH_MAX_AGE {
@@ -1546,11 +1778,16 @@ pub(crate) async fn run_sqlite_batch_writer(
                         FlushReason::Interval
                     };
                     let submitted_p1 = !pending.terminal_invocations.is_empty();
+                    let flush_batch = if submitted_p1 && pending.has_p2() && !p2_ready {
+                        pending.take_p1_terminals()
+                    } else {
+                        pending.take()
+                    };
                     if let Some(retained) =
                         flush_pending_batch_accounted(
                             &accounting,
                             &pool,
-                            pending.take(),
+                            flush_batch,
                             flush_reason,
                             prompt_cache_conversation_cache.as_ref(),
                             &terminal_runtime_store,
@@ -1573,9 +1810,51 @@ pub(crate) async fn run_sqlite_batch_writer(
                         } else if submitted_p1 {
                             p1_retry.succeeded();
                         }
-                        pending = retained.batch;
+                        match retained.p2_defer {
+                            Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                                p2_schedule.defer_pressure(
+                                    Duration::from_millis(remaining_ms),
+                                    P2WakeReason::PressureCooldownElapsed,
+                                );
+                            }
+                            Some(P2DeferReason::BackgroundBusy) => {
+                                p2_eligibility_generation = crate::db_pressure::global_db_pressure_gate()
+                                    .eligibility_generation();
+                                p2_schedule.defer_pressure(
+                                    SQLITE_P2_COALESCE_INTERVAL,
+                                    P2WakeReason::BackgroundEligible,
+                                );
+                            }
+                            None if retained.failed && retained.batch.has_p2()
+                                && retained.batch.terminal_invocations.is_empty() => {
+                                transaction_sequence = transaction_sequence.saturating_add(1);
+                                let delay = p2_schedule.failed(transaction_sequence);
+                                accounting.p2_lock_retried();
+                                warn!(
+                                    write_class = "p2_derived",
+                                    retry_generation = p2_schedule.generation as u64,
+                                    next_retry_delay_ms = delay.as_millis() as u64,
+                                    "scheduled retained P2 batch with exponential backoff"
+                                );
+                            }
+                            None if retained.batch.has_p2() => {
+                                p2_schedule.arm_if_idle(Instant::now());
+                            }
+                            None => p2_schedule.succeeded(),
+                        }
+                        if retained.batch.terminal_invocations.is_empty() {
+                            pending.merge_p2(retained.batch);
+                        } else {
+                            let mut retained_batch = retained.batch;
+                            retained_batch.merge_p2(pending.take());
+                            pending = retained_batch;
+                        }
+                        accounting.update_p2_schedule(&p2_schedule);
                     } else if submitted_p1 {
                         p1_retry.succeeded();
+                    } else {
+                        p2_schedule.succeeded();
+                        accounting.update_p2_schedule(&p2_schedule);
                     }
                 }
             }
@@ -1677,9 +1956,7 @@ async fn flush_pending_batch_accounted(
     dashboard_reconcile_gate: &Arc<Mutex<()>>,
     terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
 ) -> Option<RetainedBatch> {
-    if batch.retained_for_retry {
-        accounting.retry_deferred();
-    }
+    let was_retained_retry = batch.retained_for_retry;
     let submitted_depth = batch.logical_rows();
     let submitted_bytes = batch.estimated_memory_bytes();
     let result = flush_pending_batch(
@@ -1695,6 +1972,9 @@ async fn flush_pending_batch_accounted(
         terminal_journal,
     )
     .await;
+    if was_retained_retry && result.as_ref().is_some_and(|retained| retained.failed) {
+        accounting.retry_deferred();
+    }
     let retained_bytes = result
         .as_ref()
         .map(|retained| retained.batch.estimated_memory_bytes())
@@ -1875,6 +2155,10 @@ pub(crate) async fn flush_pending_batch(
     if batch.is_empty() {
         return None;
     }
+    let write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
+        .await;
+
     let permit = if reason.bypass_pressure_gate() {
         None
     } else {
@@ -1883,20 +2167,27 @@ pub(crate) async fn flush_pending_batch(
         {
             Ok(permit) => Some(permit),
             Err(deny_reason) => {
+                drop(write_permit);
+                accounting.p2_pressure_deferred();
                 debug!(
                     deny_reason = %deny_reason,
                     flush_priority = "P2",
                     p2_deferred_count = batch.logical_rows(),
                     "sqlite batch writer deferred P2 flush because pressure gate is closed"
                 );
-                return Some(RetainedBatch::new(batch, false));
+                let reason = match deny_reason {
+                    crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => {
+                        P2DeferReason::PressureCooldown(remaining_ms)
+                    }
+                    crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
+                        P2DeferReason::BackgroundBusy
+                    }
+                };
+                return Some(RetainedBatch::p2_deferred(batch, reason));
             }
         }
     };
-
-    let write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
-        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
-        .await;
+    accounting.p2_attempted();
 
     let deferred_batch = match flush_pending_batch_inner(
         pool,
@@ -2314,6 +2605,41 @@ mod tests {
         retry.succeeded();
         assert!(retry.ready(Instant::now()));
         assert_eq!(retry.generation, 0);
+    }
+
+    #[test]
+    fn p2_schedule_coalesces_and_separates_pressure_from_lock_retries() {
+        let accounting = PendingQueueAccounting::default();
+        let mut schedule = P2ScheduleState::default();
+        let now = Instant::now();
+        schedule.arm_if_idle(now);
+        let initial_due = schedule.due_at;
+        schedule.arm_if_idle(now + Duration::from_millis(100));
+        assert_eq!(
+            schedule.due_at, initial_due,
+            "new work must not extend deadline"
+        );
+
+        accounting.p2_pressure_deferred();
+        schedule.defer_pressure(
+            Duration::from_secs(30),
+            P2WakeReason::PressureCooldownElapsed,
+        );
+        accounting.update_p2_schedule(&schedule);
+        let pressure = accounting.snapshot();
+        assert_eq!(pressure.retry_count, 0);
+        assert_eq!(pressure.p2_pressure_defer_count, 1);
+        assert!(pressure.p2_next_attempt_in_ms >= 29_000);
+
+        let delay = schedule.failed(0);
+        accounting.p2_lock_retried();
+        accounting.retry_deferred();
+        accounting.update_p2_schedule(&schedule);
+        let locked = accounting.snapshot();
+        assert_eq!(delay, Duration::from_millis(250));
+        assert_eq!(locked.retry_count, 1);
+        assert_eq!(locked.p2_lock_retry_count, 1);
+        assert_eq!(locked.p2_wake_reason.as_deref(), Some("lock_retry"));
     }
 
     #[test]

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -74,7 +74,7 @@ struct P2ScheduleState {
 
 impl P2ScheduleState {
     fn arm_if_idle(&mut self, now: Instant) {
-        if self.due_at.is_none() {
+        if self.due_at.is_none() && self.wake_reason.is_none() {
             self.due_at = Some(now + SQLITE_P2_COALESCE_INTERVAL);
             self.wake_reason = Some(P2WakeReason::CoalescedDeadline);
             self.deferred_since.get_or_insert(now);
@@ -88,6 +88,12 @@ impl P2ScheduleState {
     fn defer_pressure(&mut self, delay: Duration, reason: P2WakeReason) {
         self.due_at = Some(Instant::now() + delay.max(Duration::from_millis(1)));
         self.wake_reason = Some(reason);
+        self.deferred_since.get_or_insert_with(Instant::now);
+    }
+
+    fn defer_until_background_eligible(&mut self) {
+        self.due_at = None;
+        self.wake_reason = Some(P2WakeReason::BackgroundEligible);
         self.deferred_since.get_or_insert_with(Instant::now);
     }
 
@@ -850,6 +856,7 @@ impl PendingBatch {
 pub(crate) struct RetainedBatch {
     batch: PendingBatch,
     failed: bool,
+    p2_lock_failure: bool,
     p2_defer: Option<P2DeferReason>,
 }
 
@@ -859,6 +866,7 @@ impl RetainedBatch {
         Self {
             batch,
             failed,
+            p2_lock_failure: false,
             p2_defer: None,
         }
     }
@@ -868,7 +876,18 @@ impl RetainedBatch {
         Self {
             batch,
             failed: false,
+            p2_lock_failure: false,
             p2_defer: Some(reason),
+        }
+    }
+
+    fn p2_failed(mut batch: PendingBatch, lock_failure: bool) -> Self {
+        batch.retained_for_retry = true;
+        Self {
+            batch,
+            failed: true,
+            p2_lock_failure: lock_failure,
+            p2_defer: None,
         }
     }
 }
@@ -876,7 +895,7 @@ impl RetainedBatch {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum P2DeferReason {
     PressureCooldown(u64),
-    BackgroundBusy,
+    BackgroundBusy { observed_generation: u64 },
 }
 
 fn estimated_option_string_bytes(value: &Option<String>) -> usize {
@@ -1706,19 +1725,19 @@ pub(crate) async fn run_sqlite_batch_writer(
                                     P2WakeReason::PressureCooldownElapsed,
                                 );
                             }
-                            Some(P2DeferReason::BackgroundBusy) => {
-                                p2_eligibility_generation = crate::db_pressure::global_db_pressure_gate()
-                                    .eligibility_generation();
-                                p2_schedule.defer_pressure(
-                                    SQLITE_P2_COALESCE_INTERVAL,
-                                    P2WakeReason::BackgroundEligible,
-                                );
+                            Some(P2DeferReason::BackgroundBusy {
+                                observed_generation,
+                            }) => {
+                                p2_eligibility_generation = observed_generation;
+                                p2_schedule.defer_until_background_eligible();
                             }
                             None if retained.failed && retained.batch.has_p2()
                                 && retained.batch.terminal_invocations.is_empty() => {
                                 transaction_sequence = transaction_sequence.saturating_add(1);
                                 p2_schedule.failed(transaction_sequence);
-                                accounting.p2_lock_retried();
+                                if retained.p2_lock_failure {
+                                    accounting.p2_lock_retried();
+                                }
                             }
                             None if retained.batch.has_p2() => {
                                 p2_schedule.arm_if_idle(Instant::now());
@@ -1817,19 +1836,19 @@ pub(crate) async fn run_sqlite_batch_writer(
                                     P2WakeReason::PressureCooldownElapsed,
                                 );
                             }
-                            Some(P2DeferReason::BackgroundBusy) => {
-                                p2_eligibility_generation = crate::db_pressure::global_db_pressure_gate()
-                                    .eligibility_generation();
-                                p2_schedule.defer_pressure(
-                                    SQLITE_P2_COALESCE_INTERVAL,
-                                    P2WakeReason::BackgroundEligible,
-                                );
+                            Some(P2DeferReason::BackgroundBusy {
+                                observed_generation,
+                            }) => {
+                                p2_eligibility_generation = observed_generation;
+                                p2_schedule.defer_until_background_eligible();
                             }
                             None if retained.failed && retained.batch.has_p2()
                                 && retained.batch.terminal_invocations.is_empty() => {
                                 transaction_sequence = transaction_sequence.saturating_add(1);
                                 let delay = p2_schedule.failed(transaction_sequence);
-                                accounting.p2_lock_retried();
+                                if retained.p2_lock_failure {
+                                    accounting.p2_lock_retried();
+                                }
                                 warn!(
                                     write_class = "p2_derived",
                                     retry_generation = p2_schedule.generation as u64,
@@ -2155,9 +2174,20 @@ pub(crate) async fn flush_pending_batch(
     if batch.is_empty() {
         return None;
     }
-    let write_permit = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
-        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
-        .await;
+    let observed_eligibility_generation =
+        crate::db_pressure::global_db_pressure_gate().eligibility_generation();
+    let Some(write_permit) =
+        crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
+            .try_acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
+    else {
+        accounting.p2_pressure_deferred();
+        return Some(RetainedBatch::p2_deferred(
+            batch,
+            P2DeferReason::BackgroundBusy {
+                observed_generation: observed_eligibility_generation,
+            },
+        ));
+    };
 
     let permit = if reason.bypass_pressure_gate() {
         None
@@ -2180,7 +2210,9 @@ pub(crate) async fn flush_pending_batch(
                         P2DeferReason::PressureCooldown(remaining_ms)
                     }
                     crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
-                        P2DeferReason::BackgroundBusy
+                        P2DeferReason::BackgroundBusy {
+                            observed_generation: observed_eligibility_generation,
+                        }
                     }
                 };
                 return Some(RetainedBatch::p2_deferred(batch, reason));
@@ -2213,7 +2245,7 @@ pub(crate) async fn flush_pending_batch(
                 "sqlite batch writer P2 flush failed"
             );
             drop(permit);
-            return Some(RetainedBatch::new(batch, true));
+            return Some(RetainedBatch::p2_failed(batch, is_sqlite_lock_error(&err)));
         }
     };
     drop(write_permit);
@@ -2640,6 +2672,23 @@ mod tests {
         assert_eq!(locked.retry_count, 1);
         assert_eq!(locked.p2_lock_retry_count, 1);
         assert_eq!(locked.p2_wake_reason.as_deref(), Some("lock_retry"));
+    }
+
+    #[test]
+    fn p2_background_busy_waits_for_eligibility_event_without_polling() {
+        let mut schedule = P2ScheduleState::default();
+        schedule.arm_if_idle(Instant::now());
+        schedule.defer_until_background_eligible();
+
+        assert!(!schedule.ready(Instant::now() + Duration::from_secs(30)));
+        assert_eq!(schedule.next_attempt_in_ms(), 0);
+        assert_eq!(schedule.wake_reason, Some(P2WakeReason::BackgroundEligible));
+
+        schedule.arm_if_idle(Instant::now());
+        assert!(schedule.due_at.is_none(), "new P2 work must only coalesce");
+
+        schedule.wake_background_eligible();
+        assert!(schedule.ready(Instant::now()));
     }
 
     #[test]

--- a/web/src/lib/api/core-foundation.ts
+++ b/web/src/lib/api/core-foundation.ts
@@ -2164,8 +2164,26 @@ export interface RuntimePressureWriterAccountingHealth {
   pendingBytes: number;
   transferBytes: number;
   retryCount: number;
+  p2FlushAttemptCount?: number;
+  p2PressureDeferCount?: number;
+  p2LockRetryCount?: number;
+  p2NextAttemptInMs?: number;
+  p2DeferredAgeMs?: number;
+  p2WakeReason?: string;
   invariantViolationCount: number;
   degradedReason?: string;
+}
+
+export interface RuntimePressurePromptCacheProjectionHealth {
+  mode: string;
+  activeTopicCount: number;
+  dirtyKeyCount: number;
+  coalescedEventCount: number;
+  fullHydrationCount: number;
+  boundedKeyHydrationCount: number;
+  livePathDbReadCount: number;
+  baselineAgeMs: number;
+  responseSource: string;
 }
 
 export interface RuntimePressureProxySqliteWriteCoordinatorHealth {
@@ -2229,6 +2247,10 @@ export interface RuntimePressureRequestPipelineHealth {
   wholeBodyMaterializationCount: number;
   rewriteBufferPeakBytes: number;
   lastFallbackReason?: string;
+  parseWindowCount?: number;
+  parseWindowCpuMs?: number;
+  parseWindowWallMs?: number;
+  parseWindowBytes?: number;
 }
 
 export interface RuntimePressureHealth {
@@ -2236,6 +2258,7 @@ export interface RuntimePressureHealth {
   process: RuntimePressureProcessHealth;
   allocator: { mallocArenaMax: string };
   writerAccounting: RuntimePressureWriterAccountingHealth;
+  promptCacheProjection?: RuntimePressurePromptCacheProjectionHealth;
   proxySqliteWriteCoordinator?: RuntimePressureProxySqliteWriteCoordinatorHealth;
   dashboardProjection: RuntimePressureDashboardProjectionHealth;
   delivery: RuntimePressureDeliveryHealth;
@@ -4106,6 +4129,7 @@ function normalizeRuntimePressureHealth(raw: unknown): RuntimePressureHealth | u
   const process = (payload.process ?? {}) as Record<string, unknown>;
   const allocator = (payload.allocator ?? {}) as Record<string, unknown>;
   const writer = (payload.writerAccounting ?? {}) as Record<string, unknown>;
+  const promptCacheProjection = (payload.promptCacheProjection ?? {}) as Record<string, unknown>;
   const writeCoordinator = payload.proxySqliteWriteCoordinator as
     | Record<string, unknown>
     | undefined;
@@ -4155,8 +4179,25 @@ function normalizeRuntimePressureHealth(raw: unknown): RuntimePressureHealth | u
       pendingBytes: number(writer.pendingBytes),
       transferBytes: number(writer.transferBytes),
       retryCount: number(writer.retryCount),
+      p2FlushAttemptCount: number(writer.p2FlushAttemptCount),
+      p2PressureDeferCount: number(writer.p2PressureDeferCount),
+      p2LockRetryCount: number(writer.p2LockRetryCount),
+      p2NextAttemptInMs: number(writer.p2NextAttemptInMs),
+      p2DeferredAgeMs: number(writer.p2DeferredAgeMs),
+      p2WakeReason: optionalString(writer.p2WakeReason),
       invariantViolationCount: number(writer.invariantViolationCount),
       degradedReason: optionalString(writer.degradedReason),
+    },
+    promptCacheProjection: {
+      mode: optionalString(promptCacheProjection.mode) ?? "unknown",
+      activeTopicCount: number(promptCacheProjection.activeTopicCount),
+      dirtyKeyCount: number(promptCacheProjection.dirtyKeyCount),
+      coalescedEventCount: number(promptCacheProjection.coalescedEventCount),
+      fullHydrationCount: number(promptCacheProjection.fullHydrationCount),
+      boundedKeyHydrationCount: number(promptCacheProjection.boundedKeyHydrationCount),
+      livePathDbReadCount: number(promptCacheProjection.livePathDbReadCount),
+      baselineAgeMs: number(promptCacheProjection.baselineAgeMs),
+      responseSource: optionalString(promptCacheProjection.responseSource) ?? "unknown",
     },
     proxySqliteWriteCoordinator: writeCoordinator
       ? {
@@ -4200,6 +4241,10 @@ function normalizeRuntimePressureHealth(raw: unknown): RuntimePressureHealth | u
           wholeBodyMaterializationCount: number(requestPipeline.wholeBodyMaterializationCount),
           rewriteBufferPeakBytes: number(requestPipeline.rewriteBufferPeakBytes),
           lastFallbackReason: optionalString(requestPipeline.lastFallbackReason),
+          parseWindowCount: number(requestPipeline.parseWindowCount),
+          parseWindowCpuMs: number(requestPipeline.parseWindowCpuMs),
+          parseWindowWallMs: number(requestPipeline.parseWindowWallMs),
+          parseWindowBytes: number(requestPipeline.parseWindowBytes),
         }
       : undefined,
   };


### PR DESCRIPTION
## Summary
- Coalesce P2 derived SQLite work on a fixed 250ms deadline and wait for pressure eligibility events instead of polling every 20ms.
- Materialize active Prompt Cache topics from bounded in-memory deltas at 500ms, with cursor-aware baselines and pressure-gated 60s reconciliation.
- Add writer and Prompt Cache diagnostics to runtime pressure health; preserve HTTP/SSE contracts and legacy kill switch.

## Delivery
- Delivery role: direct
- Base: `main` at `61bc71710b8c3b6ff4a8871a0d5bd326281f2cdd`
- Spec: `high-frequency-runtime-data-plane`, `5932d-sse-proxy-live-sync`, `vmcs3-terminal-projection-materialization`
- Spec Disposition: update
- Solutions: `sqlite-write-pressure-backpressure`
- Project Docs: `docs/system-design.md` updated
- Visual evidence: not applicable; no owner-visible UI changes

## Validation
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test -q` (2031 passed, 45 ignored)
- `cargo test -q sqlite_batch_writer`
- `cargo test -q prompt_cache_conversation_queries`
- `cargo test -q subscriptions`
- `cargo test -q system_status_and_account_roster`
- `cd web && bun x tsc -b --pretty false`
- Current-head native review: clear

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->