### PR TITLE
perf(runtime): add typed mutation bus

### DIFF
--- a/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
+++ b/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
@@ -10,15 +10,17 @@ Backfill scheduling is event-driven. Progress state owns `next_due` and wake gen
 
 P1 正常 admission 为 20ms，批次上限为 32 条或 4 MiB；失败后按 250ms 到 5s 退避。P2 使用独立 250ms 固定 deadline，pressure defer、background busy 和实际 lock retry 分开调度与计数；hourly replay 每次只执行一个既有有界 chunk，未覆盖 derived work 保留到下一轮。
 
-Prompt Cache window topic 在首个 owner 订阅时建立精确 baseline。后续 Records 按调用 identity 去重并在 500ms 后直接更新 cached payload；完整 hydrate 仅用于初始 baseline、60 秒 reconcile 或 dirty recovery。最后一个 owner 释放时丢弃 pending delta 并要求重订阅 fresh baseline。
+Prompt Cache window topic 在首个 owner 订阅时建立精确 baseline。后续 typed runtime mutations 按调用 identity 去重并在 500ms 后直接更新 cached payload；完整 hydrate 仅用于初始 baseline、60 秒 reconcile 或 dirty recovery。最后一个 owner 释放时丢弃 pending delta 并要求重订阅 fresh baseline。
 
 ## Delivery Topology
 
-- Integration branch: `prd/dashboard-runtime-delivery-plane`
+- Integration branch: `prd/typed-runtime-event-bus`
 - Final base: `main`
 - Child merge policy: risk-gated
 - Final merge policy: owner-explicit
 - Child work is tracked by GitHub Issues and targets the integration branch.
+
+`BroadcastPayload::Records` and the related prompt-cache and attempt variants are absent from the production binary. `#[cfg(test)]` observer shims preserve legacy persistence assertions while tests migrate; they never subscribe to, publish to, or affect the typed runtime mutation router.
 
 ## Module Boundaries
 
@@ -31,14 +33,14 @@ Prompt Cache window topic 在首个 owner 订阅时建立精确 baseline。后�
 ## Migration Sequence
 
 1. Make writer accounting and process diagnostics trustworthy before using them as gates.
-2. Replace duplicate request parsing/materialization with one semantic projection while preserving legacy kill-switch behavior.
+2. Replace duplicate request parsing/materialization with one semantic projection while preserving its explicit compatibility behavior.
 3. Move Dashboard live rendering to Runtime Projection and prove zero live-path DB reads.
 4. Replace mutable JSON topic fan-out with shared serialized frames and subscriber reference gating.
 5. Expose health states in System Status, complete visual evidence, then remove obsolete production paths after A/B evidence.
 
 ## Compatibility
 
-- `auto` is the default for both new pipelines. A legacy mode remains available for operational rollback during rollout.
+- The typed runtime mutation bus is mandatory in production. Legacy Dashboard and Prompt Cache runtime-bus environment modes are rejected and cannot re-enable complete-record broadcasts.
 - HTTP/SSE payload contracts are unchanged; additive System Status data is optional to clients.
 - Existing persistence, terminal journal and closed-range builders remain authoritative recovery paths.
 
@@ -61,8 +63,8 @@ Runtime Projection is implemented through `RuntimeProjectionHub` and `DashboardL
 - In `auto` mode, the producer broadcasts `DashboardCurrentSlice`, `DashboardNetworkSlice` or `DashboardTerminalSlice`. The subscription hub serializes each affected topic revision once, commits one shared `Arc<SerializedTopicFrame>` to cache/replay/broadcast, and SSE owners retain frame references rather than business payloads or mutable generic JSON.
 - Incoming slices and detached materialization commits are monotonic: stale slice revisions are rejected and the dependency graph is revalidated under the hub lock before a frame can update cache, replay or cursor state.
 - Revision delivery never rebuilds a topic base, reads SQLite, or reconciles. Network timeseries serializes its typed base by borrowing every retained point and substituting only the current slice's live point; network recent serializes the current slice by reference. Terminal totals apply their typed delta to activity and open summary bases on the fixed `5s` slice. The producer-owned `60s` runtime reconcile scans activity calendar transitions plus activity/summary rolling-duration bases, then rebuilds active stale bases outside the subscription task; activity retains a rebase-only range anchor so a terminal slice can advance its public range without deferring that rebuild. Terminal delivery only marks a stale base dirty and skips its slice until that replacement succeeds. A fresh rolling base never schedules SQLite work, a failed rebase remains isolated for the next producer reconcile, and a byte-identical rebase retains its frame and cursor. In `auto`, the shared network projection producer owns the fixed `1s` cadence for both network topics, so subscription tasks do not run a second producer. Subscriber-free topics remain dirty and rebuild an authoritative base when ownership returns.
-- The `legacy` kill switch keeps the pre-existing `DashboardActivityLive`, JSON-overlay, network-recent subscription cadence, and Records-refresh terminal delivery paths intact for one release.
-- The full topology contract opens two real `topic_sse_stream` Dashboard connections, verifies one shared frame identity for activity, summary, network timeseries and network recent, asserts zero business-payload broadcasts, JSON overlays, and complete payload clones, one serialization per materialized revision, zero live-path SQLite reads, and no lag or skipped frames. Focused coverage exercises terminal revision idempotence, cold network-only materialization, repeated-network-revision suppression, auto/legacy cadence routing, a legacy recent cadence frame through the SSE entrypoint, revision independence and the current-state p95 gate.
+- The runtime router receives compact mutation events only. It selects active topic dependencies before materialization, sends Dashboard slices to their dedicated projection materializers, and uses bounded durable identity hydration only for cold detail consumers.
+- The full topology contract opens two real `topic_sse_stream` Dashboard connections, verifies one shared frame identity for activity, summary, network timeseries and network recent, asserts zero business-payload broadcasts, JSON overlays, and complete payload clones, one serialization per materialized revision, zero live-path SQLite reads, and no lag or skipped frames. Focused coverage exercises terminal revision idempotence, cold network-only materialization, repeated-network-revision suppression, typed-router active-topic filtering, cursor-gap recovery, revision independence and the current-state p95 gate.
 
 Runtime projection maintains independent current/phase, network/rate and terminal-total dirty generations, revisions and non-extending `250ms`, `1s` and `5s` deadlines. Network-only changes do not build or advance the current slice; active network topics rearm only the network cadence so rates and recent windows decay without waking current projection. Terminal slice staging is bounded and drained on its fixed deadline even without subscribers, preventing subscriber-free retention.
 

--- a/docs/specs/high-frequency-runtime-data-plane/SPEC.md
+++ b/docs/specs/high-frequency-runtime-data-plane/SPEC.md
@@ -59,7 +59,7 @@
 - Dashboard、统计、raw detail HTTP response 不变。
 - SSE topic 名称、schema epoch、snapshot/replay/live envelope、排序、recent 与 range 语义不变。
 - `GET /api/system/status` 可 additive 增加 `runtimePressureHealth`；旧前端在字段缺失时按 unknown 兼容。
-- `DASHBOARD_RUNTIME_PROJECTION_MODE=legacy` 与 `PROXY_REQUEST_SEMANTIC_PIPELINE_MODE=legacy` 是运维 kill switch；默认 `auto`，不得暴露为 owner-facing UI 开关。Dashboard legacy delivery 只保留一个发布版本，并在新链连续 12 小时通过线上门槛后由独立清理变更删除。
+- typed runtime mutation bus 是唯一的生产热路径。`DASHBOARD_RUNTIME_PROJECTION_MODE=legacy` 与 `PROMPT_CACHE_TOPIC_PROJECTION_MODE=legacy` 已被移除；遗留值不得重新启用旧的完整记录广播或 topic 全窗重建。请求语义流水线的独立运维配置不属于 runtime bus 回退面。
 
 ## Runtime Pressure Health
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -70,7 +70,7 @@ flowchart LR
 
 ## 6. 健康与回退
 
-- `DASHBOARD_RUNTIME_PROJECTION_MODE=auto|legacy` 控制 Dashboard 投影路径；默认 `auto`。
+- typed runtime mutation bus 是 Dashboard 与 Prompt Cache 的唯一生产热路径；`DASHBOARD_RUNTIME_PROJECTION_MODE=legacy` 和 `PROMPT_CACHE_TOPIC_PROJECTION_MODE=legacy` 不再可用，不能重新启用完整记录广播或全窗 topic 重建。
 - `PROXY_REQUEST_SEMANTIC_PIPELINE_MODE=auto|legacy` 控制请求语义流水线；默认 `auto`。
 - `PROXY_SQLITE_WRITE_COORDINATOR_MODE=coordinated|legacy` 控制代理热写协调器；默认 `coordinated`，legacy 只保留一个发布周期用于显式回滚。
 - `GET /api/system/status` 的 additive `runtimePressureHealth` 展示 Dashboard producer、request parsing/materialization、RSS/Swap、allocator 与 writer accounting 健康。

--- a/src/api/slices/error_distribution_and_sse.rs
+++ b/src/api/slices/error_distribution_and_sse.rs
@@ -2128,15 +2128,12 @@ mod tests {
     }
 
     #[test]
-    fn runtime_projection_mode_keeps_auto_default_and_legacy_kill_switch() {
+    fn runtime_projection_mode_rejects_removed_legacy_kill_switch() {
         assert_eq!(
             RuntimeProjectionMode::parse(None).expect("default projection mode"),
             RuntimeProjectionMode::Auto
         );
-        assert_eq!(
-            RuntimeProjectionMode::parse(Some("legacy")).expect("legacy projection mode"),
-            RuntimeProjectionMode::Legacy
-        );
+        assert!(RuntimeProjectionMode::parse(Some("legacy")).is_err());
         assert!(RuntimeProjectionMode::parse(Some("invalid")).is_err());
     }
 
@@ -2443,7 +2440,11 @@ mod tests {
         .expect("install baseline capture");
         hub.upsert(restored.clone());
 
-        assert_eq!(hub.remove_non_terminal_by_invoke_id(&restored.invoke_id), 1);
+        assert_eq!(
+            hub.remove_non_terminal_by_invoke_id(&restored.invoke_id)
+                .len(),
+            1
+        );
         let capture = hub
             .capture_memory_snapshot()
             .expect("removed baseline-backed projection snapshot");
@@ -4400,12 +4401,17 @@ pub(crate) enum BroadcastPayload {
     Version {
         version: String,
     },
+    // Test-only observer shims let pre-existing persistence tests assert their durable
+    // side effects without reinstating complete records on the production runtime bus.
+    #[cfg(test)]
     Records {
         records: Vec<ApiInvocation>,
     },
+    #[cfg(test)]
     PromptCacheConversationChanged {
         prompt_cache_key: String,
     },
+    #[cfg(test)]
     PromptCacheConversationStickyRouteChanged {
         sticky_key: String,
         previous_upstream_account_id: i64,
@@ -4424,6 +4430,7 @@ pub(crate) enum BroadcastPayload {
         #[serde(skip)]
         slice: Box<DashboardTerminalProjectionSlice>,
     },
+    #[cfg(test)]
     #[serde(rename = "pool_attempts")]
     PoolAttempts {
         invoke_id: String,

--- a/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/bindings.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/bindings.rs
@@ -1152,19 +1152,18 @@ pub(crate) fn broadcast_prompt_cache_conversation_changed(
     state: &AppState,
     prompt_cache_key: &str,
 ) {
-    if state.broadcaster.receiver_count() == 0 {
-        return;
-    }
-    if let Err(err) = state
-        .broadcaster
-        .send(BroadcastPayload::PromptCacheConversationChanged {
+    state
+        .subscription_hub
+        .publish_runtime_mutation(RuntimeMutation::PromptCacheBindingChanged {
             prompt_cache_key: prompt_cache_key.to_string(),
-        })
+        });
+    #[cfg(test)]
     {
-        warn!(
-            ?err,
-            prompt_cache_key, "failed to broadcast prompt cache conversation change"
-        );
+        let _ = state
+            .broadcaster
+            .send(BroadcastPayload::PromptCacheConversationChanged {
+                prompt_cache_key: prompt_cache_key.to_string(),
+            });
     }
 }
 
@@ -1174,22 +1173,21 @@ pub(crate) fn broadcast_prompt_cache_conversation_sticky_route_changed(
     previous_upstream_account_id: i64,
     upstream_account_id: i64,
 ) {
-    if state.broadcaster.receiver_count() == 0 {
-        return;
-    }
-    if let Err(err) = state.broadcaster.send(
-        BroadcastPayload::PromptCacheConversationStickyRouteChanged {
+    state
+        .subscription_hub
+        .publish_runtime_mutation(RuntimeMutation::StickyRouteChanged {
             sticky_key: sticky_key.to_string(),
             previous_upstream_account_id,
             upstream_account_id,
-        },
-    ) {
-        warn!(
-            ?err,
-            sticky_key,
-            previous_upstream_account_id,
-            upstream_account_id,
-            "failed to broadcast prompt cache conversation sticky route change"
+        });
+    #[cfg(test)]
+    {
+        let _ = state.broadcaster.send(
+            BroadcastPayload::PromptCacheConversationStickyRouteChanged {
+                sticky_key: sticky_key.to_string(),
+                previous_upstream_account_id,
+                upstream_account_id,
+            },
         );
     }
 }

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -6,7 +6,7 @@ use serde::ser::{SerializeSeq, SerializeStruct};
 use serde_json::json;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{
-    Mutex as StdMutex, OnceLock,
+    Mutex as StdMutex,
     atomic::{AtomicU64, Ordering},
 };
 
@@ -36,15 +36,6 @@ const DASHBOARD_ACTIVITY_TOPIC_REFRESH_TTL: Duration = Duration::from_millis(500
 const SUMMARY_TOPIC_REFRESH_DEBOUNCE: Duration = Duration::from_millis(500);
 const PROMPT_CACHE_TOPIC_REFRESH_DEBOUNCE: Duration = Duration::from_millis(500);
 const PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
-
-fn prompt_cache_topic_projection_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        !std::env::var("PROMPT_CACHE_TOPIC_PROJECTION_MODE")
-            .ok()
-            .is_some_and(|value| value.trim().eq_ignore_ascii_case("legacy"))
-    })
-}
 #[cfg(test)]
 const DASHBOARD_RUNTIME_TOPOLOGY_CONTRACT_REASON: &str = "dashboard-runtime-topology-contract";
 #[cfg(not(test))]
@@ -388,6 +379,7 @@ type DashboardTopologySseFrameObservations = HashMap<u64, DashboardTopologyFrame
 pub(crate) struct SubscriptionHub {
     state: Mutex<SubscriptionHubState>,
     broadcaster: broadcast::Sender<SubscriptionDispatchEvent>,
+    runtime_mutation_bus: Arc<RuntimeMutationBus>,
     serialization_count: AtomicU64,
     dashboard_topology_counters: DashboardDeliveryTopologyCounters,
     #[cfg(test)]
@@ -449,12 +441,21 @@ struct CachedSubscriptionTopic {
 }
 
 #[derive(Debug, Clone)]
+struct RuntimeTopicWork {
+    topic: SubscriptionTopic,
+    terminal_event_count: u64,
+    includes_invocation_mutation: bool,
+}
+
+#[derive(Debug, Clone)]
 struct PromptCacheTopicDelta {
     row_id: i64,
     identity: String,
+    invoke_id: String,
     prompt_cache_key: Option<String>,
     sticky_key: Option<String>,
     occurred_at: Value,
+    is_runtime_removed: bool,
     status: String,
     is_terminal: bool,
     is_success: bool,
@@ -506,9 +507,11 @@ impl PromptCacheTopicDelta {
         Ok(Some(Self {
             row_id: record.id,
             identity: format!("{}\0{}", record.invoke_id, record.occurred_at),
+            invoke_id: record.invoke_id.clone(),
             prompt_cache_key,
             sticky_key,
             occurred_at,
+            is_runtime_removed: false,
             is_terminal: prompt_invocation_status_counts_toward_terminal_totals(Some(&status)),
             is_success: prompt_invocation_status_is_success_like(
                 Some(&status),
@@ -519,6 +522,55 @@ impl PromptCacheTopicDelta {
             cost: record.cost.unwrap_or_default(),
             upstream_account_id: record.upstream_account_id,
             upstream_account_name: record.upstream_account_name.clone(),
+            preview,
+        }))
+    }
+
+    fn from_runtime_mutation(
+        mutation: &RuntimeInvocationMutation,
+    ) -> Result<Option<Self>, ApiError> {
+        let Some(preview) = mutation.preview.clone() else {
+            return Ok(None);
+        };
+        let preview = serde_json::to_value(preview)?;
+        let occurred_at = preview
+            .get("occurredAt")
+            .cloned()
+            .unwrap_or_else(|| Value::String(mutation.identity.occurred_at.clone()));
+        let status = preview
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let error_message = preview.get("errorMessage").and_then(Value::as_str);
+        Ok(Some(Self {
+            row_id: mutation.row_id.unwrap_or_default(),
+            identity: format!(
+                "{}\0{}",
+                mutation.identity.invoke_id, mutation.identity.occurred_at
+            ),
+            invoke_id: mutation.identity.invoke_id.clone(),
+            prompt_cache_key: mutation.prompt_cache_key.clone(),
+            sticky_key: mutation.sticky_key.clone(),
+            occurred_at,
+            is_runtime_removed: mutation.kind == RuntimeMutationKind::RuntimeRemoved,
+            is_terminal: mutation.is_terminal,
+            is_success: prompt_invocation_status_is_success_like(Some(&status), error_message),
+            status,
+            request_tokens: preview
+                .get("totalTokens")
+                .and_then(Value::as_i64)
+                .unwrap_or_default()
+                .max(0),
+            cost: preview
+                .get("cost")
+                .and_then(Value::as_f64)
+                .unwrap_or_default(),
+            upstream_account_id: mutation.upstream_account_id,
+            upstream_account_name: preview
+                .get("upstreamAccountName")
+                .and_then(Value::as_str)
+                .map(str::to_string),
             preview,
         }))
     }
@@ -1126,6 +1178,26 @@ impl ConversationSubscriptionScope {
         }
     }
 
+    fn matches_runtime_mutation(&self, mutation: &RuntimeInvocationMutation) -> bool {
+        match self {
+            Self::PromptCacheKey(prompt_cache_key) => mutation
+                .prompt_cache_key
+                .as_deref()
+                .is_some_and(|value| value == prompt_cache_key),
+            Self::StickyKey {
+                sticky_key,
+                upstream_account_id,
+            } => {
+                mutation
+                    .sticky_key
+                    .as_deref()
+                    .or(mutation.prompt_cache_key.as_deref())
+                    .is_some_and(|value| value == sticky_key)
+                    && mutation.upstream_account_id == Some(*upstream_account_id)
+            }
+        }
+    }
+
     fn matches_sticky_route_change(
         &self,
         sticky_key: &str,
@@ -1201,11 +1273,7 @@ impl SubscriptionHub {
             )
         });
         let mut snapshot = PromptCacheTopicProjectionHealthSnapshot {
-            mode: if prompt_cache_topic_projection_enabled() {
-                "memory".to_string()
-            } else {
-                "legacy".to_string()
-            },
+            mode: "memory".to_string(),
             response_source: "memory".to_string(),
             ..PromptCacheTopicProjectionHealthSnapshot::default()
         };
@@ -1254,6 +1322,7 @@ impl SubscriptionHub {
         Self {
             state: Mutex::new(SubscriptionHubState::default()),
             broadcaster,
+            runtime_mutation_bus: Arc::new(RuntimeMutationBus::new()),
             serialization_count: AtomicU64::new(0),
             dashboard_topology_counters: DashboardDeliveryTopologyCounters::default(),
             #[cfg(test)]
@@ -1263,6 +1332,18 @@ impl SubscriptionHub {
 
     pub(crate) fn subscribe(&self) -> broadcast::Receiver<SubscriptionDispatchEvent> {
         self.broadcaster.subscribe()
+    }
+
+    pub(crate) fn publish_runtime_mutation(&self, mutation: RuntimeMutation) {
+        self.runtime_mutation_bus.publish(mutation);
+    }
+
+    pub(crate) fn runtime_mutation_bus_health(&self) -> RuntimeMutationBusHealth {
+        self.runtime_mutation_bus.health()
+    }
+
+    pub(crate) fn runtime_mutation_bus(&self) -> Arc<RuntimeMutationBus> {
+        self.runtime_mutation_bus.clone()
     }
 
     fn serialize_frame(
@@ -1509,18 +1590,23 @@ impl SubscriptionHub {
                     guard.active_subscribers.remove(&topic_key);
                     guard.active_topics.remove(&topic_key);
                     guard.prompt_cache_prebaseline_records.remove(&topic_key);
-                    if let Some(cached) = guard.topics.get_mut(&topic_key)
-                        && matches!(
+                    if let Some(cached) = guard.topics.get_mut(&topic_key) {
+                        // A disconnected owner cannot consume the mutation stream. Rebuild this
+                        // selection before it can resume instead of scanning retained caches for
+                        // every runtime event.
+                        cached.dirty = true;
+                        cached.refresh_scheduled = false;
+                        cached.latest_live_snapshot = None;
+                        if matches!(
                             cached.topic,
                             SubscriptionTopic::PromptCacheWindow { .. }
                                 | SubscriptionTopic::PromptCacheStickyWindow { .. }
-                        )
-                    {
-                        cached.prompt_cache_pending_records.clear();
-                        cached.prompt_cache_applied_terminal_ids.clear();
-                        cached.prompt_cache_refresh_scheduled = false;
-                        cached.prompt_cache_baseline_at = None;
-                        cached.dirty = true;
+                        ) {
+                            cached.prompt_cache_pending_records.clear();
+                            cached.prompt_cache_applied_terminal_ids.clear();
+                            cached.prompt_cache_refresh_scheduled = false;
+                            cached.prompt_cache_baseline_at = None;
+                        }
                     }
                 }
                 None => {}
@@ -2347,6 +2433,203 @@ impl SubscriptionHub {
         Ok(())
     }
 
+    async fn handle_runtime_mutation_batch(
+        &self,
+        state: Arc<AppState>,
+        mutations: Vec<SequencedRuntimeMutation>,
+    ) {
+        let mutations = coalesce_runtime_mutations(mutations);
+        if mutations.is_empty() {
+            return;
+        }
+        let runtime_mutations = mutations
+            .iter()
+            .map(|mutation| mutation.mutation.clone())
+            .collect::<Vec<_>>();
+        self.schedule_prompt_cache_topic_projection(state.clone(), &runtime_mutations)
+            .await;
+
+        for mutation in &runtime_mutations {
+            match mutation {
+                RuntimeMutation::PromptCacheBindingChanged { prompt_cache_key } => {
+                    if let Err(err) = self
+                        .apply_prompt_cache_binding_projection(state.as_ref(), prompt_cache_key)
+                        .await
+                    {
+                        warn!(
+                            ?err,
+                            prompt_cache_key,
+                            "failed to apply bounded prompt cache binding projection"
+                        );
+                    }
+                }
+                RuntimeMutation::StickyRouteChanged {
+                    sticky_key,
+                    previous_upstream_account_id,
+                    upstream_account_id,
+                } => {
+                    if let Err(err) = self
+                        .apply_prompt_cache_sticky_route_projection(
+                            sticky_key,
+                            *previous_upstream_account_id,
+                            *upstream_account_id,
+                        )
+                        .await
+                    {
+                        warn!(
+                            ?err,
+                            sticky_key, "failed to apply prompt cache sticky route projection"
+                        );
+                    }
+                }
+                RuntimeMutation::Invocation(_) | RuntimeMutation::AttemptChanged { .. } => {}
+            }
+        }
+
+        // Only active selections become work. Disconnection marks retained caches dirty, so this
+        // router never scans inactive payloads or clones them into the runtime hot path.
+        let affected = {
+            let guard = self.state.lock().await;
+            guard
+                .active_topics
+                .iter()
+                .filter_map(|(topic_key, topic)| {
+                    let active = guard
+                        .active_subscribers
+                        .get(topic_key)
+                        .copied()
+                        .unwrap_or_default()
+                        > 0;
+                    if !active
+                        || !runtime_mutations
+                            .iter()
+                            .any(|mutation| topic.is_affected_by_runtime_mutation(mutation))
+                    {
+                        return None;
+                    }
+                    let terminal_event_count = runtime_mutations
+                        .iter()
+                        .filter(|mutation| mutation.is_terminal_invocation())
+                        .count() as u64;
+                    Some(RuntimeTopicWork {
+                        topic: topic.clone(),
+                        terminal_event_count,
+                        includes_invocation_mutation: runtime_mutations
+                            .iter()
+                            .any(RuntimeMutation::is_invocation),
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for work in affected {
+            // Dashboard activity, summary, and network are materialized by their dedicated
+            // runtime projection slices. A generic mutation must never send them back through
+            // the DB-backed topic builder.
+            if work.topic.uses_summary_live_overlay()
+                || work.topic.uses_dashboard_activity_live_overlay()
+                || work.topic.uses_dashboard_network_live_snapshot()
+            {
+                continue;
+            }
+            if work.topic.uses_summary_topic_refresh() && work.terminal_event_count > 0 {
+                if let Err(err) = self
+                    .schedule_summary_topic_refresh(
+                        state.clone(),
+                        work.topic.clone(),
+                        work.terminal_event_count,
+                    )
+                    .await
+                {
+                    warn!(
+                        ?err,
+                        topic = %work.topic.name(),
+                        "failed to schedule summary topic refresh"
+                    );
+                }
+                continue;
+            }
+            if work.topic.uses_conversation_overview_refresh() && work.includes_invocation_mutation
+            {
+                if let Err(err) = self
+                    .schedule_conversation_overview_topic_refresh(state.clone(), work.topic.clone())
+                    .await
+                {
+                    warn!(
+                        ?err,
+                        topic = %work.topic.name(),
+                        "failed to schedule conversation overview topic refresh"
+                    );
+                }
+                continue;
+            }
+            if let Err(err) = self
+                .refresh_topic(state.clone(), work.topic.clone(), true)
+                .await
+            {
+                warn!(
+                    ?err,
+                    topic = %work.topic.name(),
+                    "failed to refresh subscription topic after typed runtime mutation"
+                );
+            }
+        }
+    }
+
+    async fn mark_runtime_mutation_gap_and_recover(
+        &self,
+        state: Arc<AppState>,
+        skipped: u64,
+        reason: &'static str,
+    ) {
+        let topics = {
+            let mut guard = self.state.lock().await;
+            let active_subscribers = guard.active_subscribers.clone();
+            let active_topics = guard
+                .active_topics
+                .iter()
+                .filter(|(topic_key, _)| {
+                    active_subscribers
+                        .get(*topic_key)
+                        .copied()
+                        .unwrap_or_default()
+                        > 0
+                })
+                .map(|(topic_key, topic)| (topic_key.clone(), topic.clone()))
+                .collect::<Vec<_>>();
+            active_topics
+                .into_iter()
+                .filter_map(|(topic_key, topic)| {
+                    let cached = guard.topics.get_mut(&topic_key)?;
+                    cached.dirty = true;
+                    cached.latest_live_snapshot = None;
+                    cached.continuity_reset_cursor = Some(cached.cursor);
+                    Some(topic)
+                })
+                .collect::<Vec<_>>()
+        };
+        warn!(
+            skipped,
+            reason,
+            recovery = "dirty_last_good",
+            active_topic_count = topics.len(),
+            "runtime mutation cursor continuity lost; scheduling bounded topic recovery"
+        );
+        for topic in topics {
+            if let Err(err) = self
+                .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                .await
+            {
+                warn!(
+                    ?err,
+                    topic = %topic.name(),
+                    reason,
+                    "runtime mutation recovery retained last-good topic frame"
+                );
+            }
+        }
+    }
+
     pub(crate) async fn handle_internal_broadcast(
         &self,
         state: Arc<AppState>,
@@ -2379,48 +2662,6 @@ impl SubscriptionHub {
                 return;
             }
             _ => {}
-        }
-        if let BroadcastPayload::Records { records } = &payload
-            && prompt_cache_topic_projection_enabled()
-        {
-            self.schedule_prompt_cache_topic_projection(state.clone(), records)
-                .await;
-        }
-        if prompt_cache_topic_projection_enabled() {
-            match &payload {
-                BroadcastPayload::PromptCacheConversationChanged { prompt_cache_key } => {
-                    if let Err(err) = self
-                        .apply_prompt_cache_binding_projection(state.as_ref(), prompt_cache_key)
-                        .await
-                    {
-                        warn!(
-                            ?err,
-                            prompt_cache_key,
-                            "failed to apply bounded prompt cache binding projection"
-                        );
-                    }
-                }
-                BroadcastPayload::PromptCacheConversationStickyRouteChanged {
-                    sticky_key,
-                    previous_upstream_account_id,
-                    upstream_account_id,
-                } => {
-                    if let Err(err) = self
-                        .apply_prompt_cache_sticky_route_projection(
-                            sticky_key,
-                            *previous_upstream_account_id,
-                            *upstream_account_id,
-                        )
-                        .await
-                    {
-                        warn!(
-                            ?err,
-                            sticky_key, "failed to apply prompt cache sticky route projection"
-                        );
-                    }
-                }
-                _ => {}
-            }
         }
         let affected = {
             let mut guard = self.state.lock().await;
@@ -2458,19 +2699,6 @@ impl SubscriptionHub {
         };
 
         for cached in affected {
-            if state.proxy_runtime_invocations.mode() == RuntimeProjectionMode::Auto
-                && matches!(
-                    &payload,
-                    BroadcastPayload::Records { records }
-                        if records
-                            .iter()
-                            .any(crate::app_state::runtime_store_record_is_terminal)
-                )
-                && (cached.topic.uses_summary_live_overlay()
-                    || cached.topic.uses_dashboard_activity_live_overlay())
-            {
-                continue;
-            }
             if cached.topic.uses_summary_live_overlay()
                 && let BroadcastPayload::DashboardActivityLive { snapshot } = &payload
             {
@@ -2482,52 +2710,6 @@ impl SubscriptionHub {
                         ?err,
                         topic = %cached.topic.name(),
                         "failed to apply summary live overlay"
-                    );
-                }
-                continue;
-            }
-
-            if cached.topic.uses_summary_topic_refresh()
-                && let BroadcastPayload::Records { records } = &payload
-            {
-                if records
-                    .iter()
-                    .any(crate::app_state::runtime_store_record_is_terminal)
-                    && let Err(err) = self
-                        .schedule_summary_topic_refresh(
-                            state.clone(),
-                            cached.topic.clone(),
-                            records.len() as u64,
-                        )
-                        .await
-                {
-                    warn!(
-                        ?err,
-                        topic = %cached.topic.name(),
-                        "failed to schedule summary topic refresh"
-                    );
-                }
-                continue;
-            }
-
-            if cached.topic.uses_conversation_overview_refresh()
-                && matches!(
-                    payload,
-                    BroadcastPayload::Records { .. }
-                        | BroadcastPayload::PromptCacheConversationStickyRouteChanged { .. }
-                )
-            {
-                if let Err(err) = self
-                    .schedule_conversation_overview_topic_refresh(
-                        state.clone(),
-                        cached.topic.clone(),
-                    )
-                    .await
-                {
-                    warn!(
-                        ?err,
-                        topic = %cached.topic.name(),
-                        "failed to schedule conversation overview topic refresh"
                     );
                 }
                 continue;
@@ -2548,32 +2730,6 @@ impl SubscriptionHub {
                         ?err,
                         topic = %cached.topic.name(),
                         "failed to apply dashboard activity live overlay"
-                    );
-                }
-                continue;
-            }
-
-            if matches!(&payload, BroadcastPayload::Records { .. })
-                && cached.topic.uses_dashboard_activity_live_overlay()
-            {
-                let needs_refresh = match &payload {
-                    BroadcastPayload::Records { records } => records
-                        .iter()
-                        .any(crate::app_state::runtime_store_record_is_terminal),
-                    _ => false,
-                };
-                if needs_refresh
-                    && let Err(err) = self
-                        .schedule_dashboard_activity_topic_refresh(
-                            state.clone(),
-                            cached.topic.clone(),
-                        )
-                        .await
-                {
-                    warn!(
-                        ?err,
-                        topic = %cached.topic.name(),
-                        "failed to schedule dashboard activity topic refresh"
                     );
                 }
                 continue;
@@ -2880,11 +3036,18 @@ impl SubscriptionHub {
     async fn schedule_prompt_cache_topic_projection(
         &self,
         state: Arc<AppState>,
-        records: &[ApiInvocation],
+        mutations: &[RuntimeMutation],
     ) {
-        let records = records
+        let records = mutations
             .iter()
-            .map(PromptCacheTopicDelta::from_record)
+            .filter_map(|mutation| match mutation {
+                RuntimeMutation::Invocation(mutation) => {
+                    Some(PromptCacheTopicDelta::from_runtime_mutation(mutation))
+                }
+                RuntimeMutation::AttemptChanged { .. }
+                | RuntimeMutation::PromptCacheBindingChanged { .. }
+                | RuntimeMutation::StickyRouteChanged { .. } => None,
+            })
             .collect::<Result<Vec<_>, _>>()
             .map(|records| records.into_iter().flatten().collect::<Vec<_>>());
         let Ok(records) = records else {
@@ -4057,6 +4220,27 @@ fn apply_prompt_cache_records_to_payload(
         let conversation_index = conversations.iter().position(|conversation| {
             conversation.get(key_field).and_then(Value::as_str) == Some(key)
         });
+        if record.is_runtime_removed {
+            let Some(index) = conversation_index else {
+                continue;
+            };
+            let Some(conversation) = conversations[index].as_object_mut() else {
+                continue;
+            };
+            let Some(recent) = conversation
+                .get_mut("recentInvocations")
+                .and_then(Value::as_array_mut)
+            else {
+                continue;
+            };
+            let count_before = recent.len();
+            recent.retain(|item| {
+                item.get("invokeId").and_then(Value::as_str) != Some(record.invoke_id.as_str())
+                    || item.get("occurredAt") != Some(&record.occurred_at)
+            });
+            changed |= recent.len() != count_before;
+            continue;
+        }
         let index = match conversation_index {
             Some(index) => index,
             None => {
@@ -4857,13 +5041,11 @@ async fn run_server_push_topic_loop(
     topic_key: String,
     topic: SubscriptionTopic,
 ) {
-    if prompt_cache_topic_projection_enabled()
-        && matches!(
-            topic,
-            SubscriptionTopic::PromptCacheWindow { .. }
-                | SubscriptionTopic::PromptCacheStickyWindow { .. }
-        )
-    {
+    if matches!(
+        topic,
+        SubscriptionTopic::PromptCacheWindow { .. }
+            | SubscriptionTopic::PromptCacheStickyWindow { .. }
+    ) {
         let mut interval = tokio::time::interval(PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         interval.tick().await;
@@ -4952,13 +5134,14 @@ pub(crate) fn spawn_subscription_broadcast_listener(state: Arc<AppState>) {
     let hub = state.subscription_hub.clone();
     let shutdown = state.shutdown.clone();
     let mut receiver = state.broadcaster.subscribe();
+    let listener_state = state.clone();
     tokio::spawn(async move {
         loop {
             tokio::select! {
                 _ = shutdown.cancelled() => return,
                 item = receiver.recv() => {
                     match item {
-                        Ok(payload) => hub.handle_internal_broadcast(state.clone(), payload).await,
+                        Ok(payload) => hub.handle_internal_broadcast(listener_state.clone(), payload).await,
                         Err(broadcast::error::RecvError::Lagged(skipped)) => {
                             warn!(skipped, "subscription mutation listener lagged");
                         }
@@ -4968,6 +5151,86 @@ pub(crate) fn spawn_subscription_broadcast_listener(state: Arc<AppState>) {
             }
         }
     });
+    spawn_runtime_mutation_router(state);
+}
+
+fn spawn_runtime_mutation_router(state: Arc<AppState>) {
+    let hub = state.subscription_hub.clone();
+    let bus = hub.runtime_mutation_bus();
+    if !bus.claim_router() {
+        return;
+    }
+    let shutdown = state.shutdown.clone();
+    let mut receiver = bus.subscribe();
+    tokio::spawn(async move {
+        let mut last_sequence = 0_u64;
+        loop {
+            let first = tokio::select! {
+                _ = shutdown.cancelled() => return,
+                item = receiver.recv() => item,
+            };
+            let first = match first {
+                Ok(first) => first,
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    bus.record_router_lag();
+                    bus.record_router_gap();
+                    last_sequence = 0;
+                    hub.mark_runtime_mutation_gap_and_recover(
+                        state.clone(),
+                        skipped,
+                        "receiver_lagged",
+                    )
+                    .await;
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => return,
+            };
+            let mut batch = vec![first];
+            let mut lagged = 0_u64;
+            while batch.len() < RUNTIME_MUTATION_ROUTER_MAX_BATCH {
+                match receiver.try_recv() {
+                    Ok(mutation) => batch.push(mutation),
+                    Err(broadcast::error::TryRecvError::Empty) => break,
+                    Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                        lagged = lagged.saturating_add(skipped);
+                        break;
+                    }
+                    Err(broadcast::error::TryRecvError::Closed) => break,
+                }
+            }
+            if lagged > 0 {
+                bus.record_router_lag();
+                bus.record_router_gap();
+                last_sequence = 0;
+                hub.mark_runtime_mutation_gap_and_recover(state.clone(), lagged, "receiver_lagged")
+                    .await;
+                continue;
+            }
+            if runtime_mutation_batch_has_sequence_gap(&mut last_sequence, &batch) {
+                bus.record_router_gap();
+                last_sequence = 0;
+                hub.mark_runtime_mutation_gap_and_recover(state.clone(), lagged, "cursor_gap")
+                    .await;
+                continue;
+            }
+            hub.handle_runtime_mutation_batch(state.clone(), batch)
+                .await;
+        }
+    });
+}
+
+fn runtime_mutation_batch_has_sequence_gap(
+    last_sequence: &mut u64,
+    batch: &[SequencedRuntimeMutation],
+) -> bool {
+    let mut gap = false;
+    for mutation in batch {
+        if mutation.sequence != last_sequence.saturating_add(1) {
+            gap = true;
+        }
+        *last_sequence = mutation.sequence;
+    }
+    gap
 }
 
 pub(crate) async fn topic_sse_stream(
@@ -5105,11 +5368,10 @@ pub(crate) async fn topic_sse_stream(
 impl SubscriptionTopic {
     fn uses_server_push_cadence(&self, mode: RuntimeProjectionMode) -> bool {
         self.is_closed_summary_topic()
-            || (prompt_cache_topic_projection_enabled()
-                && matches!(
-                    self,
-                    Self::PromptCacheWindow { .. } | Self::PromptCacheStickyWindow { .. }
-                ))
+            || matches!(
+                self,
+                Self::PromptCacheWindow { .. } | Self::PromptCacheStickyWindow { .. }
+            )
             || (mode == RuntimeProjectionMode::Legacy
                 && matches!(self, Self::DashboardNetworkRecentCurrent))
     }
@@ -5567,45 +5829,46 @@ impl SubscriptionTopic {
         )
     }
 
-    fn is_affected_by(&self, payload: &BroadcastPayload) -> bool {
-        if self.is_closed_summary_topic()
-            && matches!(
-                payload,
-                BroadcastPayload::Records { .. } | BroadcastPayload::DashboardActivityLive { .. }
-            )
-        {
-            return false;
-        }
-
-        match payload {
-            BroadcastPayload::Records { records } => match self {
-                Self::InvocationHistoryWindow { scope }
-                | Self::InvocationHistoryOverview { scope } => {
-                    records.iter().any(|record| scope.matches_record(record))
+    fn is_affected_by_runtime_mutation(&self, mutation: &RuntimeMutation) -> bool {
+        match mutation {
+            RuntimeMutation::Invocation(mutation) => {
+                if self.is_closed_summary_topic() {
+                    return false;
                 }
-                Self::DashboardActivityCurrent { .. }
-                | Self::DashboardNetworkTimeseriesWindow { .. }
-                | Self::DashboardNetworkRecentCurrent
-                | Self::DashboardWorkingConversationsCurrent { .. }
-                | Self::InvocationWindow { .. }
-                | Self::SummaryCurrent { .. }
-                | Self::TimeseriesOpenWindow { .. }
-                | Self::ParallelWorkCurrent { .. }
-                | Self::ForwardProxyLive => true,
-                Self::PromptCacheWindow { .. } | Self::PromptCacheStickyWindow { .. } => {
-                    !prompt_cache_topic_projection_enabled()
+                match self {
+                    Self::InvocationHistoryWindow { scope }
+                    | Self::InvocationHistoryOverview { scope } => {
+                        scope.matches_runtime_mutation(mutation)
+                    }
+                    Self::DashboardActivityCurrent { .. }
+                    | Self::DashboardNetworkTimeseriesWindow { .. }
+                    | Self::DashboardNetworkRecentCurrent
+                    | Self::DashboardWorkingConversationsCurrent { .. }
+                    | Self::InvocationWindow { .. }
+                    | Self::SummaryCurrent { .. }
+                    | Self::TimeseriesOpenWindow { .. }
+                    | Self::ParallelWorkCurrent { .. }
+                    | Self::ForwardProxyLive => true,
+                    Self::AppVersion
+                    | Self::QuotaCurrent
+                    | Self::PromptCacheConversationBindingCurrent { .. }
+                    | Self::PromptCacheConversationOperationsWindow { .. }
+                    | Self::PromptCacheWindow { .. }
+                    | Self::PromptCacheStickyWindow { .. }
+                    | Self::InvocationPoolAttempts { .. } => false,
                 }
-                _ => false,
-            },
-            BroadcastPayload::PromptCacheConversationChanged { prompt_cache_key } => match self {
+            }
+            RuntimeMutation::AttemptChanged { invoke_id } => matches!(
+                self,
+                Self::InvocationPoolAttempts { invoke_id: current } if current == invoke_id
+            ),
+            RuntimeMutation::PromptCacheBindingChanged { prompt_cache_key } => matches!(
+                self,
                 Self::PromptCacheConversationBindingCurrent { scope }
-                | Self::PromptCacheConversationOperationsWindow { scope, .. } => {
-                    scope.binding_key() == prompt_cache_key
-                }
-                Self::PromptCacheWindow { .. } => !prompt_cache_topic_projection_enabled(),
-                _ => false,
-            },
-            BroadcastPayload::PromptCacheConversationStickyRouteChanged {
+                    | Self::PromptCacheConversationOperationsWindow { scope, .. }
+                    if scope.binding_key() == prompt_cache_key
+            ),
+            RuntimeMutation::StickyRouteChanged {
                 sticky_key,
                 previous_upstream_account_id,
                 upstream_account_id,
@@ -5616,14 +5879,19 @@ impl SubscriptionTopic {
                     *previous_upstream_account_id,
                     *upstream_account_id,
                 ),
-                Self::PromptCacheWindow { .. } => !prompt_cache_topic_projection_enabled(),
-                Self::PromptCacheStickyWindow { account_id, .. } => {
-                    !prompt_cache_topic_projection_enabled()
-                        && (*previous_upstream_account_id == *account_id
-                            || *upstream_account_id == *account_id)
-                }
                 _ => false,
             },
+        }
+    }
+
+    fn is_affected_by(&self, payload: &BroadcastPayload) -> bool {
+        if self.is_closed_summary_topic()
+            && matches!(payload, BroadcastPayload::DashboardActivityLive { .. })
+        {
+            return false;
+        }
+
+        match payload {
             BroadcastPayload::DashboardActivityLive { .. } => {
                 matches!(
                     self,
@@ -5637,12 +5905,13 @@ impl SubscriptionTopic {
             ),
             BroadcastPayload::DashboardCurrentSlice { .. }
             | BroadcastPayload::DashboardTerminalSlice { .. } => false,
-            BroadcastPayload::PoolAttempts { invoke_id, .. } => matches!(
-                self,
-                Self::InvocationPoolAttempts { invoke_id: current } if current == invoke_id
-            ),
             BroadcastPayload::Quota { .. } => matches!(self, Self::QuotaCurrent),
             BroadcastPayload::Version { .. } => matches!(self, Self::AppVersion),
+            #[cfg(test)]
+            BroadcastPayload::Records { .. }
+            | BroadcastPayload::PoolAttempts { .. }
+            | BroadcastPayload::PromptCacheConversationChanged { .. }
+            | BroadcastPayload::PromptCacheConversationStickyRouteChanged { .. } => false,
         }
     }
 
@@ -6376,6 +6645,33 @@ fn prompt_cache_selection_params(
 mod tests {
     use super::*;
 
+    #[test]
+    fn runtime_mutation_sequence_gap_discards_partial_batch() {
+        let mut last_sequence = 0;
+        let first = [SequencedRuntimeMutation {
+            sequence: 1,
+            mutation: RuntimeMutation::AttemptChanged {
+                invoke_id: "first".to_string(),
+            },
+        }];
+        assert!(!runtime_mutation_batch_has_sequence_gap(
+            &mut last_sequence,
+            &first
+        ));
+
+        let gap = [SequencedRuntimeMutation {
+            sequence: 3,
+            mutation: RuntimeMutation::AttemptChanged {
+                invoke_id: "after-gap".to_string(),
+            },
+        }];
+        assert!(runtime_mutation_batch_has_sequence_gap(
+            &mut last_sequence,
+            &gap
+        ));
+        assert_eq!(last_sequence, 3);
+    }
+
     fn summary_topic() -> SubscriptionTopic {
         SubscriptionTopic::SummaryCurrent {
             window: "current".to_string(),
@@ -6982,6 +7278,50 @@ mod tests {
                 .expect("cached topic")
                 .replay_events
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn releasing_the_last_subscriber_marks_cached_topic_dirty() {
+        let hub = SubscriptionHub::new();
+        let topic = SubscriptionTopic::InvocationWindow {
+            limit: 20,
+            model: None,
+            status: None,
+        };
+        let topic_key = topic.cache_key().expect("invocation topic key");
+        hub.state.lock().await.topics.insert(
+            topic_key.clone(),
+            seeded_cached_topic(topic, &[], Utc::now()),
+        );
+        {
+            let mut guard = hub.state.lock().await;
+            guard.active_topics.insert(
+                topic_key.clone(),
+                SubscriptionTopic::InvocationWindow {
+                    limit: 20,
+                    model: None,
+                    status: None,
+                },
+            );
+            guard.active_subscribers.insert(topic_key.clone(), 1);
+        }
+
+        hub.release_topic_subscribers(
+            vec![topic_key.clone()],
+            vec!["invocations.window".to_string()],
+            false,
+        )
+        .await;
+
+        assert!(
+            hub.state
+                .lock()
+                .await
+                .topics
+                .get(&topic_key)
+                .is_some_and(|cached| cached.dirty),
+            "a reconnect must rebuild cached data changed while no owner was subscribed"
         );
     }
 
@@ -8513,9 +8853,20 @@ mod tests {
         assert_eq!(topic.descriptor(), descriptor);
         assert_eq!(topic.name(), "dashboard.network-recent.current");
         assert_eq!(topic.schema_epoch(), "dashboard.network-recent.current/v1");
-        assert!(topic.is_affected_by(&BroadcastPayload::Records {
-            records: Vec::new()
-        }));
+        assert!(
+            topic.is_affected_by_runtime_mutation(&RuntimeMutation::Invocation(
+                RuntimeInvocationMutation {
+                    identity: RuntimeInvocationIdentity::new("network", "2026-07-20 00:00:00"),
+                    kind: RuntimeMutationKind::RuntimeUpsert,
+                    row_id: None,
+                    is_terminal: false,
+                    prompt_cache_key: None,
+                    sticky_key: None,
+                    upstream_account_id: None,
+                    preview: None,
+                }
+            ))
+        );
         assert!(
             !topic.is_affected_by(&BroadcastPayload::DashboardActivityLive {
                 snapshot: Box::new(DashboardActivityLiveSnapshot {
@@ -8577,7 +8928,7 @@ mod tests {
     }
 
     #[test]
-    fn conversation_configuration_events_only_refresh_binding_and_operations_topics() {
+    fn typed_runtime_binding_events_only_refresh_binding_and_operations_topics() {
         let scope_params = BTreeMap::from([("promptCacheKey".to_string(), "pck-1".to_string())]);
         let calls = SubscriptionTopic::from_descriptor(&SubscriptionTopicDescriptor {
             topic: "invocation-history.window".to_string(),
@@ -8599,25 +8950,29 @@ mod tests {
             params: scope_params,
         })
         .expect("operations topic should parse");
-        let event = BroadcastPayload::PromptCacheConversationChanged {
+        let event = RuntimeMutation::PromptCacheBindingChanged {
             prompt_cache_key: "pck-1".to_string(),
         };
 
-        assert!(!calls.is_affected_by(&event));
-        assert!(!overview.is_affected_by(&event));
-        assert!(binding.is_affected_by(&event));
-        assert!(operations.is_affected_by(&event));
-        assert!(
-            !binding.is_affected_by(&BroadcastPayload::PromptCacheConversationChanged {
+        assert!(!calls.is_affected_by_runtime_mutation(&event));
+        assert!(!overview.is_affected_by_runtime_mutation(&event));
+        assert!(binding.is_affected_by_runtime_mutation(&event));
+        assert!(operations.is_affected_by_runtime_mutation(&event));
+        assert!(!binding.is_affected_by_runtime_mutation(
+            &RuntimeMutation::PromptCacheBindingChanged {
                 prompt_cache_key: "pck-2".to_string(),
+            }
+        ));
+        assert!(
+            !binding.is_affected_by_runtime_mutation(&RuntimeMutation::AttemptChanged {
+                invoke_id: "other".to_string(),
             })
         );
-        assert!(!binding.is_affected_by(&BroadcastPayload::Records {
-            records: Vec::new(),
-        }));
-        assert!(!operations.is_affected_by(&BroadcastPayload::Records {
-            records: Vec::new(),
-        }));
+        assert!(
+            !operations.is_affected_by_runtime_mutation(&RuntimeMutation::AttemptChanged {
+                invoke_id: "other".to_string(),
+            })
+        );
     }
 
     #[test]
@@ -8631,16 +8986,16 @@ mod tests {
         let prompt_cache_topic = SubscriptionTopic::InvocationHistoryOverview {
             scope: ConversationSubscriptionScope::PromptCacheKey("sticky-1".to_string()),
         };
-        let event = BroadcastPayload::PromptCacheConversationStickyRouteChanged {
+        let event = RuntimeMutation::StickyRouteChanged {
             sticky_key: "sticky-1".to_string(),
             previous_upstream_account_id: 41,
             upstream_account_id: 42,
         };
 
-        assert!(topic_for(41).is_affected_by(&event));
-        assert!(topic_for(42).is_affected_by(&event));
-        assert!(!topic_for(43).is_affected_by(&event));
-        assert!(prompt_cache_topic.is_affected_by(&event));
+        assert!(topic_for(41).is_affected_by_runtime_mutation(&event));
+        assert!(topic_for(42).is_affected_by_runtime_mutation(&event));
+        assert!(!topic_for(43).is_affected_by_runtime_mutation(&event));
+        assert!(prompt_cache_topic.is_affected_by_runtime_mutation(&event));
     }
 
     #[tokio::test]
@@ -9053,6 +9408,71 @@ mod tests {
         )
         .expect("deduplicate repeated terminal delta");
         assert_eq!(payload["conversations"][0]["requestCount"], 1);
+    }
+
+    #[test]
+    fn typed_runtime_removal_clears_the_matching_prompt_cache_preview() {
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let mut payload = serde_json::json!({ "conversations": [] });
+        let mut record = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        record.invoke_id = "runtime-removal".to_string();
+        record.prompt_cache_key = Some("cache-key".to_string());
+        record.status = Some("running".to_string());
+
+        let RuntimeMutation::Invocation(upsert) =
+            RuntimeMutation::invocation(&record, RuntimeMutationKind::RuntimeUpsert)
+        else {
+            unreachable!("runtime record must produce an invocation mutation");
+        };
+        let upsert = PromptCacheTopicDelta::from_runtime_mutation(&upsert)
+            .expect("build compact runtime delta")
+            .expect("prompt cache runtime delta");
+        let RuntimeMutation::Invocation(removal) =
+            RuntimeMutation::invocation(&record, RuntimeMutationKind::RuntimeRemoved)
+        else {
+            unreachable!("runtime removal must produce an invocation mutation");
+        };
+        let removal = PromptCacheTopicDelta::from_runtime_mutation(&removal)
+            .expect("build compact removal delta")
+            .expect("prompt cache removal delta");
+        let mut applied_terminal_ids = HashSet::new();
+
+        apply_prompt_cache_records_to_payload(
+            &topic,
+            &mut payload,
+            &[upsert],
+            &mut applied_terminal_ids,
+            0,
+        )
+        .expect("apply runtime preview");
+        assert_eq!(
+            payload["conversations"][0]["recentInvocations"]
+                .as_array()
+                .expect("recent previews")
+                .len(),
+            1
+        );
+
+        assert!(
+            apply_prompt_cache_records_to_payload(
+                &topic,
+                &mut payload,
+                &[removal],
+                &mut applied_terminal_ids,
+                0,
+            )
+            .expect("remove runtime preview")
+        );
+        assert!(
+            payload["conversations"][0]["recentInvocations"]
+                .as_array()
+                .expect("recent previews")
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -85,7 +85,6 @@ pub(crate) struct RuntimeInvocationStoreRemoveOutcome {
     pub(crate) already_terminal: bool,
 }
 
-pub(crate) const DASHBOARD_RUNTIME_PROJECTION_MODE_ENV: &str = "DASHBOARD_RUNTIME_PROJECTION_MODE";
 pub(crate) const DASHBOARD_RUNTIME_PROJECTION_COALESCE: Duration = Duration::from_millis(250);
 pub(crate) const DASHBOARD_RUNTIME_NETWORK_PROJECTION_COALESCE: Duration = Duration::from_secs(1);
 pub(crate) const DASHBOARD_RUNTIME_TERMINAL_PROJECTION_COALESCE: Duration = Duration::from_secs(5);
@@ -99,19 +98,30 @@ pub(crate) enum RuntimeProjectionMode {
 }
 
 impl RuntimeProjectionMode {
+    pub(crate) fn reject_removed_legacy_env() -> Result<()> {
+        for env_name in [
+            "DASHBOARD_RUNTIME_PROJECTION_MODE",
+            "PROMPT_CACHE_TOPIC_PROJECTION_MODE",
+        ] {
+            if std::env::var(env_name)
+                .ok()
+                .is_some_and(|value| value.trim().eq_ignore_ascii_case("legacy"))
+            {
+                bail!(
+                    "{env_name}=legacy is unsupported; the typed runtime mutation bus is mandatory"
+                );
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn parse(value: Option<&str>) -> Result<Self> {
         match value.map(str::trim).filter(|value| !value.is_empty()) {
             None | Some("auto") => Ok(Self::Auto),
-            Some("legacy") => Ok(Self::Legacy),
             Some(value) => bail!(
-                "invalid {DASHBOARD_RUNTIME_PROJECTION_MODE_ENV} value `{value}`; expected `auto` or `legacy`"
+                "runtime projection mode `{value}` is unsupported; the typed runtime mutation bus is mandatory"
             ),
         }
-    }
-
-    pub(crate) fn from_env() -> Result<Self> {
-        let value = std::env::var(DASHBOARD_RUNTIME_PROJECTION_MODE_ENV).ok();
-        Self::parse(value.as_deref())
     }
 
     pub(crate) fn as_str(self) -> &'static str {
@@ -1727,9 +1737,9 @@ impl RuntimeProjectionHub {
         removed
     }
 
-    pub(crate) fn remove_non_terminal_by_invoke_id(&self, invoke_id: &str) -> usize {
+    pub(crate) fn remove_non_terminal_by_invoke_id(&self, invoke_id: &str) -> Vec<ApiInvocation> {
         let Ok(mut guard) = self.inner.lock() else {
-            return 0;
+            return Vec::new();
         };
         let keys = guard
             .records
@@ -1739,31 +1749,36 @@ impl RuntimeProjectionHub {
             })
             .map(|(key, _)| key.clone())
             .collect::<Vec<_>>();
-        let removed_count = keys
+        let removed = keys
             .iter()
-            .filter(|key| guard.records.remove(key).is_some())
-            .count();
-        if removed_count > 0 {
+            .filter_map(|key| {
+                guard
+                    .records
+                    .remove(key)
+                    .map(|entry| (key.clone(), entry.record))
+            })
+            .collect::<Vec<_>>();
+        if !removed.is_empty() {
             let now = Instant::now();
-            for key in &keys {
+            for (key, _) in &removed {
                 guard.projection_tombstones.insert(key.clone(), now);
             }
         }
-        let pruned_count = if removed_count > 0 {
+        let pruned_count = if !removed.is_empty() {
             prune_bounded_runtime_invocation_store_locked(&mut guard, Instant::now())
         } else {
             0
         };
         drop(guard);
-        if removed_count > 0 {
-            for key in keys {
-                self.update_dashboard_runtime_record(key, None, "runtime_remove");
+        if !removed.is_empty() {
+            for (key, _) in &removed {
+                self.update_dashboard_runtime_record(key.clone(), None, "runtime_remove");
             }
         }
         if pruned_count > 0 {
             self.rebuild_dashboard_runtime_records("runtime_prune");
         }
-        removed_count
+        removed.into_iter().map(|(_, record)| record).collect()
     }
 
     pub(crate) fn remove_persisted_terminal_overlay(

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,7 @@ mod proxy_sqlite_write_coordinator;
     reason = "Runtime shutdown coordination preserves established task handles."
 )]
 mod runtime;
+mod runtime_mutation_bus;
 mod schema;
 mod share_links;
 pub(crate) use dashboard_network_speed::*;
@@ -155,6 +156,7 @@ pub(crate) use memory_diagnostics::*;
 pub(crate) use pricing::*;
 use proxy::*;
 pub(crate) use runtime::*;
+pub(crate) use runtime_mutation_bus::*;
 pub(crate) use schema::*;
 pub(crate) use share_links::*;
 use sqlite_batch_writer::*;

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -1072,17 +1072,19 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
             .flush_buffered_for_test(&state.pool)
             .await;
     }
-    if terminal_enqueued
-        && state.broadcaster.receiver_count() > 0
-        && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
-            records: vec![inserted_record],
-        })
-    {
-        warn!(
-            ?err,
-            invoke_id = %invoke_id,
-            "failed to broadcast new proxy capture record"
-        );
+    if terminal_enqueued {
+        state
+            .subscription_hub
+            .publish_runtime_mutation(RuntimeMutation::invocation(
+                &inserted_record,
+                RuntimeMutationKind::TerminalCommitted,
+            ));
+        #[cfg(test)]
+        if state.broadcaster.receiver_count() > 0 {
+            let _ = state.broadcaster.send(BroadcastPayload::Records {
+                records: vec![inserted_record.clone()],
+            });
+        }
     }
     if terminal_enqueued {
         schedule_dashboard_activity_live_snapshot(state);

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1351,16 +1351,24 @@ impl PoolViaRuntimeSnapshotCleanupGuard {
 
 impl Drop for PoolViaRuntimeSnapshotCleanupGuard {
     fn drop(&mut self) {
-        let removed_count = self
+        let removed_records = self
             .state
             .proxy_runtime_invocations
             .remove_non_terminal_by_invoke_id(&self.invoke_id);
-        if removed_count > 0 {
+        if !removed_records.is_empty() {
+            for record in &removed_records {
+                self.state
+                    .subscription_hub
+                    .publish_runtime_mutation(RuntimeMutation::invocation(
+                        record,
+                        RuntimeMutationKind::RuntimeRemoved,
+                    ));
+            }
             schedule_dashboard_activity_live_snapshot(self.state.as_ref());
         }
         debug!(
             invoke_id = %self.invoke_id,
-            removed_count,
+            removed_count = removed_records.len(),
             "request-scoped via-pool runtime snapshots cleaned up"
         );
     }

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+#[cfg(test)]
+fn broadcast_test_record_payload(state: &AppState, record: &ApiInvocation) {
+    if state.broadcaster.receiver_count() > 0 {
+        let _ = state.broadcaster.send(BroadcastPayload::Records {
+            records: vec![record.clone()],
+        });
+    }
+}
+
 pub(crate) fn upstream_account_name_from_payload(payload: Option<&str>) -> Option<String> {
     let payload = payload?;
     let value = serde_json::from_str::<Value>(payload).ok()?;
@@ -1565,13 +1574,15 @@ pub(crate) async fn broadcast_recovered_proxy_invocations(
     }
 
     let summary_invoke_id = records[0].invoke_id.clone();
-    if state.broadcaster.receiver_count() > 0 {
+    for record in &records {
         state
-            .broadcaster
-            .send(BroadcastPayload::Records { records })
-            .map_err(|err| {
-                anyhow!("failed to broadcast recovered proxy invocation records: {err}")
-            })?;
+            .subscription_hub
+            .publish_runtime_mutation(RuntimeMutation::invocation(
+                record,
+                RuntimeMutationKind::Recovery,
+            ));
+        #[cfg(test)]
+        broadcast_test_record_payload(state, record);
     }
     schedule_dashboard_activity_live_snapshot(state);
     schedule_proxy_capture_follow_up_worker(state, &summary_invoke_id).await?;
@@ -2009,32 +2020,21 @@ pub(crate) async fn broadcast_pool_upstream_attempts_snapshot(
     state: &AppState,
     invoke_id: &str,
 ) -> Result<()> {
-    if state.broadcaster.receiver_count() == 0 {
-        return Ok(());
-    }
-
-    let attempts = match query_pool_attempt_records_from_live(&state.pool, invoke_id).await {
-        Ok(attempts) => attempts,
-        Err(err) => {
-            let err = anyhow!("failed to load live pool attempts for SSE broadcast: {err:?}");
-            if crate::is_sqlite_lock_error(&err) {
-                warn!(
-                    invoke_id,
-                    sqlite_locked = true,
-                    "pool attempts snapshot broadcast skipped because sqlite is locked"
-                );
-                return Ok(());
-            }
-            return Err(err);
-        }
-    };
     state
-        .broadcaster
-        .send(BroadcastPayload::PoolAttempts {
+        .subscription_hub
+        .publish_runtime_mutation(RuntimeMutation::AttemptChanged {
+            invoke_id: invoke_id.to_string(),
+        });
+    #[cfg(test)]
+    if state.broadcaster.receiver_count() > 0 {
+        let attempts = query_pool_attempt_records_from_live(&state.pool, invoke_id)
+            .await
+            .map_err(|err| anyhow!("failed to load test pool attempt snapshot: {err:?}"))?;
+        let _ = state.broadcaster.send(BroadcastPayload::PoolAttempts {
             invoke_id: invoke_id.to_string(),
             attempts,
-        })
-        .map_err(|err| anyhow!("failed to broadcast pool attempts snapshot: {err}"))?;
+        });
+    }
     Ok(())
 }
 
@@ -3262,17 +3262,14 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_runtime_snapshot(
     state
         .dashboard_network_speed_cache
         .observe_dashboard_activity_runtime_snapshot(&persisted_record, Utc::now());
-    if state.broadcaster.receiver_count() > 0
-        && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
-            records: vec![persisted_record],
-        })
-    {
-        warn!(
-            ?err,
-            invoke_id = %invoke_id,
-            "failed to broadcast runtime proxy capture snapshot"
-        );
-    }
+    state
+        .subscription_hub
+        .publish_runtime_mutation(RuntimeMutation::invocation(
+            &persisted_record,
+            RuntimeMutationKind::RuntimeUpsert,
+        ));
+    #[cfg(test)]
+    broadcast_test_record_payload(state, &persisted_record);
     schedule_dashboard_activity_live_snapshot(state);
 
     let elapsed_ms = started.elapsed().as_millis() as u64;
@@ -3318,16 +3315,14 @@ pub(crate) fn broadcast_proxy_capture_first_token_runtime_snapshot(
     state
         .dashboard_network_speed_cache
         .observe_dashboard_activity_runtime_snapshot(&record, Utc::now());
-    if state.broadcaster.receiver_count() > 0
-        && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
-            records: vec![record],
-        })
-    {
-        warn!(
-            ?err,
-            invoke_id, "failed to broadcast first-token runtime proxy capture snapshot"
-        );
-    }
+    state
+        .subscription_hub
+        .publish_runtime_mutation(RuntimeMutation::invocation(
+            &record,
+            RuntimeMutationKind::LifecyclePhase,
+        ));
+    #[cfg(test)]
+    broadcast_test_record_payload(state, &record);
     schedule_dashboard_activity_live_snapshot(state);
 }
 
@@ -3369,17 +3364,24 @@ pub(crate) fn remove_proxy_runtime_snapshot_by_key(
         .finish_invocation(invoke_id, occurred_at);
     let removed_runtime_snapshot = state
         .proxy_runtime_invocations
-        .remove_non_terminal(invoke_id, occurred_at)
-        .is_some();
+        .remove_non_terminal(invoke_id, occurred_at);
+    if let Some(record) = &removed_runtime_snapshot {
+        state
+            .subscription_hub
+            .publish_runtime_mutation(RuntimeMutation::invocation(
+                record,
+                RuntimeMutationKind::RuntimeRemoved,
+            ));
+    }
     debug!(
         invoke_id,
         occurred_at,
         reason,
-        terminal_removed_runtime_snapshot = removed_runtime_snapshot,
+        terminal_removed_runtime_snapshot = removed_runtime_snapshot.is_some(),
         terminal_already_tombstoned = false,
         "non-terminal proxy runtime snapshot removed by key"
     );
-    removed_runtime_snapshot
+    removed_runtime_snapshot.is_some()
 }
 
 pub(crate) fn terminalize_proxy_runtime_snapshot_by_key(
@@ -3430,19 +3432,14 @@ pub(crate) fn terminalize_proxy_runtime_snapshot_by_key(
         terminal_delta_skipped_runtime_only = true,
         "non-terminal proxy runtime snapshot terminalized by key"
     );
-    if state.broadcaster.receiver_count() > 0
-        && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
-            records: vec![record],
-        })
-    {
-        warn!(
-            ?err,
-            invoke_id,
-            occurred_at,
-            reason,
-            "failed to broadcast terminalized proxy runtime snapshot"
-        );
-    }
+    state
+        .subscription_hub
+        .publish_runtime_mutation(RuntimeMutation::invocation(
+            &record,
+            RuntimeMutationKind::TerminalCommitted,
+        ));
+    #[cfg(test)]
+    broadcast_test_record_payload(state, &record);
     true
 }
 
@@ -3509,19 +3506,14 @@ pub(crate) fn terminalize_proxy_runtime_snapshot_with_error(
         terminal_delta_skipped_runtime_only = true,
         "non-terminal proxy runtime snapshot terminalized with error overlay"
     );
-    if state.broadcaster.receiver_count() > 0
-        && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
-            records: vec![record],
-        })
-    {
-        warn!(
-            ?err,
-            invoke_id,
-            occurred_at,
-            reason,
-            "failed to broadcast terminal error proxy runtime snapshot"
-        );
-    }
+    state
+        .subscription_hub
+        .publish_runtime_mutation(RuntimeMutation::invocation(
+            &record,
+            RuntimeMutationKind::TerminalCommitted,
+        ));
+    #[cfg(test)]
+    broadcast_test_record_payload(state, &record);
     true
 }
 
@@ -3604,17 +3596,15 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_terminal_record(
             .flush_buffered_for_test(&state.pool)
             .await;
     }
-    if terminal_enqueued
-        && state.broadcaster.receiver_count() > 0
-        && let Err(err) = state.broadcaster.send(BroadcastPayload::Records {
-            records: vec![persisted_record],
-        })
-    {
-        warn!(
-            ?err,
-            invoke_id = %invoke_id,
-            "failed to broadcast terminal proxy capture record"
-        );
+    if terminal_enqueued {
+        state
+            .subscription_hub
+            .publish_runtime_mutation(RuntimeMutation::invocation(
+                &persisted_record,
+                RuntimeMutationKind::TerminalCommitted,
+            ));
+        #[cfg(test)]
+        broadcast_test_record_payload(state, &persisted_record);
     }
     if terminal_enqueued {
         schedule_dashboard_activity_live_snapshot(state);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(crate) async fn run() -> Result<()> {
     dotenv().ok();
     dotenvy::from_filename(".env.local").ok();
+    RuntimeProjectionMode::reject_removed_legacy_env()?;
     init_tracing();
     let startup_started_at = Instant::now();
 
@@ -124,7 +125,7 @@ pub(crate) async fn run() -> Result<()> {
     let prompt_cache_conversation_cache =
         Arc::new(Mutex::new(PromptCacheConversationsCacheState::default()));
     let proxy_runtime_invocations =
-        Arc::new(RuntimeProjectionHub::new(RuntimeProjectionMode::from_env()?));
+        Arc::new(RuntimeProjectionHub::new(RuntimeProjectionMode::Auto));
     let dashboard_network_speed_cache =
         Arc::new(DashboardNetworkSpeedCache::new(process_started_at_utc));
     proxy_runtime_invocations
@@ -146,6 +147,7 @@ pub(crate) async fn run() -> Result<()> {
     sqlite_batch_writer.set_terminal_projection_hub(terminal_projection_hub.clone());
     let pool_account_selection_runtime = Arc::new(PoolAccountSelectionRuntime::default());
     let subscription_hub = Arc::new(SubscriptionHub::new());
+    terminal_projection_hub.set_runtime_mutation_bus(subscription_hub.runtime_mutation_bus());
 
     let state = Arc::new(AppState {
         config: config.clone(),

--- a/src/runtime_mutation_bus.rs
+++ b/src/runtime_mutation_bus.rs
@@ -1,0 +1,384 @@
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
+
+use tokio::sync::broadcast;
+
+use crate::{
+    ApiInvocation, PromptCacheConversationInvocationPreviewResponse,
+    prompt_cache_invocation_preview_from_runtime_record,
+};
+
+pub(crate) const RUNTIME_MUTATION_BUS_CAPACITY: usize = 4_096;
+pub(crate) const RUNTIME_MUTATION_ROUTER_MAX_BATCH: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RuntimeMutationKind {
+    RuntimeUpsert,
+    RuntimeRemoved,
+    LifecyclePhase,
+    TerminalCommitted,
+    TerminalPersistedAck,
+    Recovery,
+}
+
+impl RuntimeMutationKind {
+    fn precedence(self) -> u8 {
+        match self {
+            Self::RuntimeUpsert => 0,
+            Self::LifecyclePhase => 1,
+            Self::RuntimeRemoved => 2,
+            Self::TerminalCommitted => 3,
+            Self::TerminalPersistedAck => 4,
+            Self::Recovery => 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RuntimeInvocationIdentity {
+    pub(crate) invoke_id: String,
+    pub(crate) occurred_at: String,
+}
+
+impl RuntimeInvocationIdentity {
+    pub(crate) fn new(invoke_id: impl Into<String>, occurred_at: impl Into<String>) -> Self {
+        Self {
+            invoke_id: invoke_id.into(),
+            occurred_at: occurred_at.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeInvocationMutation {
+    pub(crate) identity: RuntimeInvocationIdentity,
+    pub(crate) kind: RuntimeMutationKind,
+    pub(crate) row_id: Option<i64>,
+    pub(crate) is_terminal: bool,
+    pub(crate) prompt_cache_key: Option<String>,
+    pub(crate) sticky_key: Option<String>,
+    pub(crate) upstream_account_id: Option<i64>,
+    pub(crate) preview: Option<Box<PromptCacheConversationInvocationPreviewResponse>>,
+}
+
+impl RuntimeInvocationMutation {
+    pub(crate) fn from_record(record: &ApiInvocation, kind: RuntimeMutationKind) -> Self {
+        let prompt_cache_key = normalize_key(record.prompt_cache_key.as_deref());
+        let sticky_key = normalize_key(record.sticky_key.as_deref());
+        let preview = prompt_cache_key
+            .clone()
+            .or_else(|| sticky_key.clone())
+            .map(|key| {
+                Box::new(prompt_cache_invocation_preview_from_runtime_record(
+                    record, key,
+                ))
+            });
+        Self {
+            identity: RuntimeInvocationIdentity::new(
+                record.invoke_id.clone(),
+                record.occurred_at.clone(),
+            ),
+            kind,
+            row_id: (record.id > 0).then_some(record.id),
+            is_terminal: crate::app_state::runtime_store_record_is_terminal(record),
+            prompt_cache_key,
+            sticky_key,
+            upstream_account_id: record.upstream_account_id,
+            preview,
+        }
+    }
+
+    pub(crate) fn persisted_ack(
+        invoke_id: impl Into<String>,
+        occurred_at: impl Into<String>,
+        row_id: i64,
+    ) -> Self {
+        Self {
+            identity: RuntimeInvocationIdentity::new(invoke_id, occurred_at),
+            kind: RuntimeMutationKind::TerminalPersistedAck,
+            row_id: Some(row_id),
+            is_terminal: true,
+            prompt_cache_key: None,
+            sticky_key: None,
+            upstream_account_id: None,
+            preview: None,
+        }
+    }
+
+    fn merge_from(&mut self, next: Self) {
+        if next.kind.precedence() >= self.kind.precedence() {
+            self.kind = next.kind;
+            self.is_terminal = next.is_terminal;
+        }
+        self.row_id = next.row_id.or(self.row_id);
+        self.prompt_cache_key = next.prompt_cache_key.or(self.prompt_cache_key.take());
+        self.sticky_key = next.sticky_key.or(self.sticky_key.take());
+        self.upstream_account_id = next.upstream_account_id.or(self.upstream_account_id);
+        self.preview = next.preview.or(self.preview.take());
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimeMutation {
+    Invocation(RuntimeInvocationMutation),
+    AttemptChanged {
+        invoke_id: String,
+    },
+    PromptCacheBindingChanged {
+        prompt_cache_key: String,
+    },
+    StickyRouteChanged {
+        sticky_key: String,
+        previous_upstream_account_id: i64,
+        upstream_account_id: i64,
+    },
+}
+
+impl RuntimeMutation {
+    pub(crate) fn invocation(record: &ApiInvocation, kind: RuntimeMutationKind) -> Self {
+        Self::Invocation(RuntimeInvocationMutation::from_record(record, kind))
+    }
+
+    pub(crate) fn terminal_persisted_ack(
+        invoke_id: impl Into<String>,
+        occurred_at: impl Into<String>,
+        row_id: i64,
+    ) -> Self {
+        Self::Invocation(RuntimeInvocationMutation::persisted_ack(
+            invoke_id,
+            occurred_at,
+            row_id,
+        ))
+    }
+
+    pub(crate) fn is_invocation(&self) -> bool {
+        matches!(self, Self::Invocation(_))
+    }
+
+    pub(crate) fn is_terminal_invocation(&self) -> bool {
+        matches!(self, Self::Invocation(mutation) if mutation.is_terminal)
+    }
+
+    fn key(&self) -> RuntimeMutationKey {
+        match self {
+            Self::Invocation(mutation) => RuntimeMutationKey::Invocation(mutation.identity.clone()),
+            Self::AttemptChanged { invoke_id } => RuntimeMutationKey::Attempt(invoke_id.clone()),
+            Self::PromptCacheBindingChanged { prompt_cache_key } => {
+                RuntimeMutationKey::Binding(prompt_cache_key.clone())
+            }
+            Self::StickyRouteChanged {
+                sticky_key,
+                previous_upstream_account_id,
+                upstream_account_id,
+            } => RuntimeMutationKey::StickyRoute(
+                sticky_key.clone(),
+                *previous_upstream_account_id,
+                *upstream_account_id,
+            ),
+        }
+    }
+
+    fn merge_from(&mut self, next: Self) {
+        match (self, next) {
+            (Self::Invocation(current), Self::Invocation(next)) => current.merge_from(next),
+            (current, next) => *current = next,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum RuntimeMutationKey {
+    Invocation(RuntimeInvocationIdentity),
+    Attempt(String),
+    Binding(String),
+    StickyRoute(String, i64, i64),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SequencedRuntimeMutation {
+    pub(crate) sequence: u64,
+    pub(crate) mutation: RuntimeMutation,
+}
+
+pub(crate) fn coalesce_runtime_mutations(
+    mutations: impl IntoIterator<Item = SequencedRuntimeMutation>,
+) -> Vec<SequencedRuntimeMutation> {
+    let mut indices: HashMap<RuntimeMutationKey, usize> = HashMap::new();
+    let mut coalesced: Vec<SequencedRuntimeMutation> = Vec::new();
+    for mutation in mutations {
+        let key = mutation.mutation.key();
+        if let Some(index) = indices.get(&key).copied() {
+            let current = &mut coalesced[index];
+            current.sequence = current.sequence.max(mutation.sequence);
+            current.mutation.merge_from(mutation.mutation);
+        } else {
+            indices.insert(key, coalesced.len());
+            coalesced.push(mutation);
+        }
+    }
+    coalesced.sort_by_key(|mutation| mutation.sequence);
+    coalesced
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct RuntimeMutationBusHealth {
+    pub(crate) published_count: u64,
+    pub(crate) router_lagged_count: u64,
+    pub(crate) router_gap_count: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct RuntimeMutationBus {
+    sender: broadcast::Sender<SequencedRuntimeMutation>,
+    next_sequence: AtomicU64,
+    published_count: AtomicU64,
+    router_lagged_count: AtomicU64,
+    router_gap_count: AtomicU64,
+    router_started: AtomicBool,
+}
+
+impl RuntimeMutationBus {
+    pub(crate) fn new() -> Self {
+        let (sender, _receiver) = broadcast::channel(RUNTIME_MUTATION_BUS_CAPACITY);
+        Self {
+            sender,
+            next_sequence: AtomicU64::new(0),
+            published_count: AtomicU64::new(0),
+            router_lagged_count: AtomicU64::new(0),
+            router_gap_count: AtomicU64::new(0),
+            router_started: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn publish(&self, mutation: RuntimeMutation) {
+        let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed) + 1;
+        self.published_count.fetch_add(1, Ordering::Relaxed);
+        // The runtime router owns the only receiver. Sending is non-blocking; if shutdown has
+        // already removed it there is no owner-facing consumer left to recover.
+        let _ = self
+            .sender
+            .send(SequencedRuntimeMutation { sequence, mutation });
+    }
+
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<SequencedRuntimeMutation> {
+        self.sender.subscribe()
+    }
+
+    pub(crate) fn claim_router(&self) -> bool {
+        self.router_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    pub(crate) fn record_router_lag(&self) {
+        self.router_lagged_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_router_gap(&self) {
+        self.router_gap_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn health(&self) -> RuntimeMutationBusHealth {
+        RuntimeMutationBusHealth {
+            published_count: self.published_count.load(Ordering::Relaxed),
+            router_lagged_count: self.router_lagged_count.load(Ordering::Relaxed),
+            router_gap_count: self.router_gap_count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for RuntimeMutationBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn normalize_key(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalescing_prefers_persisted_terminal_ack_without_retaining_full_records() {
+        let identity = RuntimeInvocationIdentity::new("invoke-1", "2026-08-09 12:00:00");
+        let mutations = coalesce_runtime_mutations([
+            SequencedRuntimeMutation {
+                sequence: 1,
+                mutation: RuntimeMutation::Invocation(RuntimeInvocationMutation {
+                    identity: identity.clone(),
+                    kind: RuntimeMutationKind::RuntimeUpsert,
+                    row_id: None,
+                    is_terminal: false,
+                    prompt_cache_key: None,
+                    sticky_key: None,
+                    upstream_account_id: None,
+                    preview: None,
+                }),
+            },
+            SequencedRuntimeMutation {
+                sequence: 2,
+                mutation: RuntimeMutation::terminal_persisted_ack(
+                    identity.invoke_id,
+                    identity.occurred_at,
+                    42,
+                ),
+            },
+        ]);
+
+        assert_eq!(mutations.len(), 1);
+        let RuntimeMutation::Invocation(mutation) = &mutations[0].mutation else {
+            panic!("expected invocation mutation");
+        };
+        assert_eq!(mutation.kind, RuntimeMutationKind::TerminalPersistedAck);
+        assert_eq!(mutation.row_id, Some(42));
+        assert!(mutation.is_terminal);
+    }
+
+    #[test]
+    fn ten_thousand_runtime_mutations_coalesce_by_identity() {
+        let mutations = (0..10_000).map(|sequence| SequencedRuntimeMutation {
+            sequence: sequence + 1,
+            mutation: RuntimeMutation::Invocation(RuntimeInvocationMutation {
+                identity: RuntimeInvocationIdentity::new("invoke-1", "2026-08-09 12:00:00"),
+                kind: RuntimeMutationKind::LifecyclePhase,
+                row_id: None,
+                is_terminal: false,
+                prompt_cache_key: None,
+                sticky_key: None,
+                upstream_account_id: None,
+                preview: None,
+            }),
+        });
+
+        let coalesced = coalesce_runtime_mutations(mutations);
+        assert_eq!(coalesced.len(), 1);
+        assert_eq!(coalesced[0].sequence, 10_000);
+    }
+
+    #[tokio::test]
+    async fn capacity_overflow_is_non_blocking_and_observable() {
+        let bus = RuntimeMutationBus::new();
+        let mut receiver = bus.subscribe();
+
+        for index in 0..=RUNTIME_MUTATION_BUS_CAPACITY {
+            bus.publish(RuntimeMutation::AttemptChanged {
+                invoke_id: format!("invoke-{index}"),
+            });
+        }
+
+        assert!(matches!(
+            receiver.recv().await,
+            Err(broadcast::error::RecvError::Lagged(skipped)) if skipped > 0
+        ));
+        bus.record_router_lag();
+        assert_eq!(bus.health().router_lagged_count, 1);
+    }
+}

--- a/src/terminal_projection.rs
+++ b/src/terminal_projection.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashSet, VecDeque},
     sync::{
-        Mutex,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::Instant,
@@ -10,9 +10,9 @@ use std::{
 use tokio::sync::Notify;
 
 use crate::{
-    ApiInvocation, AppState, DashboardActivityTerminalDeltaOutcome, SOURCE_PROXY,
-    apply_dashboard_activity_terminal_record, ensure_dashboard_activity_live_snapshot_producer,
-    rollback_dashboard_activity_terminal_record,
+    ApiInvocation, AppState, DashboardActivityTerminalDeltaOutcome, RuntimeMutation,
+    RuntimeMutationBus, SOURCE_PROXY, apply_dashboard_activity_terminal_record,
+    ensure_dashboard_activity_live_snapshot_producer, rollback_dashboard_activity_terminal_record,
 };
 
 pub(crate) const TERMINAL_PROJECTION_MAX_PENDING_EVENTS: usize = 10_000;
@@ -161,6 +161,7 @@ pub(crate) struct TerminalProjectionHub {
     next_event_id: AtomicU64,
     state: Mutex<TerminalProjectionHubState>,
     persisted_notify: Notify,
+    runtime_mutation_bus: Mutex<Option<Arc<RuntimeMutationBus>>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -170,6 +171,14 @@ pub(crate) struct TerminalProjectionRegistration {
 }
 
 impl TerminalProjectionHub {
+    pub(crate) fn set_runtime_mutation_bus(&self, bus: Arc<RuntimeMutationBus>) {
+        let mut target = self
+            .runtime_mutation_bus
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *target = Some(bus);
+    }
+
     pub(crate) fn register_pending(
         &self,
         record: &ApiInvocation,
@@ -293,6 +302,19 @@ impl TerminalProjectionHub {
         state.last_persisted_row_id = state.last_persisted_row_id.max(row_id);
         state.persisted_ack_count = state.persisted_ack_count.saturating_add(1);
         state.last_ack_at = Some(Instant::now());
+        let runtime_mutation_bus = self
+            .runtime_mutation_bus
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        drop(state);
+        if let Some(runtime_mutation_bus) = runtime_mutation_bus {
+            runtime_mutation_bus.publish(RuntimeMutation::terminal_persisted_ack(
+                invoke_id,
+                occurred_at,
+                row_id,
+            ));
+        }
         self.persisted_notify.notify_one();
     }
 
@@ -542,6 +564,7 @@ impl TerminalProjectionHub {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+    use crate::RuntimeMutationKind;
 
     fn timeseries_delta() -> TimeseriesTerminalDelta {
         TimeseriesTerminalDelta {
@@ -580,6 +603,24 @@ mod tests {
         let health = hub.health();
         assert_eq!(health.pending_event_count, 0);
         assert_eq!(health.pruned_event_count, 2);
+    }
+
+    #[test]
+    fn persisted_ack_emits_compact_runtime_cursor_mutation() {
+        let hub = TerminalProjectionHub::default();
+        let bus = Arc::new(RuntimeMutationBus::new());
+        let mut receiver = bus.subscribe();
+        hub.set_runtime_mutation_bus(bus);
+
+        hub.acknowledge_persisted(None, "invoke", "2026-08-09 12:00:00", 42);
+
+        let mutation = receiver.try_recv().expect("persisted ACK mutation");
+        let RuntimeMutation::Invocation(mutation) = mutation.mutation else {
+            panic!("expected compact invocation mutation");
+        };
+        assert_eq!(mutation.kind, RuntimeMutationKind::TerminalPersistedAck);
+        assert_eq!(mutation.row_id, Some(42));
+        assert!(mutation.is_terminal);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace production runtime record broadcasts with compact typed mutations
- coalesce invocation identities, route only active topic work, and recover cursor gaps as dirty-last-good
- preserve HTTP/SSE wire contracts while removing legacy runtime bus configuration

## Validation
- cargo fmt --check
- cargo check
- cargo test -q runtime_mutation_bus
- cargo test -q subscriptions
- cargo test -q terminal_projection
- cargo test -q recovered_proxy
- cargo test -q sqlite_batch_writer
- cargo clippy --locked --all-targets --all-features -- -D warnings

Refs #766