### PR TITLE
fix(sse): defer prompt-cache runtime hydration

### DIFF
--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -2136,23 +2136,27 @@ impl SubscriptionHub {
 
         let (cached, dispatch) = {
             let mut guard = self.state.lock().await;
-            if require_active_owner
-                && (guard
+            if require_active_owner {
+                let active = guard
                     .active_subscribers
                     .get(&topic_key)
                     .copied()
                     .unwrap_or_default()
-                    == 0
-                    || guard.topics.get(&topic_key).is_none_or(|cached| {
-                        Some(cached.runtime_topic_recovery_generation) != refresh_generation
-                    }))
-            {
-                if let Some(cached) = guard.topics.get_mut(&topic_key) {
-                    cached.dirty = true;
-                    cached.refresh_scheduled = false;
-                    cached.latest_live_snapshot = None;
+                    > 0;
+                let generation_matches = guard.topics.get(&topic_key).is_some_and(|cached| {
+                    Some(cached.runtime_topic_recovery_generation) == refresh_generation
+                });
+                if !active || !generation_matches {
+                    // A newer gap or owner generation owns the cache now. Only the owner that
+                    // observed this generation may dirty it; never invalidate a newer clean
+                    // frame committed by a reconnecting subscriber.
+                    if !active && let Some(cached) = guard.topics.get_mut(&topic_key) {
+                        cached.dirty = true;
+                        cached.refresh_scheduled = false;
+                        cached.latest_live_snapshot = None;
+                    }
+                    return Ok(None);
                 }
-                return Ok(None);
             }
             if let BuiltSubscriptionTopicPayload::Json(payload) = &mut built_payload
                 && let Some(live) = guard

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -38,6 +38,7 @@ const PROMPT_CACHE_TOPIC_REFRESH_DEBOUNCE: Duration = Duration::from_millis(500)
 const PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
 const RUNTIME_TOPIC_RECOVERY_QUEUE_CAPACITY: usize = 64;
 const RUNTIME_TOPIC_RECOVERY_BATCH_SIZE: usize = 8;
+const RUNTIME_TOPIC_RECOVERY_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 #[cfg(test)]
 const DASHBOARD_RUNTIME_TOPOLOGY_CONTRACT_REASON: &str = "dashboard-runtime-topology-contract";
 #[cfg(not(test))]
@@ -421,6 +422,7 @@ struct CachedSubscriptionTopic {
     conversation_overview_refresh_pending: bool,
     dirty: bool,
     runtime_topic_recovery_generation: u64,
+    runtime_topic_recovery_retry_at: Option<Instant>,
     summary_refresh_scheduled: bool,
     summary_refresh_in_flight: bool,
     summary_pending_event_count: u64,
@@ -2104,9 +2106,17 @@ impl SubscriptionHub {
         // the cache generation before building so an old result can never clear newer dirty
         // state or replace the retained last-good frame.
         let refresh_generation = if require_active_owner {
-            self.state
-                .lock()
-                .await
+            let guard = self.state.lock().await;
+            if guard
+                .active_subscribers
+                .get(&topic_key)
+                .copied()
+                .unwrap_or_default()
+                == 0
+            {
+                return Ok(None);
+            }
+            guard
                 .topics
                 .get(&topic_key)
                 .map(|cached| cached.runtime_topic_recovery_generation)
@@ -2203,6 +2213,7 @@ impl SubscriptionHub {
                 {
                     existing.dirty = false;
                     existing.refresh_scheduled = false;
+                    existing.runtime_topic_recovery_retry_at = None;
                     existing.snapshot_built_at = Instant::now();
                     existing.dashboard_materializer = refreshed_dashboard_materializer.clone();
                     existing.dashboard_base_revision = existing.cursor;
@@ -2285,6 +2296,7 @@ impl SubscriptionHub {
                     .map_or(guard.runtime_topic_recovery_generation, |entry| {
                         entry.runtime_topic_recovery_generation
                     }),
+                runtime_topic_recovery_retry_at: None,
                 summary_refresh_scheduled: guard
                     .topics
                     .get(&topic_key)
@@ -2782,7 +2794,11 @@ impl SubscriptionHub {
             let Some(cached) = guard.topics.get(&topic_key) else {
                 continue;
             };
-            if !cached.dirty {
+            if !cached.dirty
+                || cached
+                    .runtime_topic_recovery_retry_at
+                    .is_some_and(|retry_at| retry_at > Instant::now())
+            {
                 continue;
             }
             if matches!(
@@ -2848,11 +2864,13 @@ impl SubscriptionHub {
             if topics.is_empty() {
                 return;
             }
+            let mut retry_delay = None;
             for topic in topics {
                 if let Err(err) = self
                     .refresh_topic_if_active(state.clone(), topic.clone(), true)
                     .await
                 {
+                    retry_delay = Some(self.defer_runtime_topic_recovery_retry(&topic).await);
                     warn!(
                         ?err,
                         topic = %topic.name(),
@@ -2861,8 +2879,23 @@ impl SubscriptionHub {
                     );
                 }
             }
-            tokio::task::yield_now().await;
+            if let Some(delay) = retry_delay {
+                tokio::time::sleep(delay).await;
+            } else {
+                tokio::task::yield_now().await;
+            }
         }
+    }
+
+    async fn defer_runtime_topic_recovery_retry(&self, topic: &SubscriptionTopic) -> Duration {
+        let Ok(topic_key) = topic.cache_key() else {
+            return RUNTIME_TOPIC_RECOVERY_RETRY_BACKOFF;
+        };
+        if let Some(cached) = self.state.lock().await.topics.get_mut(&topic_key) {
+            cached.runtime_topic_recovery_retry_at =
+                Some(Instant::now() + RUNTIME_TOPIC_RECOVERY_RETRY_BACKOFF);
+        }
+        RUNTIME_TOPIC_RECOVERY_RETRY_BACKOFF
     }
 
     pub(crate) async fn handle_internal_broadcast(
@@ -6920,6 +6953,7 @@ fn reuse_unchanged_cached_topic(
     }
     existing.dirty = false;
     existing.refresh_scheduled = false;
+    existing.runtime_topic_recovery_retry_at = None;
     // A successful Prompt Cache baseline can serialize identically to last-good. It still
     // proves reconciliation completed, so do not keep scheduling the same cold hydration.
     existing.prompt_cache_reconcile_required = false;
@@ -7494,6 +7528,68 @@ mod tests {
             2
         );
         guard.runtime_topic_recovery_running = false;
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn inactive_owner_skips_cold_prompt_cache_hydration() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+
+        state.pool.close().await;
+
+        assert!(
+            hub.refresh_topic_if_active(state, topic, true)
+                .await
+                .expect("inactive guard must return before acquiring the closed database pool")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_recovery_retry_cooldown_defers_dirty_topic_requeue() {
+        let hub = Arc::new(SubscriptionHub::new());
+        let topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("selected-key".to_string()),
+        };
+        let topic_key = topic.cache_key().expect("history topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            let mut cached = seeded_cached_topic(topic.clone(), &[7], Utc::now());
+            cached.dirty = true;
+            guard.topics.insert(topic_key.clone(), cached);
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register history owner");
+
+        assert_eq!(
+            hub.defer_runtime_topic_recovery_retry(&topic).await,
+            RUNTIME_TOPIC_RECOVERY_RETRY_BACKOFF
+        );
+
+        let mut guard = hub.state.lock().await;
+        assert!(
+            guard
+                .topics
+                .get(&topic_key)
+                .and_then(|cached| cached.runtime_topic_recovery_retry_at)
+                .is_some_and(|retry_at| retry_at > Instant::now())
+        );
+        assert!(!SubscriptionHub::enqueue_runtime_topic_recovery_locked(
+            &mut guard
+        ));
+        assert!(guard.runtime_topic_recovery_queue.is_empty());
         drop(guard);
         drop(lease);
     }
@@ -9770,6 +9866,7 @@ mod tests {
             conversation_overview_refresh_pending: false,
             dirty: false,
             runtime_topic_recovery_generation: 0,
+            runtime_topic_recovery_retry_at: None,
             summary_refresh_scheduled: false,
             summary_refresh_in_flight: false,
             summary_pending_event_count: 0,

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -1720,6 +1720,7 @@ impl SubscriptionHub {
                         // every runtime event.
                         cached.dirty = true;
                         cached.runtime_topic_recovery_generation = recovery_generation;
+                        cached.runtime_topic_recovery_retry_at = None;
                         cached.refresh_scheduled = false;
                         cached.latest_live_snapshot = None;
                         if matches!(
@@ -2006,12 +2007,38 @@ impl SubscriptionHub {
         topic: SubscriptionTopic,
     ) -> Result<CachedSubscriptionTopic, ApiError> {
         let topic_key = topic.cache_key()?;
-        if let Some(existing) = self.state.lock().await.topics.get(&topic_key).cloned()
-            && (existing.dirty
-                || (!topic.is_closed_summary_topic()
-                    || existing.calendar_anchor == subscription_calendar_anchor(&topic)))
+        let (existing, has_active_owner) = {
+            let guard = self.state.lock().await;
+            (
+                guard.topics.get(&topic_key).cloned(),
+                guard
+                    .active_subscribers
+                    .get(&topic_key)
+                    .copied()
+                    .unwrap_or_default()
+                    > 0,
+            )
+        };
+        if let Some(existing) = existing
+            && ((has_active_owner
+                && existing.dirty
+                && !existing
+                    .dashboard_materializer
+                    .as_ref()
+                    .is_some_and(DashboardTopicMaterializer::requires_terminal_window_rebase))
+                || (!existing.dirty
+                    && (!topic.is_closed_summary_topic()
+                        || existing.calendar_anchor == subscription_calendar_anchor(&topic))))
         {
             return Ok(existing);
+        }
+        if !has_active_owner {
+            #[cfg(test)]
+            return self.refresh_topic(state, topic, false).await;
+            #[cfg(not(test))]
+            return Err(ApiError::from(anyhow!(
+                "subscription topic setup requires an active owner"
+            )));
         }
         for _ in 0..SUBSCRIPTION_INITIAL_TOPIC_BUILD_ATTEMPTS {
             if let Some(cached) = self
@@ -2772,6 +2799,7 @@ impl SubscriptionHub {
                 cached.latest_live_snapshot = None;
                 cached.continuity_reset_cursor = Some(cached.cursor);
                 cached.runtime_topic_recovery_generation = recovery_generation;
+                cached.runtime_topic_recovery_retry_at = None;
                 if matches!(
                     cached.topic,
                     SubscriptionTopic::PromptCacheWindow { .. }
@@ -3317,6 +3345,56 @@ impl SubscriptionHub {
         false
     }
 
+    async fn prompt_cache_topic_reconcile_delay(
+        &self,
+        topic: &SubscriptionTopic,
+    ) -> Option<Duration> {
+        let topic_key = topic.cache_key().ok()?;
+        let guard = self.state.lock().await;
+        let active = guard
+            .active_subscribers
+            .get(&topic_key)
+            .copied()
+            .unwrap_or_default()
+            > 0;
+        let cached = guard.topics.get(&topic_key)?;
+        if !active || (!cached.dirty && !cached.prompt_cache_reconcile_required) {
+            return None;
+        }
+        Some(
+            cached
+                .prompt_cache_baseline_at
+                .map(|baseline_at| {
+                    PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL.saturating_sub(baseline_at.elapsed())
+                })
+                .unwrap_or_default(),
+        )
+    }
+
+    async fn begin_prompt_cache_topic_reconcile(&self, topic: &SubscriptionTopic) -> bool {
+        let Ok(topic_key) = topic.cache_key() else {
+            return false;
+        };
+        let mut guard = self.state.lock().await;
+        let active = guard
+            .active_subscribers
+            .get(&topic_key)
+            .copied()
+            .unwrap_or_default()
+            > 0;
+        let Some(cached) = guard.topics.get_mut(&topic_key) else {
+            return false;
+        };
+        if !active
+            || cached.prompt_cache_reconcile_scheduled
+            || (!cached.dirty && !cached.prompt_cache_reconcile_required)
+        {
+            return false;
+        }
+        cached.prompt_cache_reconcile_scheduled = true;
+        true
+    }
+
     async fn begin_conversation_overview_topic_refresh(&self, topic: &SubscriptionTopic) -> bool {
         let Ok(topic_key) = topic.cache_key() else {
             return false;
@@ -3579,10 +3657,36 @@ impl SubscriptionHub {
     fn spawn_prompt_cache_topic_reconcile(state: Arc<AppState>, topic: SubscriptionTopic) {
         let hub = state.subscription_hub.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(PROMPT_CACHE_TOPIC_REFRESH_DEBOUNCE).await;
-            let result = hub
-                .refresh_topic_if_active(state.clone(), topic.clone(), true)
-                .await;
+            let Some(delay) = hub.prompt_cache_topic_reconcile_delay(&topic).await else {
+                hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                return;
+            };
+            tokio::time::sleep(delay).await;
+            let Ok(topic_key) = topic.cache_key() else {
+                hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                return;
+            };
+            if !hub.has_active_topic_key(&topic_key).await {
+                hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                return;
+            }
+            let result = match crate::db_pressure::global_db_pressure_gate()
+                .try_begin_background("prompt_cache_topic_reconcile")
+            {
+                Ok(_permit) => {
+                    hub.refresh_topic_if_active(state.clone(), topic.clone(), true)
+                        .await
+                }
+                Err(reason) => {
+                    tracing::debug!(
+                        topic = %topic.name(),
+                        reconcile_outcome = "pressure_deferred",
+                        defer_reason = %reason,
+                        "prompt cache topic reconcile deferred"
+                    );
+                    Ok(None)
+                }
+            };
             hub.finish_prompt_cache_topic_reconcile(&topic).await;
             if let Err(err) = result {
                 warn!(
@@ -5630,23 +5734,29 @@ async fn run_server_push_topic_loop(
                     if !hub.prompt_cache_reconcile_required(&topic_key).await {
                         continue;
                     }
-                    match crate::db_pressure::global_db_pressure_gate()
+                    if !hub.begin_prompt_cache_topic_reconcile(&topic).await {
+                        continue;
+                    }
+                    let result = match crate::db_pressure::global_db_pressure_gate()
                         .try_begin_background("prompt_cache_topic_reconcile")
                     {
                         Ok(_permit) => {
-                            if let Err(err) = hub
-                                .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                            hub.refresh_topic_if_active(state.clone(), topic.clone(), true)
                                 .await
-                            {
-                                warn!(?err, topic = %topic.name(), reconcile_outcome = "retained_last_good", "prompt cache topic reconcile failed");
-                            }
                         }
-                        Err(reason) => tracing::debug!(
-                            topic = %topic.name(),
-                            reconcile_outcome = "pressure_deferred",
-                            defer_reason = %reason,
-                            "prompt cache topic reconcile deferred"
-                        ),
+                        Err(reason) => {
+                            tracing::debug!(
+                                topic = %topic.name(),
+                                reconcile_outcome = "pressure_deferred",
+                                defer_reason = %reason,
+                                "prompt cache topic reconcile deferred"
+                            );
+                            Ok(None)
+                        }
+                    };
+                    hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                    if let Err(err) = result {
+                        warn!(?err, topic = %topic.name(), reconcile_outcome = "retained_last_good", "prompt cache topic reconcile failed");
                     }
                 }
             }
@@ -7834,6 +7944,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn newer_runtime_gap_clears_topic_recovery_cooldown() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("selected-key".to_string()),
+        };
+        let topic_key = topic.cache_key().expect("history topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            let mut cached = seeded_cached_topic(topic.clone(), &[7], Utc::now());
+            cached.dirty = true;
+            cached.runtime_topic_recovery_retry_at =
+                Some(Instant::now() + RUNTIME_TOPIC_RECOVERY_RETRY_BACKOFF);
+            guard.topics.insert(topic_key.clone(), cached);
+            guard.runtime_topic_recovery_running = true;
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register history owner");
+
+        hub.mark_runtime_mutation_gap_and_recover(state, 1, "cursor_gap")
+            .await;
+
+        let guard = hub.state.lock().await;
+        assert!(
+            guard
+                .topics
+                .get(&topic_key)
+                .expect("dirty history topic")
+                .runtime_topic_recovery_retry_at
+                .is_none()
+        );
+        assert_eq!(guard.runtime_topic_recovery_queue.len(), 1);
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
     async fn dirty_topics_do_not_bypass_bounded_gap_recovery() {
         let hub = Arc::new(SubscriptionHub::new());
         let topic = SubscriptionTopic::InvocationHistoryWindow {
@@ -7918,6 +8070,36 @@ mod tests {
         assert_eq!(cached.cursor, 7);
         assert!(Arc::ptr_eq(&cached.snapshot_frame, &last_good_frame));
         drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn dirty_prompt_cache_reconcile_respects_baseline_cadence() {
+        let hub = Arc::new(SubscriptionHub::new());
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let topic_key = topic.cache_key().expect("prompt cache topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            let mut cached = seeded_cached_topic(topic.clone(), &[7], Utc::now());
+            cached.dirty = true;
+            cached.prompt_cache_reconcile_required = true;
+            cached.prompt_cache_baseline_at = Some(Instant::now());
+            guard.topics.insert(topic_key, cached);
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register prompt cache owner");
+
+        assert!(
+            hub.prompt_cache_topic_reconcile_delay(&topic)
+                .await
+                .is_some_and(|delay| delay > Duration::from_secs(59))
+        );
         drop(lease);
     }
 

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::db_pressure::{DbPressureDenyReason, DbPressureGate};
 use axum::http::header;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -3657,45 +3658,65 @@ impl SubscriptionHub {
     fn spawn_prompt_cache_topic_reconcile(state: Arc<AppState>, topic: SubscriptionTopic) {
         let hub = state.subscription_hub.clone();
         tokio::spawn(async move {
-            let Some(delay) = hub.prompt_cache_topic_reconcile_delay(&topic).await else {
-                hub.finish_prompt_cache_topic_reconcile(&topic).await;
-                return;
-            };
-            tokio::time::sleep(delay).await;
-            let Ok(topic_key) = topic.cache_key() else {
-                hub.finish_prompt_cache_topic_reconcile(&topic).await;
-                return;
-            };
-            if !hub.has_active_topic_key(&topic_key).await {
-                hub.finish_prompt_cache_topic_reconcile(&topic).await;
-                return;
-            }
-            let result = match crate::db_pressure::global_db_pressure_gate()
-                .try_begin_background("prompt_cache_topic_reconcile")
-            {
-                Ok(_permit) => {
-                    hub.refresh_topic_if_active(state.clone(), topic.clone(), true)
-                        .await
+            loop {
+                let Some(delay) = hub.prompt_cache_topic_reconcile_delay(&topic).await else {
+                    hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                    return;
+                };
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = state.shutdown.cancelled() => {
+                        hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                        return;
+                    }
                 }
-                Err(reason) => {
-                    tracing::debug!(
-                        topic = %topic.name(),
-                        reconcile_outcome = "pressure_deferred",
-                        defer_reason = %reason,
-                        "prompt cache topic reconcile deferred"
-                    );
-                    Ok(None)
+                let Ok(topic_key) = topic.cache_key() else {
+                    hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                    return;
+                };
+                if !hub.has_active_topic_key(&topic_key).await {
+                    hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                    return;
                 }
-            };
-            hub.finish_prompt_cache_topic_reconcile(&topic).await;
-            if let Err(err) = result {
-                warn!(
-                    ?err,
-                    topic = topic.name(),
-                    response_source = "last_good",
-                    "bounded prompt cache topic reconcile failed"
-                );
-                hub.mark_topic_dirty(&topic).await;
+                let gate = crate::db_pressure::global_db_pressure_gate();
+                let observed_eligibility = gate.eligibility_generation();
+                match gate.try_begin_background("prompt_cache_topic_reconcile") {
+                    Ok(_permit) => {
+                        let result = hub
+                            .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                            .await;
+                        hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                        if let Err(err) = result {
+                            warn!(
+                                ?err,
+                                topic = topic.name(),
+                                response_source = "last_good",
+                                "bounded prompt cache topic reconcile failed"
+                            );
+                            hub.mark_topic_dirty(&topic).await;
+                        }
+                        return;
+                    }
+                    Err(reason) => {
+                        tracing::debug!(
+                            topic = %topic.name(),
+                            reconcile_outcome = "pressure_deferred",
+                            defer_reason = %reason,
+                            "prompt cache topic reconcile deferred"
+                        );
+                        tokio::select! {
+                            _ = wait_for_prompt_cache_reconcile_eligibility(
+                                gate,
+                                observed_eligibility,
+                                reason,
+                            ) => {}
+                            _ = state.shutdown.cancelled() => {
+                                hub.finish_prompt_cache_topic_reconcile(&topic).await;
+                                return;
+                            }
+                        }
+                    }
+                }
             }
         });
     }
@@ -5704,6 +5725,24 @@ fn dashboard_network_timeseries_live_point<'a>(
         .map(|point_index| (point_index, bucket))
 }
 
+async fn wait_for_prompt_cache_reconcile_eligibility(
+    gate: &DbPressureGate,
+    observed_eligibility: u64,
+    reason: DbPressureDenyReason,
+) {
+    match reason {
+        DbPressureDenyReason::PressureCooldown { remaining_ms } => {
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_millis(remaining_ms.max(1))) => {}
+                _ = gate.wait_for_eligibility_change(observed_eligibility) => {}
+            }
+        }
+        DbPressureDenyReason::BackgroundBusy => {
+            gate.wait_for_eligibility_change(observed_eligibility).await;
+        }
+    }
+}
+
 async fn run_server_push_topic_loop(
     hub: Arc<SubscriptionHub>,
     state: Arc<AppState>,
@@ -5737,27 +5776,7 @@ async fn run_server_push_topic_loop(
                     if !hub.begin_prompt_cache_topic_reconcile(&topic).await {
                         continue;
                     }
-                    let result = match crate::db_pressure::global_db_pressure_gate()
-                        .try_begin_background("prompt_cache_topic_reconcile")
-                    {
-                        Ok(_permit) => {
-                            hub.refresh_topic_if_active(state.clone(), topic.clone(), true)
-                                .await
-                        }
-                        Err(reason) => {
-                            tracing::debug!(
-                                topic = %topic.name(),
-                                reconcile_outcome = "pressure_deferred",
-                                defer_reason = %reason,
-                                "prompt cache topic reconcile deferred"
-                            );
-                            Ok(None)
-                        }
-                    };
-                    hub.finish_prompt_cache_topic_reconcile(&topic).await;
-                    if let Err(err) = result {
-                        warn!(?err, topic = %topic.name(), reconcile_outcome = "retained_last_good", "prompt cache topic reconcile failed");
-                    }
+                    SubscriptionHub::spawn_prompt_cache_topic_reconcile(state.clone(), topic.clone());
                 }
             }
         }
@@ -8101,6 +8120,27 @@ mod tests {
                 .is_some_and(|delay| delay > Duration::from_secs(59))
         );
         drop(lease);
+    }
+
+    #[tokio::test]
+    async fn prompt_cache_pressure_defer_wakes_on_eligibility_change() {
+        let gate = DbPressureGate::new(1, Duration::from_millis(10));
+        let permit = gate
+            .try_begin_background("prompt_cache_topic_reconcile")
+            .expect("occupy only background slot");
+        let observed_eligibility = gate.eligibility_generation();
+        let reason = gate
+            .try_begin_background("prompt_cache_topic_reconcile")
+            .expect_err("second background task is deferred");
+
+        drop(permit);
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            wait_for_prompt_cache_reconcile_eligibility(&gate, observed_eligibility, reason),
+        )
+        .await
+        .expect("eligible background slot wakes deferred prompt cache recovery");
     }
 
     #[tokio::test]

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -39,6 +39,7 @@ const PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
 const RUNTIME_TOPIC_RECOVERY_QUEUE_CAPACITY: usize = 64;
 const RUNTIME_TOPIC_RECOVERY_BATCH_SIZE: usize = 8;
 const RUNTIME_TOPIC_RECOVERY_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+const SUBSCRIPTION_INITIAL_TOPIC_BUILD_ATTEMPTS: usize = 3;
 #[cfg(test)]
 const DASHBOARD_RUNTIME_TOPOLOGY_CONTRACT_REASON: &str = "dashboard-runtime-topology-contract";
 #[cfg(not(test))]
@@ -1923,6 +1924,10 @@ impl SubscriptionHub {
                     });
                 }
             }
+            if cached.dirty {
+                self.schedule_dirty_topic_recovery(state.clone(), topic.clone())
+                    .await;
+            }
         }
 
         Ok(PreparedSubscriptionConnection {
@@ -1999,13 +2004,26 @@ impl SubscriptionHub {
     ) -> Result<CachedSubscriptionTopic, ApiError> {
         let topic_key = topic.cache_key()?;
         if let Some(existing) = self.state.lock().await.topics.get(&topic_key).cloned()
-            && !existing.dirty
-            && (!topic.is_closed_summary_topic()
-                || existing.calendar_anchor == subscription_calendar_anchor(&topic))
+            && (existing.dirty
+                || (!topic.is_closed_summary_topic()
+                    || existing.calendar_anchor == subscription_calendar_anchor(&topic)))
         {
             return Ok(existing);
         }
-        self.refresh_topic(state, topic, false).await
+        for _ in 0..SUBSCRIPTION_INITIAL_TOPIC_BUILD_ATTEMPTS {
+            if let Some(cached) = self
+                .refresh_topic_if_active(state.clone(), topic.clone(), false)
+                .await?
+            {
+                return Ok(cached);
+            }
+            if let Some(existing) = self.state.lock().await.topics.get(&topic_key).cloned() {
+                return Ok(existing);
+            }
+        }
+        Err(ApiError::from(anyhow!(
+            "subscription topic changed before its bounded initial snapshot was ready"
+        )))
     }
 
     async fn refresh_topic(
@@ -2773,6 +2791,66 @@ impl SubscriptionHub {
         }
     }
 
+    async fn schedule_dirty_topic_recovery(&self, state: Arc<AppState>, topic: SubscriptionTopic) {
+        if matches!(
+            &topic,
+            SubscriptionTopic::PromptCacheWindow { .. }
+                | SubscriptionTopic::PromptCacheStickyWindow { .. }
+        ) {
+            if self
+                .mark_prompt_cache_topic_dirty_and_schedule_reconcile(&topic)
+                .await
+            {
+                Self::spawn_prompt_cache_topic_reconcile(state, topic);
+            }
+            return;
+        }
+
+        let recovery_scheduled = {
+            let mut guard = self.state.lock().await;
+            Self::enqueue_runtime_topic_recovery_locked(&mut guard)
+        };
+        if recovery_scheduled {
+            let hub = state.subscription_hub.clone();
+            tokio::spawn(async move {
+                hub.run_runtime_topic_recovery(state).await;
+            });
+        }
+    }
+
+    fn next_runtime_topic_recovery_retry_delay_locked(
+        guard: &SubscriptionHubState,
+    ) -> Option<Duration> {
+        let now = Instant::now();
+        guard
+            .active_topics
+            .iter()
+            .filter_map(|(topic_key, topic)| {
+                if guard
+                    .active_subscribers
+                    .get(topic_key)
+                    .copied()
+                    .unwrap_or_default()
+                    == 0
+                    || matches!(
+                        topic,
+                        SubscriptionTopic::PromptCacheWindow { .. }
+                            | SubscriptionTopic::PromptCacheStickyWindow { .. }
+                    )
+                {
+                    return None;
+                }
+                guard.topics.get(topic_key).and_then(|cached| {
+                    cached
+                        .dirty
+                        .then_some(cached.runtime_topic_recovery_retry_at)?
+                })
+            })
+            .filter(|retry_at| *retry_at > now)
+            .map(|retry_at| retry_at.duration_since(now))
+            .min()
+    }
+
     fn enqueue_runtime_topic_recovery_locked(guard: &mut SubscriptionHubState) -> bool {
         let active_topic_keys = guard
             .active_topics
@@ -2828,7 +2906,7 @@ impl SubscriptionHub {
 
     async fn run_runtime_topic_recovery(self: Arc<Self>, state: Arc<AppState>) {
         loop {
-            let topics = {
+            let (topics, retry_delay) = {
                 let mut guard = self.state.lock().await;
                 let mut topics = Vec::with_capacity(RUNTIME_TOPIC_RECOVERY_BATCH_SIZE);
                 while topics.len() < RUNTIME_TOPIC_RECOVERY_BATCH_SIZE {
@@ -2859,21 +2937,31 @@ impl SubscriptionHub {
                         topics.push(cached.topic.clone());
                     }
                 }
-                if topics.is_empty() && guard.runtime_topic_recovery_queue.is_empty() {
+                let retry_delay = (topics.is_empty()
+                    && guard.runtime_topic_recovery_queue.is_empty())
+                .then(|| Self::next_runtime_topic_recovery_retry_delay_locked(&guard))
+                .flatten();
+                if topics.is_empty()
+                    && guard.runtime_topic_recovery_queue.is_empty()
+                    && retry_delay.is_none()
+                {
                     guard.runtime_topic_recovery_running = false;
                 }
-                topics
+                (topics, retry_delay)
             };
             if topics.is_empty() {
+                if let Some(delay) = retry_delay {
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
                 return;
             }
-            let mut retry_delay = None;
             for topic in topics {
                 if let Err(err) = self
                     .refresh_topic_if_active(state.clone(), topic.clone(), true)
                     .await
                 {
-                    retry_delay = Some(self.defer_runtime_topic_recovery_retry(&topic).await);
+                    self.defer_runtime_topic_recovery_retry(&topic).await;
                     warn!(
                         ?err,
                         topic = %topic.name(),
@@ -2882,11 +2970,7 @@ impl SubscriptionHub {
                     );
                 }
             }
-            if let Some(delay) = retry_delay {
-                tokio::time::sleep(delay).await;
-            } else {
-                tokio::task::yield_now().await;
-            }
+            tokio::task::yield_now().await;
         }
     }
 
@@ -7588,6 +7672,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dirty_last_good_reconnect_skips_synchronous_cold_hydration() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("selected-key".to_string()),
+        };
+        let topic_key = topic.cache_key().expect("history topic key");
+        let mut last_good = seeded_cached_topic(topic.clone(), &[7], Utc::now());
+        last_good.dirty = true;
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(topic_key.clone(), last_good);
+            // Keep the bounded recovery worker parked so this test can prove that preparing the
+            // connection itself never acquires SQLite for a retained last-good frame.
+            guard.runtime_topic_recovery_running = true;
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register history owner");
+        state.pool.close().await;
+
+        let prepared = hub
+            .prepare_connection(state, vec![topic.descriptor()], Vec::new())
+            .await
+            .expect("reconnect must serve last-good without a database read");
+
+        assert_eq!(prepared.initial.len(), 1);
+        let guard = hub.state.lock().await;
+        assert!(
+            guard
+                .topics
+                .get(&topic_key)
+                .expect("retained history topic")
+                .dirty
+        );
+        assert_eq!(guard.runtime_topic_recovery_queue.len(), 1);
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
     async fn runtime_recovery_retry_cooldown_defers_dirty_topic_requeue() {
         let hub = Arc::new(SubscriptionHub::new());
         let topic = SubscriptionTopic::InvocationHistoryWindow {
@@ -7622,6 +7751,16 @@ mod tests {
             &mut guard
         ));
         assert!(guard.runtime_topic_recovery_queue.is_empty());
+        assert!(SubscriptionHub::next_runtime_topic_recovery_retry_delay_locked(&guard).is_some());
+        guard
+            .topics
+            .get_mut(&topic_key)
+            .expect("dirty history topic")
+            .runtime_topic_recovery_retry_at = Some(Instant::now());
+        assert!(SubscriptionHub::enqueue_runtime_topic_recovery_locked(
+            &mut guard
+        ));
+        assert_eq!(guard.runtime_topic_recovery_queue.len(), 1);
         drop(guard);
         drop(lease);
     }

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -3152,6 +3152,34 @@ impl SubscriptionHub {
         }
     }
 
+    async fn mark_prompt_cache_topic_dirty_and_schedule_reconcile(
+        &self,
+        topic: &SubscriptionTopic,
+    ) -> bool {
+        let Ok(topic_key) = topic.cache_key() else {
+            return false;
+        };
+        let mut guard = self.state.lock().await;
+        let active = guard
+            .active_subscribers
+            .get(&topic_key)
+            .copied()
+            .unwrap_or_default()
+            > 0;
+        let Some(cached) = guard.topics.get_mut(&topic_key) else {
+            return false;
+        };
+        cached.dirty = true;
+        cached.refresh_scheduled = false;
+        cached.prompt_cache_refresh_scheduled = false;
+        cached.prompt_cache_reconcile_required = true;
+        if active && !cached.prompt_cache_reconcile_scheduled {
+            cached.prompt_cache_reconcile_scheduled = true;
+            return true;
+        }
+        false
+    }
+
     async fn begin_conversation_overview_topic_refresh(&self, topic: &SubscriptionTopic) -> bool {
         let Ok(topic_key) = topic.cache_key() else {
             return false;
@@ -3397,7 +3425,12 @@ impl SubscriptionHub {
                         response_source = "last_good",
                         "prompt cache in-memory topic materialization failed"
                     );
-                    hub.mark_topic_dirty(&topic).await;
+                    if hub
+                        .mark_prompt_cache_topic_dirty_and_schedule_reconcile(&topic)
+                        .await
+                    {
+                        SubscriptionHub::spawn_prompt_cache_topic_reconcile(state.clone(), topic);
+                    }
                 }
             });
         }
@@ -3459,15 +3492,27 @@ impl SubscriptionHub {
             let records = std::mem::take(&mut cached.prompt_cache_pending_records)
                 .into_values()
                 .collect::<Vec<_>>();
-            if records.is_empty()
-                || !apply_prompt_cache_records_to_payload(
-                    topic,
-                    &mut cached.snapshot_payload,
-                    &records,
-                    &mut cached.prompt_cache_applied_terminal_ids,
-                    cached.prompt_cache_baseline_row_id,
-                )?
-            {
+            if records.is_empty() {
+                return Ok(());
+            }
+            let applied = match apply_prompt_cache_records_to_payload(
+                topic,
+                &mut cached.snapshot_payload,
+                &records,
+                &mut cached.prompt_cache_applied_terminal_ids,
+                cached.prompt_cache_baseline_row_id,
+            ) {
+                Ok(applied) => applied,
+                Err(err) => {
+                    for record in records {
+                        cached
+                            .prompt_cache_pending_records
+                            .insert(record.identity.clone(), record);
+                    }
+                    return Err(err);
+                }
+            };
+            if !applied {
                 return Ok(());
             }
             let next_cursor = cached.cursor.saturating_add(1);
@@ -5486,7 +5531,10 @@ async fn run_server_push_topic_loop(
                     if hub.stop_server_push_task_if_idle(&topic_key).await {
                         break;
                     }
-                    if let Err(err) = hub.refresh_topic(state.clone(), topic.clone(), true).await {
+                    if let Err(err) = hub
+                        .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                        .await
+                    {
                         warn!(?err, topic = %topic.name(), "failed to push legacy network recent topic cadence");
                     }
                 }
@@ -5505,7 +5553,10 @@ async fn run_server_push_topic_loop(
                 if hub.stop_server_push_task_if_idle(&topic_key).await {
                     break;
                 }
-                if let Err(err) = hub.refresh_topic(state.clone(), topic.clone(), true).await {
+                if let Err(err) = hub
+                    .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                    .await
+                {
                     warn!(?err, topic = %topic.name(), "failed to refresh closed summary topic at calendar rollover");
                 }
             }
@@ -6869,6 +6920,9 @@ fn reuse_unchanged_cached_topic(
     }
     existing.dirty = false;
     existing.refresh_scheduled = false;
+    // A successful Prompt Cache baseline can serialize identically to last-good. It still
+    // proves reconciliation completed, so do not keep scheduling the same cold hydration.
+    existing.prompt_cache_reconcile_required = false;
     existing.snapshot_built_at = Instant::now();
     Some(existing.clone())
 }
@@ -7581,6 +7635,48 @@ mod tests {
         assert!(cached.prompt_cache_reconcile_required);
         assert!(cached.prompt_cache_reconcile_scheduled);
         assert!(cached.prompt_cache_pending_records.is_empty());
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn prompt_cache_materialization_failure_marks_and_schedules_reconcile() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let topic_key = topic.cache_key().expect("prompt cache topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(
+                topic_key.clone(),
+                seeded_cached_topic(topic.clone(), &[7], Utc::now()),
+            );
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register prompt cache owner");
+
+        assert!(
+            hub.mark_prompt_cache_topic_dirty_and_schedule_reconcile(&topic)
+                .await
+        );
+
+        let guard = hub.state.lock().await;
+        let cached = guard
+            .topics
+            .get(&topic_key)
+            .expect("active prompt cache topic");
+        assert!(cached.dirty);
+        assert!(cached.prompt_cache_reconcile_required);
+        assert!(cached.prompt_cache_reconcile_scheduled);
         drop(guard);
         drop(lease);
     }
@@ -10212,12 +10308,14 @@ mod tests {
         let topic = summary_topic();
         let mut cached = seeded_cached_topic(topic, &[], Utc::now());
         cached.refresh_scheduled = true;
+        cached.prompt_cache_reconcile_required = true;
         let payload = serde_json::to_vec(&cached.snapshot_payload).expect("cached payload");
 
         let reused = reuse_unchanged_cached_topic(&mut cached, &payload);
 
         assert!(reused.is_some());
         assert!(!cached.refresh_scheduled);
+        assert!(!cached.prompt_cache_reconcile_required);
         cached.refresh_scheduled = true;
         assert!(
             cached.refresh_scheduled,

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -9,6 +9,7 @@ use std::sync::{
     Mutex as StdMutex,
     atomic::{AtomicU64, Ordering},
 };
+use tokio::sync::Notify;
 
 const SUBSCRIPTION_REPLAY_WINDOW_SECS: i64 = 60;
 const SUBSCRIPTION_REPLAY_MAX_EVENTS_PER_TOPIC: usize = 512;
@@ -384,6 +385,7 @@ pub(crate) struct SubscriptionHub {
     state: Mutex<SubscriptionHubState>,
     broadcaster: broadcast::Sender<SubscriptionDispatchEvent>,
     runtime_mutation_bus: Arc<RuntimeMutationBus>,
+    runtime_topic_recovery_notify: Arc<Notify>,
     serialization_count: AtomicU64,
     dashboard_topology_counters: DashboardDeliveryTopologyCounters,
     #[cfg(test)]
@@ -1341,6 +1343,7 @@ impl SubscriptionHub {
             state: Mutex::new(SubscriptionHubState::default()),
             broadcaster,
             runtime_mutation_bus: Arc::new(RuntimeMutationBus::new()),
+            runtime_topic_recovery_notify: Arc::new(Notify::new()),
             serialization_count: AtomicU64::new(0),
             dashboard_topology_counters: DashboardDeliveryTopologyCounters::default(),
             #[cfg(test)]
@@ -2123,7 +2126,7 @@ impl SubscriptionHub {
         // A recovery or owner disconnect may happen while a cold build is in flight. Capture
         // the cache generation before building so an old result can never clear newer dirty
         // state or replace the retained last-good frame.
-        let refresh_generation = if require_active_owner {
+        let (refresh_generation, refresh_had_cached_topic) = if require_active_owner {
             let guard = self.state.lock().await;
             if guard
                 .active_subscribers
@@ -2134,9 +2137,13 @@ impl SubscriptionHub {
             {
                 return Ok(None);
             }
-            Some(guard.runtime_topic_recovery_generation)
+            guard
+                .topics
+                .get(&topic_key)
+                .map(|cached| (Some(cached.runtime_topic_recovery_generation), true))
+                .unwrap_or((Some(guard.runtime_topic_recovery_generation), false))
         } else {
-            None
+            (None, false)
         };
         let (mut built_payload, prompt_cache_build) = if is_prompt_cache_topic {
             let (payload, build) = self
@@ -2158,11 +2165,16 @@ impl SubscriptionHub {
                     .copied()
                     .unwrap_or_default()
                     > 0;
-                let generation_matches = Some(guard.runtime_topic_recovery_generation)
-                    == refresh_generation
-                    && guard.topics.get(&topic_key).is_none_or(|cached| {
+                let generation_matches = if refresh_had_cached_topic {
+                    guard.topics.get(&topic_key).is_some_and(|cached| {
                         Some(cached.runtime_topic_recovery_generation) == refresh_generation
-                    });
+                    })
+                } else {
+                    Some(guard.runtime_topic_recovery_generation) == refresh_generation
+                        && guard.topics.get(&topic_key).is_none_or(|cached| {
+                            Some(cached.runtime_topic_recovery_generation) == refresh_generation
+                        })
+                };
                 if !active || !generation_matches {
                     // A newer gap or owner generation owns the cache now. Only the owner that
                     // observed this generation may dirty it; never invalidate a newer clean
@@ -2789,6 +2801,7 @@ impl SubscriptionHub {
                 hub.run_runtime_topic_recovery(state).await;
             });
         }
+        self.runtime_topic_recovery_notify.notify_one();
     }
 
     async fn schedule_dirty_topic_recovery(&self, state: Arc<AppState>, topic: SubscriptionTopic) {
@@ -2816,6 +2829,7 @@ impl SubscriptionHub {
                 hub.run_runtime_topic_recovery(state).await;
             });
         }
+        self.runtime_topic_recovery_notify.notify_one();
     }
 
     fn next_runtime_topic_recovery_retry_delay_locked(
@@ -2951,7 +2965,10 @@ impl SubscriptionHub {
             };
             if topics.is_empty() {
                 if let Some(delay) = retry_delay {
-                    tokio::time::sleep(delay).await;
+                    tokio::select! {
+                        _ = tokio::time::sleep(delay) => {}
+                        _ = self.runtime_topic_recovery_notify.notified() => {}
+                    }
                     continue;
                 }
                 return;
@@ -7669,6 +7686,57 @@ mod tests {
             topic_key
         );
         drop(lease);
+    }
+
+    #[tokio::test]
+    async fn unrelated_topic_disconnect_does_not_block_active_refresh() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let active_topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("active-key".to_string()),
+        };
+        let released_topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("released-key".to_string()),
+        };
+        let active_key = active_topic.cache_key().expect("active topic key");
+        let released_key = released_topic.cache_key().expect("released topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(
+                active_key.clone(),
+                seeded_cached_topic(active_topic.clone(), &[7], Utc::now()),
+            );
+            guard.topics.insert(
+                released_key.clone(),
+                seeded_cached_topic(released_topic.clone(), &[7], Utc::now()),
+            );
+        }
+        let active_lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&active_topic))
+            .await
+            .expect("register active topic");
+        let released_lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&released_topic))
+            .await
+            .expect("register released topic");
+        hub.release_topic_subscribers(
+            vec![released_key],
+            vec![released_topic.name().to_string()],
+            false,
+        )
+        .await;
+
+        assert!(
+            hub.refresh_topic_if_active(state, active_topic, true)
+                .await
+                .expect("active refresh")
+                .is_some()
+        );
+        drop(released_lease);
+        drop(active_lease);
     }
 
     #[tokio::test]

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -403,7 +403,8 @@ struct SubscriptionHubState {
     dashboard_terminal_slice: Option<Arc<DashboardTerminalProjectionSlice>>,
     prompt_cache_prebaseline_records: HashMap<String, BTreeMap<String, PromptCacheTopicDelta>>,
     runtime_topic_recovery_generation: u64,
-    runtime_topic_recovery_queue: VecDeque<String>,
+    runtime_topic_recovery_queue: VecDeque<(String, u64)>,
+    runtime_topic_recovery_queued: HashSet<String>,
     runtime_topic_recovery_running: bool,
 }
 
@@ -425,6 +426,7 @@ struct CachedSubscriptionTopic {
     summary_pending_event_count: u64,
     summary_retry_backoff_ms: u64,
     prompt_cache_refresh_scheduled: bool,
+    prompt_cache_reconcile_scheduled: bool,
     prompt_cache_pending_records: BTreeMap<String, PromptCacheTopicDelta>,
     prompt_cache_applied_terminal_ids: HashSet<String>,
     prompt_cache_coalesced_event_count: u64,
@@ -1560,6 +1562,10 @@ impl SubscriptionHub {
                     .copied()
                     .unwrap_or_default()
                     == 0
+                    || guard
+                        .topics
+                        .get(&topic_key)
+                        .is_some_and(|cached| cached.dirty)
                     || !mutations
                         .iter()
                         .any(|mutation| topic.is_affected_by_runtime_mutation(&mutation.mutation))
@@ -1699,11 +1705,15 @@ impl SubscriptionHub {
                         Self::release_active_topic_dependencies(&mut guard, &topic_key, &topic);
                     }
                     guard.prompt_cache_prebaseline_records.remove(&topic_key);
+                    guard.runtime_topic_recovery_generation =
+                        guard.runtime_topic_recovery_generation.saturating_add(1);
+                    let recovery_generation = guard.runtime_topic_recovery_generation;
                     if let Some(cached) = guard.topics.get_mut(&topic_key) {
                         // A disconnected owner cannot consume the mutation stream. Rebuild this
                         // selection before it can resume instead of scanning retained caches for
                         // every runtime event.
                         cached.dirty = true;
+                        cached.runtime_topic_recovery_generation = recovery_generation;
                         cached.refresh_scheduled = false;
                         cached.latest_live_snapshot = None;
                         if matches!(
@@ -2090,6 +2100,19 @@ impl SubscriptionHub {
             SubscriptionTopic::PromptCacheWindow { .. }
                 | SubscriptionTopic::PromptCacheStickyWindow { .. }
         );
+        // A recovery or owner disconnect may happen while a cold build is in flight. Capture
+        // the cache generation before building so an old result can never clear newer dirty
+        // state or replace the retained last-good frame.
+        let refresh_generation = if require_active_owner {
+            self.state
+                .lock()
+                .await
+                .topics
+                .get(&topic_key)
+                .map(|cached| cached.runtime_topic_recovery_generation)
+        } else {
+            None
+        };
         let (mut built_payload, prompt_cache_build) = if is_prompt_cache_topic {
             let (payload, build) = self
                 .build_prompt_cache_consistent_baseline(state.clone(), &topic)
@@ -2104,12 +2127,15 @@ impl SubscriptionHub {
         let (cached, dispatch) = {
             let mut guard = self.state.lock().await;
             if require_active_owner
-                && guard
+                && (guard
                     .active_subscribers
                     .get(&topic_key)
                     .copied()
                     .unwrap_or_default()
                     == 0
+                    || guard.topics.get(&topic_key).is_none_or(|cached| {
+                        Some(cached.runtime_topic_recovery_generation) != refresh_generation
+                    }))
             {
                 if let Some(cached) = guard.topics.get_mut(&topic_key) {
                     cached.dirty = true;
@@ -2279,6 +2305,10 @@ impl SubscriptionHub {
                     .topics
                     .get(&topic_key)
                     .is_some_and(|entry| entry.prompt_cache_refresh_scheduled),
+                prompt_cache_reconcile_scheduled: guard
+                    .topics
+                    .get(&topic_key)
+                    .is_some_and(|entry| entry.prompt_cache_reconcile_scheduled),
                 prompt_cache_pending_records: BTreeMap::new(),
                 prompt_cache_applied_terminal_ids: if matches!(
                     topic,
@@ -2567,7 +2597,7 @@ impl SubscriptionHub {
             match &mutation.mutation {
                 RuntimeMutation::PromptCacheBindingChanged { prompt_cache_key } => {
                     if let Err(err) = self
-                        .apply_prompt_cache_binding_projection(state.as_ref(), prompt_cache_key)
+                        .apply_prompt_cache_binding_projection(state.clone(), prompt_cache_key)
                         .await
                     {
                         warn!(
@@ -2584,6 +2614,7 @@ impl SubscriptionHub {
                 } => {
                     if let Err(err) = self
                         .apply_prompt_cache_sticky_route_projection(
+                            state.clone(),
                             sticky_key,
                             *previous_upstream_account_id,
                             *upstream_account_id,
@@ -2695,6 +2726,7 @@ impl SubscriptionHub {
                 cached.refresh_scheduled = false;
                 cached.latest_live_snapshot = None;
                 cached.continuity_reset_cursor = Some(cached.cursor);
+                cached.runtime_topic_recovery_generation = recovery_generation;
                 if matches!(
                     cached.topic,
                     SubscriptionTopic::PromptCacheWindow { .. }
@@ -2706,7 +2738,6 @@ impl SubscriptionHub {
                     cached.prompt_cache_pending_records.clear();
                     cached.prompt_cache_refresh_scheduled = false;
                     cached.prompt_cache_reconcile_required = true;
-                    cached.runtime_topic_recovery_generation = recovery_generation;
                 }
             }
             let recovery_scheduled = Self::enqueue_runtime_topic_recovery_locked(&mut guard);
@@ -2728,7 +2759,6 @@ impl SubscriptionHub {
     }
 
     fn enqueue_runtime_topic_recovery_locked(guard: &mut SubscriptionHubState) -> bool {
-        let recovery_generation = guard.runtime_topic_recovery_generation;
         let active_topic_keys = guard
             .active_topics
             .keys()
@@ -2746,13 +2776,15 @@ impl SubscriptionHub {
             if guard.runtime_topic_recovery_queue.len() >= RUNTIME_TOPIC_RECOVERY_QUEUE_CAPACITY {
                 break;
             }
-            let Some(cached) = guard.topics.get_mut(&topic_key) else {
-                continue;
-            };
-            if !cached.dirty || cached.runtime_topic_recovery_generation >= recovery_generation {
+            if guard.runtime_topic_recovery_queued.contains(&topic_key) {
                 continue;
             }
-            cached.runtime_topic_recovery_generation = recovery_generation;
+            let Some(cached) = guard.topics.get(&topic_key) else {
+                continue;
+            };
+            if !cached.dirty {
+                continue;
+            }
             if matches!(
                 cached.topic,
                 SubscriptionTopic::PromptCacheWindow { .. }
@@ -2760,7 +2792,13 @@ impl SubscriptionHub {
             ) {
                 continue;
             }
-            guard.runtime_topic_recovery_queue.push_back(topic_key);
+            let recovery_generation = cached.runtime_topic_recovery_generation;
+            guard
+                .runtime_topic_recovery_queued
+                .insert(topic_key.clone());
+            guard
+                .runtime_topic_recovery_queue
+                .push_back((topic_key, recovery_generation));
         }
         if guard.runtime_topic_recovery_running || guard.runtime_topic_recovery_queue.is_empty() {
             return false;
@@ -2778,9 +2816,12 @@ impl SubscriptionHub {
                     if guard.runtime_topic_recovery_queue.is_empty() {
                         Self::enqueue_runtime_topic_recovery_locked(&mut guard);
                     }
-                    let Some(topic_key) = guard.runtime_topic_recovery_queue.pop_front() else {
+                    let Some((topic_key, recovery_generation)) =
+                        guard.runtime_topic_recovery_queue.pop_front()
+                    else {
                         break;
                     };
+                    guard.runtime_topic_recovery_queued.remove(&topic_key);
                     if guard
                         .active_subscribers
                         .get(&topic_key)
@@ -2793,7 +2834,9 @@ impl SubscriptionHub {
                     let Some(cached) = guard.topics.get(&topic_key) else {
                         continue;
                     };
-                    if cached.dirty {
+                    if cached.dirty
+                        && cached.runtime_topic_recovery_generation == recovery_generation
+                    {
                         topics.push(cached.topic.clone());
                     }
                 }
@@ -2872,6 +2915,12 @@ impl SubscriptionHub {
                     if !active {
                         cached.dirty = true;
                         cached.latest_live_snapshot = None;
+                        return None;
+                    }
+                    if cached.dirty {
+                        // Runtime cursor recovery owns this selection. Retain last-good until
+                        // its bounded work commits instead of allowing another broadcast path
+                        // to publish a partial frame.
                         return None;
                     }
                     if matches!(payload, BroadcastPayload::DashboardActivityLive { .. })
@@ -3274,9 +3323,10 @@ impl SubscriptionHub {
             return;
         }
 
-        let scheduled = {
+        let (scheduled, reconciles) = {
             let mut guard = self.state.lock().await;
             let mut scheduled = Vec::new();
+            let mut reconciles = Vec::new();
             for topic_key in active_topic_keys {
                 let Some(topic) = guard.active_topics.get(&topic_key).cloned() else {
                     continue;
@@ -3293,9 +3343,18 @@ impl SubscriptionHub {
                     }
                     continue;
                 };
-                if reconcile_required {
+                let requires_bounded_reconcile = reconcile_required || cached.dirty;
+                if requires_bounded_reconcile {
                     cached.dirty = true;
                     cached.prompt_cache_reconcile_required = true;
+                    if !cached.prompt_cache_reconcile_scheduled {
+                        cached.prompt_cache_reconcile_scheduled = true;
+                        reconciles.push(topic);
+                    }
+                    // A gap means the retained payload may be missing an earlier mutation.
+                    // Do not append a later delta to that stale frame; one active selection is
+                    // rebuilt asynchronously from its bounded cold source instead.
+                    continue;
                 }
                 if records.is_empty() {
                     continue;
@@ -3320,7 +3379,7 @@ impl SubscriptionHub {
                     scheduled.push(topic);
                 }
             }
-            scheduled
+            (scheduled, reconciles)
         };
 
         for topic in scheduled {
@@ -3341,6 +3400,38 @@ impl SubscriptionHub {
                     hub.mark_topic_dirty(&topic).await;
                 }
             });
+        }
+        for topic in reconciles {
+            Self::spawn_prompt_cache_topic_reconcile(state.clone(), topic);
+        }
+    }
+
+    fn spawn_prompt_cache_topic_reconcile(state: Arc<AppState>, topic: SubscriptionTopic) {
+        let hub = state.subscription_hub.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(PROMPT_CACHE_TOPIC_REFRESH_DEBOUNCE).await;
+            let result = hub
+                .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                .await;
+            hub.finish_prompt_cache_topic_reconcile(&topic).await;
+            if let Err(err) = result {
+                warn!(
+                    ?err,
+                    topic = topic.name(),
+                    response_source = "last_good",
+                    "bounded prompt cache topic reconcile failed"
+                );
+                hub.mark_topic_dirty(&topic).await;
+            }
+        });
+    }
+
+    async fn finish_prompt_cache_topic_reconcile(&self, topic: &SubscriptionTopic) {
+        let Ok(topic_key) = topic.cache_key() else {
+            return;
+        };
+        if let Some(cached) = self.state.lock().await.topics.get_mut(&topic_key) {
+            cached.prompt_cache_reconcile_scheduled = false;
         }
     }
 
@@ -3436,6 +3527,11 @@ impl SubscriptionHub {
             let Some(cached) = guard.topics.get_mut(topic_key) else {
                 return Ok(());
             };
+            if cached.dirty {
+                // A cursor gap makes the retained frame incomplete. Keep it byte-for-byte as
+                // last-good until the bounded reconcile below replaces it.
+                return Ok(());
+            }
             let now = Utc::now();
             let activity_cutoff = match cached.topic {
                 SubscriptionTopic::PromptCacheWindow {
@@ -3543,7 +3639,7 @@ impl SubscriptionHub {
 
     async fn apply_prompt_cache_binding_projection(
         &self,
-        state: &AppState,
+        state: Arc<AppState>,
         prompt_cache_key: &str,
     ) -> Result<(), ApiError> {
         let has_active_prompt_cache_window = {
@@ -3559,12 +3655,13 @@ impl SubscriptionHub {
         }
         let binding = serde_json::to_value(
             load_prompt_cache_conversation_binding_response_for_key(
-                state,
+                state.as_ref(),
                 prompt_cache_key.to_string(),
             )
             .await?,
         )?;
         let mut dispatches = Vec::new();
+        let mut reconciles = Vec::new();
         let mut guard = self.state.lock().await;
         let active_topic_keys = Self::active_topic_keys_for_dependency(
             &guard,
@@ -3583,6 +3680,14 @@ impl SubscriptionHub {
             let Some(cached) = guard.topics.get_mut(&topic_key) else {
                 continue;
             };
+            if cached.dirty {
+                cached.prompt_cache_reconcile_required = true;
+                if !cached.prompt_cache_reconcile_scheduled {
+                    cached.prompt_cache_reconcile_scheduled = true;
+                    reconciles.push(cached.topic.clone());
+                }
+                continue;
+            }
             cached.prompt_cache_bounded_key_hydration_count = cached
                 .prompt_cache_bounded_key_hydration_count
                 .saturating_add(1);
@@ -3592,6 +3697,10 @@ impl SubscriptionHub {
                 &binding,
             ) else {
                 cached.prompt_cache_reconcile_required = true;
+                if !cached.prompt_cache_reconcile_scheduled {
+                    cached.prompt_cache_reconcile_scheduled = true;
+                    reconciles.push(cached.topic.clone());
+                }
                 continue;
             };
             if !changed {
@@ -3623,16 +3732,21 @@ impl SubscriptionHub {
         for dispatch in dispatches {
             let _ = self.broadcaster.send(dispatch);
         }
+        for topic in reconciles {
+            Self::spawn_prompt_cache_topic_reconcile(state.clone(), topic);
+        }
         Ok(())
     }
 
     async fn apply_prompt_cache_sticky_route_projection(
         &self,
+        state: Arc<AppState>,
         sticky_key: &str,
         previous_upstream_account_id: i64,
         upstream_account_id: i64,
     ) -> Result<(), ApiError> {
         let mut dispatches = Vec::new();
+        let mut reconciles = Vec::new();
         let mut guard = self.state.lock().await;
         let active_topic_keys = Self::active_topic_keys_for_dependency(
             &guard,
@@ -3654,6 +3768,14 @@ impl SubscriptionHub {
             let Some(cached) = guard.topics.get_mut(&topic_key) else {
                 continue;
             };
+            if cached.dirty {
+                cached.prompt_cache_reconcile_required = true;
+                if !cached.prompt_cache_reconcile_scheduled {
+                    cached.prompt_cache_reconcile_scheduled = true;
+                    reconciles.push(cached.topic.clone());
+                }
+                continue;
+            }
             let SubscriptionTopic::PromptCacheStickyWindow { account_id, .. } = cached.topic else {
                 continue;
             };
@@ -3663,6 +3785,10 @@ impl SubscriptionHub {
                 .and_then(Value::as_array_mut)
             else {
                 cached.prompt_cache_reconcile_required = true;
+                if !cached.prompt_cache_reconcile_scheduled {
+                    cached.prompt_cache_reconcile_scheduled = true;
+                    reconciles.push(cached.topic.clone());
+                }
                 continue;
             };
             let before = conversations.len();
@@ -3677,6 +3803,10 @@ impl SubscriptionHub {
                 })
             {
                 cached.prompt_cache_reconcile_required = true;
+                if !cached.prompt_cache_reconcile_scheduled {
+                    cached.prompt_cache_reconcile_scheduled = true;
+                    reconciles.push(cached.topic.clone());
+                }
             }
             if conversations.len() == before {
                 continue;
@@ -3706,6 +3836,9 @@ impl SubscriptionHub {
         drop(guard);
         for dispatch in dispatches {
             let _ = self.broadcaster.send(dispatch);
+        }
+        for topic in reconciles {
+            Self::spawn_prompt_cache_topic_reconcile(state.clone(), topic);
         }
         Ok(())
     }
@@ -7260,6 +7393,198 @@ mod tests {
         drop(lease);
     }
 
+    #[tokio::test]
+    async fn repeated_runtime_gaps_dedupe_bounded_recovery_jobs() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("selected-key".to_string()),
+        };
+        let topic_key = topic.cache_key().expect("history topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(
+                topic_key.clone(),
+                seeded_cached_topic(topic.clone(), &[7], Utc::now()),
+            );
+            // Keep the worker parked so this test can observe the queued representation.
+            guard.runtime_topic_recovery_running = true;
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register history owner");
+
+        hub.mark_runtime_mutation_gap_and_recover(state.clone(), 2, "cursor_gap")
+            .await;
+        hub.mark_runtime_mutation_gap_and_recover(state.clone(), 3, "receiver_lagged")
+            .await;
+
+        let mut guard = hub.state.lock().await;
+        assert_eq!(guard.runtime_topic_recovery_queue.len(), 1);
+        assert_eq!(
+            guard.runtime_topic_recovery_queue.front(),
+            Some(&(topic_key.clone(), 1)),
+            "the queued job retains its original generation and is re-enqueued once with the\n             newer generation after the worker observes the mismatch"
+        );
+        assert!(guard.runtime_topic_recovery_queued.contains(&topic_key));
+        assert_eq!(
+            guard
+                .topics
+                .get(&topic_key)
+                .expect("active history topic")
+                .runtime_topic_recovery_generation,
+            2
+        );
+        guard.runtime_topic_recovery_running = false;
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn dirty_topics_do_not_bypass_bounded_gap_recovery() {
+        let hub = Arc::new(SubscriptionHub::new());
+        let topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("selected-key".to_string()),
+        };
+        let topic_key = topic.cache_key().expect("history topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            let mut cached = seeded_cached_topic(topic.clone(), &[7], Utc::now());
+            cached.dirty = true;
+            guard.topics.insert(topic_key, cached);
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register history owner");
+        let mutations = [SequencedRuntimeMutation {
+            sequence: 1,
+            mutation: RuntimeMutation::Invocation(RuntimeInvocationMutation {
+                identity: RuntimeInvocationIdentity::new("invoke-1", "2026-08-09 12:00:00"),
+                kind: RuntimeMutationKind::RuntimeUpsert,
+                row_id: None,
+                is_terminal: false,
+                prompt_cache_key: Some("selected-key".to_string()),
+                sticky_key: None,
+                upstream_account_id: None,
+            }),
+        }];
+
+        let guard = hub.state.lock().await;
+        assert!(SubscriptionHub::collect_runtime_topic_work(&guard, &mutations).is_empty());
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn dirty_prompt_cache_topic_retains_last_good_until_bounded_reconcile() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let topic_key = topic.cache_key().expect("prompt cache topic key");
+        let last_good = seeded_cached_topic(topic.clone(), &[7], Utc::now());
+        let last_good_frame = last_good.snapshot_frame.clone();
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(topic_key.clone(), last_good);
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register prompt cache owner");
+        hub.mark_runtime_mutation_gap_and_recover(state.clone(), 4, "cursor_gap")
+            .await;
+
+        let mut record = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        record.invoke_id = "post-gap-prompt-cache".to_string();
+        record.prompt_cache_key = Some("cache-key".to_string());
+        state.proxy_runtime_invocations.upsert(record.clone());
+        let mutations = [SequencedRuntimeMutation {
+            sequence: 5,
+            mutation: RuntimeMutation::invocation(&record, RuntimeMutationKind::RuntimeUpsert),
+        }];
+        hub.schedule_prompt_cache_topic_projection(state.clone(), &mutations)
+            .await;
+
+        let guard = hub.state.lock().await;
+        let cached = guard
+            .topics
+            .get(&topic_key)
+            .expect("active prompt cache topic");
+        assert!(cached.dirty);
+        assert!(cached.prompt_cache_reconcile_scheduled);
+        assert!(!cached.prompt_cache_refresh_scheduled);
+        assert!(cached.prompt_cache_pending_records.is_empty());
+        assert_eq!(cached.cursor, 7);
+        assert!(Arc::ptr_eq(&cached.snapshot_frame, &last_good_frame));
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn missing_runtime_identity_schedules_active_prompt_cache_reconcile() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let topic_key = topic.cache_key().expect("prompt cache topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(
+                topic_key.clone(),
+                seeded_cached_topic(topic.clone(), &[7], Utc::now()),
+            );
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register prompt cache owner");
+        let mutations = [SequencedRuntimeMutation {
+            sequence: 1,
+            mutation: RuntimeMutation::Invocation(RuntimeInvocationMutation {
+                identity: RuntimeInvocationIdentity::new("recovered", "2026-08-09 12:00:00"),
+                kind: RuntimeMutationKind::Recovery,
+                row_id: Some(1),
+                is_terminal: true,
+                prompt_cache_key: Some("cache-key".to_string()),
+                sticky_key: None,
+                upstream_account_id: None,
+            }),
+        }];
+
+        hub.schedule_prompt_cache_topic_projection(state.clone(), &mutations)
+            .await;
+
+        let guard = hub.state.lock().await;
+        let cached = guard
+            .topics
+            .get(&topic_key)
+            .expect("active prompt cache topic");
+        assert!(cached.dirty);
+        assert!(cached.prompt_cache_reconcile_required);
+        assert!(cached.prompt_cache_reconcile_scheduled);
+        assert!(cached.prompt_cache_pending_records.is_empty());
+        drop(guard);
+        drop(lease);
+    }
+
     fn summary_topic() -> SubscriptionTopic {
         SubscriptionTopic::SummaryCurrent {
             window: "current".to_string(),
@@ -9354,6 +9679,7 @@ mod tests {
             summary_pending_event_count: 0,
             summary_retry_backoff_ms: 0,
             prompt_cache_refresh_scheduled: false,
+            prompt_cache_reconcile_scheduled: false,
             prompt_cache_pending_records: BTreeMap::new(),
             prompt_cache_applied_terminal_ids: HashSet::new(),
             prompt_cache_coalesced_event_count: 0,

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -36,6 +36,8 @@ const DASHBOARD_ACTIVITY_TOPIC_REFRESH_TTL: Duration = Duration::from_millis(500
 const SUMMARY_TOPIC_REFRESH_DEBOUNCE: Duration = Duration::from_millis(500);
 const PROMPT_CACHE_TOPIC_REFRESH_DEBOUNCE: Duration = Duration::from_millis(500);
 const PROMPT_CACHE_TOPIC_RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
+const RUNTIME_TOPIC_RECOVERY_QUEUE_CAPACITY: usize = 64;
+const RUNTIME_TOPIC_RECOVERY_BATCH_SIZE: usize = 8;
 #[cfg(test)]
 const DASHBOARD_RUNTIME_TOPOLOGY_CONTRACT_REASON: &str = "dashboard-runtime-topology-contract";
 #[cfg(not(test))]
@@ -400,6 +402,9 @@ struct SubscriptionHubState {
     dashboard_network_slice: Option<Arc<DashboardNetworkProjectionSlice>>,
     dashboard_terminal_slice: Option<Arc<DashboardTerminalProjectionSlice>>,
     prompt_cache_prebaseline_records: HashMap<String, BTreeMap<String, PromptCacheTopicDelta>>,
+    runtime_topic_recovery_generation: u64,
+    runtime_topic_recovery_queue: VecDeque<String>,
+    runtime_topic_recovery_running: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -414,6 +419,7 @@ struct CachedSubscriptionTopic {
     conversation_overview_refresh_in_flight: bool,
     conversation_overview_refresh_pending: bool,
     dirty: bool,
+    runtime_topic_recovery_generation: u64,
     summary_refresh_scheduled: bool,
     summary_refresh_in_flight: bool,
     summary_pending_event_count: u64,
@@ -477,7 +483,7 @@ struct PromptCacheTopicDelta {
     cost: f64,
     upstream_account_id: Option<i64>,
     upstream_account_name: Option<String>,
-    preview: Value,
+    preview: Option<Value>,
 }
 
 struct PromptCacheBaselineBuild {
@@ -536,28 +542,31 @@ impl PromptCacheTopicDelta {
             cost: record.cost.unwrap_or_default(),
             upstream_account_id: record.upstream_account_id,
             upstream_account_name: record.upstream_account_name.clone(),
-            preview,
+            preview: Some(preview),
         }))
     }
 
     fn from_runtime_mutation(
         mutation: &RuntimeInvocationMutation,
+        runtime_record: Option<&ApiInvocation>,
     ) -> Result<Option<Self>, ApiError> {
-        let Some(preview) = mutation.preview.clone() else {
-            return Ok(None);
-        };
-        let preview = serde_json::to_value(preview)?;
-        let occurred_at = preview
-            .get("occurredAt")
-            .cloned()
-            .unwrap_or_else(|| Value::String(mutation.identity.occurred_at.clone()));
-        let status = preview
-            .get("status")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown")
-            .to_string();
-        let error_message = preview.get("errorMessage").and_then(Value::as_str);
-        Ok(Some(Self {
+        if mutation.kind == RuntimeMutationKind::RuntimeRemoved {
+            return Ok(Self::from_runtime_removal(mutation));
+        }
+        runtime_record
+            .map(Self::from_record)
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn from_runtime_removal(mutation: &RuntimeInvocationMutation) -> Option<Self> {
+        if mutation.prompt_cache_key.is_none() && mutation.sticky_key.is_none() {
+            return None;
+        }
+        let occurred_at = parse_to_utc_datetime(&mutation.identity.occurred_at)
+            .map(format_utc_iso)
+            .unwrap_or_else(|| mutation.identity.occurred_at.clone());
+        Some(Self {
             row_id: mutation.row_id.unwrap_or_default(),
             identity: format!(
                 "{}\0{}",
@@ -566,27 +575,17 @@ impl PromptCacheTopicDelta {
             invoke_id: mutation.identity.invoke_id.clone(),
             prompt_cache_key: mutation.prompt_cache_key.clone(),
             sticky_key: mutation.sticky_key.clone(),
-            occurred_at,
-            is_runtime_removed: mutation.kind == RuntimeMutationKind::RuntimeRemoved,
+            occurred_at: Value::String(occurred_at),
+            is_runtime_removed: true,
+            status: "unknown".to_string(),
             is_terminal: mutation.is_terminal,
-            is_success: prompt_invocation_status_is_success_like(Some(&status), error_message),
-            status,
-            request_tokens: preview
-                .get("totalTokens")
-                .and_then(Value::as_i64)
-                .unwrap_or_default()
-                .max(0),
-            cost: preview
-                .get("cost")
-                .and_then(Value::as_f64)
-                .unwrap_or_default(),
+            is_success: false,
+            request_tokens: 0,
+            cost: 0.0,
             upstream_account_id: mutation.upstream_account_id,
-            upstream_account_name: preview
-                .get("upstreamAccountName")
-                .and_then(Value::as_str)
-                .map(str::to_string),
-            preview,
-        }))
+            upstream_account_name: None,
+            preview: None,
+        })
     }
 }
 
@@ -2254,6 +2253,12 @@ impl SubscriptionHub {
                     .get(&topic_key)
                     .is_some_and(|entry| entry.conversation_overview_refresh_pending),
                 dirty: false,
+                runtime_topic_recovery_generation: guard
+                    .topics
+                    .get(&topic_key)
+                    .map_or(guard.runtime_topic_recovery_generation, |entry| {
+                        entry.runtime_topic_recovery_generation
+                    }),
                 summary_refresh_scheduled: guard
                     .topics
                     .get(&topic_key)
@@ -2664,51 +2669,156 @@ impl SubscriptionHub {
         skipped: u64,
         reason: &'static str,
     ) {
-        let topics = {
+        let (active_topic_count, recovery_scheduled) = {
             let mut guard = self.state.lock().await;
-            let active_subscribers = guard.active_subscribers.clone();
-            let active_topics = guard
+            guard.runtime_topic_recovery_generation =
+                guard.runtime_topic_recovery_generation.saturating_add(1);
+            let recovery_generation = guard.runtime_topic_recovery_generation;
+            let active_topic_keys = guard
                 .active_topics
                 .iter()
                 .filter(|(topic_key, _)| {
-                    active_subscribers
+                    guard
+                        .active_subscribers
                         .get(*topic_key)
                         .copied()
                         .unwrap_or_default()
                         > 0
                 })
-                .map(|(topic_key, topic)| (topic_key.clone(), topic.clone()))
+                .map(|(topic_key, _)| topic_key.clone())
                 .collect::<Vec<_>>();
-            active_topics
-                .into_iter()
-                .filter_map(|(topic_key, topic)| {
-                    let cached = guard.topics.get_mut(&topic_key)?;
-                    cached.dirty = true;
-                    cached.latest_live_snapshot = None;
-                    cached.continuity_reset_cursor = Some(cached.cursor);
-                    Some(topic)
-                })
-                .collect::<Vec<_>>()
+            for topic_key in &active_topic_keys {
+                let Some(cached) = guard.topics.get_mut(topic_key) else {
+                    continue;
+                };
+                cached.dirty = true;
+                cached.refresh_scheduled = false;
+                cached.latest_live_snapshot = None;
+                cached.continuity_reset_cursor = Some(cached.cursor);
+                if matches!(
+                    cached.topic,
+                    SubscriptionTopic::PromptCacheWindow { .. }
+                        | SubscriptionTopic::PromptCacheStickyWindow { .. }
+                ) {
+                    // Prompt Cache keeps its last-good frame. Its server-push reconciler performs
+                    // the bounded cold rebuild later instead of doing a full window build from
+                    // this cursor-gap handler.
+                    cached.prompt_cache_pending_records.clear();
+                    cached.prompt_cache_refresh_scheduled = false;
+                    cached.prompt_cache_reconcile_required = true;
+                    cached.runtime_topic_recovery_generation = recovery_generation;
+                }
+            }
+            let recovery_scheduled = Self::enqueue_runtime_topic_recovery_locked(&mut guard);
+            (active_topic_keys.len(), recovery_scheduled)
         };
         warn!(
             skipped,
             reason,
             recovery = "dirty_last_good",
-            active_topic_count = topics.len(),
+            active_topic_count,
             "runtime mutation cursor continuity lost; scheduling bounded topic recovery"
         );
-        for topic in topics {
-            if let Err(err) = self
-                .refresh_topic_if_active(state.clone(), topic.clone(), true)
-                .await
-            {
-                warn!(
-                    ?err,
-                    topic = %topic.name(),
-                    reason,
-                    "runtime mutation recovery retained last-good topic frame"
-                );
+        if recovery_scheduled {
+            let hub = state.subscription_hub.clone();
+            tokio::spawn(async move {
+                hub.run_runtime_topic_recovery(state).await;
+            });
+        }
+    }
+
+    fn enqueue_runtime_topic_recovery_locked(guard: &mut SubscriptionHubState) -> bool {
+        let recovery_generation = guard.runtime_topic_recovery_generation;
+        let active_topic_keys = guard
+            .active_topics
+            .keys()
+            .filter(|topic_key| {
+                guard
+                    .active_subscribers
+                    .get(*topic_key)
+                    .copied()
+                    .unwrap_or_default()
+                    > 0
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for topic_key in active_topic_keys {
+            if guard.runtime_topic_recovery_queue.len() >= RUNTIME_TOPIC_RECOVERY_QUEUE_CAPACITY {
+                break;
             }
+            let Some(cached) = guard.topics.get_mut(&topic_key) else {
+                continue;
+            };
+            if !cached.dirty || cached.runtime_topic_recovery_generation >= recovery_generation {
+                continue;
+            }
+            cached.runtime_topic_recovery_generation = recovery_generation;
+            if matches!(
+                cached.topic,
+                SubscriptionTopic::PromptCacheWindow { .. }
+                    | SubscriptionTopic::PromptCacheStickyWindow { .. }
+            ) {
+                continue;
+            }
+            guard.runtime_topic_recovery_queue.push_back(topic_key);
+        }
+        if guard.runtime_topic_recovery_running || guard.runtime_topic_recovery_queue.is_empty() {
+            return false;
+        }
+        guard.runtime_topic_recovery_running = true;
+        true
+    }
+
+    async fn run_runtime_topic_recovery(self: Arc<Self>, state: Arc<AppState>) {
+        loop {
+            let topics = {
+                let mut guard = self.state.lock().await;
+                let mut topics = Vec::with_capacity(RUNTIME_TOPIC_RECOVERY_BATCH_SIZE);
+                while topics.len() < RUNTIME_TOPIC_RECOVERY_BATCH_SIZE {
+                    if guard.runtime_topic_recovery_queue.is_empty() {
+                        Self::enqueue_runtime_topic_recovery_locked(&mut guard);
+                    }
+                    let Some(topic_key) = guard.runtime_topic_recovery_queue.pop_front() else {
+                        break;
+                    };
+                    if guard
+                        .active_subscribers
+                        .get(&topic_key)
+                        .copied()
+                        .unwrap_or_default()
+                        == 0
+                    {
+                        continue;
+                    }
+                    let Some(cached) = guard.topics.get(&topic_key) else {
+                        continue;
+                    };
+                    if cached.dirty {
+                        topics.push(cached.topic.clone());
+                    }
+                }
+                if topics.is_empty() && guard.runtime_topic_recovery_queue.is_empty() {
+                    guard.runtime_topic_recovery_running = false;
+                }
+                topics
+            };
+            if topics.is_empty() {
+                return;
+            }
+            for topic in topics {
+                if let Err(err) = self
+                    .refresh_topic_if_active(state.clone(), topic.clone(), true)
+                    .await
+                {
+                    warn!(
+                        ?err,
+                        topic = %topic.name(),
+                        recovery = "dirty_last_good",
+                        "bounded runtime mutation recovery retained last-good topic frame"
+                    );
+                }
+            }
+            tokio::task::yield_now().await;
         }
     }
 
@@ -3120,47 +3230,76 @@ impl SubscriptionHub {
         state: Arc<AppState>,
         mutations: &[SequencedRuntimeMutation],
     ) {
-        let records = mutations
-            .iter()
-            .filter_map(|mutation| match &mutation.mutation {
-                RuntimeMutation::Invocation(mutation) => {
-                    Some(PromptCacheTopicDelta::from_runtime_mutation(mutation))
-                }
-                RuntimeMutation::AttemptChanged { .. }
-                | RuntimeMutation::PromptCacheBindingChanged { .. }
-                | RuntimeMutation::StickyRouteChanged { .. } => None,
-            })
-            .collect::<Result<Vec<_>, _>>()
-            .map(|records| records.into_iter().flatten().collect::<Vec<_>>());
-        let Ok(records) = records else {
-            warn!("failed to build compact prompt cache topic delta");
-            return;
+        // The active dependency lookup comes before the identity hydration below. A runtime
+        // mutation is deliberately compact, so inactive Prompt Cache topics never cause a
+        // preview build, runtime-record clone, JSON conversion, or cold read.
+        let active_topic_keys = {
+            let guard = self.state.lock().await;
+            Self::active_topic_keys_for_dependency(
+                &guard,
+                &RuntimeTopicDependency::PromptCacheProjection,
+            )
         };
-        if records.is_empty() {
+        if active_topic_keys.is_empty() {
+            return;
+        }
+
+        let mut records = Vec::new();
+        let mut reconcile_required = false;
+        for mutation in mutations {
+            let RuntimeMutation::Invocation(mutation) = &mutation.mutation else {
+                continue;
+            };
+            if mutation.prompt_cache_key.is_none() && mutation.sticky_key.is_none() {
+                continue;
+            }
+            let runtime_record =
+                (mutation.kind != RuntimeMutationKind::RuntimeRemoved).then(|| {
+                    state.proxy_runtime_invocations.record_by_identity(
+                        &mutation.identity.invoke_id,
+                        &mutation.identity.occurred_at,
+                    )
+                });
+            let runtime_record = runtime_record.flatten();
+            match PromptCacheTopicDelta::from_runtime_mutation(mutation, runtime_record.as_ref()) {
+                Ok(Some(record)) => records.push(record),
+                Ok(None) => reconcile_required = true,
+                Err(err) => {
+                    reconcile_required = true;
+                    warn!(?err, "failed to build active prompt cache topic delta");
+                }
+            }
+        }
+        if records.is_empty() && !reconcile_required {
             return;
         }
 
         let scheduled = {
             let mut guard = self.state.lock().await;
-            let active_topic_keys = Self::active_topic_keys_for_dependency(
-                &guard,
-                &RuntimeTopicDependency::PromptCacheProjection,
-            );
             let mut scheduled = Vec::new();
             for topic_key in active_topic_keys {
                 let Some(topic) = guard.active_topics.get(&topic_key).cloned() else {
                     continue;
                 };
                 let Some(cached) = guard.topics.get_mut(&topic_key) else {
-                    let pending = guard
-                        .prompt_cache_prebaseline_records
-                        .entry(topic_key)
-                        .or_default();
-                    for record in &records {
-                        pending.insert(record.identity.clone(), record.clone());
+                    if !records.is_empty() {
+                        let pending = guard
+                            .prompt_cache_prebaseline_records
+                            .entry(topic_key)
+                            .or_default();
+                        for record in &records {
+                            pending.insert(record.identity.clone(), record.clone());
+                        }
                     }
                     continue;
                 };
+                if reconcile_required {
+                    cached.dirty = true;
+                    cached.prompt_cache_reconcile_required = true;
+                }
+                if records.is_empty() {
+                    continue;
+                }
                 let before = cached.prompt_cache_pending_records.len();
                 for record in &records {
                     cached
@@ -4319,7 +4458,6 @@ fn apply_prompt_cache_records_to_payload(
             SubscriptionTopic::PromptCacheStickyWindow { .. } => "stickyKey",
             _ => return Ok(false),
         };
-        let preview = record.preview.clone();
         let occurred_at = record.occurred_at.clone();
         let status = record.status.as_str();
         let is_terminal = record.is_terminal;
@@ -4349,6 +4487,10 @@ fn apply_prompt_cache_records_to_payload(
             changed |= recent.len() != count_before;
             continue;
         }
+        let Some(preview) = record.preview.as_ref() else {
+            continue;
+        };
+        let preview = preview.clone();
         let index = match conversation_index {
             Some(index) => index,
             None => {
@@ -6907,7 +7049,6 @@ mod tests {
                 prompt_cache_key: Some("selected-key".to_string()),
                 sticky_key: None,
                 upstream_account_id: None,
-                preview: None,
             }),
         }];
 
@@ -7024,6 +7165,97 @@ mod tests {
             !projection_keys.contains(&inactive_key),
             "retained inactive prompt cache windows must not receive runtime deltas"
         );
+        drop(guard);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn inactive_prompt_cache_owner_skips_runtime_projection_materialization() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let topic_key = topic.cache_key().expect("prompt cache topic key");
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(
+                topic_key.clone(),
+                seeded_cached_topic(topic.clone(), &[7], Utc::now()),
+            );
+        }
+        let mut record = dashboard_runtime_topology_live_record("2026-08-08 10:00:00");
+        record.invoke_id = "inactive-prompt-cache".to_string();
+        record.prompt_cache_key = Some("cache-key".to_string());
+        state.proxy_runtime_invocations.upsert(record.clone());
+        let mutations = [SequencedRuntimeMutation {
+            sequence: 1,
+            mutation: RuntimeMutation::invocation(&record, RuntimeMutationKind::RuntimeUpsert),
+        }];
+
+        hub.schedule_prompt_cache_topic_projection(state.clone(), &mutations)
+            .await;
+
+        let guard = hub.state.lock().await;
+        let cached = guard
+            .topics
+            .get(&topic_key)
+            .expect("retained inactive prompt cache topic");
+        assert_eq!(cached.cursor, 7);
+        assert!(cached.prompt_cache_pending_records.is_empty());
+        assert!(!cached.prompt_cache_refresh_scheduled);
+        assert!(
+            !guard
+                .prompt_cache_prebaseline_records
+                .contains_key(&topic_key),
+            "an inactive owner must not receive deferred prompt cache work"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_gap_preserves_prompt_cache_last_good_and_defers_reconcile() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::PromptCacheWindow {
+            selection: PromptCacheConversationSelection::Count(20),
+            detail_level: PromptCacheConversationDetailLevel::Full,
+            recent_invocation_limit: Some(16),
+        };
+        let topic_key = topic.cache_key().expect("prompt cache topic key");
+        let last_good = seeded_cached_topic(topic.clone(), &[7], Utc::now());
+        let last_good_frame = last_good.snapshot_frame.clone();
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(topic_key.clone(), last_good);
+        }
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register prompt cache owner");
+
+        hub.mark_runtime_mutation_gap_and_recover(state.clone(), 4, "cursor_gap")
+            .await;
+
+        let guard = hub.state.lock().await;
+        let cached = guard
+            .topics
+            .get(&topic_key)
+            .expect("active prompt cache topic");
+        assert!(cached.dirty);
+        assert_eq!(cached.continuity_reset_cursor, Some(7));
+        assert!(cached.prompt_cache_reconcile_required);
+        assert_eq!(cached.prompt_cache_full_hydration_count, 0);
+        assert!(Arc::ptr_eq(&cached.snapshot_frame, &last_good_frame));
+        assert!(guard.runtime_topic_recovery_queue.is_empty());
+        assert!(!guard.runtime_topic_recovery_running);
         drop(guard);
         drop(lease);
     }
@@ -9116,6 +9348,7 @@ mod tests {
             conversation_overview_refresh_in_flight: false,
             conversation_overview_refresh_pending: false,
             dirty: false,
+            runtime_topic_recovery_generation: 0,
             summary_refresh_scheduled: false,
             summary_refresh_in_flight: false,
             summary_pending_event_count: 0,
@@ -9219,7 +9452,6 @@ mod tests {
                     prompt_cache_key: None,
                     sticky_key: None,
                     upstream_account_id: None,
-                    preview: None,
                 }
             ))
         );
@@ -9779,12 +10011,7 @@ mod tests {
         record.prompt_cache_key = Some("cache-key".to_string());
         record.status = Some("running".to_string());
 
-        let RuntimeMutation::Invocation(upsert) =
-            RuntimeMutation::invocation(&record, RuntimeMutationKind::RuntimeUpsert)
-        else {
-            unreachable!("runtime record must produce an invocation mutation");
-        };
-        let upsert = PromptCacheTopicDelta::from_runtime_mutation(&upsert)
+        let upsert = PromptCacheTopicDelta::from_record(&record)
             .expect("build compact runtime delta")
             .expect("prompt cache runtime delta");
         let RuntimeMutation::Invocation(removal) =
@@ -9792,7 +10019,7 @@ mod tests {
         else {
             unreachable!("runtime removal must produce an invocation mutation");
         };
-        let removal = PromptCacheTopicDelta::from_runtime_mutation(&removal)
+        let removal = PromptCacheTopicDelta::from_runtime_mutation(&removal, None)
             .expect("build compact removal delta")
             .expect("prompt cache removal delta");
         let mut applied_terminal_ids = HashSet::new();

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -2116,10 +2116,7 @@ impl SubscriptionHub {
             {
                 return Ok(None);
             }
-            guard
-                .topics
-                .get(&topic_key)
-                .map(|cached| cached.runtime_topic_recovery_generation)
+            Some(guard.runtime_topic_recovery_generation)
         } else {
             None
         };
@@ -2143,9 +2140,11 @@ impl SubscriptionHub {
                     .copied()
                     .unwrap_or_default()
                     > 0;
-                let generation_matches = guard.topics.get(&topic_key).is_some_and(|cached| {
-                    Some(cached.runtime_topic_recovery_generation) == refresh_generation
-                });
+                let generation_matches = Some(guard.runtime_topic_recovery_generation)
+                    == refresh_generation
+                    && guard.topics.get(&topic_key).is_none_or(|cached| {
+                        Some(cached.runtime_topic_recovery_generation) == refresh_generation
+                    });
                 if !active || !generation_matches {
                     // A newer gap or owner generation owns the cache now. Only the owner that
                     // observed this generation may dirty it; never invalidate a newer clean
@@ -7557,6 +7556,35 @@ mod tests {
                 .expect("inactive guard must return before acquiring the closed database pool")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn active_owner_without_cached_topic_commits_guarded_refresh() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::InvocationHistoryWindow {
+            scope: ConversationSubscriptionScope::PromptCacheKey("selected-key".to_string()),
+        };
+        let topic_key = topic.cache_key().expect("history topic key");
+        let lease = hub
+            .register_topic_subscribers(std::slice::from_ref(&topic))
+            .await
+            .expect("register history owner");
+
+        let cached = hub
+            .refresh_topic_if_active(state, topic, true)
+            .await
+            .expect("active owner can cold build")
+            .expect("guarded refresh commits when no generation changed");
+
+        assert_eq!(
+            cached.topic.cache_key().expect("cached topic key"),
+            topic_key
+        );
+        drop(lease);
     }
 
     #[tokio::test]

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -2694,7 +2694,7 @@ impl SubscriptionHub {
                 continue;
             }
             if let Err(err) = self
-                .refresh_topic(state.clone(), work.topic.clone(), true)
+                .refresh_topic_if_active(state.clone(), work.topic.clone(), true)
                 .await
             {
                 warn!(
@@ -3010,7 +3010,7 @@ impl SubscriptionHub {
             }
 
             if let Err(err) = self
-                .refresh_topic(state.clone(), cached.topic.clone(), true)
+                .refresh_topic_if_active(state.clone(), cached.topic.clone(), true)
                 .await
             {
                 warn!(

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1822,6 +1822,18 @@ impl RuntimeProjectionHub {
         snapshot
     }
 
+    pub(crate) fn record_by_identity(
+        &self,
+        invoke_id: &str,
+        occurred_at: &str,
+    ) -> Option<ApiInvocation> {
+        let guard = self.inner.lock().ok()?;
+        guard
+            .records
+            .get(&RuntimeInvocationKey::new(invoke_id, occurred_at))
+            .map(|entry| entry.record.clone())
+    }
+
     #[cfg(test)]
     pub(crate) fn backdate_for_test(&self, invoke_id: &str, occurred_at: &str, age: Duration) {
         let Some(updated_at) = Instant::now().checked_sub(age) else {

--- a/src/runtime_mutation_bus.rs
+++ b/src/runtime_mutation_bus.rs
@@ -6,10 +6,7 @@ use std::{
 use serde::Serialize;
 use tokio::sync::broadcast;
 
-use crate::{
-    ApiInvocation, PromptCacheConversationInvocationPreviewResponse,
-    prompt_cache_invocation_preview_from_runtime_record,
-};
+use crate::ApiInvocation;
 
 pub(crate) const RUNTIME_MUTATION_BUS_CAPACITY: usize = 4_096;
 pub(crate) const RUNTIME_MUTATION_ROUTER_MAX_BATCH: usize = 256;
@@ -61,21 +58,12 @@ pub(crate) struct RuntimeInvocationMutation {
     pub(crate) prompt_cache_key: Option<String>,
     pub(crate) sticky_key: Option<String>,
     pub(crate) upstream_account_id: Option<i64>,
-    pub(crate) preview: Option<Box<PromptCacheConversationInvocationPreviewResponse>>,
 }
 
 impl RuntimeInvocationMutation {
     pub(crate) fn from_record(record: &ApiInvocation, kind: RuntimeMutationKind) -> Self {
         let prompt_cache_key = normalize_key(record.prompt_cache_key.as_deref());
         let sticky_key = normalize_key(record.sticky_key.as_deref());
-        let preview = prompt_cache_key
-            .clone()
-            .or_else(|| sticky_key.clone())
-            .map(|key| {
-                Box::new(prompt_cache_invocation_preview_from_runtime_record(
-                    record, key,
-                ))
-            });
         Self {
             identity: RuntimeInvocationIdentity::new(
                 record.invoke_id.clone(),
@@ -87,7 +75,6 @@ impl RuntimeInvocationMutation {
             prompt_cache_key,
             sticky_key,
             upstream_account_id: record.upstream_account_id,
-            preview,
         }
     }
 
@@ -104,7 +91,6 @@ impl RuntimeInvocationMutation {
             prompt_cache_key: None,
             sticky_key: None,
             upstream_account_id: None,
-            preview: None,
         }
     }
 
@@ -117,7 +103,6 @@ impl RuntimeInvocationMutation {
         self.prompt_cache_key = next.prompt_cache_key.or(self.prompt_cache_key.take());
         self.sticky_key = next.sticky_key.or(self.sticky_key.take());
         self.upstream_account_id = next.upstream_account_id.or(self.upstream_account_id);
-        self.preview = next.preview.or(self.preview.take());
     }
 }
 
@@ -371,7 +356,6 @@ mod tests {
                     prompt_cache_key: None,
                     sticky_key: None,
                     upstream_account_id: None,
-                    preview: None,
                 }),
             },
             SequencedRuntimeMutation {
@@ -405,7 +389,6 @@ mod tests {
                 prompt_cache_key: None,
                 sticky_key: None,
                 upstream_account_id: None,
-                preview: None,
             }),
         });
 


### PR DESCRIPTION
## Summary
- Remove full Preview/JSON data from runtime invocation bus mutations.
- Resolve Prompt Cache records by identity only after active dependency routing.
- Convert cursor-gap recovery into bounded background work while retaining Prompt Cache last-good frames.

## Delivery
- Delivery role: child repair for #767.
- Integration branch: `prd/typed-runtime-event-bus`.
- Risk: subscription hot-path and recovery semantics.

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- targeted inactive Prompt Cache, gap recovery, typed runtime, and runtime mutation tests
- pre-commit: fmt, Web typecheck, clippy, commitlint

## Spec
- Spec: `docs/specs/high-frequency-runtime-data-plane/SPEC.md`
- Spec Disposition: link; HTTP/SSE schema, topic names, cursors, and last-good payload contracts are unchanged.
- Solutions: -
- Project Docs: -