### PR TITLE
fix(maintenance): make startup backfill event-driven

### DIFF
--- a/docs/solutions/performance/sqlite-write-pressure-backpressure.md
+++ b/docs/solutions/performance/sqlite-write-pressure-backpressure.md
@@ -95,6 +95,7 @@
 - 对业务优先的 terminal admission，可在数据库同目录维护带校验的 append-only journal：先 journal append，再异步入 SQLite；按固定短窗口 group commit，SQLite ACK 后删除完整确认的 segment。必须把 journal pending records/bytes、ACK age、replay count 与 overflow durability mode 作为结构化 telemetry。journal overflow 选择内存可用性时，不得宣称 crash-safe。
 - Dashboard read model 遇到 writer pressure 时不得为了 60 秒 reconcile 再竞争一次 SQLite barrier。已有 last-good baseline 的 selection 应以 expiry delta 继续服务，并将 reconcile deferred 明确记录；必须设置最长 defer 上限，超过上限再做一次补偿尝试。
 - 不可恢复的历史 payload backlog 必须标为 source-unavailable，并退出 actionable backlog。仅在 archive/payload 恢复事件唤醒，外加每日受行数和耗时限制的 probe；否则退避 ticker 会把永久缺失输入伪装成持续工作。
+- event-driven backfill 不能只在表中保存 `next_run_after`，supervisor 也必须把 recovered deadline 镜像为内存等待条件。否则即使任务本身已退避，固定 supervisor ticker 仍会周期性查询每个 progress row、运行无关 maintenance 并写审计记录。repair wake 必须携带受影响 task 集合，pressure defer 只更新该 task 的 retry deadline，空闲 pass 不创建 `system_task_runs`。
 
 ## 何时升级方案
 

--- a/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
+++ b/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
@@ -4,7 +4,7 @@
 
 The next delivery boundary is a single typed runtime mutation bus and router. Hot events carry identity, lifecycle, aggregate, and cursor fields only; they do not carry full invocation records, generic JSON values, or mutable topic snapshots. Topic work is selected from active dependency indexes before any materialization. Historical and detail consumers use bounded identity hydration.
 
-Backfill scheduling is event-driven. Progress state owns `next_due` and wake generation; source-unavailable work sleeps until an archive/payload/coverage event or its daily bounded probe. A no-op pass does not create a task-run audit row. Health aggregates event-bus lag, projection recovery, and writer pressure using in-memory counters without adding status-page SQL.
+Backfill scheduling is event-driven. `startup_backfill_progress` persists each task cursor, `next_run_after`, source-unavailable state, daily probe deadline and wake generation; the supervisor mirrors the recovered per-task deadlines in memory, then sleeps until the earliest deadline or a matching task wake. Archive materialization wakes only archive-activity and historical-rollup work. A source-unavailable probe remains bounded to 100 rows or two seconds, while pressure deferral persists a retry deadline without producing a `system_task_runs` audit row. A no-op pass does not run unrelated rollup maintenance or create a task-run audit row. Health aggregates event-bus lag, projection recovery, and writer pressure using in-memory counters without adding status-page SQL.
 
 `ProxySqliteWriteCoordinator` 是代理热写的统一 admission 面。实现覆盖 terminal P1/P2 actor、attempt 生命周期和 route success/failure 汇聚路径，并通过 `runtimePressureHealth.proxySqliteWriteCoordinator` 暴露 active class、各优先级 waiter 与 legacy bypass 计数。
 

--- a/docs/specs/high-frequency-runtime-data-plane/SPEC.md
+++ b/docs/specs/high-frequency-runtime-data-plane/SPEC.md
@@ -53,6 +53,7 @@
 - terminal totals 使用 `5s` 内存发布，baseline reconcile 使用 `60s` cadence。压力或 last-good 状态机沿用既有退避与精确恢复语义。
 - `PendingQueueAccounting` 统一拥有 enqueue、coalesce、batch replacement、P1 -> P2 transfer 与 completion 的 byte/depth 变化；业务阶段不得直接执行裸 `fetch_sub`。
 - accounting 不变量破坏必须进入 degraded health 并保留证据，不能 wrap 到 `usize::MAX` 或继续报告 healthy。
+- startup backfill 的 supervisor 按持久化 task deadline 或匹配 repair wake 调度，不使用全局固定 ticker。空闲等待不得扫描 task progress、执行无关 maintenance 或写 `system_task_runs`；source-unavailable task 只在相关 archive/payload/coverage 输入变化或每日受限 probe 时运行。
 
 ## Public Contracts
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, TcpStream},
     process::{Child, Command},
-    sync::{Mutex, RwLock, Semaphore, broadcast, mpsc, oneshot, watch},
+    sync::{Mutex, Notify, RwLock, Semaphore, broadcast, mpsc, oneshot, watch},
     task::JoinHandle,
     time::{MissedTickBehavior, interval, sleep, timeout},
 };

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -2075,7 +2075,7 @@ pub(crate) async fn repair_active_account_activity_v2_coverage_best_effort(
     pool: &Pool<Sqlite>,
     hourly_rollup_sync_lock: &Mutex<()>,
     reason: &'static str,
-) {
+) -> Option<ActiveAccountActivityV2RepairOutcome> {
     let gate = crate::db_pressure::global_db_pressure_gate();
     let _permit = match gate.try_begin_background("account_activity_v2_priority_repair") {
         Ok(permit) => permit,
@@ -2086,18 +2086,22 @@ pub(crate) async fn repair_active_account_activity_v2_coverage_best_effort(
                 wake_reason = "active_window_coverage_check",
                 "active Dashboard coverage repair deferred by database pressure gate"
             );
-            return;
+            return None;
         }
     };
     let _guard = hourly_rollup_sync_lock.lock().await;
-    if let Err(err) = repair_active_account_activity_v2_coverage(pool).await {
-        gate.record_error("account_activity_v2_priority_repair", &err);
-        warn!(
-            error = %err,
-            reason,
-            wake_reason = "active_window_coverage_check",
-            "active Dashboard coverage repair failed"
-        );
+    match repair_active_account_activity_v2_coverage(pool).await {
+        Ok(outcome) => Some(outcome),
+        Err(err) => {
+            gate.record_error("account_activity_v2_priority_repair", &err);
+            warn!(
+                error = %err,
+                reason,
+                wake_reason = "active_window_coverage_check",
+                "active Dashboard coverage repair failed"
+            );
+            None
+        }
     }
 }
 

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -80,10 +80,26 @@ async fn sync_hourly_rollups_from_live_tables_once(
             break;
         }
     }
-    repair_live_invocation_account_activity_v2_once(pool).await?;
+    let repaired_activity_v2_rows = repair_live_invocation_account_activity_v2_once(pool).await?;
+    wake_historical_rollups_for_live_activity_v2_coverage(pool, repaired_activity_v2_rows).await?;
     if let Some(days) = invocation_live_days {
         maintain_parallel_work_rollups(pool, Some(shanghai_retention_cutoff(days).timestamp()))
             .await?;
+    }
+    Ok(())
+}
+
+pub(crate) async fn wake_historical_rollups_for_live_activity_v2_coverage(
+    pool: &Pool<Sqlite>,
+    repaired_activity_v2_rows: u64,
+) -> Result<()> {
+    if repaired_activity_v2_rows > 0 {
+        wake_startup_backfill_tasks(
+            pool,
+            &[StartupBackfillTask::HistoricalRollups],
+            "live_account_activity_v2_coverage_updated",
+        )
+        .await?;
     }
     Ok(())
 }
@@ -2071,11 +2087,18 @@ pub(crate) async fn refresh_hourly_rollups_for_read_surfaces_best_effort(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ActiveAccountActivityV2RepairResult {
+    Repaired(ActiveAccountActivityV2RepairOutcome),
+    Deferred,
+    Failed,
+}
+
 pub(crate) async fn repair_active_account_activity_v2_coverage_best_effort(
     pool: &Pool<Sqlite>,
     hourly_rollup_sync_lock: &Mutex<()>,
     reason: &'static str,
-) -> Option<ActiveAccountActivityV2RepairOutcome> {
+) -> ActiveAccountActivityV2RepairResult {
     let gate = crate::db_pressure::global_db_pressure_gate();
     let _permit = match gate.try_begin_background("account_activity_v2_priority_repair") {
         Ok(permit) => permit,
@@ -2086,12 +2109,12 @@ pub(crate) async fn repair_active_account_activity_v2_coverage_best_effort(
                 wake_reason = "active_window_coverage_check",
                 "active Dashboard coverage repair deferred by database pressure gate"
             );
-            return None;
+            return ActiveAccountActivityV2RepairResult::Deferred;
         }
     };
     let _guard = hourly_rollup_sync_lock.lock().await;
     match repair_active_account_activity_v2_coverage(pool).await {
-        Ok(outcome) => Some(outcome),
+        Ok(outcome) => ActiveAccountActivityV2RepairResult::Repaired(outcome),
         Err(err) => {
             gate.record_error("account_activity_v2_priority_repair", &err);
             warn!(
@@ -2100,7 +2123,7 @@ pub(crate) async fn repair_active_account_activity_v2_coverage_best_effort(
                 wake_reason = "active_window_coverage_check",
                 "active Dashboard coverage repair failed"
             );
-            None
+            ActiveAccountActivityV2RepairResult::Failed
         }
     }
 }

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -993,9 +993,12 @@ pub(crate) async fn run_data_retention_maintenance(
             account_rows_written = manifest_refresh.account_rows_written,
             "refreshed upstream activity manifest before waking archive backfill"
         );
-        wake_source_unavailable_backfills(
+        wake_startup_backfill_tasks(
             pool,
-            StartupBackfillTask::UpstreamActivityArchives.name(),
+            &[
+                StartupBackfillTask::UpstreamActivityArchives,
+                StartupBackfillTask::HistoricalRollups,
+            ],
             if pruned.1 > 0 {
                 "invocation_detail_prune_archive_materialized"
             } else {

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -9,7 +9,7 @@ pub(crate) fn push_backfill_sample(samples: &mut Vec<String>, sample: String) {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum StartupBackfillTask {
     ProxyUsage,
     ProxyCost,
@@ -24,6 +24,111 @@ pub(crate) enum StartupBackfillTask {
     UpstreamActivityArchives,
     PoolUpstreamNodeHealthArchives,
     HistoricalRollups,
+}
+
+#[derive(Debug, Default)]
+struct StartupBackfillScheduler {
+    wake_generation: AtomicU64,
+    notify: Notify,
+    woken_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
+    next_due: std::sync::Mutex<HashMap<StartupBackfillTask, DateTime<Utc>>>,
+}
+
+impl StartupBackfillScheduler {
+    fn wake(&self, task: StartupBackfillTask) {
+        if let Ok(mut tasks) = self.woken_tasks.lock() {
+            tasks.insert(task);
+        }
+        if let Ok(mut next_due) = self.next_due.lock() {
+            next_due.insert(task, Utc::now());
+        }
+        self.wake_generation.fetch_add(1, Ordering::AcqRel);
+        self.notify.notify_waiters();
+    }
+
+    fn generation(&self) -> u64 {
+        self.wake_generation.load(Ordering::Acquire)
+    }
+
+    fn drain_woken_tasks(&self) -> Vec<StartupBackfillTask> {
+        let Ok(mut tasks) = self.woken_tasks.lock() else {
+            return Vec::new();
+        };
+        StartupBackfillTask::ordered_tasks()
+            .iter()
+            .copied()
+            .filter(|task| tasks.remove(task))
+            .collect()
+    }
+
+    fn drain_due_tasks(&self, now: DateTime<Utc>) -> Vec<StartupBackfillTask> {
+        let Ok(mut next_due) = self.next_due.lock() else {
+            return Vec::new();
+        };
+        let due_tasks = StartupBackfillTask::ordered_tasks()
+            .iter()
+            .copied()
+            .filter(|task| next_due.get(task).is_some_and(|due| *due <= now))
+            .collect::<Vec<_>>();
+        for task in &due_tasks {
+            next_due.remove(task);
+        }
+        due_tasks
+    }
+
+    fn record_next_due(&self, task: StartupBackfillTask, due: DateTime<Utc>) {
+        if let Ok(mut next_due) = self.next_due.lock() {
+            next_due.insert(task, due);
+        }
+    }
+
+    fn clear_next_due(&self, task: StartupBackfillTask) {
+        if let Ok(mut next_due) = self.next_due.lock() {
+            next_due.remove(&task);
+        }
+    }
+
+    fn next_due(&self) -> Option<DateTime<Utc>> {
+        self.next_due
+            .lock()
+            .ok()
+            .and_then(|next_due| next_due.values().min().cloned())
+    }
+
+    async fn wait_for_wake(&self, observed_generation: u64) {
+        loop {
+            let notified = self.notify.notified();
+            if self.generation() != observed_generation {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+static STARTUP_BACKFILL_SCHEDULER: Lazy<StartupBackfillScheduler> =
+    Lazy::new(StartupBackfillScheduler::default);
+
+fn startup_backfill_wait_duration(next_due: Option<DateTime<Utc>>) -> Duration {
+    match next_due {
+        Some(deadline) => (deadline - Utc::now()).to_std().unwrap_or(Duration::ZERO),
+        None => Duration::from_secs(24 * 60 * 60),
+    }
+}
+
+fn startup_backfill_progress_due(progress: &StartupBackfillProgress) -> DateTime<Utc> {
+    progress
+        .next_run_after
+        .as_deref()
+        .and_then(parse_to_utc_datetime)
+        .unwrap_or_else(Utc::now)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StartupBackfillTaskRunOutcome {
+    actionable: bool,
+    failed: bool,
+    next_due: DateTime<Utc>,
 }
 
 impl StartupBackfillTask {
@@ -444,54 +549,86 @@ pub(crate) async fn save_startup_backfill_progress(
     Ok(())
 }
 
-pub(crate) async fn wake_source_unavailable_backfills(
+pub(crate) async fn wake_startup_backfill_tasks(
     pool: &Pool<Sqlite>,
-    task_name: &str,
+    tasks: &[StartupBackfillTask],
     wake_reason: &'static str,
 ) -> Result<u64> {
-    let outcome = sqlx::query(
-        r#"
-        UPDATE startup_backfill_progress
-        SET
-            next_run_after = NULL,
-            next_probe_at = NULL,
-            suspension_reason = NULL,
-            wake_generation = wake_generation + 1,
-            last_status = ?1
-        WHERE task_name = ?2
-          AND last_status = ?3
-        "#,
-    )
-    .bind(STARTUP_BACKFILL_STATUS_IDLE)
-    .bind(task_name)
-    .bind(STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE)
-    .execute(pool)
-    .await?;
-    let woken = outcome.rows_affected();
-    if woken > 0 {
+    let mut woken = 0;
+    for task in tasks {
+        let task_name = task.name();
+        let outcome = sqlx::query(
+            r#"
+            INSERT INTO startup_backfill_progress (
+                task_name,
+                cursor_id,
+                next_run_after,
+                zero_update_streak,
+                last_started_at,
+                last_finished_at,
+                last_scanned,
+                last_updated,
+                last_status,
+                suspension_reason,
+                next_probe_at,
+                wake_generation
+            )
+            VALUES (?1, 0, NULL, 0, NULL, NULL, 0, 0, ?2, NULL, NULL, 1)
+            ON CONFLICT(task_name) DO UPDATE SET
+                next_run_after = NULL,
+                next_probe_at = NULL,
+                suspension_reason = NULL,
+                wake_generation = startup_backfill_progress.wake_generation + 1,
+                last_status = ?2
+            "#,
+        )
+        .bind(task_name)
+        .bind(STARTUP_BACKFILL_STATUS_IDLE)
+        .execute(pool)
+        .await?;
+        woken += outcome.rows_affected();
+        STARTUP_BACKFILL_SCHEDULER.wake(*task);
+    }
+    if !tasks.is_empty() {
         info!(
-            task_name,
-            wake_reason, woken, "woke source-unavailable startup backfill"
+            wake_reason,
+            woken,
+            task_count = tasks.len(),
+            "woke affected startup backfill tasks"
         );
     }
     Ok(woken)
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct StartupBackfillMaintenancePass {
+    pub(crate) ran_actionable_task: bool,
+    pub(crate) had_failure: bool,
+}
+
+fn selected_task_includes(
+    selected_tasks: Option<&[StartupBackfillTask]>,
+    task: StartupBackfillTask,
+) -> bool {
+    let tasks = match selected_tasks {
+        Some(tasks) => tasks,
+        None => StartupBackfillTask::ordered_tasks(),
+    };
+    tasks.contains(&task)
+}
+
 pub(crate) async fn run_startup_backfill_maintenance_pass(
     state: Arc<AppState>,
     cancel: &CancellationToken,
-) {
-    let task_run = begin_system_task_run(
-        &state.pool,
-        SystemTaskKind::StartupBackfill,
-        "pass",
-        Some("startup backfill maintenance pass started".to_string()),
-    )
-    .await
-    .ok();
+    selected_tasks: Option<&[StartupBackfillTask]>,
+) -> StartupBackfillMaintenancePass {
     let mut had_failure = false;
     let mut ran_actionable_task = false;
-    for task in StartupBackfillTask::ordered_tasks() {
+    let tasks = match selected_tasks {
+        Some(tasks) => tasks,
+        None => StartupBackfillTask::ordered_tasks(),
+    };
+    for task in tasks {
         if cancel.is_cancelled() {
             info!(
                 task = task.log_label(),
@@ -505,12 +642,28 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
                 task = task.log_label(),
                 "startup backfill task is disabled by config"
             );
+            STARTUP_BACKFILL_SCHEDULER.clear_next_due(*task);
             continue;
         }
-        match run_startup_backfill_task_if_due(&state, *task).await {
-            Ok(ran) => ran_actionable_task |= ran,
+        match run_startup_backfill_task_if_due_outcome(
+            &state,
+            *task,
+            crate::db_pressure::global_db_pressure_gate(),
+        )
+        .await
+        {
+            Ok(outcome) => {
+                STARTUP_BACKFILL_SCHEDULER.record_next_due(*task, outcome.next_due);
+                ran_actionable_task |= outcome.actionable;
+                had_failure |= outcome.failed;
+            }
             Err(err) => {
                 had_failure = true;
+                STARTUP_BACKFILL_SCHEDULER.record_next_due(
+                    *task,
+                    Utc::now()
+                        + ChronoDuration::seconds(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS as i64),
+                );
                 crate::db_pressure::global_db_pressure_gate()
                     .record_error("startup_backfill", &err);
                 warn!(task = task.log_label(), error = %err, "startup backfill supervisor pass failed");
@@ -525,44 +678,68 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             "startup backfill maintenance pass",
         )
         .await;
-    } else {
-        repair_active_account_activity_v2_coverage_best_effort(
-            &state.pool,
-            state.hourly_rollup_sync_lock.as_ref(),
-            "startup backfill active coverage check",
-        )
-        .await;
-    }
-
-    if !cancel.is_cancelled() {
-        let _guard = state.hourly_rollup_sync_lock.lock().await;
-        let live_start_epoch =
-            shanghai_retention_cutoff(state.config.invocation_max_days).timestamp();
-        if let Err(err) = maintain_parallel_work_rollups(&state.pool, Some(live_start_epoch)).await
-        {
-            had_failure = true;
-            crate::db_pressure::global_db_pressure_gate()
-                .record_error("parallel_work_rollup_maintenance", &err);
-            warn!(error = %err, "parallel-work rollup maintenance pass failed");
+        if !cancel.is_cancelled() {
+            let _guard = state.hourly_rollup_sync_lock.lock().await;
+            let live_start_epoch =
+                shanghai_retention_cutoff(state.config.invocation_max_days).timestamp();
+            if let Err(err) =
+                maintain_parallel_work_rollups(&state.pool, Some(live_start_epoch)).await
+            {
+                had_failure = true;
+                crate::db_pressure::global_db_pressure_gate()
+                    .record_error("parallel_work_rollup_maintenance", &err);
+                warn!(error = %err, "parallel-work rollup maintenance pass failed");
+            }
         }
     }
-    if let Some(run) = task_run.as_ref() {
-        finish_system_task_run_batched(
-            state.as_ref(),
-            run,
-            if had_failure {
-                SystemTaskStatus::Failed
-            } else {
-                SystemTaskStatus::Success
-            },
-            Some(if had_failure {
-                "startup backfill maintenance pass completed with failures".to_string()
-            } else {
-                "startup backfill maintenance pass completed".to_string()
-            }),
-            None,
+
+    // Coverage repair belongs to the historical-rollup task. It remains bounded to two buckets
+    // and runs only during the initial pass or when that task is explicitly due or woken.
+    if !cancel.is_cancelled()
+        && selected_task_includes(selected_tasks, StartupBackfillTask::HistoricalRollups)
+    {
+        let repair_outcome = repair_active_account_activity_v2_coverage_best_effort(
+            &state.pool,
+            state.hourly_rollup_sync_lock.as_ref(),
+            "startup backfill historical-rollup coverage repair",
         )
         .await;
+        ran_actionable_task |=
+            repair_outcome.is_some_and(|outcome| outcome.repaired_bucket_count > 0);
+    }
+
+    if ran_actionable_task || had_failure {
+        let task_run = begin_system_task_run(
+            &state.pool,
+            SystemTaskKind::StartupBackfill,
+            "event_or_due",
+            Some("startup backfill maintenance changed data or failed".to_string()),
+        )
+        .await
+        .ok();
+        if let Some(run) = task_run.as_ref() {
+            finish_system_task_run_batched(
+                state.as_ref(),
+                run,
+                if had_failure {
+                    SystemTaskStatus::Failed
+                } else {
+                    SystemTaskStatus::Success
+                },
+                Some(if had_failure {
+                    "startup backfill maintenance pass completed with failures".to_string()
+                } else {
+                    "startup backfill maintenance pass completed".to_string()
+                }),
+                None,
+            )
+            .await;
+        }
+    }
+
+    StartupBackfillMaintenancePass {
+        ran_actionable_task,
+        had_failure,
     }
 }
 
@@ -577,12 +754,13 @@ pub(crate) async fn run_startup_backfill_task_if_due(
     state: &Arc<AppState>,
     task: StartupBackfillTask,
 ) -> Result<bool> {
-    run_startup_backfill_task_if_due_with_gate(
+    run_startup_backfill_task_if_due_outcome(
         state,
         task,
         crate::db_pressure::global_db_pressure_gate(),
     )
     .await
+    .map(|outcome| outcome.actionable)
 }
 
 pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
@@ -590,12 +768,26 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
 ) -> Result<bool> {
+    run_startup_backfill_task_if_due_outcome(state, task, gate)
+        .await
+        .map(|outcome| outcome.actionable)
+}
+
+async fn run_startup_backfill_task_if_due_outcome(
+    state: &Arc<AppState>,
+    task: StartupBackfillTask,
+    gate: &crate::db_pressure::DbPressureGate,
+) -> Result<StartupBackfillTaskRunOutcome> {
     if !startup_backfill_task_enabled(state.as_ref(), task) {
         debug!(
             task = task.log_label(),
             "startup backfill task is disabled by config"
         );
-        return Ok(false);
+        return Ok(StartupBackfillTaskRunOutcome {
+            actionable: false,
+            failed: false,
+            next_due: Utc::now() + ChronoDuration::days(1),
+        });
     }
 
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
@@ -613,25 +805,59 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
             last_updated = progress.last_updated,
             "startup backfill task is not due"
         );
-        return Ok(false);
+        return Ok(StartupBackfillTaskRunOutcome {
+            actionable: false,
+            failed: false,
+            next_due: startup_backfill_progress_due(&progress),
+        });
     }
 
     let _permit = match gate.try_begin_background("startup_backfill") {
         Ok(permit) => permit,
         Err(reason) => {
-            warn!(
+            let retry_after = match reason {
+                crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => {
+                    Utc::now() + ChronoDuration::milliseconds(remaining_ms as i64)
+                }
+                crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
+                    Utc::now()
+                        + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
+                }
+            };
+            let retry_after = format_utc_iso(retry_after);
+            save_startup_backfill_progress(
+                &state.pool,
+                &task_name,
+                StartupBackfillProgressUpdate {
+                    cursor_id: progress.cursor_id,
+                    scanned: progress.last_scanned,
+                    updated: progress.last_updated,
+                    zero_update_streak: progress.zero_update_streak,
+                    next_run_after: &retry_after,
+                    status: &progress.last_status,
+                    suspension_reason: progress.suspension_reason.as_deref(),
+                },
+            )
+            .await?;
+            info!(
                 task = task.log_label(),
                 reason = %reason,
-                "startup backfill task skipped because database pressure gate is closed"
+                next_retry_after = %retry_after,
+                wake_reason = "pressure_defer",
+                "startup backfill task deferred because database pressure gate is closed"
             );
-            return Ok(false);
+            return Ok(StartupBackfillTaskRunOutcome {
+                actionable: false,
+                failed: false,
+                next_due: parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now),
+            });
         }
     };
 
     mark_startup_backfill_running(&state.pool, &task_name, progress.cursor_id).await?;
 
     let started_at = Instant::now();
-    let actionable = match run_startup_backfill_task(
+    let outcome = match run_startup_backfill_task(
         state,
         task,
         progress.cursor_id,
@@ -692,7 +918,11 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                 samples = %startup_backfill_samples_text(&run.samples),
                 "startup backfill pass finished"
             );
-            startup_backfill_run_is_actionable(&run)
+            StartupBackfillTaskRunOutcome {
+                actionable: startup_backfill_run_is_actionable(&run),
+                failed: false,
+                next_due: parse_to_utc_datetime(&next_run_after).unwrap_or_else(Utc::now),
+            }
         }
         Err(err) => {
             let retry_after = format_utc_iso(
@@ -721,11 +951,15 @@ pub(crate) async fn run_startup_backfill_task_if_due_with_gate(
                 error = %err,
                 "startup backfill pass failed"
             );
-            false
+            StartupBackfillTaskRunOutcome {
+                actionable: false,
+                failed: true,
+                next_due: parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now),
+            }
         }
     };
 
-    Ok(actionable)
+    Ok(outcome)
 }
 
 fn startup_backfill_run_is_actionable(run: &StartupBackfillRunState) -> bool {
@@ -1081,11 +1315,19 @@ pub(crate) async fn run_startup_backfill_task(
             ))
         }
         StartupBackfillTask::HistoricalRollups => {
+            let historical_elapsed_budget = if source_unavailable_probe {
+                Duration::from_secs(2)
+            } else {
+                Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)
+            };
             let before =
                 load_historical_rollup_backfill_snapshot(&state.pool, &state.config).await?;
             if before.pending_usage_breakdown_batches > 0 {
-                let priority_elapsed_budget =
-                    Duration::from_secs(STARTUP_HISTORICAL_ROLLUP_PRIORITY_BUDGET_SECS);
+                let priority_elapsed_budget = if source_unavailable_probe {
+                    historical_elapsed_budget
+                } else {
+                    Duration::from_secs(STARTUP_HISTORICAL_ROLLUP_PRIORITY_BUDGET_SECS)
+                };
                 let skip_pending_archives =
                     (cursor_id as u64 % before.pending_usage_breakdown_batches) as usize;
                 let summary = materialize_usage_breakdown_historical_rollups_bounded_from_skip(
@@ -1152,7 +1394,7 @@ pub(crate) async fn run_startup_backfill_task(
                 &state.config,
                 false,
                 Some(1),
-                Some(Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)),
+                Some(historical_elapsed_budget),
                 skip_pending_archives,
             )
             .await?;
@@ -1249,7 +1491,9 @@ pub(crate) fn spawn_startup_backfill_maintenance(
         let prep_cli = CliArgs::default();
         let mut startup_prep_pending =
             !run_startup_persistent_prep_best_effort(&state, &prep_cli).await;
-        run_startup_backfill_maintenance_pass(state.clone(), &cancel).await;
+        let mut startup_prep_retry_at = startup_prep_pending
+            .then(|| Instant::now() + Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS));
+        run_startup_backfill_maintenance_pass(state.clone(), &cancel, None).await;
         // Register before either P2 supervisor is scheduled so long-term pruning cannot
         // reclaim a terminal event ahead of the minute projection consumer.
         state
@@ -1258,22 +1502,49 @@ pub(crate) fn spawn_startup_backfill_maintenance(
         spawn_long_term_projection_supervisor(state.clone(), cancel.clone());
         spawn_timeseries_minute_projection_supervisor(state.clone(), cancel.clone());
 
-        let mut ticker = interval(Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS));
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        ticker.tick().await;
+        let mut observed_generation = STARTUP_BACKFILL_SCHEDULER.generation();
 
         loop {
+            let next_due = STARTUP_BACKFILL_SCHEDULER.next_due();
+            let mut wait_for = startup_backfill_wait_duration(next_due);
+            if let Some(retry_at) = startup_prep_retry_at {
+                wait_for = wait_for.min(retry_at.saturating_duration_since(Instant::now()));
+            }
+
             tokio::select! {
                 _ = cancel.cancelled() => {
                     info!("startup backfill maintenance received shutdown");
                     break;
                 }
-                _ = ticker.tick() => {
-                    if startup_prep_pending {
+                _ = STARTUP_BACKFILL_SCHEDULER.wait_for_wake(observed_generation) => {
+                    observed_generation = STARTUP_BACKFILL_SCHEDULER.generation();
+                    let tasks = STARTUP_BACKFILL_SCHEDULER.drain_woken_tasks();
+                    if !tasks.is_empty() {
+                        run_startup_backfill_maintenance_pass(state.clone(), &cancel, Some(&tasks)).await;
+                    }
+                }
+                _ = sleep(wait_for) => {
+                    observed_generation = STARTUP_BACKFILL_SCHEDULER.generation();
+                    STARTUP_BACKFILL_SCHEDULER.drain_woken_tasks();
+                    if startup_prep_pending
+                        && startup_prep_retry_at.is_none_or(|retry_at| retry_at <= Instant::now())
+                    {
                         startup_prep_pending =
                             !run_startup_persistent_prep_best_effort(&state, &prep_cli).await;
+                        startup_prep_retry_at = startup_prep_pending.then(|| {
+                            Instant::now()
+                                + Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS)
+                        });
                     }
-                    run_startup_backfill_maintenance_pass(state.clone(), &cancel).await;
+                    let due_tasks = STARTUP_BACKFILL_SCHEDULER.drain_due_tasks(Utc::now());
+                    if !due_tasks.is_empty() {
+                        run_startup_backfill_maintenance_pass(
+                            state.clone(),
+                            &cancel,
+                            Some(&due_tasks),
+                        )
+                        .await;
+                    }
                 }
             }
         }
@@ -1312,6 +1583,31 @@ mod startup_backfill_tests {
             startup_backfill_next_delay(&run, 99),
             Duration::from_secs(15 * 60)
         );
+    }
+
+    #[test]
+    fn overdue_backfill_deadline_runs_without_an_idle_sleep() {
+        assert_eq!(
+            startup_backfill_wait_duration(Some(Utc::now() - ChronoDuration::seconds(1))),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn scheduler_drains_only_tasks_with_an_expired_deadline() {
+        let scheduler = StartupBackfillScheduler::default();
+        let future_due = Utc::now() + ChronoDuration::hours(1);
+        scheduler.record_next_due(
+            StartupBackfillTask::HistoricalRollups,
+            Utc::now() - ChronoDuration::seconds(1),
+        );
+        scheduler.record_next_due(StartupBackfillTask::ReasoningEffort, future_due);
+
+        assert_eq!(
+            scheduler.drain_due_tasks(Utc::now()),
+            vec![StartupBackfillTask::HistoricalRollups]
+        );
+        assert_eq!(scheduler.next_due(), Some(future_due));
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -191,6 +191,44 @@ impl StartupBackfillTask {
     }
 }
 
+pub(crate) fn startup_backfill_tasks_for_terminal(
+    record: &ApiInvocation,
+) -> Vec<StartupBackfillTask> {
+    let has_request_raw = record.request_raw_path.is_some();
+    let has_response_raw = record.response_raw_path.is_some();
+    let is_success = record.status.as_deref().is_some_and(|status| {
+        matches!(
+            status.trim().to_ascii_lowercase().as_str(),
+            "success" | "warning_success"
+        )
+    });
+    let mut tasks = Vec::new();
+
+    if is_success && record.total_tokens.is_none() && has_response_raw {
+        tasks.push(StartupBackfillTask::ProxyUsage);
+    }
+    if has_request_raw && record.prompt_cache_key.is_none() {
+        tasks.push(StartupBackfillTask::PromptCacheKey);
+    }
+    if has_request_raw && record.requested_service_tier.is_none() {
+        tasks.push(StartupBackfillTask::RequestedServiceTier);
+    }
+    if has_request_raw && record.reasoning_effort.is_none() {
+        tasks.push(StartupBackfillTask::ReasoningEffort);
+    }
+    if has_response_raw && record.service_tier.is_none() {
+        tasks.push(StartupBackfillTask::InvocationServiceTier);
+    }
+    if !is_success
+        && (record.failure_kind.is_none()
+            || record.failure_class.is_none()
+            || record.is_actionable.is_none())
+    {
+        tasks.push(StartupBackfillTask::FailureClassification);
+    }
+    tasks
+}
+
 #[derive(Debug, Clone, FromRow)]
 pub(crate) struct StartupBackfillProgressRow {
     task_name: String,
@@ -394,6 +432,22 @@ pub(crate) fn startup_backfill_samples_text(samples: &[String]) -> String {
         "-".to_string()
     } else {
         samples.join(" | ")
+    }
+}
+
+fn startup_backfill_scan_limit(source_unavailable_probe: bool) -> u64 {
+    if source_unavailable_probe {
+        100
+    } else {
+        STARTUP_BACKFILL_SCAN_LIMIT
+    }
+}
+
+fn startup_backfill_run_budget(source_unavailable_probe: bool) -> Duration {
+    if source_unavailable_probe {
+        Duration::from_secs(2)
+    } else {
+        Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)
     }
 }
 
@@ -617,6 +671,41 @@ fn selected_task_includes(
     tasks.contains(&task)
 }
 
+pub(crate) async fn defer_startup_backfill_task(
+    state: &AppState,
+    task: StartupBackfillTask,
+    delay: Duration,
+    wake_reason: &'static str,
+) -> Result<()> {
+    let task_name = startup_backfill_task_progress_key(state, task).await;
+    let progress = load_startup_backfill_progress(&state.pool, &task_name).await?;
+    let retry_after = Utc::now() + ChronoDuration::from_std(delay).unwrap_or_default();
+    let retry_after = format_utc_iso(retry_after);
+    save_startup_backfill_progress(
+        &state.pool,
+        &task_name,
+        StartupBackfillProgressUpdate {
+            cursor_id: progress.cursor_id,
+            scanned: progress.last_scanned,
+            updated: progress.last_updated,
+            zero_update_streak: progress.zero_update_streak,
+            next_run_after: &retry_after,
+            status: &progress.last_status,
+            suspension_reason: progress.suspension_reason.as_deref(),
+        },
+    )
+    .await?;
+    let retry_at = parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now);
+    STARTUP_BACKFILL_SCHEDULER.record_next_due(task, retry_at);
+    info!(
+        task = task.log_label(),
+        next_retry_after = %retry_after,
+        wake_reason,
+        "startup backfill task retry scheduled"
+    );
+    Ok(())
+}
+
 pub(crate) async fn run_startup_backfill_maintenance_pass(
     state: Arc<AppState>,
     cancel: &CancellationToken,
@@ -704,8 +793,28 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             "startup backfill historical-rollup coverage repair",
         )
         .await;
-        ran_actionable_task |=
-            repair_outcome.is_some_and(|outcome| outcome.repaired_bucket_count > 0);
+        match repair_outcome {
+            ActiveAccountActivityV2RepairResult::Repaired(outcome) => {
+                ran_actionable_task |= outcome.repaired_bucket_count > 0;
+            }
+            outcome @ (ActiveAccountActivityV2RepairResult::Deferred
+            | ActiveAccountActivityV2RepairResult::Failed) => {
+                had_failure |= matches!(outcome, ActiveAccountActivityV2RepairResult::Failed);
+                if let Err(err) = defer_startup_backfill_task(
+                    state.as_ref(),
+                    StartupBackfillTask::HistoricalRollups,
+                    Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS),
+                    "coverage_repair_retry",
+                )
+                .await
+                {
+                    had_failure = true;
+                    crate::db_pressure::global_db_pressure_gate()
+                        .record_error("startup_backfill_coverage_retry", &err);
+                    warn!(error = %err, "failed to schedule startup backfill coverage retry");
+                }
+            }
+        }
     }
 
     if ran_actionable_task || had_failure {
@@ -973,11 +1082,8 @@ pub(crate) async fn run_startup_backfill_task(
     zero_update_streak: u32,
     source_unavailable_probe: bool,
 ) -> Result<(StartupBackfillRunState, String)> {
-    let max_elapsed = Some(if source_unavailable_probe {
-        Duration::from_secs(2)
-    } else {
-        Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)
-    });
+    let scan_limit = startup_backfill_scan_limit(source_unavailable_probe);
+    let max_elapsed = Some(startup_backfill_run_budget(source_unavailable_probe));
     let raw_path_fallback_root = state.config.database_path.parent();
     match task {
         StartupBackfillTask::ProxyUsage => {
@@ -987,7 +1093,7 @@ pub(crate) async fn run_startup_backfill_task(
                 cursor_id,
                 snapshot_max_id,
                 raw_path_fallback_root,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1032,7 +1138,7 @@ pub(crate) async fn run_startup_backfill_task(
                 &attempt_version,
                 &requested_tier_price_version,
                 &response_tier_price_version,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1058,7 +1164,7 @@ pub(crate) async fn run_startup_backfill_task(
                 &state.pool,
                 cursor_id,
                 raw_path_fallback_root,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1086,7 +1192,7 @@ pub(crate) async fn run_startup_backfill_task(
                 &state.pool,
                 cursor_id,
                 raw_path_fallback_root,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1114,7 +1220,7 @@ pub(crate) async fn run_startup_backfill_task(
                 &state.pool,
                 cursor_id,
                 raw_path_fallback_root,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1140,7 +1246,7 @@ pub(crate) async fn run_startup_backfill_task(
                 &state.pool,
                 cursor_id,
                 raw_path_fallback_root,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1168,7 +1274,7 @@ pub(crate) async fn run_startup_backfill_task(
                 &state.pool,
                 cursor_id,
                 raw_path_fallback_root,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1189,7 +1295,7 @@ pub(crate) async fn run_startup_backfill_task(
             let outcome = backfill_pool_upstream_request_attempt_public_ids_from_cursor(
                 &state.pool,
                 cursor_id,
-                Some(STARTUP_BACKFILL_SCAN_LIMIT),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1252,11 +1358,7 @@ pub(crate) async fn run_startup_backfill_task(
         StartupBackfillTask::UpstreamActivityArchives => {
             let summary = backfill_upstream_account_last_activity_from_archives(
                 &state.pool,
-                Some(if source_unavailable_probe {
-                    100
-                } else {
-                    STARTUP_BACKFILL_SCAN_LIMIT
-                }),
+                Some(scan_limit),
                 max_elapsed,
             )
             .await?;
@@ -1282,16 +1384,13 @@ pub(crate) async fn run_startup_backfill_task(
         }
         StartupBackfillTask::PoolUpstreamNodeHealthArchives => {
             let _guard = state.hourly_rollup_sync_lock.lock().await;
-            let cache_summary = backfill_pool_upstream_node_health_archives(
-                &state.pool,
-                Some(1),
-                Some(Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)),
-            )
-            .await?;
+            let cache_summary =
+                backfill_pool_upstream_node_health_archives(&state.pool, Some(1), max_elapsed)
+                    .await?;
             let hourly_summary = backfill_pool_upstream_node_health_hourly_archives(
                 &state.pool,
                 Some(1),
-                Some(Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)),
+                max_elapsed,
             )
             .await?;
             Ok((
@@ -1315,11 +1414,7 @@ pub(crate) async fn run_startup_backfill_task(
             ))
         }
         StartupBackfillTask::HistoricalRollups => {
-            let historical_elapsed_budget = if source_unavailable_probe {
-                Duration::from_secs(2)
-            } else {
-                Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)
-            };
+            let historical_elapsed_budget = startup_backfill_run_budget(source_unavailable_probe);
             let before =
                 load_historical_rollup_backfill_snapshot(&state.pool, &state.config).await?;
             if before.pending_usage_breakdown_batches > 0 {
@@ -1634,6 +1729,54 @@ mod startup_backfill_tests {
         assert!(!startup_backfill_run_is_actionable(
             &StartupBackfillRunState::default()
         ));
+    }
+
+    #[test]
+    fn terminal_payload_input_wakes_only_missing_field_repairs() {
+        let mut record = crate::tests::test_proxy_capture_record(
+            "startup-backfill-terminal-wake",
+            "2026-08-09 12:00:00",
+        );
+        record.usage.total_tokens = None;
+        record.cost = None;
+        record.payload = Some("{}".to_string());
+        record.req_raw.path = Some("/tmp/request.raw".to_string());
+        record.resp_raw.path = Some("/tmp/response.raw".to_string());
+
+        let tasks =
+            startup_backfill_tasks_for_terminal(&api_invocation_from_runtime_record(&record));
+
+        assert_eq!(
+            tasks,
+            vec![
+                StartupBackfillTask::ProxyUsage,
+                StartupBackfillTask::PromptCacheKey,
+                StartupBackfillTask::RequestedServiceTier,
+                StartupBackfillTask::ReasoningEffort,
+                StartupBackfillTask::InvocationServiceTier,
+            ]
+        );
+
+        let complete =
+            api_invocation_from_runtime_record(&crate::tests::test_proxy_capture_record(
+                "startup-backfill-terminal-complete",
+                "2026-08-09 12:01:00",
+            ));
+        assert!(startup_backfill_tasks_for_terminal(&complete).is_empty());
+    }
+
+    #[test]
+    fn source_unavailable_probe_uses_one_shared_budget() {
+        assert_eq!(startup_backfill_scan_limit(true), 100);
+        assert_eq!(startup_backfill_run_budget(true), Duration::from_secs(2));
+        assert_eq!(
+            startup_backfill_scan_limit(false),
+            STARTUP_BACKFILL_SCAN_LIMIT
+        );
+        assert_eq!(
+            startup_backfill_run_budget(false),
+            Duration::from_secs(STARTUP_BACKFILL_RUN_BUDGET_SECS)
+        );
     }
 
     #[test]

--- a/src/proxy/raw_capture.rs
+++ b/src/proxy/raw_capture.rs
@@ -1017,6 +1017,7 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
     }
     let projection = register_terminal_projection_before_enqueue(state, &inserted_record).await;
     let delta = &projection.dashboard;
+    let startup_backfill_tasks = startup_backfill_tasks_for_terminal(&inserted_record);
     debug!(
         invoke_id = %invoke_id,
         terminal_delta_applied_selection_count = delta.applied_selection_count,
@@ -1034,6 +1035,7 @@ pub(crate) async fn persist_and_broadcast_proxy_capture(
                 raw_capture: true,
                 dashboard_terminal_sequence: delta.terminal_sequence,
                 terminal_projection_event_ids: projection.event_id.into_iter().collect(),
+                startup_backfill_tasks,
             });
     let terminal_enqueued = terminal_enqueue.enqueued;
     if !terminal_enqueued {

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -3549,6 +3549,7 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_terminal_record(
     }
     let projection = register_terminal_projection_before_enqueue(state, &persisted_record).await;
     let delta = &projection.dashboard;
+    let startup_backfill_tasks = startup_backfill_tasks_for_terminal(&persisted_record);
     debug!(
         invoke_id = %invoke_id,
         terminal_delta_applied_selection_count = delta.applied_selection_count,
@@ -3566,6 +3567,7 @@ pub(crate) async fn persist_and_broadcast_proxy_capture_terminal_record(
                 raw_capture: false,
                 dashboard_terminal_sequence: delta.terminal_sequence,
                 terminal_projection_event_ids: projection.event_id.into_iter().collect(),
+                startup_backfill_tasks,
             });
     let terminal_enqueued = terminal_enqueue.enqueued;
     if !terminal_enqueued {

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -495,6 +495,9 @@ pub(crate) struct BatchedTerminalInvocationWrite {
     pub(crate) raw_capture: bool,
     pub(crate) dashboard_terminal_sequence: Option<u64>,
     pub(crate) terminal_projection_event_ids: Vec<u64>,
+    // Computed from the already-materialized terminal record before P1 admission. This keeps
+    // event-driven repair discovery out of the SQLite transaction and avoids another payload parse.
+    pub(crate) startup_backfill_tasks: Vec<StartupBackfillTask>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -521,6 +524,11 @@ impl BatchedTerminalInvocationWrite {
                 self.terminal_projection_event_ids
                     .capacity()
                     .saturating_mul(std::mem::size_of::<u64>()),
+            )
+            .saturating_add(
+                self.startup_backfill_tasks
+                    .capacity()
+                    .saturating_mul(std::mem::size_of::<StartupBackfillTask>()),
             )
     }
 }
@@ -690,6 +698,11 @@ impl PendingBatch {
                             .extend(entry.get().terminal_projection_event_ids.iter().copied());
                         terminal.terminal_projection_event_ids.sort_unstable();
                         terminal.terminal_projection_event_ids.dedup();
+                        for task in entry.get().startup_backfill_tasks.iter().copied() {
+                            if !terminal.startup_backfill_tasks.contains(&task) {
+                                terminal.startup_backfill_tasks.push(task);
+                            }
+                        }
                         let new_bytes = terminal.estimated_memory_bytes();
                         entry.insert(terminal);
                         self.coalesced_rows += 1;
@@ -2328,6 +2341,7 @@ pub(crate) async fn flush_pending_batch_inner(
     let mut should_invalidate_prompt_cache_conversations = false;
     let _dashboard_reconcile_guard = dashboard_reconcile_gate.lock().await;
     let mut persisted_terminals = Vec::with_capacity(batch.terminal_invocations.len());
+    let mut startup_backfill_wake_tasks = Vec::new();
     if !batch.terminal_invocations.is_empty() {
         let mut terminal_tx = pool.begin().await?;
         for terminal in batch.terminal_invocations.values() {
@@ -2381,6 +2395,11 @@ pub(crate) async fn flush_pending_batch_inner(
     }
 
     for (terminal, invocation_id, occurred_at) in persisted_terminals {
+        for task in terminal.startup_backfill_tasks.iter().copied() {
+            if !startup_backfill_wake_tasks.contains(&task) {
+                startup_backfill_wake_tasks.push(task);
+            }
+        }
         let dashboard_cache = dashboard_activity_snapshot_cache
             .lock()
             .ok()
@@ -2435,6 +2454,26 @@ pub(crate) async fn flush_pending_batch_inner(
                 )),
             },
         ));
+    }
+
+    if !startup_backfill_wake_tasks.is_empty() {
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            if let Err(err) = wake_startup_backfill_tasks(
+                &pool,
+                &startup_backfill_wake_tasks,
+                "terminal_payload_repair_input",
+            )
+            .await
+            {
+                warn!(
+                    error = %err,
+                    task_count = startup_backfill_wake_tasks.len(),
+                    wake_reason = "terminal_payload_repair_input",
+                    "failed to wake startup backfill after terminal persistence"
+                );
+            }
+        });
     }
 
     if batch.attempt_progress.is_empty()
@@ -2824,6 +2863,7 @@ mod tests {
             raw_capture: false,
             dashboard_terminal_sequence,
             terminal_projection_event_ids: Vec::new(),
+            startup_backfill_tasks: Vec::new(),
         }
     }
 
@@ -2833,11 +2873,17 @@ mod tests {
         let accounting = PendingQueueAccounting::default();
         let mut first = terminal_write_for_coalescing("coalesced-terminal", Some(7));
         first.terminal_projection_event_ids.extend(0..64);
+        first
+            .startup_backfill_tasks
+            .push(StartupBackfillTask::ProxyUsage);
         let first = SqliteBatchWrite::TerminalInvocation(first);
         accounting.enqueue(first.estimated_memory_bytes());
         batch.push_accounted(first, &accounting);
         let mut second = terminal_write_for_coalescing("coalesced-terminal", None);
         second.terminal_projection_event_ids.extend(64..128);
+        second
+            .startup_backfill_tasks
+            .push(StartupBackfillTask::ReasoningEffort);
         let second = SqliteBatchWrite::TerminalInvocation(second);
         accounting.enqueue(second.estimated_memory_bytes());
         batch.push_accounted(second, &accounting);
@@ -2852,6 +2898,13 @@ mod tests {
             terminal.terminal_projection_event_ids,
             (0..128).collect::<Vec<_>>()
         );
+        assert_eq!(
+            terminal.startup_backfill_tasks,
+            vec![
+                StartupBackfillTask::ReasoningEffort,
+                StartupBackfillTask::ProxyUsage,
+            ]
+        );
         assert_eq!(batch.coalesced_rows, 1);
         assert_eq!(
             batch.estimated_memory_bytes(),
@@ -2862,6 +2915,48 @@ mod tests {
             batch.estimated_memory_bytes()
         );
         assert_eq!(accounting.snapshot().pending_depth, batch.logical_rows());
+    }
+
+    #[tokio::test]
+    async fn persisted_terminal_wakes_only_its_backfill_tasks_after_p1_commit() {
+        let pool = test_pool().await;
+        let task = StartupBackfillTask::ReasoningEffort;
+        let record = crate::tests::test_proxy_capture_record(
+            "batch-terminal-backfill-wake",
+            "2026-08-09 12:00:00",
+        );
+
+        SqliteBatchWriter::flush_for_test(
+            &pool,
+            vec![SqliteBatchWrite::TerminalInvocation(
+                BatchedTerminalInvocationWrite {
+                    capture_started: None,
+                    raw_capture: false,
+                    dashboard_terminal_sequence: None,
+                    terminal_projection_event_ids: Vec::new(),
+                    startup_backfill_tasks: vec![task],
+                    record,
+                },
+            )],
+        )
+        .await;
+
+        let wake_deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let progress = load_startup_backfill_progress(&pool, task.name())
+                .await
+                .expect("load terminal-woken backfill progress");
+            if progress.wake_generation > 0 {
+                assert!(progress.is_due(Utc::now()));
+                assert_eq!(progress.last_status, STARTUP_BACKFILL_STATUS_IDLE);
+                break;
+            }
+            assert!(
+                Instant::now() < wake_deadline,
+                "terminal P1 commit did not wake the matching startup backfill task"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     #[tokio::test]
@@ -3389,6 +3484,7 @@ mod tests {
                     raw_capture: false,
                     dashboard_terminal_sequence: None,
                     terminal_projection_event_ids: Vec::new(),
+                    startup_backfill_tasks: Vec::new(),
                     record,
                 },
             )],
@@ -3492,6 +3588,7 @@ mod tests {
                 raw_capture: false,
                 dashboard_terminal_sequence: None,
                 terminal_projection_event_ids: Vec::new(),
+                startup_backfill_tasks: Vec::new(),
                 record,
             },
         )));
@@ -3568,6 +3665,7 @@ mod tests {
             raw_capture: true,
             dashboard_terminal_sequence: None,
             terminal_projection_event_ids: Vec::new(),
+            startup_backfill_tasks: Vec::new(),
         }));
         let journal = Arc::new(std::sync::Mutex::new(Some(journal)));
         let mut pending = PendingBatch::default();
@@ -3638,6 +3736,7 @@ mod tests {
                 raw_capture: false,
                 dashboard_terminal_sequence: None,
                 terminal_projection_event_ids: Vec::new(),
+                startup_backfill_tasks: Vec::new(),
                 record,
             },
         )));

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::warn;
 
-use crate::{BatchedTerminalInvocationWrite, ProxyCaptureRecord};
+use crate::{
+    BatchedTerminalInvocationWrite, ProxyCaptureRecord, api_invocation_from_runtime_record,
+    startup_backfill_tasks_for_terminal,
+};
 
 pub(crate) const TERMINAL_JOURNAL_SEGMENT_BYTES: u64 = 16 * 1024 * 1024;
 pub(crate) const TERMINAL_JOURNAL_MAX_BYTES: u64 = 512 * 1024 * 1024;
@@ -408,14 +411,21 @@ impl TerminalJournal {
         let replay = std::mem::take(&mut self.replay);
         replay
             .into_iter()
-            .map(|entry| BatchedTerminalInvocationWrite {
-                record: entry.record,
-                capture_started: entry.capture_elapsed_ms.and_then(|elapsed_ms| {
-                    Instant::now().checked_sub(Duration::from_millis(elapsed_ms))
-                }),
-                raw_capture: entry.raw_capture,
-                dashboard_terminal_sequence: None,
-                terminal_projection_event_ids: Vec::new(),
+            .map(|entry| {
+                let record = entry.record;
+                let startup_backfill_tasks = startup_backfill_tasks_for_terminal(
+                    &api_invocation_from_runtime_record(&record),
+                );
+                BatchedTerminalInvocationWrite {
+                    record,
+                    capture_started: entry.capture_elapsed_ms.and_then(|elapsed_ms| {
+                        Instant::now().checked_sub(Duration::from_millis(elapsed_ms))
+                    }),
+                    raw_capture: entry.raw_capture,
+                    dashboard_terminal_sequence: None,
+                    terminal_projection_event_ids: Vec::new(),
+                    startup_backfill_tasks,
+                }
             })
             .collect()
     }

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1119,6 +1119,112 @@ async fn startup_backfill_not_due_check_does_not_claim_background_gate() {
 }
 
 #[tokio::test]
+async fn startup_backfill_idle_pass_does_not_create_a_system_task_run() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count startup backfill task runs before idle pass");
+
+    let cancel = CancellationToken::new();
+    let outcome = run_startup_backfill_maintenance_pass(state.clone(), &cancel, None).await;
+
+    let after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count startup backfill task runs after idle pass");
+    assert!(!outcome.ran_actionable_task);
+    assert!(!outcome.had_failure);
+    assert_eq!(
+        after, before,
+        "idle maintenance must not create task-run audit rows"
+    );
+}
+
+#[tokio::test]
+async fn startup_backfill_event_wakes_only_the_matching_task() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let archive_task = StartupBackfillTask::UpstreamActivityArchives;
+    let historical_task = StartupBackfillTask::HistoricalRollups;
+    let suspended_until = format_utc_iso(Utc::now() + ChronoDuration::days(1));
+
+    for task in [archive_task, historical_task] {
+        save_startup_backfill_progress(
+            &state.pool,
+            task.name(),
+            StartupBackfillProgressUpdate {
+                cursor_id: 7,
+                scanned: 100,
+                updated: 0,
+                zero_update_streak: 4,
+                next_run_after: &suspended_until,
+                status: STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE,
+                suspension_reason: Some("source_unavailable"),
+            },
+        )
+        .await
+        .expect("seed source-unavailable startup backfill progress");
+    }
+
+    wake_startup_backfill_tasks(&state.pool, &[archive_task], "test_archive_available")
+        .await
+        .expect("wake affected archive task");
+
+    let archive_progress = load_startup_backfill_progress(&state.pool, archive_task.name())
+        .await
+        .expect("load woken archive progress");
+    assert!(archive_progress.is_due(Utc::now()));
+    assert_eq!(archive_progress.last_status, STARTUP_BACKFILL_STATUS_IDLE);
+    assert_eq!(archive_progress.suspension_reason, None);
+    assert_eq!(archive_progress.next_probe_at, None);
+    assert_eq!(archive_progress.wake_generation, 1);
+
+    let historical_progress = load_startup_backfill_progress(&state.pool, historical_task.name())
+        .await
+        .expect("load unaffected historical progress");
+    assert!(!historical_progress.is_due(Utc::now()));
+    assert_eq!(
+        historical_progress.last_status,
+        STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn startup_backfill_pressure_defer_persists_a_retry_deadline() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::ReasoningEffort;
+    let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
+    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(1));
+    let _held = gate
+        .try_begin_background("test_pressure")
+        .expect("hold background slot");
+
+    let ran = run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+        .await
+        .expect("defer startup backfill when the gate is busy");
+    assert!(!ran);
+
+    let progress = load_startup_backfill_progress(&state.pool, &task_name)
+        .await
+        .expect("load pressure-deferred progress");
+    assert!(!progress.is_due(Utc::now()));
+    assert_eq!(progress.last_status, STARTUP_BACKFILL_STATUS_IDLE);
+}
+
+#[tokio::test]
 async fn failure_classification_backfill_skips_success_rows_with_complete_defaults() {
     let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
         .await

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1225,6 +1225,66 @@ async fn startup_backfill_pressure_defer_persists_a_retry_deadline() {
 }
 
 #[tokio::test]
+async fn coverage_repair_defer_persists_the_historical_retry_deadline() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::HistoricalRollups;
+
+    defer_startup_backfill_task(
+        state.as_ref(),
+        task,
+        Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS),
+        "test_coverage_repair_retry",
+    )
+    .await
+    .expect("schedule the coverage repair retry");
+
+    let progress = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load coverage retry progress");
+    let retry_at = progress
+        .next_run_after
+        .as_deref()
+        .and_then(parse_to_utc_datetime)
+        .expect("coverage retry deadline");
+    assert!(retry_at > Utc::now());
+    assert!(retry_at <= Utc::now() + ChronoDuration::seconds(30));
+    assert!(!progress.is_due(Utc::now()));
+}
+
+#[tokio::test]
+async fn live_activity_v2_coverage_progress_wakes_historical_rollups() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::HistoricalRollups;
+
+    wake_historical_rollups_for_live_activity_v2_coverage(&state.pool, 0)
+        .await
+        .expect("skip an unchanged live v2 coverage cursor");
+    assert_eq!(
+        load_startup_backfill_progress(&state.pool, task.name())
+            .await
+            .expect("load unchanged coverage progress")
+            .wake_generation,
+        0
+    );
+
+    wake_historical_rollups_for_live_activity_v2_coverage(&state.pool, 1)
+        .await
+        .expect("wake after live v2 coverage cursor progress");
+
+    let progress = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load coverage-woken startup backfill progress");
+    assert!(progress.wake_generation > 0);
+    assert!(progress.is_due(Utc::now()));
+}
+
+#[tokio::test]
 async fn failure_classification_backfill_skips_success_rows_with_complete_defaults() {
     let pool = SqlitePool::connect("sqlite::memory:?cache=shared")
         .await


### PR DESCRIPTION
## Summary
- Replace idle startup-backfill polling with persisted due dates and matching event wakes.
- Wake targeted repair tasks after durable terminal persistence and live account-activity v2 coverage progress.
- Persist a bounded retry deadline when active coverage repair is deferred or fails.
- Apply the shared 100-row / 2-second source-unavailable probe budget to all backfill branches.

Closes #765

## Validation
- cargo fmt --check
- cargo check -q
- cargo test -q startup_backfill
- cargo test -q sqlite_batch_writer
- cargo test -q coverage_repair_defer
- cargo test -q persisted_terminal_wakes_only_its_backfill_tasks_after_p1_commit
- cargo test -q startup_backfill_idle_pass_does_not_create_a_system_task_run
- cargo test -q startup_backfill_pressure_defer_persists_a_retry_deadline
- cargo test -q archive_backfill_and_materialization (70-test target completed; long-session output was not returned by the host)
- native pre-commit hook: Rust check, rustfmt, web typecheck
- native commit-msg hook: commitlint

## Contract Review
- Public HTTP/SSE contracts unchanged.
- Terminal wake is computed from the already-materialized record and scheduled only after the P1 transaction commits.
- Journal replay derives the same compact task set without changing journal wire data.
- Coverage wake is emitted only when the v2 live cursor advances; coverage defer/failure persists a retry deadline.
- Source-unavailable probes share the 100-row / 2-second budget.

Head: d8415427344ef7dc0960c859d6b3f1cdc3f13b01
Signed commit verified by GPG.