### PR TITLE
fix(runtime): coordinate deferred backfill wakes

### DIFF
--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -31,6 +31,37 @@ pub(crate) fn prompt_cache_key_from_payload(payload: Option<&str>) -> Option<Str
         .map(ToOwned::to_owned)
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct TerminalPayloadMetadata {
+    pub(crate) prompt_cache_key: Option<String>,
+    pub(crate) upstream_account_id: Option<i64>,
+}
+
+pub(crate) fn terminal_payload_metadata(payload: Option<&str>) -> TerminalPayloadMetadata {
+    let Some(payload) = payload else {
+        return TerminalPayloadMetadata::default();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(payload) else {
+        return TerminalPayloadMetadata::default();
+    };
+    let prompt_cache_key = value
+        .get("promptCacheKey")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let upstream_account_id = value.get("upstreamAccountId").and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+            .or_else(|| value.as_str().and_then(|value| value.parse::<i64>().ok()))
+    });
+    TerminalPayloadMetadata {
+        prompt_cache_key,
+        upstream_account_id,
+    }
+}
+
 pub(crate) fn sticky_key_from_payload(payload: Option<&str>) -> Option<String> {
     let payload = payload?;
     let value = serde_json::from_str::<Value>(payload).ok()?;

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -3007,7 +3007,54 @@ pub(crate) async fn update_existing_proxy_invocation_record_tx(
 }
 
 pub(crate) fn api_invocation_from_runtime_record(record: &ProxyCaptureRecord) -> ApiInvocation {
-    let payload = record.payload.as_deref();
+    let payload = record
+        .payload
+        .as_deref()
+        .and_then(|payload| serde_json::from_str::<Value>(payload).ok());
+    let payload_text = |key: &str| {
+        payload
+            .as_ref()
+            .and_then(|value| value.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    let payload_i64 = |key: &str| {
+        payload
+            .as_ref()
+            .and_then(|value| value.get(key))
+            .and_then(crate::proxy::json_value_to_i64)
+    };
+    let payload_f64 = |key: &str| {
+        payload
+            .as_ref()
+            .and_then(|value| value.get(key))
+            .and_then(Value::as_f64)
+    };
+    let prompt_cache_key = payload_text("promptCacheKey");
+    let sticky_key = payload
+        .as_ref()
+        .and_then(|value| {
+            value
+                .get("stickyKey")
+                .or_else(|| value.get("promptCacheKey"))
+        })
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let upstream_account_id = payload
+        .as_ref()
+        .and_then(|value| value.get("upstreamAccountId"))
+        .and_then(crate::proxy::json_value_to_i64);
+    let upstream_account_name = payload_text("upstreamAccountName");
+    let blocked_binding_json = payload
+        .as_ref()
+        .and_then(|value| value.get("blockedBinding"))
+        .filter(|value| value.is_object())
+        .and_then(|value| serde_json::to_string(value).ok());
+    let blocked_binding = parse_blocked_binding_json(blocked_binding_json.as_deref());
     let failure = resolve_failure_classification(
         Some(record.status.as_str()),
         record.error_message.as_deref(),
@@ -3020,15 +3067,15 @@ pub(crate) fn api_invocation_from_runtime_record(record: &ProxyCaptureRecord) ->
         invoke_id: record.invoke_id.clone(),
         occurred_at: record.occurred_at.clone(),
         source: SOURCE_PROXY.to_string(),
-        proxy_display_name: payload_text(payload, "proxyDisplayName"),
+        proxy_display_name: payload_text("proxyDisplayName"),
         model: record.model.clone(),
-        request_model: payload_text(payload, "requestModel"),
-        response_model: payload_text(payload, "responseModel"),
+        request_model: payload_text("requestModel"),
+        response_model: payload_text("responseModel"),
         input_tokens: record.usage.input_tokens,
         output_tokens: record.usage.output_tokens,
         cache_input_tokens: record.usage.cache_input_tokens,
         reasoning_tokens: record.usage.reasoning_tokens,
-        reasoning_effort: payload_text(payload, "reasoningEffort"),
+        reasoning_effort: payload_text("reasoningEffort"),
         total_tokens: record.usage.total_tokens,
         cost: record.cost,
         cost_input: record.cost_breakdown.map(|value| value.input),
@@ -3042,40 +3089,40 @@ pub(crate) fn api_invocation_from_runtime_record(record: &ProxyCaptureRecord) ->
         status: Some(record.status.clone()),
         live_phase: None,
         error_message: record.error_message.clone(),
-        downstream_status_code: payload_i64(payload, "downstreamStatusCode"),
+        downstream_status_code: payload_i64("downstreamStatusCode"),
         failure_kind: failure
             .failure_kind
             .clone()
             .or_else(|| record.failure_kind.clone()),
-        blocked_binding: blocked_binding_from_payload(payload),
-        blocked_binding_json: blocked_binding_json_from_payload(payload),
-        stream_terminal_event: payload_text(payload, "streamTerminalEvent"),
-        upstream_error_code: payload_text(payload, "upstreamErrorCode"),
-        upstream_error_message: payload_text(payload, "upstreamErrorMessage"),
-        downstream_error_message: payload_text(payload, "downstreamErrorMessage"),
-        upstream_request_id: payload_text(payload, "upstreamRequestId"),
+        blocked_binding,
+        blocked_binding_json,
+        stream_terminal_event: payload_text("streamTerminalEvent"),
+        upstream_error_code: payload_text("upstreamErrorCode"),
+        upstream_error_message: payload_text("upstreamErrorMessage"),
+        downstream_error_message: payload_text("downstreamErrorMessage"),
+        upstream_request_id: payload_text("upstreamRequestId"),
         failure_class: Some(failure.failure_class.as_str().to_string()),
         is_actionable: Some(failure.is_actionable),
-        endpoint: payload_text(payload, "endpoint"),
-        compaction_request_kind: payload_text(payload, "compactionRequestKind"),
-        compaction_response_kind: payload_text(payload, "compactionResponseKind"),
-        image_intent: payload_text(payload, "imageIntent"),
-        requester_ip: payload_text(payload, "requesterIp"),
-        prompt_cache_key: prompt_cache_key_from_payload(payload),
-        sticky_key: sticky_key_from_payload(payload),
-        route_mode: payload_text(payload, "routeMode"),
-        upstream_account_id: upstream_account_id_from_payload(payload),
-        upstream_account_name: upstream_account_name_from_payload(payload),
-        response_content_encoding: payload_text(payload, "responseContentEncoding"),
-        request_compression_algorithm: payload_text(payload, "requestCompressionAlgorithm"),
+        endpoint: payload_text("endpoint"),
+        compaction_request_kind: payload_text("compactionRequestKind"),
+        compaction_response_kind: payload_text("compactionResponseKind"),
+        image_intent: payload_text("imageIntent"),
+        requester_ip: payload_text("requesterIp"),
+        prompt_cache_key,
+        sticky_key,
+        route_mode: payload_text("routeMode"),
+        upstream_account_id,
+        upstream_account_name,
+        response_content_encoding: payload_text("responseContentEncoding"),
+        request_compression_algorithm: payload_text("requestCompressionAlgorithm"),
         transport: None,
-        pool_attempt_count: payload_i64(payload, "poolAttemptCount"),
-        pool_distinct_account_count: payload_i64(payload, "poolDistinctAccountCount"),
-        pool_attempt_terminal_reason: payload_text(payload, "poolAttemptTerminalReason"),
-        requested_service_tier: payload_text(payload, "requestedServiceTier"),
-        service_tier: payload_text(payload, "serviceTier"),
-        billing_service_tier: payload_text(payload, "billingServiceTier"),
-        proxy_weight_delta: payload_f64(payload, "proxyWeightDelta"),
+        pool_attempt_count: payload_i64("poolAttemptCount"),
+        pool_distinct_account_count: payload_i64("poolDistinctAccountCount"),
+        pool_attempt_terminal_reason: payload_text("poolAttemptTerminalReason"),
+        requested_service_tier: payload_text("requestedServiceTier"),
+        service_tier: payload_text("serviceTier"),
+        billing_service_tier: payload_text("billingServiceTier"),
+        proxy_weight_delta: payload_f64("proxyWeightDelta"),
         cost_estimated: Some(record.cost_estimated as i64),
         price_version: record.price_version.clone(),
         cost_audit: None,

--- a/src/proxy/usage_persistence.rs
+++ b/src/proxy/usage_persistence.rs
@@ -3214,7 +3214,20 @@ pub(crate) async fn touch_invocation_upstream_account_last_activity_tx(
     occurred_at: &str,
     payload: Option<&str>,
 ) -> Result<()> {
-    if let Some(upstream_account_id) = upstream_account_id_from_payload(payload) {
+    touch_upstream_account_last_activity_tx(
+        tx,
+        occurred_at,
+        upstream_account_id_from_payload(payload),
+    )
+    .await
+}
+
+pub(crate) async fn touch_upstream_account_last_activity_tx(
+    tx: &mut SqliteConnection,
+    occurred_at: &str,
+    upstream_account_id: Option<i64>,
+) -> Result<()> {
+    if let Some(upstream_account_id) = upstream_account_id {
         sqlx::query(
             r#"
             UPDATE pool_upstream_accounts

--- a/src/proxy_sqlite_write_coordinator.rs
+++ b/src/proxy_sqlite_write_coordinator.rs
@@ -110,6 +110,7 @@ impl ProxySqliteWriteCoordinator {
                 class,
                 coordinated: false,
                 lock_wait: requested_at.elapsed(),
+                notify_background_eligibility: false,
             };
         }
 
@@ -135,6 +136,7 @@ impl ProxySqliteWriteCoordinator {
                         class,
                         coordinated: true,
                         lock_wait: requested_at.elapsed(),
+                        notify_background_eligibility: true,
                     };
                 }
             }
@@ -155,6 +157,7 @@ impl ProxySqliteWriteCoordinator {
                 class,
                 coordinated: false,
                 lock_wait: requested_at.elapsed(),
+                notify_background_eligibility: false,
             });
         }
         let mut state = self.state.lock().expect("proxy sqlite coordinator state");
@@ -167,6 +170,7 @@ impl ProxySqliteWriteCoordinator {
             class,
             coordinated: true,
             lock_wait: requested_at.elapsed(),
+            notify_background_eligibility: true,
         })
     }
 
@@ -193,6 +197,7 @@ pub(crate) struct ProxySqliteWritePermit {
     class: ProxySqliteWriteClass,
     coordinated: bool,
     lock_wait: Duration,
+    notify_background_eligibility: bool,
 }
 
 impl ProxySqliteWritePermit {
@@ -202,6 +207,10 @@ impl ProxySqliteWritePermit {
 
     pub(crate) fn write_class(&self) -> &'static str {
         self.class.as_str()
+    }
+
+    pub(crate) fn suppress_background_eligibility_wakeup(&mut self) {
+        self.notify_background_eligibility = false;
     }
 }
 
@@ -242,7 +251,9 @@ impl Drop for ProxySqliteWritePermit {
             state.active = None;
         }
         self.coordinator.notify.notify_waiters();
-        crate::db_pressure::global_db_pressure_gate().notify_background_eligibility();
+        if self.notify_background_eligibility {
+            crate::db_pressure::global_db_pressure_gate().notify_background_eligibility();
+        }
     }
 }
 

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -2067,14 +2067,14 @@ pub(crate) async fn run_sqlite_batch_writer(
                                     &mut write_receiver,
                                     &mut pending,
                                     &accounting,
-                                    SQLITE_BATCH_MAX_ROWS,
+                                    SQLITE_BATCH_CHANNEL_CAPACITY,
                                     &queued_p1_count,
                                 );
                                 drain_terminal_journal_deferred_writes(
                                     &terminal_journal,
                                     &mut pending,
                                     &accounting,
-                                    SQLITE_BATCH_MAX_ROWS,
+                                    SQLITE_BATCH_CHANNEL_CAPACITY,
                                     &queued_p1_count,
                                 );
                                 let abandoned = std::mem::take(&mut pending);
@@ -2118,7 +2118,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             let flush_batch = take_next_bounded_batch(&mut pending);
                             let flush_rows = flush_batch.logical_rows();
                             let flush_bytes = flush_batch.estimated_memory_bytes();
-                            let shutdown_quarantine = shutdown_system_task_batch(&flush_batch);
+                            let shutdown_quarantine = shutdown_recovery_batch(&flush_batch);
                             let retained = match timeout_at(
                                 shutdown_deadline.into(),
                                 flush_pending_batch_accounted(
@@ -2412,7 +2412,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                         let flush_batch = take_next_bounded_batch(&mut pending);
                         let flush_rows = flush_batch.logical_rows();
                         let flush_bytes = flush_batch.estimated_memory_bytes();
-                        let shutdown_quarantine = shutdown_system_task_batch(&flush_batch);
+                        let shutdown_quarantine = shutdown_recovery_batch(&flush_batch);
                         let retained = match timeout_at(
                             shutdown_deadline.into(),
                             flush_pending_batch_accounted(
@@ -2947,11 +2947,12 @@ fn quarantine_system_task_batch(
     Ok(batch.system_task_finishes.len())
 }
 
-fn shutdown_system_task_batch(batch: &PendingBatch) -> Option<PendingBatch> {
-    if batch.system_task_finishes.is_empty() {
+fn shutdown_recovery_batch(batch: &PendingBatch) -> Option<PendingBatch> {
+    if batch.terminal_invocations.is_empty() && batch.system_task_finishes.is_empty() {
         return None;
     }
     let mut quarantine = PendingBatch {
+        terminal_invocations: batch.terminal_invocations.clone(),
         system_task_finishes: batch.system_task_finishes.clone(),
         ..PendingBatch::default()
     };
@@ -2974,12 +2975,21 @@ fn quarantine_shutdown_batch(
     let journal = journal
         .as_mut()
         .ok_or_else(|| anyhow::anyhow!("terminal journal unavailable for shutdown quarantine"))?;
-    let error = anyhow!(error.to_string());
+    let error = error.to_string();
+    let mut errors = Vec::new();
     let terminals = batch.terminal_invocations.values().collect::<Vec<_>>();
-    journal.quarantine_terminals(&terminals, &format!("{error:#}"))?;
+    if let Err(err) = journal.quarantine_terminals(&terminals, &error) {
+        errors.push(format!("terminal quarantine failed: {err:#}"));
+    }
     let finishes = batch.system_task_finishes.values().collect::<Vec<_>>();
-    journal.quarantine_system_task_finishes(&finishes, &format!("{error:#}"))?;
-    Ok(())
+    if let Err(err) = journal.quarantine_system_task_finishes(&finishes, &error) {
+        errors.push(format!("system-task quarantine failed: {err:#}"));
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(errors.join("; ")))
+    }
 }
 
 fn release_shutdown_pending_batch(

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -13,7 +13,7 @@ use sqlx::{Pool, Sqlite, SqliteConnection};
 use tokio::{
     sync::{Mutex, RwLock, mpsc, oneshot},
     task::JoinHandle,
-    time::{MissedTickBehavior, interval, sleep},
+    time::{MissedTickBehavior, interval, sleep, timeout_at},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
@@ -592,7 +592,7 @@ impl BatchedTerminalInvocationWrite {
         )
     }
 
-    fn estimated_memory_bytes(&self) -> usize {
+    pub(crate) fn estimated_memory_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
             .saturating_add(self.record.estimated_memory_bytes())
             .saturating_add(
@@ -1310,7 +1310,7 @@ impl SqliteBatchWriter {
             .unwrap_or_default();
         let mut terminal_journal = terminal_journal;
         if let Some(journal) = terminal_journal.as_mut() {
-            journal.queue_replay_for_dispatch();
+            journal.queue_replay_for_dispatch(SQLITE_BATCH_MAX_ROWS);
         }
         let terminal_journal = Arc::new(std::sync::Mutex::new(terminal_journal));
         queued_p1_count.store(replay_writes, Ordering::SeqCst);
@@ -1677,31 +1677,74 @@ impl SqliteBatchWriter {
         let Some(handle) = self.handle.lock().await.take() else {
             return;
         };
+        let shutdown_deadline = tokio::time::Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE;
         let (sender, receiver) = oneshot::channel();
         let queued_depth_snapshot = self
             .write_sender
             .max_capacity()
             .saturating_sub(self.write_sender.capacity());
-        if let Err(err) = self
-            .control_sender
-            .send(SqliteBatchWriterControl::Shutdown {
-                queued_depth_snapshot,
-                responder: sender,
-            })
-            .await
+        let barrier_sent = match timeout_at(
+            shutdown_deadline,
+            self.control_sender
+                .send(SqliteBatchWriterControl::Shutdown {
+                    queued_depth_snapshot,
+                    responder: sender,
+                }),
+        )
+        .await
         {
-            warn!(error = %err, "sqlite batch writer shutdown barrier could not be queued");
-        } else if let Ok(Err(err)) = receiver.await {
-            warn!(error = %err, "sqlite batch writer shutdown drain failed");
+            Ok(Ok(())) => true,
+            Ok(Err(err)) => {
+                warn!(error = %err, "sqlite batch writer shutdown barrier could not be queued");
+                false
+            }
+            Err(_) => {
+                warn!("sqlite batch writer shutdown barrier queue timed out");
+                false
+            }
+        };
+        if barrier_sent {
+            match timeout_at(shutdown_deadline, receiver).await {
+                Ok(Ok(Err(err))) => {
+                    warn!(error = %err, "sqlite batch writer shutdown drain failed");
+                }
+                Ok(Err(err)) => {
+                    warn!(error = %err, "sqlite batch writer shutdown responder dropped");
+                }
+                Err(_) => {
+                    warn!("sqlite batch writer shutdown drain timed out");
+                }
+                Ok(Ok(Ok(()))) => {}
+            }
         }
-        if let Err(err) = handle.await {
-            warn!(error = %err, "sqlite batch writer task failed during shutdown");
+        let mut handle = handle;
+        match timeout_at(shutdown_deadline, &mut handle).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => warn!(error = %err, "sqlite batch writer task failed during shutdown"),
+            Err(_) => {
+                warn!("sqlite batch writer task exceeded shutdown deadline; aborting");
+                handle.abort();
+                let _ = handle.await;
+            }
         }
         self.journal_sync_shutdown.cancel();
-        if let Some(handle) = self.journal_sync_handle.lock().await.take()
-            && let Err(err) = handle.await
-        {
-            warn!(error = %err, "terminal journal sync task failed during shutdown");
+        if let Some(mut handle) = self.journal_sync_handle.lock().await.take() {
+            match timeout_at(
+                tokio::time::Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE,
+                &mut handle,
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    warn!(error = %err, "terminal journal sync task failed during shutdown")
+                }
+                Err(_) => {
+                    warn!("terminal journal sync task exceeded shutdown deadline; aborting");
+                    handle.abort();
+                    let _ = handle.await;
+                }
+            }
         }
     }
 
@@ -2046,22 +2089,35 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 continue;
                             }
                             let flush_batch = take_next_bounded_batch(&mut pending);
-                            let Some(retained) = flush_pending_batch_accounted(
-                                &accounting,
-                                &pool,
-                                pricing_catalog.as_ref(),
-                                flush_batch,
-                                FlushReason::Shutdown,
-                                prompt_cache_conversation_cache.as_ref(),
-                                &terminal_runtime_store,
-                                &dashboard_activity_snapshot_cache,
-                                &terminal_projection_hub,
-                                &dashboard_reconcile_gate,
-                                &terminal_journal,
+                            let flush_rows = flush_batch.logical_rows();
+                            let flush_bytes = flush_batch.estimated_memory_bytes();
+                            let retained = match timeout_at(
+                                shutdown_deadline.into(),
+                                flush_pending_batch_accounted(
+                                    &accounting,
+                                    &pool,
+                                    pricing_catalog.as_ref(),
+                                    flush_batch,
+                                    FlushReason::Shutdown,
+                                    prompt_cache_conversation_cache.as_ref(),
+                                    &terminal_runtime_store,
+                                    &dashboard_activity_snapshot_cache,
+                                    &terminal_projection_hub,
+                                    &dashboard_reconcile_gate,
+                                    &terminal_journal,
+                                ),
                             )
                             .await
-                            else {
-                                continue;
+                            {
+                                Ok(Some(retained)) => retained,
+                                Ok(None) => continue,
+                                Err(_) => {
+                                    accounting.release(flush_rows, flush_bytes);
+                                    result = Err(format!(
+                                        "sqlite batch writer shutdown flush exceeded deadline with {flush_rows} rows"
+                                    ));
+                                    break;
+                                }
                             };
                             let logical_rows = retained.batch.logical_rows();
                             let failed = retained.failed;
@@ -2303,22 +2359,36 @@ pub(crate) async fn run_sqlite_batch_writer(
                             break;
                         }
                         let flush_batch = take_next_bounded_batch(&mut pending);
-                        let Some(retained) = flush_pending_batch_accounted(
-                            &accounting,
-                            &pool,
-                            pricing_catalog.as_ref(),
-                            flush_batch,
-                            FlushReason::Shutdown,
-                            prompt_cache_conversation_cache.as_ref(),
-                            &terminal_runtime_store,
-                            &dashboard_activity_snapshot_cache,
-                            &terminal_projection_hub,
-                            &dashboard_reconcile_gate,
-                            &terminal_journal,
+                        let flush_rows = flush_batch.logical_rows();
+                        let flush_bytes = flush_batch.estimated_memory_bytes();
+                        let retained = match timeout_at(
+                            shutdown_deadline.into(),
+                            flush_pending_batch_accounted(
+                                &accounting,
+                                &pool,
+                                pricing_catalog.as_ref(),
+                                flush_batch,
+                                FlushReason::Shutdown,
+                                prompt_cache_conversation_cache.as_ref(),
+                                &terminal_runtime_store,
+                                &dashboard_activity_snapshot_cache,
+                                &terminal_projection_hub,
+                                &dashboard_reconcile_gate,
+                                &terminal_journal,
+                            ),
                         )
                         .await
-                        else {
-                            continue;
+                        {
+                            Ok(Some(retained)) => retained,
+                            Ok(None) => continue,
+                            Err(_) => {
+                                accounting.release(flush_rows, flush_bytes);
+                                warn!(
+                                    flush_rows,
+                                    "sqlite batch writer receiver shutdown flush exceeded deadline"
+                                );
+                                break;
+                            }
                         };
                         let retained_rows_before_merge = retained.batch.logical_rows();
                         let retained_bytes_before_merge = retained.batch.estimated_memory_bytes();
@@ -2640,6 +2710,8 @@ fn drain_terminal_journal_deferred_writes(
     if let Ok(mut guard) = terminal_journal.lock()
         && let Some(journal) = guard.as_mut()
     {
+        let deferred_capacity = max_writes.saturating_sub(journal.deferred_write_count());
+        journal.queue_replay_for_dispatch(deferred_capacity);
         for terminal in journal.take_deferred_writes(max_writes) {
             decrement_queued_p1_count(queued_p1_count);
             let write = SqliteBatchWrite::TerminalInvocation(terminal);
@@ -2810,12 +2882,15 @@ fn release_shutdown_pending_batch(
     batch: &PendingBatch,
     reason: &str,
 ) -> Result<()> {
+    let mut quarantine_error = None;
     if !batch.system_task_finishes.is_empty() {
         let error = anyhow::anyhow!(reason.to_string());
-        quarantine_system_task_batch(terminal_journal, batch, &error)?;
+        if let Err(err) = quarantine_system_task_batch(terminal_journal, batch, &error) {
+            quarantine_error = Some(err);
+        }
     }
     accounting.release(batch.logical_rows(), batch.estimated_memory_bytes());
-    Ok(())
+    quarantine_error.map_or(Ok(()), Err)
 }
 
 #[expect(
@@ -3344,7 +3419,7 @@ pub(crate) async fn flush_pending_batch_inner(
                 .await
                 .with_context(|| "flush terminal runtime proxy invocation")?
             };
-            let derived_identity = if let Some(persisted) = persisted {
+            let derived_identity = if let Some(persisted) = persisted.as_ref() {
                 if persisted
                     .prompt_cache_key
                     .as_deref()
@@ -3352,7 +3427,7 @@ pub(crate) async fn flush_pending_batch_inner(
                 {
                     should_invalidate_prompt_cache_conversations = true;
                 }
-                Some((persisted.id, persisted.occurred_at))
+                Some((persisted.id, persisted.occurred_at.clone()))
             } else {
                 let identity = load_persisted_invocation_identity_tx(
                     terminal_tx.as_mut(),
@@ -3369,12 +3444,19 @@ pub(crate) async fn flush_pending_batch_inner(
                 terminal.record.occurred_at
             )
         })?;
-            persisted_terminals.push((terminal, invocation_id, occurred_at));
+            let payload_metadata =
+                persisted
+                    .as_ref()
+                    .map(|record| crate::TerminalPayloadMetadata {
+                        prompt_cache_key: record.prompt_cache_key.clone(),
+                        upstream_account_id: record.upstream_account_id,
+                    });
+            persisted_terminals.push((terminal, invocation_id, occurred_at, payload_metadata));
         }
         terminal_tx.commit().await?;
     }
 
-    for (terminal, invocation_id, occurred_at) in persisted_terminals {
+    for (terminal, invocation_id, occurred_at, payload_metadata) in persisted_terminals {
         deferred_batch.add_startup_backfill_wake_tasks(&terminal.startup_backfill_tasks);
         let dashboard_cache = dashboard_activity_snapshot_cache
             .lock()
@@ -3413,7 +3495,11 @@ pub(crate) async fn flush_pending_batch_inner(
                 }
             }
         }
-        let payload_metadata = crate::terminal_payload_metadata(terminal.record.payload.as_deref());
+        // The persistence helper already materialized this payload into the returned invocation.
+        // Reuse those fields instead of parsing the same terminal payload again on the P2 path.
+        let payload_metadata = payload_metadata.unwrap_or_else(|| {
+            crate::terminal_payload_metadata(terminal.record.payload.as_deref())
+        });
         if payload_metadata
             .prompt_cache_key
             .as_deref()

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -138,12 +138,21 @@ async fn wait_for_p2_deadline(due_at: Option<Instant>) {
     }
 }
 
-fn p2_deadline_ready(
-    pending: &PendingBatch,
-    p2_schedule: &P2ScheduleState,
-    write_receiver: &mpsc::Receiver<SqliteBatchWrite>,
-) -> bool {
-    pending.has_p2() && write_receiver.is_empty() && p2_schedule.ready(Instant::now())
+fn p2_deadline_ready(pending: &PendingBatch, p2_schedule: &P2ScheduleState) -> bool {
+    pending.has_p2() && p2_schedule.ready(Instant::now())
+}
+
+fn drain_queued_writes_before_dispatch(
+    write_receiver: &mut mpsc::Receiver<SqliteBatchWrite>,
+    pending: &mut PendingBatch,
+    accounting: &PendingQueueAccounting,
+    p2_schedule: &mut P2ScheduleState,
+) {
+    drain_queued_batch_writes(write_receiver, pending, accounting, SQLITE_BATCH_MAX_ROWS);
+    if pending.has_p2() {
+        p2_schedule.arm_if_idle(Instant::now());
+        accounting.update_p2_schedule(p2_schedule);
+    }
 }
 
 impl P1RetryState {
@@ -1576,6 +1585,12 @@ pub(crate) async fn run_sqlite_batch_writer(
     let mut transaction_sequence = 0_u64;
 
     loop {
+        drain_queued_writes_before_dispatch(
+            &mut write_receiver,
+            &mut pending,
+            &accounting,
+            &mut p2_schedule,
+        );
         tokio::select! {
             biased;
             _ = crate::db_pressure::global_db_pressure_gate()
@@ -1589,7 +1604,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                 accounting.update_p2_schedule(&p2_schedule);
             }
             _ = wait_for_p2_deadline(p2_schedule.due_at),
-                if p2_deadline_ready(&pending, &p2_schedule, &write_receiver) =>
+                if p2_deadline_ready(&pending, &p2_schedule) =>
             {
                 let now = Instant::now();
                 let submitted_p1 = !pending.terminal_invocations.is_empty() && p1_retry.ready(now);
@@ -1749,7 +1764,11 @@ pub(crate) async fn run_sqlite_batch_writer(
                                     Ok(())
                                 }
                             }
-                            None => Ok(()),
+                            None => {
+                                p2_schedule.succeeded();
+                                accounting.update_p2_schedule(&p2_schedule);
+                                Ok(())
+                            },
                         };
                         let _ = responder.send(result);
                     }
@@ -2891,7 +2910,8 @@ mod tests {
     }
 
     #[test]
-    fn queued_p1_write_blocks_ready_p2_deadline() {
+    fn queued_p1_write_is_drained_before_ready_p2_deadline() {
+        let accounting = PendingQueueAccounting::default();
         let mut pending = PendingBatch::default();
         pending.push(SqliteBatchWrite::AccountSelectedTouch(
             BatchedAccountSelectedTouch {
@@ -2901,17 +2921,58 @@ mod tests {
         ));
         let mut schedule = P2ScheduleState::default();
         schedule.wake_background_eligible();
-        let (sender, receiver) = mpsc::channel(1);
+        let (sender, mut receiver) = mpsc::channel(1);
         sender
             .try_send(SqliteBatchWrite::TerminalInvocation(
                 terminal_write_for_coalescing("queued-p1-priority", None),
             ))
             .expect("queue P1 terminal");
+        drain_queued_writes_before_dispatch(
+            &mut receiver,
+            &mut pending,
+            &accounting,
+            &mut schedule,
+        );
 
         assert!(
-            !p2_deadline_ready(&pending, &schedule, &receiver),
-            "a queued P1 terminal must be received before a ready P2 deadline"
+            receiver.is_empty(),
+            "queued P1 must be classified before checking the P2 deadline"
         );
+        assert_eq!(pending.terminal_invocations.len(), 1);
+        assert!(p2_deadline_ready(&pending, &schedule));
+    }
+
+    #[test]
+    fn queued_p2_does_not_block_ready_p2_deadline() {
+        let accounting = PendingQueueAccounting::default();
+        let mut pending = PendingBatch::default();
+        pending.push(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: 999_997,
+                selected_at: "2026-08-10T12:00:00Z".to_string(),
+            },
+        ));
+        let mut schedule = P2ScheduleState::default();
+        schedule.wake_background_eligible();
+        let (sender, mut receiver) = mpsc::channel(1);
+        sender
+            .try_send(SqliteBatchWrite::AccountSelectedTouch(
+                BatchedAccountSelectedTouch {
+                    account_id: 999_996,
+                    selected_at: "2026-08-10T12:00:01Z".to_string(),
+                },
+            ))
+            .expect("queue P2 write");
+
+        drain_queued_writes_before_dispatch(
+            &mut receiver,
+            &mut pending,
+            &accounting,
+            &mut schedule,
+        );
+
+        assert!(receiver.is_empty());
+        assert!(p2_deadline_ready(&pending, &schedule));
     }
 
     #[tokio::test]
@@ -3717,6 +3778,134 @@ mod tests {
         assert_eq!(row.1, Some(23.0));
         assert_eq!(row.2, Some(37.0));
         writer.shutdown_and_drain().await;
+    }
+
+    #[tokio::test]
+    async fn flush_now_resets_completed_p2_schedule() {
+        let pool = test_pool().await;
+        let writer = SqliteBatchWriter::spawn(
+            pool.clone(),
+            CancellationToken::new(),
+            Arc::new(Mutex::new(PromptCacheConversationsCacheState::default())),
+            Arc::new(RwLock::new(PricingCatalog::default())),
+            &std::env::temp_dir().join(format!("sqlite-batch-writer-{}.db", nanoid::nanoid!())),
+        );
+        assert!(writer.enqueue(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: 999_995,
+                selected_at: "2026-08-10T12:00:00Z".to_string(),
+            },
+        )));
+
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                if writer.accounting_snapshot().p2_wake_reason.as_deref()
+                    == Some("coalesced_deadline")
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("writer should arm the P2 coalescing deadline before FlushNow");
+
+        writer
+            .flush_now(&pool)
+            .await
+            .expect("FlushNow should complete the pending P2 batch");
+        let reset = writer.accounting_snapshot();
+        assert_eq!(reset.pending_depth, 0);
+        assert_eq!(reset.p2_next_attempt_in_ms, 0);
+        assert_eq!(reset.p2_wake_reason, None);
+
+        assert!(writer.enqueue(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: 999_994,
+                selected_at: "2026-08-10T12:00:01Z".to_string(),
+            },
+        )));
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                let snapshot = writer.accounting_snapshot();
+                if snapshot.p2_wake_reason.as_deref() == Some("coalesced_deadline") {
+                    assert!(snapshot.p2_next_attempt_in_ms >= 200);
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("new P2 work should receive a full coalescing interval");
+        writer.shutdown_and_drain().await;
+    }
+
+    #[tokio::test]
+    async fn queued_p2_work_does_not_starve_its_scheduled_flush() {
+        let pool = test_pool().await;
+        let writer = SqliteBatchWriter::spawn(
+            pool.clone(),
+            CancellationToken::new(),
+            Arc::new(Mutex::new(PromptCacheConversationsCacheState::default())),
+            Arc::new(RwLock::new(PricingCatalog::default())),
+            &std::env::temp_dir().join(format!("sqlite-batch-writer-{}.db", nanoid::nanoid!())),
+        );
+        assert!(writer.enqueue(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: 999_993,
+                selected_at: "2026-08-10T12:00:00Z".to_string(),
+            },
+        )));
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                if writer.accounting_snapshot().p2_wake_reason.as_deref()
+                    == Some("coalesced_deadline")
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("writer should arm the P2 coalescing deadline");
+
+        let producer_active = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let producer = {
+            let producer_active = producer_active.clone();
+            let producer_writer = writer.clone();
+            tokio::spawn(async move {
+                while producer_active.load(std::sync::atomic::Ordering::Acquire) {
+                    for _ in 0..1024 {
+                        let _ = producer_writer.enqueue(SqliteBatchWrite::AccountSelectedTouch(
+                            BatchedAccountSelectedTouch {
+                                account_id: 999_992,
+                                selected_at: "2026-08-10T12:00:01Z".to_string(),
+                            },
+                        ));
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        let resumed = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if writer.accounting_snapshot().p2_flush_attempt_count > 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .is_ok();
+        producer_active.store(false, std::sync::atomic::Ordering::Release);
+        producer.abort();
+        let _ = producer.await;
+        writer.shutdown_and_drain().await;
+        assert!(
+            resumed,
+            "queued P2 writes must not prevent the scheduled P2 flush"
+        );
     }
 
     #[tokio::test]

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -896,6 +896,9 @@ impl PendingBatch {
         self.terminal_estimated_bytes = self
             .terminal_estimated_bytes
             .saturating_sub(estimated_bytes);
+        if !self.has_p2() {
+            self.oldest_at = None;
+        }
         Self {
             enqueued_rows: terminal_invocations.len(),
             estimated_bytes,
@@ -985,7 +988,7 @@ impl PendingBatch {
         if !self.startup_backfill_wake_tasks.is_empty()
             && should_take(
                 self.startup_backfill_wake_tasks
-                    .len()
+                    .capacity()
                     .saturating_mul(std::mem::size_of::<StartupBackfillTask>()),
             )
         {

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1332,6 +1332,7 @@ impl SqliteBatchWriter {
         let cache_for_task = prompt_cache_conversation_cache.clone();
         let handle = tokio::spawn(run_sqlite_batch_writer(
             pool,
+            database_path.to_path_buf(),
             write_receiver,
             control_receiver,
             accounting.clone(),
@@ -1879,6 +1880,7 @@ impl SqliteBatchWriter {
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_sqlite_batch_writer(
     pool: Pool<Sqlite>,
+    database_path: std::path::PathBuf,
     mut write_receiver: mpsc::Receiver<SqliteBatchWrite>,
     mut control_receiver: mpsc::Receiver<SqliteBatchWriterControl>,
     accounting: Arc<PendingQueueAccounting>,
@@ -2082,6 +2084,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 let _ = release_shutdown_pending_batch(
                                     &accounting,
                                     &terminal_journal,
+                                    &database_path,
                                     &abandoned,
                                     "shutdown drain deadline exceeded",
                                 )
@@ -2144,6 +2147,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                                     if let Some(quarantine) = shutdown_quarantine.as_ref()
                                         && let Err(err) = quarantine_shutdown_batch(
                                             &terminal_journal,
+                                            &database_path,
                                             quarantine,
                                             "shutdown flush deadline exceeded",
                                         )
@@ -2234,6 +2238,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             if let Err(err) = release_shutdown_pending_batch(
                                 &accounting,
                                 &terminal_journal,
+                                &database_path,
                                 &abandoned,
                                 "shutdown drain stopped after flush timeout",
                             ) {
@@ -2392,6 +2397,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             let _ = release_shutdown_pending_batch(
                                 &accounting,
                                 &terminal_journal,
+                                &database_path,
                                 &abandoned,
                                 "receiver shutdown drain deadline exceeded",
                             )
@@ -2438,6 +2444,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 if let Some(quarantine) = shutdown_quarantine.as_ref()
                                     && let Err(err) = quarantine_shutdown_batch(
                                         &terminal_journal,
+                                        &database_path,
                                         quarantine,
                                         "receiver shutdown flush deadline exceeded",
                                     )
@@ -2526,6 +2533,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                         if let Err(err) = release_shutdown_pending_batch(
                             &accounting,
                             &terminal_journal,
+                            &database_path,
                             &abandoned,
                             "receiver shutdown drain stopped after flush timeout",
                         ) {
@@ -2964,42 +2972,64 @@ fn shutdown_recovery_batch(batch: &PendingBatch) -> Option<PendingBatch> {
 
 fn quarantine_shutdown_batch(
     terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    database_path: &std::path::Path,
     batch: &PendingBatch,
     error: &str,
 ) -> Result<()> {
     if batch.terminal_invocations.is_empty() && batch.system_task_finishes.is_empty() {
         return Ok(());
     }
-    let mut journal = terminal_journal
-        .lock()
-        .map_err(|_| anyhow::anyhow!("terminal journal lock poisoned"))?;
-    let journal = journal
-        .as_mut()
-        .ok_or_else(|| anyhow::anyhow!("terminal journal unavailable for shutdown quarantine"))?;
     let error = error.to_string();
-    let mut errors = Vec::new();
     let terminals = batch.terminal_invocations.values().collect::<Vec<_>>();
-    if let Err(err) = journal.quarantine_terminals(&terminals, &error) {
-        errors.push(format!("terminal quarantine failed: {err:#}"));
-    }
     let finishes = batch.system_task_finishes.values().collect::<Vec<_>>();
-    if let Err(err) = journal.quarantine_system_task_finishes(&finishes, &error) {
-        errors.push(format!("system-task quarantine failed: {err:#}"));
+    let mut errors = Vec::new();
+    match terminal_journal.lock() {
+        Ok(mut guard) => match guard.as_mut() {
+            Some(journal) => {
+                if let Err(err) = journal.quarantine_terminals(&terminals, &error) {
+                    errors.push(format!("terminal quarantine failed: {err:#}"));
+                }
+                if let Err(err) = journal.quarantine_system_task_finishes(&finishes, &error) {
+                    errors.push(format!("system-task quarantine failed: {err:#}"));
+                }
+            }
+            None => errors.push("terminal journal unavailable for shutdown quarantine".to_string()),
+        },
+        Err(_) => errors.push("terminal journal lock poisoned".to_string()),
     }
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(anyhow!(errors.join("; ")))
+        match TerminalJournal::quarantine_shutdown_batch_at_database_path(
+            database_path,
+            &terminals,
+            &finishes,
+            &error,
+        ) {
+            Ok(()) => {
+                warn!(
+                    errors = ?errors,
+                    "shutdown quarantine used the independent recovery sink"
+                );
+                Ok(())
+            }
+            Err(fallback_error) => Err(anyhow!(
+                "{}; independent recovery sink failed: {fallback_error:#}",
+                errors.join("; ")
+            )),
+        }
     }
 }
 
 fn release_shutdown_pending_batch(
     accounting: &PendingQueueAccounting,
     terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    database_path: &std::path::Path,
     batch: &PendingBatch,
     reason: &str,
 ) -> Result<()> {
-    let quarantine_error = quarantine_shutdown_batch(terminal_journal, batch, reason).err();
+    let quarantine_error =
+        quarantine_shutdown_batch(terminal_journal, database_path, batch, reason).err();
     accounting.release(batch.logical_rows(), batch.estimated_memory_bytes());
     quarantine_error.map_or(Ok(()), Err)
 }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1438,6 +1438,10 @@ impl SqliteBatchWriter {
             };
         }
 
+        let _p1_priority_guard = self
+            .p1_priority_gate
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         let journal = self
             .terminal_journal
             .lock()
@@ -1477,11 +1481,6 @@ impl SqliteBatchWriter {
     ) -> bool {
         let estimated_bytes = write.estimated_memory_bytes();
         let is_p1 = is_p1_terminal_write(&write);
-        let _p1_priority_guard = is_p1.then(|| {
-            self.p1_priority_gate
-                .lock()
-                .unwrap_or_else(|error| error.into_inner())
-        });
         self.accounting.enqueue(estimated_bytes);
         if is_p1 {
             self.queued_p1_count.fetch_add(1, Ordering::SeqCst);
@@ -1974,7 +1973,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                 let now = Instant::now();
                 let submitted_p1 = !pending.terminal_invocations.is_empty() && p1_retry.ready(now);
                 let flush_batch = if submitted_p1 {
-                    pending.take()
+                    pending.take_p1_terminals()
                 } else {
                     pending.take_p2_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                 };
@@ -2731,9 +2730,11 @@ pub(crate) async fn flush_pending_batch(
                 "sqlite batch writer P2 flush failed"
             );
             drop(permit);
+            let retryable_failure = crate::db_pressure::is_db_pressure_error(&err)
+                || !batch.system_task_finishes.is_empty();
             return Some(RetainedBatch::p2_failed(
                 batch,
-                crate::db_pressure::is_db_pressure_error(&err),
+                retryable_failure,
                 is_sqlite_lock_error(&err),
             ));
         }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -138,6 +138,14 @@ async fn wait_for_p2_deadline(due_at: Option<Instant>) {
     }
 }
 
+fn p2_deadline_ready(
+    pending: &PendingBatch,
+    p2_schedule: &P2ScheduleState,
+    write_receiver: &mpsc::Receiver<SqliteBatchWrite>,
+) -> bool {
+    pending.has_p2() && write_receiver.is_empty() && p2_schedule.ready(Instant::now())
+}
+
 impl P1RetryState {
     fn ready(&self, now: Instant) -> bool {
         self.due_at.is_none_or(|due_at| now >= due_at)
@@ -1581,7 +1589,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                 accounting.update_p2_schedule(&p2_schedule);
             }
             _ = wait_for_p2_deadline(p2_schedule.due_at),
-                if pending.has_p2() && p2_schedule.ready(Instant::now()) =>
+                if p2_deadline_ready(&pending, &p2_schedule, &write_receiver) =>
             {
                 let now = Instant::now();
                 let submitted_p1 = !pending.terminal_invocations.is_empty() && p1_retry.ready(now);
@@ -1703,6 +1711,35 @@ pub(crate) async fn run_sqlite_batch_writer(
                             Some(retained) => {
                                 let logical_rows = retained.batch.logical_rows();
                                 let failed = retained.failed;
+                                match retained.p2_defer {
+                                    Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                                        p2_schedule.defer_pressure(
+                                            Duration::from_millis(remaining_ms),
+                                            P2WakeReason::PressureCooldownElapsed,
+                                        );
+                                    }
+                                    Some(P2DeferReason::BackgroundBusy {
+                                        observed_generation,
+                                    }) => {
+                                        p2_eligibility_generation = observed_generation;
+                                        p2_schedule.defer_until_background_eligible();
+                                    }
+                                    None if retained.failed
+                                        && retained.batch.has_p2()
+                                        && retained.batch.terminal_invocations.is_empty() =>
+                                    {
+                                        transaction_sequence = transaction_sequence.saturating_add(1);
+                                        p2_schedule.failed(transaction_sequence);
+                                        if retained.p2_lock_failure {
+                                            accounting.p2_lock_retried();
+                                        }
+                                    }
+                                    None if retained.batch.has_p2() => {
+                                        p2_schedule.arm_if_idle(Instant::now());
+                                    }
+                                    None => p2_schedule.succeeded(),
+                                }
+                                accounting.update_p2_schedule(&p2_schedule);
                                 pending = retained.batch;
                                 if failed {
                                     Err(format!(
@@ -2853,6 +2890,30 @@ mod tests {
         .expect("P2 pressure deadline should eventually wake");
     }
 
+    #[test]
+    fn queued_p1_write_blocks_ready_p2_deadline() {
+        let mut pending = PendingBatch::default();
+        pending.push(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: 999_998,
+                selected_at: "2026-08-10T12:00:00Z".to_string(),
+            },
+        ));
+        let mut schedule = P2ScheduleState::default();
+        schedule.wake_background_eligible();
+        let (sender, receiver) = mpsc::channel(1);
+        sender
+            .try_send(SqliteBatchWrite::TerminalInvocation(
+                terminal_write_for_coalescing("queued-p1-priority", None),
+            ))
+            .expect("queue P1 terminal");
+
+        assert!(
+            !p2_deadline_ready(&pending, &schedule, &receiver),
+            "a queued P1 terminal must be received before a ready P2 deadline"
+        );
+    }
+
     #[tokio::test]
     async fn p2_eligibility_wake_resumes_a_deferred_flush() {
         let mut schedule = P2ScheduleState::default();
@@ -3981,6 +4042,109 @@ mod tests {
         assert_eq!(completed.pending_bytes, 0);
         assert_eq!(completed.state, "healthy");
 
+        writer.shutdown_and_drain().await;
+    }
+
+    #[tokio::test]
+    async fn flush_now_schedules_retained_p2_for_coordinator_eligibility() {
+        let pool = test_pool().await;
+        let coordinator = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator();
+        let initial = coordinator.snapshot().await;
+        assert!(initial.active_write_class.is_none());
+        assert_eq!(initial.p1_waiter_count, 0);
+        assert_eq!(initial.interactive_waiter_count, 0);
+        assert_eq!(initial.p2_waiter_count, 0);
+
+        let active_p2 = coordinator
+            .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
+            .await;
+        let interactive_coordinator = coordinator.clone();
+        let interactive_waiter = tokio::spawn(async move {
+            interactive_coordinator
+                .acquire(
+                    crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::InteractiveProxy,
+                )
+                .await
+        });
+        let waiter_deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if coordinator.snapshot().await.interactive_waiter_count == 1 {
+                break;
+            }
+            assert!(
+                Instant::now() < waiter_deadline,
+                "interactive coordinator waiter did not register"
+            );
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        let writer = SqliteBatchWriter::spawn(
+            pool.clone(),
+            CancellationToken::new(),
+            Arc::new(Mutex::new(PromptCacheConversationsCacheState::default())),
+            Arc::new(RwLock::new(PricingCatalog::default())),
+            &std::env::temp_dir().join(format!("sqlite-batch-writer-{}.db", nanoid::nanoid!())),
+        );
+        assert!(writer.enqueue(SqliteBatchWrite::TerminalInvocation(
+            BatchedTerminalInvocationWrite {
+                record: crate::tests::test_proxy_capture_record(
+                    "flush-now-coordinator-p2",
+                    "2026-08-10 12:00:00",
+                ),
+                capture_started: None,
+                raw_capture: false,
+                dashboard_terminal_sequence: None,
+                terminal_projection_event_ids: Vec::new(),
+                startup_backfill_tasks: Vec::new(),
+            },
+        )));
+
+        let flush_writer = writer.clone();
+        let flush_pool = pool.clone();
+        let flush_task = tokio::spawn(async move { flush_writer.flush_now(&flush_pool).await });
+        let p1_deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if coordinator.snapshot().await.p1_waiter_count == 1 {
+                break;
+            }
+            assert!(
+                Instant::now() < p1_deadline,
+                "P1 coordinator waiter did not register"
+            );
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        drop(active_p2);
+
+        tokio::time::timeout(Duration::from_secs(2), flush_task)
+            .await
+            .expect("flush_now should finish after the P1 coordinator permit is released")
+            .expect("flush_now task should complete")
+            .expect("deferred P2 should not fail the flush_now barrier");
+        let scheduled = writer.accounting_snapshot();
+        assert_eq!(
+            scheduled.p2_wake_reason.as_deref(),
+            Some("background_eligible"),
+            "retained P2 must wait on coordinator eligibility"
+        );
+        assert!(scheduled.pending_depth > 0);
+
+        let interactive_permit = tokio::time::timeout(Duration::from_secs(2), interactive_waiter)
+            .await
+            .expect("interactive waiter should be admitted after P1 commits")
+            .expect("interactive waiter task should complete");
+        drop(interactive_permit);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let snapshot = writer.accounting_snapshot();
+                if snapshot.pending_depth == 0 && snapshot.p2_flush_attempt_count > 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("eligibility notification should resume the retained P2 flush");
         writer.shutdown_and_drain().await;
     }
 

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -372,6 +372,11 @@ impl PendingQueueAccounting {
         );
     }
 
+    pub(crate) fn release(&self, depth: usize, bytes: usize) {
+        self.subtract(&self.pending_depth, depth, "release", "pending_depth");
+        self.subtract(&self.pending_bytes, bytes, "release", "pending_bytes");
+    }
+
     pub(crate) fn snapshot(&self) -> PendingQueueAccountingSnapshot {
         let last_invariant_violation = self
             .last_invariant_violation
@@ -534,7 +539,7 @@ impl FlushReason {
     }
 
     fn bypass_pressure_gate(self) -> bool {
-        matches!(self, Self::Shutdown)
+        false
     }
 }
 
@@ -2042,12 +2047,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             retained_batch.merge_all(pending.take());
                             let retained_depth = retained_batch.logical_rows();
                             let retained_bytes = retained_batch.estimated_memory_bytes();
-                            accounting.complete(
-                                retained_depth,
-                                0,
-                                retained_bytes,
-                                0,
-                            );
+                            accounting.release(retained_depth, retained_bytes);
                             if failed {
                                 result = Err(format!(
                                     "sqlite batch writer retained {logical_rows} logical rows after shutdown flush"
@@ -2204,19 +2204,23 @@ pub(crate) async fn run_sqlite_batch_writer(
             }
             maybe_write = write_receiver.recv() => {
                 let Some(write) = maybe_write else {
-                    drain_terminal_journal_deferred_writes(
-                        &terminal_journal,
-                        &mut pending,
-                        &accounting,
-                        usize::MAX,
-                        &queued_p1_count,
-                    );
-                    if !pending.is_empty()
-                        && let Some(retained) = flush_pending_batch_accounted(
+                    loop {
+                        drain_terminal_journal_deferred_writes(
+                            &terminal_journal,
+                            &mut pending,
+                            &accounting,
+                            SQLITE_BATCH_MAX_ROWS,
+                            &queued_p1_count,
+                        );
+                        if pending.is_empty() {
+                            break;
+                        }
+                        let flush_batch = take_next_bounded_batch(&mut pending);
+                        let Some(retained) = flush_pending_batch_accounted(
                             &accounting,
                             &pool,
                             pricing_catalog.as_ref(),
-                            pending.take(),
+                            flush_batch,
                             FlushReason::Shutdown,
                             prompt_cache_conversation_cache.as_ref(),
                             &terminal_runtime_store,
@@ -2226,19 +2230,21 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &terminal_journal,
                         )
                         .await
-                    {
-                        accounting.complete(
-                            retained.batch.logical_rows(),
-                            0,
-                            retained.batch.estimated_memory_bytes(),
-                            0,
-                        );
+                        else {
+                            continue;
+                        };
+                        let mut retained_batch = retained.batch;
+                        retained_batch.merge_all(pending.take());
+                        let retained_rows = retained_batch.logical_rows();
+                        let retained_bytes = retained_batch.estimated_memory_bytes();
+                        accounting.release(retained_rows, retained_bytes);
                         warn!(
-                            retained_rows = retained.batch.logical_rows(),
-                            retained_bytes = retained.batch.estimated_memory_bytes(),
+                            retained_rows,
+                            retained_bytes,
                             failed = retained.failed,
                             "sqlite batch writer released retained memory accounting after receiver shutdown"
                         );
+                        break;
                     }
                     return;
                 };
@@ -2262,14 +2268,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                     let p2_ready = p2_schedule.ready(Instant::now())
                         && queued_p1_count.load(Ordering::SeqCst) == 0;
                     let flush_batch = if !pending.terminal_invocations.is_empty() {
-                        if pending.has_p2() {
-                            pending.take_p1_terminal_chunk(
-                                SQLITE_BATCH_MAX_ROWS,
-                                SQLITE_BATCH_MAX_BYTES,
-                            )
-                        } else {
-                            pending.take()
-                        }
+                        pending.take_p1_terminal_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                     } else if p2_ready {
                         pending.take_p2_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                     } else {
@@ -2920,6 +2919,9 @@ pub(crate) async fn flush_pending_batch(
             }
         }
     }
+    let system_task_retryable_failure = system_task_failure
+        .as_ref()
+        .is_some_and(crate::db_pressure::is_db_pressure_error);
 
     match flush_pending_batch_inner(
         pool,
@@ -2936,13 +2938,30 @@ pub(crate) async fn flush_pending_batch(
         Ok(main_deferred) => {
             deferred_batch.merge_p2(main_deferred);
             if system_task_failure.is_some() {
+                if !system_task_retryable_failure {
+                    warn!(
+                        flush_priority = "P2",
+                        system_task_scope = %summarize_system_task_batch_scope(
+                            system_task_batch
+                                .as_ref()
+                                .expect("system task failure must retain its isolated batch")
+                        ),
+                        "discarded deterministic system-task completion after failed finalization"
+                    );
+                    drop(permit);
+                    return if deferred_batch.is_empty() {
+                        None
+                    } else {
+                        Some(RetainedBatch::new(deferred_batch, false))
+                    };
+                }
                 let mut retry_batch =
                     system_task_batch.expect("system task failure must retain its isolated batch");
                 retry_batch.merge_p2(deferred_batch);
                 drop(permit);
                 return Some(RetainedBatch::p2_failed(
                     retry_batch,
-                    true,
+                    system_task_retryable_failure,
                     system_task_lock_failure,
                 ));
             }
@@ -2965,7 +2984,7 @@ pub(crate) async fn flush_pending_batch(
                     system_task_batch.expect("system task failure must retain its isolated batch");
                 return Some(RetainedBatch::p2_failed(
                     retry_batch,
-                    true,
+                    system_task_retryable_failure,
                     system_task_lock_failure,
                 ));
             }
@@ -2975,7 +2994,8 @@ pub(crate) async fn flush_pending_batch(
                     retry_batch.merge_p2(batch);
                     return Some(RetainedBatch::p2_failed(
                         retry_batch,
-                        true,
+                        system_task_retryable_failure
+                            || crate::db_pressure::is_db_pressure_error(&err),
                         system_task_lock_failure || is_sqlite_lock_error(&err),
                     ));
                 }
@@ -2989,8 +3009,7 @@ pub(crate) async fn flush_pending_batch(
                     is_sqlite_lock_error(&err),
                 ));
             }
-            let retryable_failure = crate::db_pressure::is_db_pressure_error(&err)
-                || !batch.system_task_finishes.is_empty();
+            let retryable_failure = crate::db_pressure::is_db_pressure_error(&err);
             return Some(RetainedBatch::p2_failed(
                 batch,
                 retryable_failure,
@@ -3280,10 +3299,10 @@ pub(crate) async fn flush_pending_batch_inner(
         .await?;
     }
 
-    let invocation_derived = batch.invocation_derived.clone();
     let mut terminal_overlay_keys = Vec::new();
-    if !invocation_derived.is_empty() {
-        let target_invocation_id = invocation_derived
+    if !batch.invocation_derived.is_empty() {
+        let target_invocation_id = batch
+            .invocation_derived
             .keys()
             .next_back()
             .copied()
@@ -3295,7 +3314,8 @@ pub(crate) async fn flush_pending_batch_inner(
         let live_rollup_cursor_after =
             load_hourly_rollup_live_progress_tx(tx.as_mut(), HOURLY_ROLLUP_DATASET_INVOCATIONS)
                 .await?;
-        let skipped_terminal_ids = invocation_derived
+        let skipped_terminal_ids = batch
+            .invocation_derived
             .keys()
             .filter(|invocation_id| **invocation_id <= live_rollup_cursor_before)
             .copied()
@@ -3304,7 +3324,7 @@ pub(crate) async fn flush_pending_batch_inner(
             recompute_invocation_hourly_rollups_for_ids_tx(tx.as_mut(), &skipped_terminal_ids)
                 .await?;
         }
-        for derived in invocation_derived.values() {
+        for derived in batch.invocation_derived.values() {
             if derived.invocation_id > live_rollup_cursor_after {
                 deferred_batch.push(SqliteBatchWrite::InvocationDerived(derived.clone()));
                 continue;

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1553,22 +1553,54 @@ impl SqliteBatchWriter {
             TerminalJournalDurabilityMode::MemoryOverflow
         ) {
             let terminals = [&recovery_terminal];
-            if let Err(err) = TerminalJournal::quarantine_shutdown_batch_at_database_path(
-                &self.database_path,
-                &terminals,
-                &[],
-                "terminal journal memory-overflow recovery",
-            ) {
+            let mut recovery_persisted = false;
+            if let Ok(mut guard) = self.terminal_journal.lock()
+                && let Some(journal) = guard.as_mut()
+            {
+                match journal.quarantine_shutdown_batch(
+                    &terminals,
+                    &[],
+                    "terminal journal memory-overflow recovery",
+                ) {
+                    Ok(()) => {
+                        journal.remember_shutdown_recovery(&terminals);
+                        recovery_persisted = true;
+                    }
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            invoke_id = %recovery_terminal.record.invoke_id,
+                            occurred_at = %recovery_terminal.record.occurred_at,
+                            "terminal memory-overflow recovery sink failed"
+                        );
+                        if TerminalJournal::quarantine_shutdown_batch_at_database_path(
+                            &self.database_path,
+                            &terminals,
+                            &[],
+                            "terminal journal memory-overflow recovery",
+                        )
+                        .is_ok()
+                        {
+                            journal.remember_shutdown_recovery(&terminals);
+                            recovery_persisted = true;
+                        }
+                    }
+                }
+            }
+            if !recovery_persisted
+                && let Err(err) = TerminalJournal::quarantine_shutdown_batch_at_database_path(
+                    &self.database_path,
+                    &terminals,
+                    &[],
+                    "terminal journal memory-overflow recovery",
+                )
+            {
                 warn!(
                     error = %err,
                     invoke_id = %recovery_terminal.record.invoke_id,
                     occurred_at = %recovery_terminal.record.occurred_at,
                     "terminal memory-overflow recovery sink failed"
                 );
-            } else if let Ok(mut journal) = self.terminal_journal.lock()
-                && let Some(journal) = journal.as_mut()
-            {
-                journal.remember_shutdown_recovery(&terminals);
             }
         }
         TerminalEnqueueOutcome {
@@ -3021,6 +3053,7 @@ fn quarantine_shutdown_batch(
     let terminals = batch.terminal_invocations.values().collect::<Vec<_>>();
     let finishes = batch.system_task_finishes.values().collect::<Vec<_>>();
     let mut errors = Vec::new();
+    let mut recovery_persisted = false;
     match terminal_journal.lock() {
         Ok(mut guard) => match guard.as_mut() {
             Some(journal) => {
@@ -3030,10 +3063,23 @@ fn quarantine_shutdown_batch(
                 if let Err(err) = journal.quarantine_system_task_finishes(&finishes, &error) {
                     errors.push(format!("system-task quarantine failed: {err:#}"));
                 }
+                if !errors.is_empty() {
+                    match journal.quarantine_shutdown_batch(&terminals, &finishes, &error) {
+                        Ok(()) => {
+                            journal.remember_shutdown_recovery(&terminals);
+                            recovery_persisted = true;
+                        }
+                        Err(err) => errors.push(format!("shutdown recovery failed: {err:#}")),
+                    }
+                }
             }
             None => errors.push("terminal journal unavailable for shutdown quarantine".to_string()),
         },
         Err(_) => errors.push("terminal journal lock poisoned".to_string()),
+    }
+    if recovery_persisted {
+        warn!(errors = ?errors, "shutdown quarantine used the journal recovery sink");
+        return Ok(());
     }
     if errors.is_empty() {
         Ok(())

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -625,6 +625,8 @@ pub(crate) enum SqliteBatchWrite {
     InvocationDerived(BatchedInvocationDerivedWrites),
     AccountSelectedTouch(BatchedAccountSelectedTouch),
     SystemTaskFinish(BatchedSystemTaskFinish),
+    #[cfg(test)]
+    StartupBackfillWake(StartupBackfillTask),
 }
 
 pub(crate) enum SqliteBatchWriterControl {
@@ -852,6 +854,17 @@ impl PendingBatch {
                     0
                 }
             }
+            #[cfg(test)]
+            SqliteBatchWrite::StartupBackfillWake(task) => {
+                if self.startup_backfill_wake_tasks.contains(&task) {
+                    self.coalesced_rows += 1;
+                    write_bytes
+                } else {
+                    self.startup_backfill_wake_tasks.push(task);
+                    self.add_estimate(write_bytes, false);
+                    0
+                }
+            }
         }
     }
 
@@ -1042,6 +1055,11 @@ impl PendingBatch {
                 .into_values()
                 .map(SqliteBatchWrite::SystemTaskFinish),
         );
+        writes.extend(
+            self.startup_backfill_wake_tasks
+                .into_iter()
+                .map(SqliteBatchWrite::StartupBackfillWake),
+        );
         writes
     }
 }
@@ -1050,6 +1068,7 @@ impl PendingBatch {
 pub(crate) struct RetainedBatch {
     batch: PendingBatch,
     failed: bool,
+    p2_retryable_failure: bool,
     p2_lock_failure: bool,
     p2_defer: Option<P2DeferReason>,
 }
@@ -1060,6 +1079,7 @@ impl RetainedBatch {
         Self {
             batch,
             failed,
+            p2_retryable_failure: false,
             p2_lock_failure: false,
             p2_defer: None,
         }
@@ -1070,16 +1090,18 @@ impl RetainedBatch {
         Self {
             batch,
             failed: false,
+            p2_retryable_failure: false,
             p2_lock_failure: false,
             p2_defer: Some(reason),
         }
     }
 
-    fn p2_failed(mut batch: PendingBatch, lock_failure: bool) -> Self {
+    fn p2_failed(mut batch: PendingBatch, retryable_failure: bool, lock_failure: bool) -> Self {
         batch.retained_for_retry = true;
         Self {
             batch,
             failed: true,
+            p2_retryable_failure: retryable_failure,
             p2_lock_failure: lock_failure,
             p2_defer: None,
         }
@@ -1106,6 +1128,8 @@ impl SqliteBatchWrite {
                 estimated_account_selected_touch_memory_bytes(touch)
             }
             Self::SystemTaskFinish(finish) => estimated_system_task_finish_memory_bytes(finish),
+            #[cfg(test)]
+            Self::StartupBackfillWake(_) => std::mem::size_of::<StartupBackfillTask>(),
         }
     }
 }
@@ -1817,6 +1841,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                                         p2_schedule.defer_until_background_eligible();
                                     }
                                     None if retained.failed
+                                        && retained.p2_retryable_failure
                                         && retained.batch.has_p2()
                                         && retained.batch.terminal_invocations.is_empty() =>
                                     {
@@ -1989,7 +2014,9 @@ pub(crate) async fn run_sqlite_batch_writer(
                             p2_eligibility_generation = observed_generation;
                             p2_schedule.defer_until_background_eligible();
                         }
-                        None if retained.failed && retained.batch.has_p2()
+                        None if retained.failed
+                            && retained.p2_retryable_failure
+                            && retained.batch.has_p2()
                             && retained.batch.terminal_invocations.is_empty() => {
                             transaction_sequence = transaction_sequence.saturating_add(1);
                             let delay = p2_schedule.failed(transaction_sequence);
@@ -2149,7 +2176,9 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 p2_eligibility_generation = observed_generation;
                                 p2_schedule.defer_until_background_eligible();
                             }
-                            None if retained.failed && retained.batch.has_p2()
+                            None if retained.failed
+                                && retained.p2_retryable_failure
+                                && retained.batch.has_p2()
                                 && retained.batch.terminal_invocations.is_empty() => {
                                 transaction_sequence = transaction_sequence.saturating_add(1);
                                 p2_schedule.failed(transaction_sequence);
@@ -2383,7 +2412,7 @@ async fn flush_pending_batch_accounted(
     .await;
     let discard_non_retryable_p2 = result.as_ref().is_some_and(|retained| {
         retained.failed
-            && !retained.p2_lock_failure
+            && !retained.p2_retryable_failure
             && retained.batch.terminal_invocations.is_empty()
     });
     if discard_non_retryable_p2 {
@@ -2592,7 +2621,7 @@ pub(crate) async fn flush_pending_batch(
     }
     let observed_eligibility_generation =
         crate::db_pressure::global_db_pressure_gate().eligibility_generation();
-    let Some(write_permit) =
+    let Some(mut write_permit) =
         crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator()
             .try_acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
     else {
@@ -2613,6 +2642,12 @@ pub(crate) async fn flush_pending_batch(
         {
             Ok(permit) => Some(permit),
             Err(deny_reason) => {
+                if matches!(
+                    deny_reason,
+                    crate::db_pressure::DbPressureDenyReason::BackgroundBusy
+                ) {
+                    write_permit.suppress_background_eligibility_wakeup();
+                }
                 drop(write_permit);
                 accounting.p2_pressure_deferred();
                 debug!(
@@ -2662,7 +2697,11 @@ pub(crate) async fn flush_pending_batch(
                 "sqlite batch writer P2 flush failed"
             );
             drop(permit);
-            return Some(RetainedBatch::p2_failed(batch, is_sqlite_lock_error(&err)));
+            return Some(RetainedBatch::p2_failed(
+                batch,
+                crate::db_pressure::is_db_pressure_error(&err),
+                is_sqlite_lock_error(&err),
+            ));
         }
     };
     drop(write_permit);

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -998,6 +998,9 @@ impl PendingBatch {
         chunk.enqueued_rows = chunk.logical_rows();
         self.enqueued_rows = self.logical_rows();
         chunk.coalesced_rows = 0;
+        if self.is_empty() {
+            self.oldest_at = None;
+        }
         chunk
     }
 
@@ -2416,10 +2419,17 @@ async fn flush_pending_batch_accounted(
             && retained.batch.terminal_invocations.is_empty()
     });
     if discard_non_retryable_p2 {
+        let discarded_overlay_count = result
+            .as_ref()
+            .map(|retained| {
+                cleanup_discarded_p2_runtime_overlays(&retained.batch, terminal_runtime_store)
+            })
+            .unwrap_or_default();
         warn!(
             flush_priority = "P2",
             submitted_depth,
             submitted_bytes,
+            discarded_overlay_count,
             "discarded non-retryable P2 batch after deterministic failure; durable source remains authoritative"
         );
     }
@@ -2447,6 +2457,27 @@ async fn flush_pending_batch_accounted(
     } else {
         result
     }
+}
+
+fn cleanup_discarded_p2_runtime_overlays(
+    batch: &PendingBatch,
+    terminal_runtime_store: &Arc<std::sync::Mutex<Option<Arc<ProxyRuntimeInvocationStore>>>>,
+) -> usize {
+    let Some(runtime_store) = terminal_runtime_store
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().cloned())
+    else {
+        return 0;
+    };
+    batch
+        .invocation_derived
+        .values()
+        .filter_map(|derived| derived.terminal_overlay_key.as_ref())
+        .filter(|(invoke_id, occurred_at)| {
+            runtime_store.remove_persisted_terminal_overlay(invoke_id, occurred_at)
+        })
+        .count()
 }
 
 #[expect(

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1516,6 +1516,9 @@ impl SqliteBatchWriter {
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 self.accounting.rollback_enqueue(estimated_bytes);
+                if is_p1 {
+                    decrement_queued_p1_count(&self.queued_p1_count);
+                }
                 self.dropped_writes.fetch_add(1, Ordering::Relaxed);
                 warn!("terminal journal-backed retry could not reach closed sqlite batch writer");
                 false
@@ -1978,6 +1981,17 @@ pub(crate) async fn run_sqlite_batch_writer(
                     pending.take_p2_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                 };
                 drop(priority_guard);
+                if flush_batch.terminal_invocations.is_empty()
+                    && flush_batch.estimated_memory_bytes() > SQLITE_BATCH_MAX_BYTES
+                {
+                    warn!(
+                        flush_priority = "P2",
+                        batch_rows = flush_batch.logical_rows(),
+                        batch_bytes = flush_batch.estimated_memory_bytes(),
+                        max_batch_bytes = SQLITE_BATCH_MAX_BYTES,
+                        "isolating oversized single P2 write"
+                    );
+                }
                 if let Some(retained) =
                     flush_pending_batch_accounted(
                         &accounting,
@@ -2138,6 +2152,17 @@ pub(crate) async fn run_sqlite_batch_writer(
                         continue;
                     };
                     drop(priority_guard);
+                    if flush_batch.terminal_invocations.is_empty()
+                        && flush_batch.estimated_memory_bytes() > SQLITE_BATCH_MAX_BYTES
+                    {
+                        warn!(
+                            flush_priority = "P2",
+                            batch_rows = flush_batch.logical_rows(),
+                            batch_bytes = flush_batch.estimated_memory_bytes(),
+                            max_batch_bytes = SQLITE_BATCH_MAX_BYTES,
+                            "isolating oversized single P2 write"
+                        );
+                    }
                     let submitted_p1 = !flush_batch.terminal_invocations.is_empty();
                     let submitted_p2 = flush_batch.has_p2();
                     if let Some(retained) =
@@ -2725,10 +2750,12 @@ pub(crate) async fn flush_pending_batch(
     };
 
     let mut deferred_batch = PendingBatch::default();
-    if let Some(system_task_batch) = system_task_batch {
+    let mut system_task_failure = None;
+    let mut system_task_lock_failure = false;
+    if let Some(system_task_batch) = system_task_batch.as_ref() {
         match flush_pending_batch_inner(
             pool,
-            &system_task_batch,
+            system_task_batch,
             pricing_catalog,
             prompt_cache_conversation_cache,
             terminal_runtime_store,
@@ -2748,15 +2775,11 @@ pub(crate) async fn flush_pending_batch(
                     p2_deferred_count = system_task_batch.logical_rows(),
                     elapsed_ms = started.elapsed().as_millis() as u64,
                     flush_reason,
-                    system_task_scope = %summarize_system_task_batch_scope(&system_task_batch),
+                    system_task_scope = %summarize_system_task_batch_scope(system_task_batch),
                     "sqlite batch writer P2 system-task flush failed"
                 );
-                drop(permit);
-                return Some(RetainedBatch::p2_failed(
-                    system_task_batch,
-                    true,
-                    is_sqlite_lock_error(&err),
-                ));
+                system_task_lock_failure = is_sqlite_lock_error(&err);
+                system_task_failure = Some(err);
             }
         }
     }
@@ -2773,7 +2796,20 @@ pub(crate) async fn flush_pending_batch(
     )
     .await
     {
-        Ok(main_deferred) => deferred_batch.merge_p2(main_deferred),
+        Ok(main_deferred) => {
+            deferred_batch.merge_p2(main_deferred);
+            if system_task_failure.is_some() {
+                let mut retry_batch =
+                    system_task_batch.expect("system task failure must retain its isolated batch");
+                retry_batch.merge_p2(deferred_batch);
+                drop(permit);
+                return Some(RetainedBatch::p2_failed(
+                    retry_batch,
+                    true,
+                    system_task_lock_failure,
+                ));
+            }
+        }
         Err(err) => {
             crate::db_pressure::global_db_pressure_gate()
                 .record_error("sqlite_batch_writer_p2", &err);
@@ -2786,9 +2822,30 @@ pub(crate) async fn flush_pending_batch(
                 "sqlite batch writer P2 flush failed"
             );
             drop(permit);
+            if system_task_failure.is_some() && !crate::db_pressure::is_db_pressure_error(&err) {
+                cleanup_discarded_p2_runtime_overlays(&batch, terminal_runtime_store);
+                let retry_batch =
+                    system_task_batch.expect("system task failure must retain its isolated batch");
+                return Some(RetainedBatch::p2_failed(
+                    retry_batch,
+                    true,
+                    system_task_lock_failure,
+                ));
+            }
+            if let Some(system_task_batch) = system_task_batch {
+                let mut retry_batch = system_task_batch;
+                retry_batch.merge_p2(batch);
+                return Some(RetainedBatch::p2_failed(
+                    retry_batch,
+                    true,
+                    system_task_lock_failure || is_sqlite_lock_error(&err),
+                ));
+            }
+            let retryable_failure = crate::db_pressure::is_db_pressure_error(&err)
+                || !batch.system_task_finishes.is_empty();
             return Some(RetainedBatch::p2_failed(
                 batch,
-                crate::db_pressure::is_db_pressure_error(&err),
+                retryable_failure,
                 is_sqlite_lock_error(&err),
             ));
         }

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -908,6 +908,86 @@ impl PendingBatch {
         p2
     }
 
+    fn take_p2_chunk(&mut self, max_rows: usize, max_bytes: usize) -> Self {
+        if !self.has_p2() || max_rows == 0 || max_bytes == 0 {
+            return Self::default();
+        }
+
+        let oldest_at = self.oldest_at;
+        let mut chunk = Self {
+            oldest_at,
+            retained_for_retry: self.retained_for_retry,
+            ..Self::default()
+        };
+        let mut selected_rows = 0_usize;
+        let mut selected_bytes = 0_usize;
+        let mut should_take = |bytes: usize| {
+            if selected_rows >= max_rows {
+                return false;
+            }
+            if selected_rows > 0 && selected_bytes.saturating_add(bytes) > max_bytes {
+                return false;
+            }
+            selected_rows += 1;
+            selected_bytes = selected_bytes.saturating_add(bytes);
+            true
+        };
+
+        let attempt_progress = std::mem::take(&mut self.attempt_progress);
+        for (key, progress) in attempt_progress {
+            let bytes = estimated_attempt_progress_memory_bytes(&progress);
+            if should_take(bytes) {
+                chunk.attempt_progress.insert(key, progress);
+            } else {
+                self.attempt_progress.insert(key, progress);
+            }
+        }
+        let invocation_derived = std::mem::take(&mut self.invocation_derived);
+        for (key, derived) in invocation_derived {
+            let bytes = estimated_invocation_derived_memory_bytes(&derived);
+            if should_take(bytes) {
+                chunk.invocation_derived.insert(key, derived);
+            } else {
+                self.invocation_derived.insert(key, derived);
+            }
+        }
+        let account_selected_touches = std::mem::take(&mut self.account_selected_touches);
+        for (key, touch) in account_selected_touches {
+            let bytes = estimated_account_selected_touch_memory_bytes(&touch);
+            if should_take(bytes) {
+                chunk.account_selected_touches.insert(key, touch);
+            } else {
+                self.account_selected_touches.insert(key, touch);
+            }
+        }
+        let system_task_finishes = std::mem::take(&mut self.system_task_finishes);
+        for (key, finish) in system_task_finishes {
+            let bytes = estimated_system_task_finish_memory_bytes(&finish);
+            if should_take(bytes) {
+                chunk.system_task_finishes.insert(key, finish);
+            } else {
+                self.system_task_finishes.insert(key, finish);
+            }
+        }
+        if !self.startup_backfill_wake_tasks.is_empty()
+            && should_take(
+                self.startup_backfill_wake_tasks
+                    .len()
+                    .saturating_mul(std::mem::size_of::<StartupBackfillTask>()),
+            )
+        {
+            chunk.startup_backfill_wake_tasks =
+                std::mem::take(&mut self.startup_backfill_wake_tasks);
+        }
+
+        self.recalculate_estimates();
+        chunk.recalculate_estimates();
+        chunk.enqueued_rows = chunk.logical_rows();
+        self.enqueued_rows = self.logical_rows();
+        chunk.coalesced_rows = 0;
+        chunk
+    }
+
     fn add_startup_backfill_wake_tasks(&mut self, tasks: &[StartupBackfillTask]) {
         for task in tasks {
             if !self.startup_backfill_wake_tasks.contains(task) {
@@ -1077,6 +1157,7 @@ impl PendingBatch {
 pub(crate) struct SqliteBatchWriter {
     write_sender: mpsc::Sender<SqliteBatchWrite>,
     queued_p1_count: Arc<AtomicUsize>,
+    p1_priority_gate: Arc<std::sync::Mutex<()>>,
     control_sender: mpsc::Sender<SqliteBatchWriterControl>,
     accounting: Arc<PendingQueueAccounting>,
     dropped_writes: Arc<AtomicU64>,
@@ -1107,6 +1188,7 @@ impl SqliteBatchWriter {
     ) -> Arc<Self> {
         let (write_sender, write_receiver) = mpsc::channel(SQLITE_BATCH_CHANNEL_CAPACITY);
         let queued_p1_count = Arc::new(AtomicUsize::new(0));
+        let p1_priority_gate = Arc::new(std::sync::Mutex::new(()));
         let (control_sender, control_receiver) = mpsc::channel(128);
         let accounting = Arc::new(PendingQueueAccounting::default());
         let dropped_writes = Arc::new(AtomicU64::new(0));
@@ -1124,7 +1206,12 @@ impl SqliteBatchWriter {
             .as_ref()
             .map(|journal| journal.stats().replay_count)
             .unwrap_or_default();
+        let mut terminal_journal = terminal_journal;
+        if let Some(journal) = terminal_journal.as_mut() {
+            journal.queue_replay_for_dispatch();
+        }
         let terminal_journal = Arc::new(std::sync::Mutex::new(terminal_journal));
+        queued_p1_count.store(replay_writes, Ordering::SeqCst);
         let dashboard_reconcile_gate = Arc::new(Mutex::new(()));
         let journal_sync_shutdown = shutdown.child_token();
         #[cfg(not(test))]
@@ -1148,10 +1235,12 @@ impl SqliteBatchWriter {
             dashboard_reconcile_gate.clone(),
             terminal_journal.clone(),
             queued_p1_count.clone(),
+            p1_priority_gate.clone(),
         ));
         let writer = Arc::new(Self {
             write_sender,
             queued_p1_count,
+            p1_priority_gate,
             control_sender,
             accounting,
             dropped_writes,
@@ -1169,11 +1258,6 @@ impl SqliteBatchWriter {
             buffered_writes: None,
             #[cfg(test)]
             auto_flush_terminal_for_test: std::sync::atomic::AtomicBool::new(true),
-        });
-        writer.terminal_journal.lock().ok().and_then(|mut journal| {
-            journal
-                .as_mut()
-                .map(TerminalJournal::queue_replay_for_dispatch)
         });
         if replay_writes > 0 {
             warn!(
@@ -1200,6 +1284,7 @@ impl SqliteBatchWriter {
         Arc::new(Self {
             write_sender,
             queued_p1_count: Arc::new(AtomicUsize::new(0)),
+            p1_priority_gate: Arc::new(std::sync::Mutex::new(())),
             control_sender,
             accounting: Arc::new(PendingQueueAccounting::default()),
             dropped_writes: Arc::new(AtomicU64::new(0)),
@@ -1259,6 +1344,11 @@ impl SqliteBatchWriter {
     pub(crate) fn enqueue(&self, write: SqliteBatchWrite) -> bool {
         let estimated_bytes = write.estimated_memory_bytes();
         let is_p1 = is_p1_terminal_write(&write);
+        let _p1_priority_guard = is_p1.then(|| {
+            self.p1_priority_gate
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+        });
         #[cfg(test)]
         if let Some(buffered_writes) = &self.buffered_writes {
             match buffered_writes.lock() {
@@ -1356,17 +1446,19 @@ impl SqliteBatchWriter {
         durability_mode: TerminalJournalDurabilityMode,
     ) -> bool {
         let estimated_bytes = write.estimated_memory_bytes();
-        self.accounting.enqueue(estimated_bytes);
         let is_p1 = is_p1_terminal_write(&write);
+        let _p1_priority_guard = is_p1.then(|| {
+            self.p1_priority_gate
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+        });
+        self.accounting.enqueue(estimated_bytes);
         if is_p1 {
             self.queued_p1_count.fetch_add(1, Ordering::SeqCst);
         }
         match self.write_sender.try_send(write) {
             Ok(()) => true,
             Err(mpsc::error::TrySendError::Full(write)) => {
-                if is_p1 {
-                    decrement_queued_p1_count(&self.queued_p1_count);
-                }
                 self.accounting.rollback_enqueue(estimated_bytes);
                 let deferred = matches!(durability_mode, TerminalJournalDurabilityMode::Journal)
                     && self
@@ -1382,6 +1474,9 @@ impl SqliteBatchWriter {
                             })
                         })
                         .unwrap_or(false);
+                if is_p1 && !deferred {
+                    decrement_queued_p1_count(&self.queued_p1_count);
+                }
                 if !deferred {
                     self.dropped_writes.fetch_add(1, Ordering::Relaxed);
                     warn!(
@@ -1634,6 +1729,7 @@ pub(crate) async fn run_sqlite_batch_writer(
     dashboard_reconcile_gate: Arc<Mutex<()>>,
     terminal_journal: Arc<std::sync::Mutex<Option<TerminalJournal>>>,
     queued_p1_count: Arc<AtomicUsize>,
+    p1_priority_gate: Arc<std::sync::Mutex<()>>,
 ) {
     let mut ticker = interval(SQLITE_BATCH_FLUSH_INTERVAL);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -1687,6 +1783,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &mut pending,
                             &accounting,
                             usize::MAX,
+                            &queued_p1_count,
                         );
                         let result = match flush_pending_batch_accounted(
                             &accounting,
@@ -1766,6 +1863,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             &mut pending,
                             &accounting,
                             usize::MAX,
+                            &queued_p1_count,
                         );
                         let result = if pending.is_empty() {
                             Ok(())
@@ -1819,6 +1917,16 @@ pub(crate) async fn run_sqlite_batch_writer(
             _ = wait_for_p2_deadline(p2_schedule.due_at),
                 if p2_deadline_ready(&pending, &p2_schedule, &queued_p1_count) =>
             {
+                let priority_guard = p1_priority_gate
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                drain_terminal_journal_deferred_writes(
+                    &terminal_journal,
+                    &mut pending,
+                    &accounting,
+                    SQLITE_BATCH_MAX_ROWS,
+                    &queued_p1_count,
+                );
                 drain_queued_writes_before_p2_dispatch(
                     &mut write_receiver,
                     &mut pending,
@@ -1826,13 +1934,20 @@ pub(crate) async fn run_sqlite_batch_writer(
                     &mut p2_schedule,
                     &queued_p1_count,
                 );
+                if queued_p1_count.load(Ordering::SeqCst) != 0 {
+                    drop(priority_guard);
+                    p2_schedule.arm_if_idle(Instant::now());
+                    accounting.update_p2_schedule(&p2_schedule);
+                    continue;
+                }
                 let now = Instant::now();
                 let submitted_p1 = !pending.terminal_invocations.is_empty() && p1_retry.ready(now);
                 let flush_batch = if submitted_p1 {
                     pending.take()
                 } else {
-                    pending.take_p2()
+                    pending.take_p2_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                 };
+                drop(priority_guard);
                 if let Some(retained) =
                     flush_pending_batch_accounted(
                         &accounting,
@@ -1916,6 +2031,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                     &mut pending,
                     &accounting,
                     deferred_capacity,
+                    &queued_p1_count,
                 );
             }
             maybe_write = write_receiver.recv() => {
@@ -1925,6 +2041,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                         &mut pending,
                         &accounting,
                         usize::MAX,
+                        &queued_p1_count,
                     );
                     if !pending.is_empty()
                         && let Some(retained) = flush_pending_batch_accounted(
@@ -1971,15 +2088,24 @@ pub(crate) async fn run_sqlite_batch_writer(
                     && (!pending.terminal_invocations.is_empty()
                         || p2_schedule.ready(Instant::now()))
                 {
-                    let p2_ready = p2_schedule.ready(Instant::now());
-                    let flush_batch = if !pending.terminal_invocations.is_empty()
-                        && pending.has_p2()
-                        && !p2_ready
-                    {
-                        pending.take_p1_terminals()
+                    let priority_guard = p1_priority_gate
+                        .lock()
+                        .unwrap_or_else(|error| error.into_inner());
+                    let p2_ready = p2_schedule.ready(Instant::now())
+                        && queued_p1_count.load(Ordering::SeqCst) == 0;
+                    let flush_batch = if !pending.terminal_invocations.is_empty() {
+                        if pending.has_p2() {
+                            pending.take_p1_terminals()
+                        } else {
+                            pending.take()
+                        }
+                    } else if p2_ready {
+                        pending.take_p2_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                     } else {
-                        pending.take()
+                        drop(priority_guard);
+                        continue;
                     };
+                    drop(priority_guard);
                     let submitted_p1 = !flush_batch.terminal_invocations.is_empty();
                     let submitted_p2 = flush_batch.has_p2();
                     if let Some(retained) =
@@ -2179,6 +2305,7 @@ fn drain_terminal_journal_deferred_writes(
     pending: &mut PendingBatch,
     accounting: &PendingQueueAccounting,
     max_writes: usize,
+    queued_p1_count: &AtomicUsize,
 ) {
     if max_writes == 0 {
         return;
@@ -2187,6 +2314,7 @@ fn drain_terminal_journal_deferred_writes(
         && let Some(journal) = guard.as_mut()
     {
         for terminal in journal.take_deferred_writes(max_writes) {
+            decrement_queued_p1_count(queued_p1_count);
             let write = SqliteBatchWrite::TerminalInvocation(terminal);
             accounting.enqueue(write.estimated_memory_bytes());
             accounting.retry_deferred();
@@ -2253,15 +2381,30 @@ async fn flush_pending_batch_accounted(
         terminal_journal,
     )
     .await;
+    let discard_non_retryable_p2 = result.as_ref().is_some_and(|retained| {
+        retained.failed
+            && !retained.p2_lock_failure
+            && retained.batch.terminal_invocations.is_empty()
+    });
+    if discard_non_retryable_p2 {
+        warn!(
+            flush_priority = "P2",
+            submitted_depth,
+            submitted_bytes,
+            "discarded non-retryable P2 batch after deterministic failure; durable source remains authoritative"
+        );
+    }
     if was_retained_retry && result.as_ref().is_some_and(|retained| retained.failed) {
         accounting.retry_deferred();
     }
     let retained_bytes = result
         .as_ref()
+        .filter(|_| !discard_non_retryable_p2)
         .map(|retained| retained.batch.estimated_memory_bytes())
         .unwrap_or_default();
     let retained_depth = result
         .as_ref()
+        .filter(|_| !discard_non_retryable_p2)
         .map(|retained| retained.batch.logical_rows())
         .unwrap_or_default();
     accounting.complete(
@@ -2270,7 +2413,11 @@ async fn flush_pending_batch_accounted(
         submitted_bytes,
         retained_bytes,
     );
-    result
+    if discard_non_retryable_p2 {
+        None
+    } else {
+        result
+    }
 }
 
 #[expect(
@@ -2719,9 +2866,25 @@ pub(crate) async fn flush_pending_batch_inner(
         } else {
             None
         };
+        let wake_tasks = batch
+            .startup_backfill_wake_tasks
+            .iter()
+            .copied()
+            .filter(|task| {
+                let available = pricing_catalog.is_some()
+                    || !matches!(task, StartupBackfillTask::ProxyCost);
+                if !available {
+                    warn!(
+                        task = task.name(),
+                        "skipping startup backfill wake because its runtime pricing catalog is unavailable"
+                    );
+                }
+                available
+            })
+            .collect::<Vec<_>>();
         wake_startup_backfill_tasks_with_pricing_catalog(
             pool,
-            &batch.startup_backfill_wake_tasks,
+            &wake_tasks,
             pricing_catalog.as_ref(),
             "terminal_payload_repair_input",
         )
@@ -3241,6 +3404,21 @@ mod tests {
         .execute(&pool)
         .await
         .expect("seed P2 account");
+        for offset in 1..=SQLITE_BATCH_MAX_ROWS {
+            let account_id = ACCOUNT_ID + offset as i64;
+            sqlx::query(
+                r#"
+                INSERT INTO pool_upstream_accounts (
+                    id, kind, provider, display_name, status, enabled, last_selected_at, created_at, updated_at
+                )
+                VALUES (?1, 'api_key', 'codex', 'Priority Test', 'active', 1, NULL, '2026-08-10T12:00:00Z', '2026-08-10T12:00:00Z')
+                "#,
+            )
+            .bind(account_id)
+            .execute(&pool)
+            .await
+            .expect("seed deep P2 account");
+        }
         sqlx::query("CREATE TABLE batch_writer_dispatch_order (write_class TEXT NOT NULL)")
             .execute(&pool)
             .await
@@ -3262,7 +3440,7 @@ mod tests {
             r#"
             CREATE TRIGGER batch_writer_p2_dispatch_order
             AFTER UPDATE OF last_selected_at ON pool_upstream_accounts
-            WHEN NEW.id = 999998
+            WHEN NEW.id BETWEEN 999998 AND 1000030
             BEGIN
                 INSERT INTO batch_writer_dispatch_order (write_class) VALUES ('p2');
             END
@@ -3302,7 +3480,7 @@ mod tests {
         for offset in 0..=SQLITE_BATCH_MAX_ROWS {
             assert!(writer.enqueue(SqliteBatchWrite::AccountSelectedTouch(
                 BatchedAccountSelectedTouch {
-                    account_id: ACCOUNT_ID,
+                    account_id: ACCOUNT_ID + offset as i64,
                     selected_at: format!("2026-08-10T12:01:{offset:02}Z"),
                 },
             )));
@@ -3332,9 +3510,13 @@ mod tests {
 
         let order = order.expect("writer should dispatch both P1 and P2 work");
         assert_eq!(
-            order,
-            vec!["p1".to_string(), "p2".to_string()],
+            order.first().map(String::as_str),
+            Some("p1"),
             "the writer must classify the full queued snapshot before dispatching overdue P2 work"
+        );
+        assert!(
+            order.iter().skip(1).all(|class| class == "p2"),
+            "all remaining writes should be bounded P2 chunks"
         );
     }
 
@@ -4561,7 +4743,14 @@ mod tests {
         let mut pending = PendingBatch::default();
 
         let accounting = PendingQueueAccounting::default();
-        drain_terminal_journal_deferred_writes(&journal, &mut pending, &accounting, usize::MAX);
+        let queued_p1_count = AtomicUsize::new(0);
+        drain_terminal_journal_deferred_writes(
+            &journal,
+            &mut pending,
+            &accounting,
+            usize::MAX,
+            &queued_p1_count,
+        );
 
         assert_eq!(pending.terminal_invocations.len(), 1);
         let snapshot = accounting.snapshot();

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -13,7 +13,7 @@ use sqlx::{Pool, Sqlite, SqliteConnection};
 use tokio::{
     sync::{Mutex, RwLock, mpsc, oneshot},
     task::JoinHandle,
-    time::{MissedTickBehavior, interval},
+    time::{MissedTickBehavior, interval, sleep},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
@@ -128,6 +128,13 @@ impl P2ScheduleState {
         self.deferred_since
             .map(|started| started.elapsed().as_millis() as u64)
             .unwrap_or_default()
+    }
+}
+
+async fn wait_for_p2_deadline(due_at: Option<Instant>) {
+    match due_at {
+        Some(due_at) => sleep(due_at.saturating_duration_since(Instant::now())).await,
+        None => std::future::pending::<()>().await,
     }
 }
 
@@ -578,6 +585,7 @@ pub(crate) struct PendingBatch {
     invocation_derived: BTreeMap<i64, BatchedInvocationDerivedWrites>,
     account_selected_touches: HashMap<i64, BatchedAccountSelectedTouch>,
     system_task_finishes: HashMap<i64, BatchedSystemTaskFinish>,
+    startup_backfill_wake_tasks: Vec<StartupBackfillTask>,
     enqueued_rows: usize,
     coalesced_rows: usize,
     estimated_bytes: usize,
@@ -636,6 +644,11 @@ impl PendingBatch {
                     .values()
                     .map(estimated_system_task_finish_memory_bytes)
                     .sum::<usize>(),
+            )
+            .saturating_add(
+                self.startup_backfill_wake_tasks
+                    .capacity()
+                    .saturating_mul(std::mem::size_of::<StartupBackfillTask>()),
             );
         self.terminal_estimated_bytes = self
             .terminal_invocations
@@ -650,6 +663,7 @@ impl PendingBatch {
             && self.invocation_derived.is_empty()
             && self.account_selected_touches.is_empty()
             && self.system_task_finishes.is_empty()
+            && self.startup_backfill_wake_tasks.is_empty()
     }
 
     fn has_p2(&self) -> bool {
@@ -657,6 +671,7 @@ impl PendingBatch {
             || !self.invocation_derived.is_empty()
             || !self.account_selected_touches.is_empty()
             || !self.system_task_finishes.is_empty()
+            || !self.startup_backfill_wake_tasks.is_empty()
     }
 
     fn logical_rows(&self) -> usize {
@@ -665,6 +680,7 @@ impl PendingBatch {
             + self.invocation_derived.len()
             + self.account_selected_touches.len()
             + self.system_task_finishes.len()
+            + usize::from(!self.startup_backfill_wake_tasks.is_empty())
     }
 
     fn age(&self) -> Duration {
@@ -817,6 +833,30 @@ impl PendingBatch {
         }
     }
 
+    fn take_p2(&mut self) -> Self {
+        let mut p2 = std::mem::take(self);
+        let terminal_invocations = std::mem::take(&mut p2.terminal_invocations);
+        let terminal_estimated_bytes = p2.terminal_estimated_bytes;
+        p2.estimated_bytes = p2.estimated_bytes.saturating_sub(terminal_estimated_bytes);
+        p2.terminal_estimated_bytes = 0;
+
+        self.terminal_invocations = terminal_invocations;
+        self.estimated_bytes = terminal_estimated_bytes;
+        self.terminal_estimated_bytes = terminal_estimated_bytes;
+        self.enqueued_rows = self.terminal_invocations.len();
+        self.oldest_at = p2.oldest_at;
+        p2
+    }
+
+    fn add_startup_backfill_wake_tasks(&mut self, tasks: &[StartupBackfillTask]) {
+        for task in tasks {
+            if !self.startup_backfill_wake_tasks.contains(task) {
+                self.startup_backfill_wake_tasks.push(*task);
+            }
+        }
+        self.recalculate_estimates();
+    }
+
     fn merge_p2(&mut self, mut other: Self) {
         self.attempt_progress.extend(other.attempt_progress.drain());
         self.invocation_derived.extend(other.invocation_derived);
@@ -824,6 +864,7 @@ impl PendingBatch {
             .extend(other.account_selected_touches.drain());
         self.system_task_finishes
             .extend(other.system_task_finishes.drain());
+        self.add_startup_backfill_wake_tasks(&other.startup_backfill_wake_tasks);
         self.enqueued_rows = self.enqueued_rows.saturating_add(other.enqueued_rows);
         self.coalesced_rows = self.coalesced_rows.saturating_add(other.coalesced_rows);
         self.recalculate_estimates();
@@ -1539,6 +1580,92 @@ pub(crate) async fn run_sqlite_batch_writer(
                 p2_schedule.wake_background_eligible();
                 accounting.update_p2_schedule(&p2_schedule);
             }
+            _ = wait_for_p2_deadline(p2_schedule.due_at),
+                if pending.has_p2() && p2_schedule.ready(Instant::now()) =>
+            {
+                let now = Instant::now();
+                let submitted_p1 = !pending.terminal_invocations.is_empty() && p1_retry.ready(now);
+                let flush_batch = if submitted_p1 {
+                    pending.take()
+                } else {
+                    pending.take_p2()
+                };
+                if let Some(retained) =
+                    flush_pending_batch_accounted(
+                        &accounting,
+                        &pool,
+                        pricing_catalog.as_ref(),
+                        flush_batch,
+                        FlushReason::Interval,
+                        prompt_cache_conversation_cache.as_ref(),
+                        &terminal_runtime_store,
+                        &dashboard_activity_snapshot_cache,
+                        &terminal_projection_hub,
+                        &dashboard_reconcile_gate,
+                        &terminal_journal,
+                    )
+                    .await
+                {
+                    if retained.failed && !retained.batch.terminal_invocations.is_empty() {
+                        transaction_sequence = transaction_sequence.saturating_add(1);
+                        let delay = p1_retry.failed(transaction_sequence);
+                        warn!(
+                            write_class = "p1_terminal",
+                            retry_generation = p1_retry.generation as u64,
+                            next_retry_delay_ms = delay.as_millis() as u64,
+                            "scheduled retained P1 batch with exponential backoff"
+                        );
+                    } else if submitted_p1 {
+                        p1_retry.succeeded();
+                    }
+                    match retained.p2_defer {
+                        Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                            p2_schedule.defer_pressure(
+                                Duration::from_millis(remaining_ms),
+                                P2WakeReason::PressureCooldownElapsed,
+                            );
+                        }
+                        Some(P2DeferReason::BackgroundBusy {
+                            observed_generation,
+                        }) => {
+                            p2_eligibility_generation = observed_generation;
+                            p2_schedule.defer_until_background_eligible();
+                        }
+                        None if retained.failed && retained.batch.has_p2()
+                            && retained.batch.terminal_invocations.is_empty() => {
+                            transaction_sequence = transaction_sequence.saturating_add(1);
+                            let delay = p2_schedule.failed(transaction_sequence);
+                            if retained.p2_lock_failure {
+                                accounting.p2_lock_retried();
+                            }
+                            warn!(
+                                write_class = "p2_derived",
+                                retry_generation = p2_schedule.generation as u64,
+                                next_retry_delay_ms = delay.as_millis() as u64,
+                                "scheduled retained P2 batch with exponential backoff"
+                            );
+                        }
+                        None if retained.batch.has_p2() => {
+                            p2_schedule.arm_if_idle(Instant::now());
+                        }
+                        None => p2_schedule.succeeded(),
+                    }
+                    if retained.batch.terminal_invocations.is_empty() {
+                        pending.merge_p2(retained.batch);
+                    } else {
+                        let mut retained_batch = retained.batch;
+                        retained_batch.merge_p2(pending.take());
+                        pending = retained_batch;
+                    }
+                    accounting.update_p2_schedule(&p2_schedule);
+                } else {
+                    if submitted_p1 {
+                        p1_retry.succeeded();
+                    }
+                    p2_schedule.succeeded();
+                    accounting.update_p2_schedule(&p2_schedule);
+                }
+            }
             maybe_control = control_receiver.recv(), if !control_closed => {
                 if let Some(control) = maybe_control {
                     match control {
@@ -1796,118 +1923,81 @@ pub(crate) async fn run_sqlite_batch_writer(
                 }
             }
             _ = ticker.tick() => {
-                if !pending.is_empty() {
-                    if !pending.terminal_invocations.is_empty() && !p1_retry.ready(Instant::now()) {
-                        continue;
+                if pending.terminal_invocations.is_empty() || !p1_retry.ready(Instant::now()) {
+                    continue;
+                }
+                let flush_reason = if pending.age() >= SQLITE_BATCH_MAX_AGE {
+                    if pending.age() >= SQLITE_BATCH_STALE_WARN_AGE {
+                        warn!(
+                            logical_rows = pending.logical_rows(),
+                            enqueued_rows = pending.enqueued_rows,
+                            coalesced_rows = pending.coalesced_rows,
+                            oldest_age_ms = pending.age().as_millis() as u64,
+                            flush_reason = FlushReason::MaxAge.as_str(),
+                            "sqlite batch writer pending terminal writes are stale under database pressure"
+                        );
                     }
-                    let p2_ready = p2_schedule.ready(Instant::now());
-                    if pending.terminal_invocations.is_empty() && !p2_ready {
-                        continue;
-                    }
-                    let flush_reason = if pending.age() >= SQLITE_BATCH_MAX_AGE {
-                        if pending.age() >= SQLITE_BATCH_STALE_WARN_AGE {
-                            warn!(
-                                logical_rows = pending.logical_rows(),
-                                enqueued_rows = pending.enqueued_rows,
-                                coalesced_rows = pending.coalesced_rows,
-                                oldest_age_ms = pending.age().as_millis() as u64,
-                                flush_reason = FlushReason::MaxAge.as_str(),
-                                "sqlite batch writer pending derived writes are stale under database pressure"
-                            );
-                        } else {
-                            debug!(
-                                logical_rows = pending.logical_rows(),
-                                enqueued_rows = pending.enqueued_rows,
-                                coalesced_rows = pending.coalesced_rows,
-                                oldest_age_ms = pending.age().as_millis() as u64,
-                                flush_reason = FlushReason::MaxAge.as_str(),
-                                "sqlite batch writer pending derived writes reached max age"
-                            );
-                        }
-                        FlushReason::MaxAge
+                    FlushReason::MaxAge
+                } else {
+                    FlushReason::Interval
+                };
+                let flush_batch = pending.take_p1_terminals();
+                if let Some(retained) =
+                    flush_pending_batch_accounted(
+                        &accounting,
+                        &pool,
+                        pricing_catalog.as_ref(),
+                        flush_batch,
+                        flush_reason,
+                        prompt_cache_conversation_cache.as_ref(),
+                        &terminal_runtime_store,
+                        &dashboard_activity_snapshot_cache,
+                        &terminal_projection_hub,
+                        &dashboard_reconcile_gate,
+                        &terminal_journal,
+                    )
+                    .await
+                {
+                    if retained.failed && !retained.batch.terminal_invocations.is_empty() {
+                        transaction_sequence = transaction_sequence.saturating_add(1);
+                        let delay = p1_retry.failed(transaction_sequence);
+                        warn!(
+                            write_class = "p1_terminal",
+                            retry_generation = p1_retry.generation as u64,
+                            next_retry_delay_ms = delay.as_millis() as u64,
+                            "scheduled retained P1 batch with exponential backoff"
+                        );
                     } else {
-                        FlushReason::Interval
-                    };
-                    let submitted_p1 = !pending.terminal_invocations.is_empty();
-                    let flush_batch = if submitted_p1 && pending.has_p2() && !p2_ready {
-                        pending.take_p1_terminals()
-                    } else {
-                        pending.take()
-                    };
-                    if let Some(retained) =
-                        flush_pending_batch_accounted(
-                            &accounting,
-                            &pool,
-                            pricing_catalog.as_ref(),
-                            flush_batch,
-                            flush_reason,
-                            prompt_cache_conversation_cache.as_ref(),
-                            &terminal_runtime_store,
-                            &dashboard_activity_snapshot_cache,
-                            &terminal_projection_hub,
-                            &dashboard_reconcile_gate,
-                            &terminal_journal,
-                        )
-                        .await
-                    {
-                        if retained.failed && !retained.batch.terminal_invocations.is_empty() {
-                            transaction_sequence = transaction_sequence.saturating_add(1);
-                            let delay = p1_retry.failed(transaction_sequence);
-                            warn!(
-                                write_class = "p1_terminal",
-                                retry_generation = p1_retry.generation as u64,
-                                next_retry_delay_ms = delay.as_millis() as u64,
-                                "scheduled retained P1 batch with exponential backoff"
-                            );
-                        } else if submitted_p1 {
-                            p1_retry.succeeded();
-                        }
-                        match retained.p2_defer {
-                            Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
-                                p2_schedule.defer_pressure(
-                                    Duration::from_millis(remaining_ms),
-                                    P2WakeReason::PressureCooldownElapsed,
-                                );
-                            }
-                            Some(P2DeferReason::BackgroundBusy {
-                                observed_generation,
-                            }) => {
-                                p2_eligibility_generation = observed_generation;
-                                p2_schedule.defer_until_background_eligible();
-                            }
-                            None if retained.failed && retained.batch.has_p2()
-                                && retained.batch.terminal_invocations.is_empty() => {
-                                transaction_sequence = transaction_sequence.saturating_add(1);
-                                let delay = p2_schedule.failed(transaction_sequence);
-                                if retained.p2_lock_failure {
-                                    accounting.p2_lock_retried();
-                                }
-                                warn!(
-                                    write_class = "p2_derived",
-                                    retry_generation = p2_schedule.generation as u64,
-                                    next_retry_delay_ms = delay.as_millis() as u64,
-                                    "scheduled retained P2 batch with exponential backoff"
-                                );
-                            }
-                            None if retained.batch.has_p2() => {
-                                p2_schedule.arm_if_idle(Instant::now());
-                            }
-                            None => p2_schedule.succeeded(),
-                        }
-                        if retained.batch.terminal_invocations.is_empty() {
-                            pending.merge_p2(retained.batch);
-                        } else {
-                            let mut retained_batch = retained.batch;
-                            retained_batch.merge_p2(pending.take());
-                            pending = retained_batch;
-                        }
-                        accounting.update_p2_schedule(&p2_schedule);
-                    } else if submitted_p1 {
                         p1_retry.succeeded();
-                    } else {
-                        p2_schedule.succeeded();
-                        accounting.update_p2_schedule(&p2_schedule);
                     }
+                    match retained.p2_defer {
+                        Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                            p2_schedule.defer_pressure(
+                                Duration::from_millis(remaining_ms),
+                                P2WakeReason::PressureCooldownElapsed,
+                            );
+                        }
+                        Some(P2DeferReason::BackgroundBusy {
+                            observed_generation,
+                        }) => {
+                            p2_eligibility_generation = observed_generation;
+                            p2_schedule.defer_until_background_eligible();
+                        }
+                        None if retained.batch.has_p2() => {
+                            p2_schedule.arm_if_idle(Instant::now());
+                        }
+                        None => p2_schedule.succeeded(),
+                    }
+                    if retained.batch.terminal_invocations.is_empty() {
+                        pending.merge_p2(retained.batch);
+                    } else {
+                        let mut retained_batch = retained.batch;
+                        retained_batch.merge_p2(pending.take());
+                        pending = retained_batch;
+                    }
+                    accounting.update_p2_schedule(&p2_schedule);
+                } else {
+                    p1_retry.succeeded();
                 }
             }
         }
@@ -2080,6 +2170,7 @@ pub(crate) async fn flush_pending_batch(
     let oldest_age_ms = batch.age().as_millis() as u64;
 
     let flush_reason = reason.as_str();
+    let p2_pending_before_p1 = batch.has_p2();
     let p1_batch = batch.take_p1_terminals();
     if !p1_batch.is_empty() {
         let transaction_id = format!("p1-{}", started.elapsed().as_nanos());
@@ -2211,6 +2302,9 @@ pub(crate) async fn flush_pending_batch(
 
     if batch.is_empty() {
         return None;
+    }
+    if !p2_pending_before_p1 && !reason.bypass_pressure_gate() {
+        return Some(RetainedBatch::new(batch, false));
     }
     let observed_eligibility_generation =
         crate::db_pressure::global_db_pressure_gate().eligibility_generation();
@@ -2372,7 +2466,6 @@ pub(crate) async fn flush_pending_batch_inner(
     let mut should_invalidate_prompt_cache_conversations = false;
     let _dashboard_reconcile_guard = dashboard_reconcile_gate.lock().await;
     let mut persisted_terminals = Vec::with_capacity(batch.terminal_invocations.len());
-    let mut startup_backfill_wake_tasks = Vec::new();
     if !batch.terminal_invocations.is_empty() {
         let mut terminal_tx = pool.begin().await?;
         for terminal in batch.terminal_invocations.values() {
@@ -2426,11 +2519,7 @@ pub(crate) async fn flush_pending_batch_inner(
     }
 
     for (terminal, invocation_id, occurred_at) in persisted_terminals {
-        for task in terminal.startup_backfill_tasks.iter().copied() {
-            if !startup_backfill_wake_tasks.contains(&task) {
-                startup_backfill_wake_tasks.push(task);
-            }
-        }
+        deferred_batch.add_startup_backfill_wake_tasks(&terminal.startup_backfill_tasks);
         let dashboard_cache = dashboard_activity_snapshot_cache
             .lock()
             .ok()
@@ -2487,30 +2576,19 @@ pub(crate) async fn flush_pending_batch_inner(
         ));
     }
 
-    if !startup_backfill_wake_tasks.is_empty() {
-        let pool = pool.clone();
+    if !batch.startup_backfill_wake_tasks.is_empty() {
         let pricing_catalog = if let Some(pricing_catalog) = pricing_catalog {
             Some(pricing_catalog.read().await.clone())
         } else {
             None
         };
-        tokio::spawn(async move {
-            if let Err(err) = wake_startup_backfill_tasks_with_pricing_catalog(
-                &pool,
-                &startup_backfill_wake_tasks,
-                pricing_catalog.as_ref(),
-                "terminal_payload_repair_input",
-            )
-            .await
-            {
-                warn!(
-                    error = %err,
-                    task_count = startup_backfill_wake_tasks.len(),
-                    wake_reason = "terminal_payload_repair_input",
-                    "failed to wake startup backfill after terminal persistence"
-                );
-            }
-        });
+        wake_startup_backfill_tasks_with_pricing_catalog(
+            pool,
+            &batch.startup_backfill_wake_tasks,
+            pricing_catalog.as_ref(),
+            "terminal_payload_repair_input",
+        )
+        .await?;
     }
 
     if batch.attempt_progress.is_empty()
@@ -2750,8 +2828,33 @@ mod tests {
         assert_eq!(locked.p2_wake_reason.as_deref(), Some("lock_retry"));
     }
 
-    #[test]
-    fn p2_background_busy_waits_for_eligibility_event_without_polling() {
+    #[tokio::test]
+    async fn p2_pressure_defer_waits_for_its_deadline_without_a_20ms_retry() {
+        let mut schedule = P2ScheduleState::default();
+        schedule.defer_pressure(
+            Duration::from_millis(80),
+            P2WakeReason::PressureCooldownElapsed,
+        );
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(40),
+                wait_for_p2_deadline(schedule.due_at),
+            )
+            .await
+            .is_err(),
+            "P2 pressure defer must not wake on the 20ms P1 ticker"
+        );
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            wait_for_p2_deadline(schedule.due_at),
+        )
+        .await
+        .expect("P2 pressure deadline should eventually wake");
+    }
+
+    #[tokio::test]
+    async fn p2_eligibility_wake_resumes_a_deferred_flush() {
         let mut schedule = P2ScheduleState::default();
         schedule.arm_if_idle(Instant::now());
         schedule.defer_until_background_eligible();
@@ -2763,8 +2866,25 @@ mod tests {
         schedule.arm_if_idle(Instant::now());
         assert!(schedule.due_at.is_none(), "new P2 work must only coalesce");
 
+        let gate = crate::db_pressure::DbPressureGate::new(1, Duration::ZERO);
+        let permit = gate
+            .try_begin_background("test_p2_eligibility_wake")
+            .expect("acquire background permit");
+        let observed_generation = gate.eligibility_generation();
+        let wait_for_eligibility = gate.wait_for_eligibility_change(observed_generation);
+        drop(permit);
+        tokio::time::timeout(Duration::from_millis(100), wait_for_eligibility)
+            .await
+            .expect("releasing background capacity should notify P2 eligibility waiters");
+
         schedule.wake_background_eligible();
         assert!(schedule.ready(Instant::now()));
+        tokio::time::timeout(
+            Duration::from_millis(20),
+            wait_for_p2_deadline(schedule.due_at),
+        )
+        .await
+        .expect("eligibility wake should make P2 dispatch immediately");
     }
 
     #[test]
@@ -2845,6 +2965,54 @@ mod tests {
             .expect("connect sqlite memory pool");
         ensure_schema(&pool).await.expect("ensure schema");
         pool
+    }
+
+    #[tokio::test]
+    async fn normal_p2_flush_runs_after_its_scheduled_deadline() {
+        let pool = test_pool().await;
+        let mut schedule = P2ScheduleState::default();
+        schedule.arm_if_idle(Instant::now());
+        tokio::time::timeout(
+            SQLITE_P2_COALESCE_INTERVAL + Duration::from_millis(100),
+            wait_for_p2_deadline(schedule.due_at),
+        )
+        .await
+        .expect("normal P2 coalescing deadline should elapse");
+
+        let accounting = PendingQueueAccounting::default();
+        let mut batch = PendingBatch::default();
+        batch.push(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: 999_999,
+                selected_at: "2026-08-10T12:00:00Z".to_string(),
+            },
+        ));
+        let terminal_runtime_store = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_activity_snapshot_cache = Arc::new(std::sync::Mutex::new(None));
+        let terminal_projection_hub = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_reconcile_gate = Arc::new(Mutex::new(()));
+        let terminal_journal = Arc::new(std::sync::Mutex::new(None));
+
+        let retained = flush_pending_batch(
+            &accounting,
+            &pool,
+            None,
+            batch,
+            FlushReason::Interval,
+            None,
+            &terminal_runtime_store,
+            &dashboard_activity_snapshot_cache,
+            &terminal_projection_hub,
+            &dashboard_reconcile_gate,
+            &terminal_journal,
+        )
+        .await;
+
+        assert!(
+            retained.is_none(),
+            "normal P2 batch should flush without retention"
+        );
+        assert_eq!(accounting.snapshot().p2_flush_attempt_count, 1);
     }
 
     async fn pending_attempt(pool: &SqlitePool, invoke_id: &str) -> PendingPoolAttemptRecord {
@@ -2955,45 +3123,74 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn persisted_terminal_wakes_only_its_backfill_tasks_after_p1_commit() {
+    async fn p1_terminal_defers_backfill_wake_to_the_coordinated_p2_batch() {
         let pool = test_pool().await;
         let task = StartupBackfillTask::ReasoningEffort;
         let record = crate::tests::test_proxy_capture_record(
             "batch-terminal-backfill-wake",
             "2026-08-09 12:00:00",
         );
+        let mut batch = PendingBatch::default();
+        batch.push(SqliteBatchWrite::TerminalInvocation(
+            BatchedTerminalInvocationWrite {
+                capture_started: None,
+                raw_capture: false,
+                dashboard_terminal_sequence: None,
+                terminal_projection_event_ids: Vec::new(),
+                startup_backfill_tasks: vec![task],
+                record,
+            },
+        ));
+        let terminal_runtime_store = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_activity_snapshot_cache = Arc::new(std::sync::Mutex::new(None));
+        let terminal_projection_hub = Arc::new(std::sync::Mutex::new(None));
+        let dashboard_reconcile_gate = Arc::new(Mutex::new(()));
 
-        SqliteBatchWriter::flush_for_test(
+        let deferred = flush_pending_batch_inner(
             &pool,
-            vec![SqliteBatchWrite::TerminalInvocation(
-                BatchedTerminalInvocationWrite {
-                    capture_started: None,
-                    raw_capture: false,
-                    dashboard_terminal_sequence: None,
-                    terminal_projection_event_ids: Vec::new(),
-                    startup_backfill_tasks: vec![task],
-                    record,
-                },
-            )],
+            &batch,
+            None,
+            None,
+            &terminal_runtime_store,
+            &dashboard_activity_snapshot_cache,
+            &terminal_projection_hub,
+            &dashboard_reconcile_gate,
         )
-        .await;
+        .await
+        .expect("flush terminal P1 batch");
 
-        let wake_deadline = Instant::now() + Duration::from_secs(1);
-        loop {
-            let progress = load_startup_backfill_progress(&pool, task.name())
-                .await
-                .expect("load terminal-woken backfill progress");
-            if progress.wake_generation > 0 {
-                assert!(progress.is_due(Utc::now()));
-                assert_eq!(progress.last_status, STARTUP_BACKFILL_STATUS_IDLE);
-                break;
-            }
-            assert!(
-                Instant::now() < wake_deadline,
-                "terminal P1 commit did not wake the matching startup backfill task"
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        let direct_wake_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM startup_backfill_progress WHERE task_name = ?1",
+        )
+        .bind(task.name())
+        .fetch_one(&pool)
+        .await
+        .expect("count direct P1 backfill wakes");
+        assert_eq!(
+            direct_wake_count, 0,
+            "P1 persistence must not directly write startup backfill progress"
+        );
+        assert_eq!(deferred.startup_backfill_wake_tasks, vec![task]);
+
+        flush_pending_batch_inner(
+            &pool,
+            &deferred,
+            None,
+            None,
+            &terminal_runtime_store,
+            &dashboard_activity_snapshot_cache,
+            &terminal_projection_hub,
+            &dashboard_reconcile_gate,
+        )
+        .await
+        .expect("flush coordinated P2 backfill wake");
+
+        let progress = load_startup_backfill_progress(&pool, task.name())
+            .await
+            .expect("load terminal-woken backfill progress");
+        assert_eq!(progress.wake_generation, 1);
+        assert!(progress.is_due(Utc::now()));
+        assert_eq!(progress.last_status, STARTUP_BACKFILL_STATUS_IDLE);
     }
 
     #[tokio::test]

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -189,7 +189,7 @@ fn drain_queued_writes_before_p2_dispatch(
     queued_p1_count: &AtomicUsize,
 ) {
     // A snapshot keeps the priority scan bounded even while P2 producers continue writing.
-    let queued_messages = write_receiver.len();
+    let queued_messages = write_receiver.len().min(SQLITE_BATCH_MAX_ROWS);
     drain_queued_writes_before_dispatch(
         write_receiver,
         pending,
@@ -534,7 +534,7 @@ impl FlushReason {
     }
 
     fn bypass_pressure_gate(self) -> bool {
-        matches!(self, Self::Barrier | Self::Shutdown)
+        matches!(self, Self::Shutdown)
     }
 }
 
@@ -911,6 +911,53 @@ impl PendingBatch {
         }
     }
 
+    fn take_p1_terminal_chunk(&mut self, max_rows: usize, max_bytes: usize) -> Self {
+        if self.terminal_invocations.is_empty() || max_rows == 0 || max_bytes == 0 {
+            return Self::default();
+        }
+        let mut selected_keys = Vec::new();
+        let mut selected_bytes = 0_usize;
+        for (key, terminal) in &self.terminal_invocations {
+            let bytes = terminal.estimated_memory_bytes();
+            if selected_keys.len() >= max_rows {
+                break;
+            }
+            if !selected_keys.is_empty() && selected_bytes.saturating_add(bytes) > max_bytes {
+                break;
+            }
+            selected_keys.push(key.clone());
+            selected_bytes = selected_bytes.saturating_add(bytes);
+            if bytes > max_bytes {
+                break;
+            }
+        }
+        let terminal_invocations = selected_keys
+            .into_iter()
+            .filter_map(|key| {
+                self.terminal_invocations
+                    .remove(&key)
+                    .map(|write| (key, write))
+            })
+            .collect::<BTreeMap<_, _>>();
+        if terminal_invocations.is_empty() {
+            return Self::default();
+        }
+        self.recalculate_estimates();
+        let mut chunk = Self {
+            terminal_invocations,
+            oldest_at: self.oldest_at,
+            retained_for_retry: self.retained_for_retry,
+            ..Self::default()
+        };
+        chunk.recalculate_estimates();
+        chunk.enqueued_rows = chunk.logical_rows();
+        self.enqueued_rows = self.logical_rows();
+        if self.is_empty() {
+            self.oldest_at = None;
+        }
+        chunk
+    }
+
     fn take_p2(&mut self) -> Self {
         let mut p2 = std::mem::take(self);
         let terminal_invocations = std::mem::take(&mut p2.terminal_invocations);
@@ -1041,6 +1088,16 @@ impl PendingBatch {
             (Some(current), Some(other)) => Some(current.min(other)),
             (current, other) => current.or(other),
         };
+    }
+
+    fn merge_all(&mut self, mut other: Self) {
+        let terminal_invocations = std::mem::take(&mut other.terminal_invocations);
+        let terminal_count = terminal_invocations.len();
+        for terminal in terminal_invocations.into_values() {
+            self.push(SqliteBatchWrite::TerminalInvocation(terminal));
+        }
+        other.enqueued_rows = other.enqueued_rows.saturating_sub(terminal_count);
+        self.merge_p2(other);
     }
 
     #[cfg(test)]
@@ -1813,109 +1870,160 @@ pub(crate) async fn run_sqlite_batch_writer(
                         queued_depth_snapshot,
                         responder,
                     } => {
-                        drain_queued_batch_writes(
-                            &mut write_receiver,
-                            &mut pending,
-                            &accounting,
-                            queued_depth_snapshot,
-                            &queued_p1_count,
-                        );
-                        drain_terminal_journal_deferred_writes(
-                            &terminal_journal,
-                            &mut pending,
-                            &accounting,
-                            usize::MAX,
-                            &queued_p1_count,
-                        );
-                        let result = match flush_pending_batch_accounted(
-                            &accounting,
-                            &pool,
-                            pricing_catalog.as_ref(),
-                            pending.take(),
-                            FlushReason::Barrier,
-                            prompt_cache_conversation_cache.as_ref(),
-                            &terminal_runtime_store,
-                            &dashboard_activity_snapshot_cache,
-                            &terminal_projection_hub,
-                            &dashboard_reconcile_gate,
-                            &terminal_journal,
-                        )
-                        .await
-                        {
-                            Some(retained) => {
-                                let logical_rows = retained.batch.logical_rows();
-                                let failed = retained.failed;
-                                match retained.p2_defer {
-                                    Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
-                                        p2_schedule.defer_pressure(
-                                            Duration::from_millis(remaining_ms),
-                                            P2WakeReason::PressureCooldownElapsed,
-                                        );
-                                    }
-                                    Some(P2DeferReason::BackgroundBusy {
-                                        observed_generation,
-                                    }) => {
-                                        p2_eligibility_generation = observed_generation;
-                                        p2_schedule.defer_until_background_eligible();
-                                    }
-                                    None if retained.failed
-                                        && retained.p2_retryable_failure
-                                        && retained.batch.has_p2()
-                                        && retained.batch.terminal_invocations.is_empty() =>
-                                    {
-                                        transaction_sequence = transaction_sequence.saturating_add(1);
-                                        p2_schedule.failed(transaction_sequence);
-                                        if retained.p2_lock_failure {
-                                            accounting.p2_lock_retried();
-                                        }
-                                    }
-                                    None if retained.batch.has_p2() => {
-                                        p2_schedule.arm_if_idle(Instant::now());
-                                    }
-                                    None => p2_schedule.succeeded(),
+                        let mut remaining_queued = queued_depth_snapshot;
+                        let mut result = Ok(());
+                        loop {
+                            let drained = drain_queued_batch_writes(
+                                &mut write_receiver,
+                                &mut pending,
+                                &accounting,
+                                remaining_queued.min(SQLITE_BATCH_MAX_ROWS),
+                                &queued_p1_count,
+                            );
+                            remaining_queued = remaining_queued.saturating_sub(drained);
+                            drain_terminal_journal_deferred_writes(
+                                &terminal_journal,
+                                &mut pending,
+                                &accounting,
+                                SQLITE_BATCH_MAX_ROWS,
+                                &queued_p1_count,
+                            );
+                            if pending.is_empty() {
+                                if remaining_queued == 0 || drained == 0 {
+                                    break;
                                 }
-                                accounting.update_p2_schedule(&p2_schedule);
-                                pending = retained.batch;
-                                if failed {
-                                    Err(format!(
-                                        "sqlite batch writer retained {logical_rows} logical rows after forced flush"
-                                    ))
-                                } else {
-                                    Ok(())
-                                }
+                                continue;
                             }
-                            None => {
+                            let flush_batch = take_next_bounded_batch(&mut pending);
+                            if flush_batch.is_empty() {
+                                break;
+                            }
+                            if flush_batch.terminal_invocations.is_empty()
+                                && flush_batch.estimated_memory_bytes() > SQLITE_BATCH_MAX_BYTES
+                            {
+                                warn!(
+                                    flush_priority = "P2",
+                                    batch_rows = flush_batch.logical_rows(),
+                                    batch_bytes = flush_batch.estimated_memory_bytes(),
+                                    max_batch_bytes = SQLITE_BATCH_MAX_BYTES,
+                                    "isolating oversized single P2 write"
+                                );
+                            }
+                            let Some(retained) = flush_pending_batch_accounted(
+                                &accounting,
+                                &pool,
+                                pricing_catalog.as_ref(),
+                                flush_batch,
+                                FlushReason::Barrier,
+                                prompt_cache_conversation_cache.as_ref(),
+                                &terminal_runtime_store,
+                                &dashboard_activity_snapshot_cache,
+                                &terminal_projection_hub,
+                                &dashboard_reconcile_gate,
+                                &terminal_journal,
+                            )
+                            .await
+                            else {
                                 p2_schedule.succeeded();
                                 accounting.update_p2_schedule(&p2_schedule);
-                                Ok(())
-                            },
-                        };
+                                if pending.is_empty() && remaining_queued == 0 {
+                                    break;
+                                }
+                                continue;
+                            };
+                            let logical_rows = retained.batch.logical_rows();
+                            let failed = retained.failed;
+                            if retained.failed && !retained.batch.terminal_invocations.is_empty() {
+                                transaction_sequence = transaction_sequence.saturating_add(1);
+                                let delay = p1_retry.failed(transaction_sequence);
+                                warn!(
+                                    write_class = "p1_terminal",
+                                    retry_generation = p1_retry.generation as u64,
+                                    next_retry_delay_ms = delay.as_millis() as u64,
+                                    "scheduled retained P1 batch after forced flush failure"
+                                );
+                            } else {
+                                p1_retry.succeeded();
+                            }
+                            match retained.p2_defer {
+                                Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                                    p2_schedule.defer_pressure(
+                                        Duration::from_millis(remaining_ms),
+                                        P2WakeReason::PressureCooldownElapsed,
+                                    );
+                                }
+                                Some(P2DeferReason::BackgroundBusy {
+                                    observed_generation,
+                                }) => {
+                                    p2_eligibility_generation = observed_generation;
+                                    p2_schedule.defer_until_background_eligible();
+                                }
+                                None if retained.failed
+                                    && retained.p2_retryable_failure
+                                    && retained.batch.has_p2()
+                                    && retained.batch.terminal_invocations.is_empty() =>
+                                {
+                                    transaction_sequence = transaction_sequence.saturating_add(1);
+                                    p2_schedule.failed(transaction_sequence);
+                                    if retained.p2_lock_failure {
+                                        accounting.p2_lock_retried();
+                                    }
+                                }
+                                None if retained.batch.has_p2() => {
+                                    p2_schedule.arm_if_idle(Instant::now());
+                                }
+                                None => p2_schedule.succeeded(),
+                            }
+                            accounting.update_p2_schedule(&p2_schedule);
+                            let p2_deferred = retained.p2_defer.is_some();
+                            let mut retained_batch = retained.batch;
+                            retained_batch.merge_all(pending.take());
+                            pending = retained_batch;
+                            if failed {
+                                result = Err(format!(
+                                    "sqlite batch writer retained {logical_rows} logical rows after forced flush"
+                                ));
+                                break;
+                            }
+                            if p2_deferred {
+                                break;
+                            }
+                            if pending.is_empty() && remaining_queued == 0 {
+                                break;
+                            }
+                        }
                         let _ = responder.send(result);
                     }
                     SqliteBatchWriterControl::Shutdown { responder, .. } => {
                         write_receiver.close();
-                        drain_queued_batch_writes(
-                            &mut write_receiver,
-                            &mut pending,
-                            &accounting,
-                            usize::MAX,
-                            &queued_p1_count,
-                        );
-                        drain_terminal_journal_deferred_writes(
-                            &terminal_journal,
-                            &mut pending,
-                            &accounting,
-                            usize::MAX,
-                            &queued_p1_count,
-                        );
-                        let result = if pending.is_empty() {
-                            Ok(())
-                        } else {
-                            match flush_pending_batch_accounted(
+                        let mut result = Ok(());
+                        loop {
+                            let drained = drain_queued_batch_writes(
+                                &mut write_receiver,
+                                &mut pending,
+                                &accounting,
+                                SQLITE_BATCH_MAX_ROWS,
+                                &queued_p1_count,
+                            );
+                            drain_terminal_journal_deferred_writes(
+                                &terminal_journal,
+                                &mut pending,
+                                &accounting,
+                                SQLITE_BATCH_MAX_ROWS,
+                                &queued_p1_count,
+                            );
+                            if pending.is_empty() {
+                                if drained == 0 {
+                                    break;
+                                }
+                                continue;
+                            }
+                            let flush_batch = take_next_bounded_batch(&mut pending);
+                            let Some(retained) = flush_pending_batch_accounted(
                                 &accounting,
                                 &pool,
                                 pricing_catalog.as_ref(),
-                                pending.take(),
+                                flush_batch,
                                 FlushReason::Shutdown,
                                 prompt_cache_conversation_cache.as_ref(),
                                 &terminal_runtime_store,
@@ -1925,30 +2033,34 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 &terminal_journal,
                             )
                             .await
-                            {
-                                Some(retained) => {
-                                    let logical_rows = retained.batch.logical_rows();
-                                    accounting.complete(
-                                        retained.batch.logical_rows(),
-                                        0,
-                                        retained.batch.estimated_memory_bytes(),
-                                        0,
-                                    );
-                                    if retained.failed {
-                                        Err(format!(
-                                            "sqlite batch writer retained {logical_rows} logical rows after shutdown flush"
-                                        ))
-                                    } else {
-                                        warn!(
-                                            logical_rows,
-                                            "sqlite batch writer skipped deferred P2 writes during shutdown after P1 drain"
-                                        );
-                                        Ok(())
-                                    }
-                                }
-                                None => Ok(()),
+                            else {
+                                continue;
+                            };
+                            let logical_rows = retained.batch.logical_rows();
+                            let failed = retained.failed;
+                            let mut retained_batch = retained.batch;
+                            retained_batch.merge_all(pending.take());
+                            let retained_depth = retained_batch.logical_rows();
+                            let retained_bytes = retained_batch.estimated_memory_bytes();
+                            accounting.complete(
+                                retained_depth,
+                                0,
+                                retained_bytes,
+                                0,
+                            );
+                            if failed {
+                                result = Err(format!(
+                                    "sqlite batch writer retained {logical_rows} logical rows after shutdown flush"
+                                ));
+                                break;
                             }
-                        };
+                            warn!(
+                                logical_rows,
+                                retained_bytes,
+                                "sqlite batch writer skipped deferred P2 writes during shutdown after P1 drain"
+                            );
+                            break;
+                        }
                         let _ = responder.send(result);
                         return;
                     }
@@ -1986,7 +2098,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                 let now = Instant::now();
                 let submitted_p1 = !pending.terminal_invocations.is_empty() && p1_retry.ready(now);
                 let flush_batch = if submitted_p1 {
-                    pending.take_p1_terminals()
+                    pending.take_p1_terminal_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                 } else {
                     pending.take_p2_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
                 };
@@ -2068,7 +2180,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                         pending.merge_p2(retained.batch);
                     } else {
                         let mut retained_batch = retained.batch;
-                        retained_batch.merge_p2(pending.take());
+                        retained_batch.merge_all(pending.take());
                         pending = retained_batch;
                     }
                     accounting.update_p2_schedule(&p2_schedule);
@@ -2151,7 +2263,10 @@ pub(crate) async fn run_sqlite_batch_writer(
                         && queued_p1_count.load(Ordering::SeqCst) == 0;
                     let flush_batch = if !pending.terminal_invocations.is_empty() {
                         if pending.has_p2() {
-                            pending.take_p1_terminals()
+                            pending.take_p1_terminal_chunk(
+                                SQLITE_BATCH_MAX_ROWS,
+                                SQLITE_BATCH_MAX_BYTES,
+                            )
                         } else {
                             pending.take()
                         }
@@ -2236,7 +2351,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             pending.merge_p2(retained.batch);
                         } else {
                             let mut retained_batch = retained.batch;
-                            retained_batch.merge_p2(pending.take());
+                            retained_batch.merge_all(pending.take());
                             pending = retained_batch;
                         }
                     } else {
@@ -2269,7 +2384,8 @@ pub(crate) async fn run_sqlite_batch_writer(
                 } else {
                     FlushReason::Interval
                 };
-                let flush_batch = pending.take_p1_terminals();
+                let flush_batch = pending
+                    .take_p1_terminal_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES);
                 if let Some(retained) =
                     flush_pending_batch_accounted(
                         &accounting,
@@ -2320,7 +2436,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                         pending.merge_p2(retained.batch);
                     } else {
                         let mut retained_batch = retained.batch;
-                        retained_batch.merge_p2(pending.take());
+                        retained_batch.merge_all(pending.take());
                         pending = retained_batch;
                     }
                     accounting.update_p2_schedule(&p2_schedule);
@@ -2398,7 +2514,8 @@ pub(crate) fn drain_queued_batch_writes(
     accounting: &PendingQueueAccounting,
     max_messages: usize,
     queued_p1_count: &AtomicUsize,
-) {
+) -> usize {
+    let mut drained = 0_usize;
     for _ in 0..max_messages {
         match write_receiver.try_recv() {
             Ok(write) => {
@@ -2406,11 +2523,21 @@ pub(crate) fn drain_queued_batch_writes(
                     decrement_queued_p1_count(queued_p1_count);
                 }
                 pending.push_accounted(write, accounting);
+                drained = drained.saturating_add(1);
             }
             Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
                 break;
             }
         }
+    }
+    drained
+}
+
+fn take_next_bounded_batch(pending: &mut PendingBatch) -> PendingBatch {
+    if !pending.terminal_invocations.is_empty() {
+        pending.take_p1_terminal_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
+    } else {
+        pending.take_p2_chunk(SQLITE_BATCH_MAX_ROWS, SQLITE_BATCH_MAX_BYTES)
     }
 }
 

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -31,6 +31,7 @@ pub(crate) const SQLITE_BATCH_MAX_BYTES: usize = 4 * 1024 * 1024;
 pub(crate) const SQLITE_BATCH_MAX_AGE: Duration = Duration::from_secs(5);
 pub(crate) const SQLITE_BATCH_STALE_WARN_AGE: Duration = Duration::from_secs(30);
 pub(crate) const SQLITE_BATCH_CHANNEL_CAPACITY: usize = 10_000;
+const SQLITE_SHUTDOWN_DRAIN_DEADLINE: Duration = Duration::from_secs(5);
 const SQLITE_P1_RETRY_DELAYS: [Duration; 5] = [
     Duration::from_millis(250),
     Duration::from_millis(500),
@@ -2001,7 +2002,29 @@ pub(crate) async fn run_sqlite_batch_writer(
                     SqliteBatchWriterControl::Shutdown { responder, .. } => {
                         write_receiver.close();
                         let mut result = Ok(());
+                        let shutdown_deadline = Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE;
                         loop {
+                            if Instant::now() >= shutdown_deadline {
+                                let _ = drain_queued_batch_writes(
+                                    &mut write_receiver,
+                                    &mut pending,
+                                    &accounting,
+                                    usize::MAX,
+                                    &queued_p1_count,
+                                );
+                                let _ = release_shutdown_pending_batch(
+                                    &accounting,
+                                    &terminal_journal,
+                                    &pending,
+                                    "shutdown drain deadline exceeded",
+                                )
+                                .map_err(|err| {
+                                    result = Err(format!(
+                                        "sqlite batch writer shutdown quarantine failed: {err:#}"
+                                    ));
+                                });
+                                break;
+                            }
                             let drained = drain_queued_batch_writes(
                                 &mut write_receiver,
                                 &mut pending,
@@ -2048,16 +2071,39 @@ pub(crate) async fn run_sqlite_batch_writer(
                             let pending_bytes_before_merge = pending.estimated_memory_bytes();
                             let p2_defer_reason = retained.p2_defer;
                             let p2_deferred = p2_defer_reason.is_some();
+                            let p2_retryable_failure = retained.p2_retryable_failure;
                             let mut retained_batch = retained.batch;
                             retained_batch.merge_all(pending.take());
+                            let merged_rows = retained_batch.logical_rows();
+                            let merged_bytes = retained_batch.estimated_memory_bytes();
+                            accounting.replace_batch(
+                                retained_rows_before_merge + pending_rows_before_merge,
+                                merged_rows,
+                                retained_bytes_before_merge + pending_bytes_before_merge,
+                                merged_bytes,
+                            );
                             if failed {
+                                let retry_delay = if !retained_batch.terminal_invocations.is_empty() {
+                                    transaction_sequence = transaction_sequence.saturating_add(1);
+                                    Some(p1_retry.failed(transaction_sequence))
+                                } else if p2_retryable_failure {
+                                    transaction_sequence = transaction_sequence.saturating_add(1);
+                                    Some(p2_schedule.failed(transaction_sequence))
+                                } else {
+                                    None
+                                };
+                                if retry_delay.is_some() && Instant::now() < shutdown_deadline {
+                                    pending = retained_batch;
+                                    let delay = retry_delay
+                                        .unwrap_or(Duration::from_millis(1))
+                                        .min(shutdown_deadline.saturating_duration_since(Instant::now()));
+                                    sleep(delay).await;
+                                    continue;
+                                }
                                 result = Err(format!(
                                     "sqlite batch writer retained {logical_rows} logical rows after shutdown flush"
                                 ));
-                                accounting.release(
-                                    retained_rows_before_merge + pending_rows_before_merge,
-                                    retained_bytes_before_merge + pending_bytes_before_merge,
-                                );
+                                accounting.release(merged_rows, merged_bytes);
                                 break;
                             }
                             if !retained_batch.terminal_invocations.is_empty() {
@@ -2074,7 +2120,10 @@ pub(crate) async fn run_sqlite_batch_writer(
                                         Duration::from_millis(250)
                                     }
                                 };
-                                sleep(delay).await;
+                                sleep(delay.min(
+                                    shutdown_deadline.saturating_duration_since(Instant::now()),
+                                ))
+                                .await;
                                 continue;
                             }
                             if !retained_batch.is_empty() {
@@ -2229,7 +2278,20 @@ pub(crate) async fn run_sqlite_batch_writer(
             }
             maybe_write = write_receiver.recv() => {
                 let Some(write) = maybe_write else {
+                    let shutdown_deadline = Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE;
                     loop {
+                        if Instant::now() >= shutdown_deadline {
+                            let _ = release_shutdown_pending_batch(
+                                &accounting,
+                                &terminal_journal,
+                                &pending,
+                                "receiver shutdown drain deadline exceeded",
+                            )
+                            .map_err(|err| {
+                                warn!(error = %err, "receiver shutdown quarantine failed");
+                            });
+                            break;
+                        }
                         drain_terminal_journal_deferred_writes(
                             &terminal_journal,
                             &mut pending,
@@ -2264,13 +2326,36 @@ pub(crate) async fn run_sqlite_batch_writer(
                         let pending_bytes_before_merge = pending.estimated_memory_bytes();
                         let p2_defer_reason = retained.p2_defer;
                         let p2_deferred = p2_defer_reason.is_some();
+                        let p2_retryable_failure = retained.p2_retryable_failure;
                         let mut retained_batch = retained.batch;
                         retained_batch.merge_all(pending.take());
+                        let merged_rows = retained_batch.logical_rows();
+                        let merged_bytes = retained_batch.estimated_memory_bytes();
+                        accounting.replace_batch(
+                            retained_rows_before_merge + pending_rows_before_merge,
+                            merged_rows,
+                            retained_bytes_before_merge + pending_bytes_before_merge,
+                            merged_bytes,
+                        );
                         if retained.failed {
-                            accounting.release(
-                                retained_rows_before_merge + pending_rows_before_merge,
-                                retained_bytes_before_merge + pending_bytes_before_merge,
-                            );
+                            let retry_delay = if !retained_batch.terminal_invocations.is_empty() {
+                                transaction_sequence = transaction_sequence.saturating_add(1);
+                                Some(p1_retry.failed(transaction_sequence))
+                            } else if p2_retryable_failure {
+                                transaction_sequence = transaction_sequence.saturating_add(1);
+                                Some(p2_schedule.failed(transaction_sequence))
+                            } else {
+                                None
+                            };
+                            if retry_delay.is_some() && Instant::now() < shutdown_deadline {
+                                pending = retained_batch;
+                                let delay = retry_delay
+                                    .unwrap_or(Duration::from_millis(1))
+                                    .min(shutdown_deadline.saturating_duration_since(Instant::now()));
+                                sleep(delay).await;
+                                continue;
+                            }
+                            accounting.release(merged_rows, merged_bytes);
                             warn!(
                                 retained_rows = retained_batch.logical_rows(),
                                 retained_bytes = retained_batch.estimated_memory_bytes(),
@@ -2292,7 +2377,10 @@ pub(crate) async fn run_sqlite_batch_writer(
                                     Duration::from_millis(250)
                                 }
                             };
-                            sleep(delay).await;
+                            sleep(delay.min(
+                                shutdown_deadline.saturating_duration_since(Instant::now()),
+                            ))
+                            .await;
                             continue;
                         }
                         if !retained_batch.is_empty() {
@@ -2714,6 +2802,20 @@ fn quarantine_system_task_batch(
         journal.quarantine_system_task_finish(finish, &error)?;
     }
     Ok(batch.system_task_finishes.len())
+}
+
+fn release_shutdown_pending_batch(
+    accounting: &PendingQueueAccounting,
+    terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    batch: &PendingBatch,
+    reason: &str,
+) -> Result<()> {
+    if !batch.system_task_finishes.is_empty() {
+        let error = anyhow::anyhow!(reason.to_string());
+        quarantine_system_task_batch(terminal_journal, batch, &error)?;
+    }
+    accounting.release(batch.logical_rows(), batch.estimated_memory_bytes());
+    Ok(())
 }
 
 #[expect(
@@ -3311,7 +3413,9 @@ pub(crate) async fn flush_pending_batch_inner(
                 }
             }
         }
-        if prompt_cache_key_from_payload(terminal.record.payload.as_deref())
+        let payload_metadata = crate::terminal_payload_metadata(terminal.record.payload.as_deref());
+        if payload_metadata
+            .prompt_cache_key
             .as_deref()
             .is_some_and(|key| !key.trim().is_empty())
         {
@@ -3321,9 +3425,7 @@ pub(crate) async fn flush_pending_batch_inner(
             BatchedInvocationDerivedWrites {
                 invocation_id,
                 occurred_at,
-                upstream_account_id: crate::upstream_account_id_from_payload(
-                    terminal.record.payload.as_deref(),
-                ),
+                upstream_account_id: payload_metadata.upstream_account_id,
                 terminal_overlay_key: Some((
                     terminal.record.invoke_id.clone(),
                     terminal.record.occurred_at.clone(),

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1274,6 +1274,7 @@ pub(crate) struct SqliteBatchWriter {
         Arc<std::sync::Mutex<Option<Arc<Mutex<DashboardActivitySnapshotCacheState>>>>>,
     terminal_projection_hub: Arc<std::sync::Mutex<Option<Arc<TerminalProjectionHub>>>>,
     terminal_journal: Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    database_path: std::path::PathBuf,
     dashboard_reconcile_gate: Arc<Mutex<()>>,
     #[cfg(test)]
     prompt_cache_conversation_cache: Option<Arc<Mutex<PromptCacheConversationsCacheState>>>,
@@ -1357,6 +1358,7 @@ impl SqliteBatchWriter {
             dashboard_activity_snapshot_cache,
             terminal_projection_hub,
             terminal_journal,
+            database_path: database_path.to_path_buf(),
             dashboard_reconcile_gate,
             #[cfg(test)]
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
@@ -1401,6 +1403,7 @@ impl SqliteBatchWriter {
             dashboard_activity_snapshot_cache: Arc::new(std::sync::Mutex::new(None)),
             terminal_projection_hub: Arc::new(std::sync::Mutex::new(None)),
             terminal_journal: Arc::new(std::sync::Mutex::new(None)),
+            database_path: std::path::PathBuf::from("test-sqlite-batch-writer.db"),
             dashboard_reconcile_gate: Arc::new(Mutex::new(())),
             prompt_cache_conversation_cache: Some(prompt_cache_conversation_cache),
             handle: Mutex::new(None),
@@ -1521,6 +1524,7 @@ impl SqliteBatchWriter {
             .p1_priority_gate
             .lock()
             .unwrap_or_else(|error| error.into_inner());
+        let recovery_terminal = terminal.clone();
         let journal = self
             .terminal_journal
             .lock()
@@ -1544,6 +1548,25 @@ impl SqliteBatchWriter {
             SqliteBatchWrite::TerminalInvocation(terminal),
             journal.durability_mode,
         );
+        if matches!(
+            journal.durability_mode,
+            TerminalJournalDurabilityMode::MemoryOverflow
+        ) {
+            let terminals = [&recovery_terminal];
+            if let Err(err) = TerminalJournal::quarantine_shutdown_batch_at_database_path(
+                &self.database_path,
+                &terminals,
+                &[],
+                "terminal journal memory-overflow recovery",
+            ) {
+                warn!(
+                    error = %err,
+                    invoke_id = %recovery_terminal.record.invoke_id,
+                    occurred_at = %recovery_terminal.record.occurred_at,
+                    "terminal memory-overflow recovery sink failed"
+                );
+            }
+        }
         TerminalEnqueueOutcome {
             enqueued,
             durability_mode: journal.durability_mode,
@@ -1726,14 +1749,25 @@ impl SqliteBatchWriter {
         }
         let mut handle = handle;
         let worker_deadline = tokio::time::Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE;
-        match timeout_at(worker_deadline, &mut handle).await {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => warn!(error = %err, "sqlite batch writer task failed during shutdown"),
-            Err(_) => {
-                warn!("sqlite batch writer task exceeded shutdown deadline; aborting");
-                handle.abort();
-                let _ = handle.await;
+        let worker_timed_out = match timeout_at(worker_deadline, &mut handle).await {
+            Ok(Ok(())) => false,
+            Ok(Err(err)) => {
+                warn!(error = %err, "sqlite batch writer task failed during shutdown");
+                false
             }
+            Err(_) => {
+                warn!(
+                    "sqlite batch writer task exceeded shutdown deadline; retaining worker ownership for recovery"
+                );
+                true
+            }
+        };
+        if worker_timed_out {
+            // Do not abort a worker that still owns an in-flight batch. The worker's own
+            // bounded shutdown path will quarantine that batch; keeping the handle lets a
+            // later shutdown attempt observe completion instead of losing memory-overflow P1.
+            *self.handle.lock().await = Some(handle);
+            return;
         }
         let (abandoned_depth, abandoned_bytes) = self.accounting.clear_after_shutdown();
         self.queued_p1_count.store(0, Ordering::SeqCst);

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -558,7 +558,7 @@ pub(crate) struct BatchedAttemptProgress {
 pub(crate) struct BatchedInvocationDerivedWrites {
     pub(crate) invocation_id: i64,
     pub(crate) occurred_at: String,
-    pub(crate) payload: Option<String>,
+    pub(crate) upstream_account_id: Option<i64>,
     pub(crate) terminal_overlay_key: Option<(String, String)>,
 }
 
@@ -1226,7 +1226,6 @@ fn estimated_attempt_progress_memory_bytes(progress: &BatchedAttemptProgress) ->
 fn estimated_invocation_derived_memory_bytes(derived: &BatchedInvocationDerivedWrites) -> usize {
     std::mem::size_of::<BatchedInvocationDerivedWrites>()
         .saturating_add(derived.occurred_at.capacity())
-        .saturating_add(estimated_option_string_bytes(&derived.payload))
         .saturating_add(
             derived
                 .terminal_overlay_key
@@ -2043,23 +2042,49 @@ pub(crate) async fn run_sqlite_batch_writer(
                             };
                             let logical_rows = retained.batch.logical_rows();
                             let failed = retained.failed;
+                            let retained_rows_before_merge = retained.batch.logical_rows();
+                            let retained_bytes_before_merge = retained.batch.estimated_memory_bytes();
+                            let pending_rows_before_merge = pending.logical_rows();
+                            let pending_bytes_before_merge = pending.estimated_memory_bytes();
+                            let p2_defer_reason = retained.p2_defer;
+                            let p2_deferred = p2_defer_reason.is_some();
                             let mut retained_batch = retained.batch;
                             retained_batch.merge_all(pending.take());
-                            let retained_depth = retained_batch.logical_rows();
-                            let retained_bytes = retained_batch.estimated_memory_bytes();
-                            accounting.release(retained_depth, retained_bytes);
                             if failed {
                                 result = Err(format!(
                                     "sqlite batch writer retained {logical_rows} logical rows after shutdown flush"
                                 ));
+                                accounting.release(
+                                    retained_rows_before_merge + pending_rows_before_merge,
+                                    retained_bytes_before_merge + pending_bytes_before_merge,
+                                );
                                 break;
+                            }
+                            if !retained_batch.terminal_invocations.is_empty() {
+                                pending = retained_batch;
+                                continue;
+                            }
+                            if p2_deferred {
+                                pending = retained_batch;
+                                let delay = match p2_defer_reason {
+                                    Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                                        Duration::from_millis(remaining_ms.max(1))
+                                    }
+                                    Some(P2DeferReason::BackgroundBusy { .. }) | None => {
+                                        Duration::from_millis(250)
+                                    }
+                                };
+                                sleep(delay).await;
+                                continue;
+                            }
+                            if !retained_batch.is_empty() {
+                                pending = retained_batch;
+                                continue;
                             }
                             warn!(
                                 logical_rows,
-                                retained_bytes,
-                                "sqlite batch writer skipped deferred P2 writes during shutdown after P1 drain"
+                                "sqlite batch writer completed shutdown drain"
                             );
-                            break;
                         }
                         let _ = responder.send(result);
                         return;
@@ -2233,17 +2258,47 @@ pub(crate) async fn run_sqlite_batch_writer(
                         else {
                             continue;
                         };
+                        let retained_rows_before_merge = retained.batch.logical_rows();
+                        let retained_bytes_before_merge = retained.batch.estimated_memory_bytes();
+                        let pending_rows_before_merge = pending.logical_rows();
+                        let pending_bytes_before_merge = pending.estimated_memory_bytes();
+                        let p2_defer_reason = retained.p2_defer;
+                        let p2_deferred = p2_defer_reason.is_some();
                         let mut retained_batch = retained.batch;
                         retained_batch.merge_all(pending.take());
-                        let retained_rows = retained_batch.logical_rows();
-                        let retained_bytes = retained_batch.estimated_memory_bytes();
-                        accounting.release(retained_rows, retained_bytes);
-                        warn!(
-                            retained_rows,
-                            retained_bytes,
-                            failed = retained.failed,
-                            "sqlite batch writer released retained memory accounting after receiver shutdown"
-                        );
+                        if retained.failed {
+                            accounting.release(
+                                retained_rows_before_merge + pending_rows_before_merge,
+                                retained_bytes_before_merge + pending_bytes_before_merge,
+                            );
+                            warn!(
+                                retained_rows = retained_batch.logical_rows(),
+                                retained_bytes = retained_batch.estimated_memory_bytes(),
+                                "sqlite batch writer released failed retained memory accounting after receiver shutdown"
+                            );
+                            break;
+                        }
+                        if !retained_batch.terminal_invocations.is_empty() {
+                            pending = retained_batch;
+                            continue;
+                        }
+                        if p2_deferred {
+                            pending = retained_batch;
+                            let delay = match p2_defer_reason {
+                                Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                                    Duration::from_millis(remaining_ms.max(1))
+                                }
+                                Some(P2DeferReason::BackgroundBusy { .. }) | None => {
+                                    Duration::from_millis(250)
+                                }
+                            };
+                            sleep(delay).await;
+                            continue;
+                        }
+                        if !retained_batch.is_empty() {
+                            pending = retained_batch;
+                            continue;
+                        }
                         break;
                     }
                     return;
@@ -2643,6 +2698,24 @@ fn cleanup_discarded_p2_runtime_overlays(
         .count()
 }
 
+fn quarantine_system_task_batch(
+    terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    batch: &PendingBatch,
+    error: &anyhow::Error,
+) -> Result<usize> {
+    let mut journal = terminal_journal
+        .lock()
+        .map_err(|_| anyhow::anyhow!("terminal journal lock poisoned"))?;
+    let journal = journal
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("terminal journal unavailable for quarantine"))?;
+    let error = format!("{error:#}");
+    for finish in batch.system_task_finishes.values() {
+        journal.quarantine_system_task_finish(finish, &error)?;
+    }
+    Ok(batch.system_task_finishes.len())
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "Flush dependencies mirror the single-writer ownership boundaries."
@@ -2937,16 +3010,35 @@ pub(crate) async fn flush_pending_batch(
     {
         Ok(main_deferred) => {
             deferred_batch.merge_p2(main_deferred);
-            if system_task_failure.is_some() {
+            if let Some(system_task_error) = system_task_failure.as_ref() {
                 if !system_task_retryable_failure {
+                    let system_task_batch_ref = system_task_batch
+                        .as_ref()
+                        .expect("system task failure must retain its isolated batch");
+                    let quarantine_result = quarantine_system_task_batch(
+                        terminal_journal,
+                        system_task_batch_ref,
+                        system_task_error,
+                    );
+                    if let Err(quarantine_error) = quarantine_result {
+                        warn!(
+                            error = %quarantine_error,
+                            flush_priority = "P2",
+                            system_task_scope = %summarize_system_task_batch_scope(
+                                system_task_batch_ref
+                            ),
+                            "system-task quarantine failed; retaining completion for retry"
+                        );
+                        let mut retry_batch = system_task_batch
+                            .expect("system task failure must retain its isolated batch");
+                        retry_batch.merge_p2(deferred_batch);
+                        drop(permit);
+                        return Some(RetainedBatch::p2_failed(retry_batch, true, false));
+                    }
                     warn!(
                         flush_priority = "P2",
-                        system_task_scope = %summarize_system_task_batch_scope(
-                            system_task_batch
-                                .as_ref()
-                                .expect("system task failure must retain its isolated batch")
-                        ),
-                        "discarded deterministic system-task completion after failed finalization"
+                        system_task_scope = %summarize_system_task_batch_scope(system_task_batch_ref),
+                        "quarantined deterministic system-task completion after failed finalization"
                     );
                     drop(permit);
                     return if deferred_batch.is_empty() {
@@ -2978,10 +3070,22 @@ pub(crate) async fn flush_pending_batch(
                 "sqlite batch writer P2 flush failed"
             );
             drop(permit);
-            if system_task_failure.is_some() && !crate::db_pressure::is_db_pressure_error(&err) {
+            if !crate::db_pressure::is_db_pressure_error(&err)
+                && let Some(system_task_error) = system_task_failure.as_ref()
+            {
                 cleanup_discarded_p2_runtime_overlays(&batch, terminal_runtime_store);
                 let retry_batch =
                     system_task_batch.expect("system task failure must retain its isolated batch");
+                if !system_task_retryable_failure
+                    && quarantine_system_task_batch(
+                        terminal_journal,
+                        &retry_batch,
+                        system_task_error,
+                    )
+                    .is_ok()
+                {
+                    return None;
+                }
                 return Some(RetainedBatch::p2_failed(
                     retry_batch,
                     system_task_retryable_failure,
@@ -2989,7 +3093,21 @@ pub(crate) async fn flush_pending_batch(
                 ));
             }
             if let Some(system_task_batch) = system_task_batch {
-                if system_task_failure.is_some() {
+                if let Some(system_task_error) = system_task_failure.as_ref() {
+                    if !system_task_retryable_failure
+                        && quarantine_system_task_batch(
+                            terminal_journal,
+                            &system_task_batch,
+                            system_task_error,
+                        )
+                        .is_ok()
+                    {
+                        return Some(RetainedBatch::p2_failed(
+                            batch,
+                            crate::db_pressure::is_db_pressure_error(&err),
+                            is_sqlite_lock_error(&err),
+                        ));
+                    }
                     let mut retry_batch = system_task_batch;
                     retry_batch.merge_p2(batch);
                     return Some(RetainedBatch::p2_failed(
@@ -3203,7 +3321,9 @@ pub(crate) async fn flush_pending_batch_inner(
             BatchedInvocationDerivedWrites {
                 invocation_id,
                 occurred_at,
-                payload: terminal.record.payload.clone(),
+                upstream_account_id: crate::upstream_account_id_from_payload(
+                    terminal.record.payload.as_deref(),
+                ),
                 terminal_overlay_key: Some((
                     terminal.record.invoke_id.clone(),
                     terminal.record.occurred_at.clone(),
@@ -3332,10 +3452,10 @@ pub(crate) async fn flush_pending_batch_inner(
             if let Some(key) = derived.terminal_overlay_key.clone() {
                 terminal_overlay_keys.push(key);
             }
-            touch_invocation_upstream_account_last_activity_tx(
+            crate::touch_upstream_account_last_activity_tx(
                 tx.as_mut(),
                 &derived.occurred_at,
-                derived.payload.as_deref(),
+                derived.upstream_account_id,
             )
             .await?;
         }
@@ -4773,7 +4893,7 @@ mod tests {
                 BatchedInvocationDerivedWrites {
                     invocation_id: max_id,
                     occurred_at: "2026-07-01 10:00:00".to_string(),
-                    payload: None,
+                    upstream_account_id: None,
                     terminal_overlay_key: None,
                 },
             )],

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -138,8 +138,24 @@ async fn wait_for_p2_deadline(due_at: Option<Instant>) {
     }
 }
 
-fn p2_deadline_ready(pending: &PendingBatch, p2_schedule: &P2ScheduleState) -> bool {
-    pending.has_p2() && p2_schedule.ready(Instant::now())
+fn p2_deadline_ready(
+    pending: &PendingBatch,
+    p2_schedule: &P2ScheduleState,
+    queued_p1_count: &AtomicUsize,
+) -> bool {
+    pending.has_p2()
+        && p2_schedule.ready(Instant::now())
+        && queued_p1_count.load(Ordering::SeqCst) == 0
+}
+
+fn is_p1_terminal_write(write: &SqliteBatchWrite) -> bool {
+    matches!(write, SqliteBatchWrite::TerminalInvocation(_))
+}
+
+fn decrement_queued_p1_count(queued_p1_count: &AtomicUsize) {
+    let _ = queued_p1_count.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+        count.checked_sub(1)
+    });
 }
 
 fn drain_queued_writes_before_dispatch(
@@ -147,12 +163,39 @@ fn drain_queued_writes_before_dispatch(
     pending: &mut PendingBatch,
     accounting: &PendingQueueAccounting,
     p2_schedule: &mut P2ScheduleState,
+    max_messages: usize,
+    queued_p1_count: &AtomicUsize,
 ) {
-    drain_queued_batch_writes(write_receiver, pending, accounting, SQLITE_BATCH_MAX_ROWS);
+    drain_queued_batch_writes(
+        write_receiver,
+        pending,
+        accounting,
+        max_messages,
+        queued_p1_count,
+    );
     if pending.has_p2() {
         p2_schedule.arm_if_idle(Instant::now());
         accounting.update_p2_schedule(p2_schedule);
     }
+}
+
+fn drain_queued_writes_before_p2_dispatch(
+    write_receiver: &mut mpsc::Receiver<SqliteBatchWrite>,
+    pending: &mut PendingBatch,
+    accounting: &PendingQueueAccounting,
+    p2_schedule: &mut P2ScheduleState,
+    queued_p1_count: &AtomicUsize,
+) {
+    // A snapshot keeps the priority scan bounded even while P2 producers continue writing.
+    let queued_messages = write_receiver.len();
+    drain_queued_writes_before_dispatch(
+        write_receiver,
+        pending,
+        accounting,
+        p2_schedule,
+        queued_messages,
+        queued_p1_count,
+    );
 }
 
 impl P1RetryState {
@@ -1033,6 +1076,7 @@ impl PendingBatch {
 #[derive(Debug)]
 pub(crate) struct SqliteBatchWriter {
     write_sender: mpsc::Sender<SqliteBatchWrite>,
+    queued_p1_count: Arc<AtomicUsize>,
     control_sender: mpsc::Sender<SqliteBatchWriterControl>,
     accounting: Arc<PendingQueueAccounting>,
     dropped_writes: Arc<AtomicU64>,
@@ -1062,6 +1106,7 @@ impl SqliteBatchWriter {
         database_path: &Path,
     ) -> Arc<Self> {
         let (write_sender, write_receiver) = mpsc::channel(SQLITE_BATCH_CHANNEL_CAPACITY);
+        let queued_p1_count = Arc::new(AtomicUsize::new(0));
         let (control_sender, control_receiver) = mpsc::channel(128);
         let accounting = Arc::new(PendingQueueAccounting::default());
         let dropped_writes = Arc::new(AtomicU64::new(0));
@@ -1102,9 +1147,11 @@ impl SqliteBatchWriter {
             terminal_projection_hub.clone(),
             dashboard_reconcile_gate.clone(),
             terminal_journal.clone(),
+            queued_p1_count.clone(),
         ));
         let writer = Arc::new(Self {
             write_sender,
+            queued_p1_count,
             control_sender,
             accounting,
             dropped_writes,
@@ -1152,6 +1199,7 @@ impl SqliteBatchWriter {
         let (control_sender, _control_receiver) = mpsc::channel(1);
         Arc::new(Self {
             write_sender,
+            queued_p1_count: Arc::new(AtomicUsize::new(0)),
             control_sender,
             accounting: Arc::new(PendingQueueAccounting::default()),
             dropped_writes: Arc::new(AtomicU64::new(0)),
@@ -1210,6 +1258,7 @@ impl SqliteBatchWriter {
 
     pub(crate) fn enqueue(&self, write: SqliteBatchWrite) -> bool {
         let estimated_bytes = write.estimated_memory_bytes();
+        let is_p1 = is_p1_terminal_write(&write);
         #[cfg(test)]
         if let Some(buffered_writes) = &self.buffered_writes {
             match buffered_writes.lock() {
@@ -1231,9 +1280,15 @@ impl SqliteBatchWriter {
         }
 
         self.accounting.enqueue(estimated_bytes);
+        if is_p1 {
+            self.queued_p1_count.fetch_add(1, Ordering::SeqCst);
+        }
         match self.write_sender.try_send(write) {
             Ok(()) => true,
             Err(err) => {
+                if is_p1 {
+                    decrement_queued_p1_count(&self.queued_p1_count);
+                }
                 self.accounting.rollback_enqueue(estimated_bytes);
                 self.dropped_writes.fetch_add(1, Ordering::Relaxed);
                 warn!(
@@ -1302,9 +1357,16 @@ impl SqliteBatchWriter {
     ) -> bool {
         let estimated_bytes = write.estimated_memory_bytes();
         self.accounting.enqueue(estimated_bytes);
+        let is_p1 = is_p1_terminal_write(&write);
+        if is_p1 {
+            self.queued_p1_count.fetch_add(1, Ordering::SeqCst);
+        }
         match self.write_sender.try_send(write) {
             Ok(()) => true,
             Err(mpsc::error::TrySendError::Full(write)) => {
+                if is_p1 {
+                    decrement_queued_p1_count(&self.queued_p1_count);
+                }
                 self.accounting.rollback_enqueue(estimated_bytes);
                 let deferred = matches!(durability_mode, TerminalJournalDurabilityMode::Journal)
                     && self
@@ -1571,6 +1633,7 @@ pub(crate) async fn run_sqlite_batch_writer(
     terminal_projection_hub: Arc<std::sync::Mutex<Option<Arc<TerminalProjectionHub>>>>,
     dashboard_reconcile_gate: Arc<Mutex<()>>,
     terminal_journal: Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    queued_p1_count: Arc<AtomicUsize>,
 ) {
     let mut ticker = interval(SQLITE_BATCH_FLUSH_INTERVAL);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -1590,6 +1653,8 @@ pub(crate) async fn run_sqlite_batch_writer(
             &mut pending,
             &accounting,
             &mut p2_schedule,
+            SQLITE_BATCH_MAX_ROWS,
+            &queued_p1_count,
         );
         tokio::select! {
             biased;
@@ -1603,9 +1668,164 @@ pub(crate) async fn run_sqlite_batch_writer(
                 p2_schedule.wake_background_eligible();
                 accounting.update_p2_schedule(&p2_schedule);
             }
+            maybe_control = control_receiver.recv(), if !control_closed => {
+                if let Some(control) = maybe_control {
+                    match control {
+                    SqliteBatchWriterControl::FlushNow {
+                        queued_depth_snapshot,
+                        responder,
+                    } => {
+                        drain_queued_batch_writes(
+                            &mut write_receiver,
+                            &mut pending,
+                            &accounting,
+                            queued_depth_snapshot,
+                            &queued_p1_count,
+                        );
+                        drain_terminal_journal_deferred_writes(
+                            &terminal_journal,
+                            &mut pending,
+                            &accounting,
+                            usize::MAX,
+                        );
+                        let result = match flush_pending_batch_accounted(
+                            &accounting,
+                            &pool,
+                            pricing_catalog.as_ref(),
+                            pending.take(),
+                            FlushReason::Barrier,
+                            prompt_cache_conversation_cache.as_ref(),
+                            &terminal_runtime_store,
+                            &dashboard_activity_snapshot_cache,
+                            &terminal_projection_hub,
+                            &dashboard_reconcile_gate,
+                            &terminal_journal,
+                        )
+                        .await
+                        {
+                            Some(retained) => {
+                                let logical_rows = retained.batch.logical_rows();
+                                let failed = retained.failed;
+                                match retained.p2_defer {
+                                    Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
+                                        p2_schedule.defer_pressure(
+                                            Duration::from_millis(remaining_ms),
+                                            P2WakeReason::PressureCooldownElapsed,
+                                        );
+                                    }
+                                    Some(P2DeferReason::BackgroundBusy {
+                                        observed_generation,
+                                    }) => {
+                                        p2_eligibility_generation = observed_generation;
+                                        p2_schedule.defer_until_background_eligible();
+                                    }
+                                    None if retained.failed
+                                        && retained.batch.has_p2()
+                                        && retained.batch.terminal_invocations.is_empty() =>
+                                    {
+                                        transaction_sequence = transaction_sequence.saturating_add(1);
+                                        p2_schedule.failed(transaction_sequence);
+                                        if retained.p2_lock_failure {
+                                            accounting.p2_lock_retried();
+                                        }
+                                    }
+                                    None if retained.batch.has_p2() => {
+                                        p2_schedule.arm_if_idle(Instant::now());
+                                    }
+                                    None => p2_schedule.succeeded(),
+                                }
+                                accounting.update_p2_schedule(&p2_schedule);
+                                pending = retained.batch;
+                                if failed {
+                                    Err(format!(
+                                        "sqlite batch writer retained {logical_rows} logical rows after forced flush"
+                                    ))
+                                } else {
+                                    Ok(())
+                                }
+                            }
+                            None => {
+                                p2_schedule.succeeded();
+                                accounting.update_p2_schedule(&p2_schedule);
+                                Ok(())
+                            },
+                        };
+                        let _ = responder.send(result);
+                    }
+                    SqliteBatchWriterControl::Shutdown { responder, .. } => {
+                        write_receiver.close();
+                        drain_queued_batch_writes(
+                            &mut write_receiver,
+                            &mut pending,
+                            &accounting,
+                            usize::MAX,
+                            &queued_p1_count,
+                        );
+                        drain_terminal_journal_deferred_writes(
+                            &terminal_journal,
+                            &mut pending,
+                            &accounting,
+                            usize::MAX,
+                        );
+                        let result = if pending.is_empty() {
+                            Ok(())
+                        } else {
+                            match flush_pending_batch_accounted(
+                                &accounting,
+                                &pool,
+                                pricing_catalog.as_ref(),
+                                pending.take(),
+                                FlushReason::Shutdown,
+                                prompt_cache_conversation_cache.as_ref(),
+                                &terminal_runtime_store,
+                                &dashboard_activity_snapshot_cache,
+                                &terminal_projection_hub,
+                                &dashboard_reconcile_gate,
+                                &terminal_journal,
+                            )
+                            .await
+                            {
+                                Some(retained) => {
+                                    let logical_rows = retained.batch.logical_rows();
+                                    accounting.complete(
+                                        retained.batch.logical_rows(),
+                                        0,
+                                        retained.batch.estimated_memory_bytes(),
+                                        0,
+                                    );
+                                    if retained.failed {
+                                        Err(format!(
+                                            "sqlite batch writer retained {logical_rows} logical rows after shutdown flush"
+                                        ))
+                                    } else {
+                                        warn!(
+                                            logical_rows,
+                                            "sqlite batch writer skipped deferred P2 writes during shutdown after P1 drain"
+                                        );
+                                        Ok(())
+                                    }
+                                }
+                                None => Ok(()),
+                            }
+                        };
+                        let _ = responder.send(result);
+                        return;
+                    }
+                    }
+                } else {
+                    control_closed = true;
+                }
+            }
             _ = wait_for_p2_deadline(p2_schedule.due_at),
-                if p2_deadline_ready(&pending, &p2_schedule) =>
+                if p2_deadline_ready(&pending, &p2_schedule, &queued_p1_count) =>
             {
+                drain_queued_writes_before_p2_dispatch(
+                    &mut write_receiver,
+                    &mut pending,
+                    &accounting,
+                    &mut p2_schedule,
+                    &queued_p1_count,
+                );
                 let now = Instant::now();
                 let submitted_p1 = !pending.terminal_invocations.is_empty() && p1_retry.ready(now);
                 let flush_batch = if submitted_p1 {
@@ -1689,152 +1909,6 @@ pub(crate) async fn run_sqlite_batch_writer(
                     accounting.update_p2_schedule(&p2_schedule);
                 }
             }
-            maybe_control = control_receiver.recv(), if !control_closed => {
-                if let Some(control) = maybe_control {
-                    match control {
-                    SqliteBatchWriterControl::FlushNow {
-                        queued_depth_snapshot,
-                        responder,
-                    } => {
-                        drain_queued_batch_writes(
-                            &mut write_receiver,
-                            &mut pending,
-                            &accounting,
-                            queued_depth_snapshot,
-                        );
-                        drain_terminal_journal_deferred_writes(
-                            &terminal_journal,
-                            &mut pending,
-                            &accounting,
-                            usize::MAX,
-                        );
-                        let result = match flush_pending_batch_accounted(
-                            &accounting,
-                            &pool,
-                            pricing_catalog.as_ref(),
-                            pending.take(),
-                            FlushReason::Barrier,
-                            prompt_cache_conversation_cache.as_ref(),
-                            &terminal_runtime_store,
-                            &dashboard_activity_snapshot_cache,
-                            &terminal_projection_hub,
-                            &dashboard_reconcile_gate,
-                            &terminal_journal,
-                        )
-                        .await
-                        {
-                            Some(retained) => {
-                                let logical_rows = retained.batch.logical_rows();
-                                let failed = retained.failed;
-                                match retained.p2_defer {
-                                    Some(P2DeferReason::PressureCooldown(remaining_ms)) => {
-                                        p2_schedule.defer_pressure(
-                                            Duration::from_millis(remaining_ms),
-                                            P2WakeReason::PressureCooldownElapsed,
-                                        );
-                                    }
-                                    Some(P2DeferReason::BackgroundBusy {
-                                        observed_generation,
-                                    }) => {
-                                        p2_eligibility_generation = observed_generation;
-                                        p2_schedule.defer_until_background_eligible();
-                                    }
-                                    None if retained.failed
-                                        && retained.batch.has_p2()
-                                        && retained.batch.terminal_invocations.is_empty() =>
-                                    {
-                                        transaction_sequence = transaction_sequence.saturating_add(1);
-                                        p2_schedule.failed(transaction_sequence);
-                                        if retained.p2_lock_failure {
-                                            accounting.p2_lock_retried();
-                                        }
-                                    }
-                                    None if retained.batch.has_p2() => {
-                                        p2_schedule.arm_if_idle(Instant::now());
-                                    }
-                                    None => p2_schedule.succeeded(),
-                                }
-                                accounting.update_p2_schedule(&p2_schedule);
-                                pending = retained.batch;
-                                if failed {
-                                    Err(format!(
-                                        "sqlite batch writer retained {logical_rows} logical rows after forced flush"
-                                    ))
-                                } else {
-                                    Ok(())
-                                }
-                            }
-                            None => {
-                                p2_schedule.succeeded();
-                                accounting.update_p2_schedule(&p2_schedule);
-                                Ok(())
-                            },
-                        };
-                        let _ = responder.send(result);
-                    }
-                    SqliteBatchWriterControl::Shutdown { responder, .. } => {
-                        write_receiver.close();
-                        drain_queued_batch_writes(
-                            &mut write_receiver,
-                            &mut pending,
-                            &accounting,
-                            usize::MAX,
-                        );
-                        drain_terminal_journal_deferred_writes(
-                            &terminal_journal,
-                            &mut pending,
-                            &accounting,
-                            usize::MAX,
-                        );
-                        let result = if pending.is_empty() {
-                            Ok(())
-                        } else {
-                            match flush_pending_batch_accounted(
-                                &accounting,
-                                &pool,
-                                pricing_catalog.as_ref(),
-                                pending.take(),
-                                FlushReason::Shutdown,
-                                prompt_cache_conversation_cache.as_ref(),
-                                &terminal_runtime_store,
-                                &dashboard_activity_snapshot_cache,
-                                &terminal_projection_hub,
-                                &dashboard_reconcile_gate,
-                                &terminal_journal,
-                            )
-                            .await
-                            {
-                                Some(retained) => {
-                                    let logical_rows = retained.batch.logical_rows();
-                                    accounting.complete(
-                                        retained.batch.logical_rows(),
-                                        0,
-                                        retained.batch.estimated_memory_bytes(),
-                                        0,
-                                    );
-                                    if retained.failed {
-                                        Err(format!(
-                                            "sqlite batch writer retained {logical_rows} logical rows after shutdown flush"
-                                        ))
-                                    } else {
-                                        warn!(
-                                            logical_rows,
-                                            "sqlite batch writer skipped deferred P2 writes during shutdown after P1 drain"
-                                        );
-                                        Ok(())
-                                    }
-                                }
-                                None => Ok(()),
-                            }
-                        };
-                        let _ = responder.send(result);
-                        return;
-                    }
-                    }
-                } else {
-                    control_closed = true;
-                }
-            }
             _ = deferred_ticker.tick() => {
                 let deferred_capacity = SQLITE_BATCH_MAX_ROWS.saturating_sub(pending.logical_rows());
                 drain_terminal_journal_deferred_writes(
@@ -1883,6 +1957,9 @@ pub(crate) async fn run_sqlite_batch_writer(
                     }
                     return;
                 };
+                if is_p1_terminal_write(&write) {
+                    decrement_queued_p1_count(&queued_p1_count);
+                }
                 pending.push_accounted(write, &accounting);
                 if pending.has_p2() {
                     p2_schedule.arm_if_idle(Instant::now());
@@ -2123,10 +2200,14 @@ pub(crate) fn drain_queued_batch_writes(
     pending: &mut PendingBatch,
     accounting: &PendingQueueAccounting,
     max_messages: usize,
+    queued_p1_count: &AtomicUsize,
 ) {
     for _ in 0..max_messages {
         match write_receiver.try_recv() {
             Ok(write) => {
+                if is_p1_terminal_write(&write) {
+                    decrement_queued_p1_count(queued_p1_count);
+                }
                 pending.push_accounted(write, accounting);
             }
             Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
@@ -2921,6 +3002,7 @@ mod tests {
         ));
         let mut schedule = P2ScheduleState::default();
         schedule.wake_background_eligible();
+        let queued_p1_count = AtomicUsize::new(0);
         let (sender, mut receiver) = mpsc::channel(1);
         sender
             .try_send(SqliteBatchWrite::TerminalInvocation(
@@ -2932,6 +3014,8 @@ mod tests {
             &mut pending,
             &accounting,
             &mut schedule,
+            SQLITE_BATCH_MAX_ROWS,
+            &queued_p1_count,
         );
 
         assert!(
@@ -2939,7 +3023,7 @@ mod tests {
             "queued P1 must be classified before checking the P2 deadline"
         );
         assert_eq!(pending.terminal_invocations.len(), 1);
-        assert!(p2_deadline_ready(&pending, &schedule));
+        assert!(p2_deadline_ready(&pending, &schedule, &queued_p1_count));
     }
 
     #[test]
@@ -2954,6 +3038,7 @@ mod tests {
         ));
         let mut schedule = P2ScheduleState::default();
         schedule.wake_background_eligible();
+        let queued_p1_count = AtomicUsize::new(0);
         let (sender, mut receiver) = mpsc::channel(1);
         sender
             .try_send(SqliteBatchWrite::AccountSelectedTouch(
@@ -2969,10 +3054,12 @@ mod tests {
             &mut pending,
             &accounting,
             &mut schedule,
+            SQLITE_BATCH_MAX_ROWS,
+            &queued_p1_count,
         );
 
         assert!(receiver.is_empty());
-        assert!(p2_deadline_ready(&pending, &schedule));
+        assert!(p2_deadline_ready(&pending, &schedule, &queued_p1_count));
     }
 
     #[tokio::test]
@@ -3135,6 +3222,120 @@ mod tests {
             "normal P2 batch should flush without retention"
         );
         assert_eq!(accounting.snapshot().p2_flush_attempt_count, 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn p1_queued_after_a_deep_p2_backlog_runs_first() {
+        const ACCOUNT_ID: i64 = 999_998;
+        const P1_INVOKE_ID: &str = "deep-deferred-p2-p1-priority";
+
+        let pool = test_pool().await;
+        sqlx::query(
+            r#"
+            INSERT INTO pool_upstream_accounts (
+                id, kind, provider, display_name, status, enabled, last_selected_at, created_at, updated_at
+            )
+            VALUES (999998, 'api_key', 'codex', 'Priority Test', 'active', 1, NULL, '2026-08-10T12:00:00Z', '2026-08-10T12:00:00Z')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("seed P2 account");
+        sqlx::query("CREATE TABLE batch_writer_dispatch_order (write_class TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .expect("create dispatch order table");
+        sqlx::query(
+            r#"
+            CREATE TRIGGER batch_writer_p1_dispatch_order
+            AFTER INSERT ON codex_invocations
+            WHEN NEW.invoke_id = 'deep-deferred-p2-p1-priority'
+            BEGIN
+                INSERT INTO batch_writer_dispatch_order (write_class) VALUES ('p1');
+            END
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("create P1 dispatch order trigger");
+        sqlx::query(
+            r#"
+            CREATE TRIGGER batch_writer_p2_dispatch_order
+            AFTER UPDATE OF last_selected_at ON pool_upstream_accounts
+            WHEN NEW.id = 999998
+            BEGIN
+                INSERT INTO batch_writer_dispatch_order (write_class) VALUES ('p2');
+            END
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("create P2 dispatch order trigger");
+
+        let writer = SqliteBatchWriter::spawn(
+            pool.clone(),
+            CancellationToken::new(),
+            Arc::new(Mutex::new(PromptCacheConversationsCacheState::default())),
+            Arc::new(RwLock::new(PricingCatalog::default())),
+            &std::env::temp_dir().join(format!("sqlite-batch-writer-{}.db", nanoid::nanoid!())),
+        );
+
+        assert!(writer.enqueue(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: ACCOUNT_ID,
+                selected_at: "2026-08-10T12:00:00Z".to_string(),
+            },
+        )));
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if writer.accounting_snapshot().p2_wake_reason.as_deref()
+                    == Some("coalesced_deadline")
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("initial P2 batch should arm its fixed coalescing deadline");
+
+        for offset in 0..=SQLITE_BATCH_MAX_ROWS {
+            assert!(writer.enqueue(SqliteBatchWrite::AccountSelectedTouch(
+                BatchedAccountSelectedTouch {
+                    account_id: ACCOUNT_ID,
+                    selected_at: format!("2026-08-10T12:01:{offset:02}Z"),
+                },
+            )));
+        }
+        assert!(writer.enqueue(SqliteBatchWrite::TerminalInvocation(
+            terminal_write_for_coalescing(P1_INVOKE_ID, None),
+        )));
+
+        // Keep the single-threaded writer asleep until its fixed P2 deadline is overdue.
+        std::thread::sleep(SQLITE_P2_COALESCE_INTERVAL + Duration::from_millis(10));
+        let order = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let order = sqlx::query_scalar::<_, String>(
+                    "SELECT write_class FROM batch_writer_dispatch_order ORDER BY rowid",
+                )
+                .fetch_all(&pool)
+                .await
+                .expect("load writer dispatch order");
+                if order.len() >= 2 {
+                    return order;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await;
+        writer.shutdown_and_drain().await;
+
+        let order = order.expect("writer should dispatch both P1 and P2 work");
+        assert_eq!(
+            order,
+            vec!["p1".to_string(), "p2".to_string()],
+            "the writer must classify the full queued snapshot before dispatching overdue P2 work"
+        );
     }
 
     async fn pending_attempt(pool: &SqlitePool, invoke_id: &str) -> PendingPoolAttemptRecord {

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -142,10 +142,12 @@ fn p2_deadline_ready(
     pending: &PendingBatch,
     p2_schedule: &P2ScheduleState,
     queued_p1_count: &AtomicUsize,
+    p1_retry: &P1RetryState,
 ) -> bool {
     pending.has_p2()
         && p2_schedule.ready(Instant::now())
         && queued_p1_count.load(Ordering::SeqCst) == 0
+        && p1_retry.ready(Instant::now())
 }
 
 fn is_p1_terminal_write(write: &SqliteBatchWrite) -> bool {
@@ -940,6 +942,14 @@ impl PendingBatch {
         let mut should_take = |bytes: usize| {
             if selected_rows >= max_rows {
                 return false;
+            }
+            // A single logical write can exceed the batch budget. Keep it
+            // isolated rather than combining it with any other P2 write;
+            // the caller emits an explicit oversized-batch diagnostic.
+            if selected_rows == 0 && bytes > max_bytes {
+                selected_rows = 1;
+                selected_bytes = bytes;
+                return true;
             }
             if selected_rows > 0 && selected_bytes.saturating_add(bytes) > max_bytes {
                 return false;
@@ -1948,7 +1958,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                 }
             }
             _ = wait_for_p2_deadline(p2_schedule.due_at),
-                if p2_deadline_ready(&pending, &p2_schedule, &queued_p1_count) =>
+                if p2_deadline_ready(&pending, &p2_schedule, &queued_p1_count, &p1_retry) =>
             {
                 let priority_guard = p1_priority_gate
                     .lock()
@@ -2833,12 +2843,23 @@ pub(crate) async fn flush_pending_batch(
                 ));
             }
             if let Some(system_task_batch) = system_task_batch {
-                let mut retry_batch = system_task_batch;
-                retry_batch.merge_p2(batch);
+                if system_task_failure.is_some() {
+                    let mut retry_batch = system_task_batch;
+                    retry_batch.merge_p2(batch);
+                    return Some(RetainedBatch::p2_failed(
+                        retry_batch,
+                        true,
+                        system_task_lock_failure || is_sqlite_lock_error(&err),
+                    ));
+                }
+                if !crate::db_pressure::is_db_pressure_error(&err) {
+                    cleanup_discarded_p2_runtime_overlays(&batch, terminal_runtime_store);
+                    return None;
+                }
                 return Some(RetainedBatch::p2_failed(
-                    retry_batch,
+                    batch,
                     true,
-                    system_task_lock_failure || is_sqlite_lock_error(&err),
+                    is_sqlite_lock_error(&err),
                 ));
             }
             let retryable_failure = crate::db_pressure::is_db_pressure_error(&err)
@@ -3371,7 +3392,12 @@ mod tests {
             "queued P1 must be classified before checking the P2 deadline"
         );
         assert_eq!(pending.terminal_invocations.len(), 1);
-        assert!(p2_deadline_ready(&pending, &schedule, &queued_p1_count));
+        assert!(p2_deadline_ready(
+            &pending,
+            &schedule,
+            &queued_p1_count,
+            &P1RetryState::default()
+        ));
     }
 
     #[test]
@@ -3407,7 +3433,35 @@ mod tests {
         );
 
         assert!(receiver.is_empty());
-        assert!(p2_deadline_ready(&pending, &schedule, &queued_p1_count));
+        assert!(p2_deadline_ready(
+            &pending,
+            &schedule,
+            &queued_p1_count,
+            &P1RetryState::default()
+        ));
+    }
+
+    #[test]
+    fn p1_retry_backoff_blocks_p2_deadline() {
+        let mut pending = PendingBatch::default();
+        pending.push(SqliteBatchWrite::AccountSelectedTouch(
+            BatchedAccountSelectedTouch {
+                account_id: 999_995,
+                selected_at: "2026-08-10T12:00:00Z".to_string(),
+            },
+        ));
+        let mut schedule = P2ScheduleState::default();
+        schedule.wake_background_eligible();
+        let queued_p1_count = AtomicUsize::new(0);
+        let mut p1_retry = P1RetryState::default();
+        p1_retry.failed(0);
+
+        assert!(!p2_deadline_ready(
+            &pending,
+            &schedule,
+            &queued_p1_count,
+            &p1_retry
+        ));
     }
 
     #[tokio::test]

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1565,6 +1565,10 @@ impl SqliteBatchWriter {
                     occurred_at = %recovery_terminal.record.occurred_at,
                     "terminal memory-overflow recovery sink failed"
                 );
+            } else if let Ok(mut journal) = self.terminal_journal.lock()
+                && let Some(journal) = journal.as_mut()
+            {
+                journal.remember_shutdown_recovery(&terminals);
             }
         }
         TerminalEnqueueOutcome {
@@ -3041,6 +3045,11 @@ fn quarantine_shutdown_batch(
             &error,
         ) {
             Ok(()) => {
+                if let Ok(mut guard) = terminal_journal.lock()
+                    && let Some(journal) = guard.as_mut()
+                {
+                    journal.remember_shutdown_recovery(&terminals);
+                }
                 warn!(
                     errors = ?errors,
                     "shutdown quarantine used the independent recovery sink"

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -1724,7 +1724,8 @@ impl SqliteBatchWriter {
             }
         }
         let mut handle = handle;
-        match timeout_at(shutdown_deadline, &mut handle).await {
+        let worker_deadline = tokio::time::Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE;
+        match timeout_at(worker_deadline, &mut handle).await {
             Ok(Ok(())) => {}
             Ok(Err(err)) => warn!(error = %err, "sqlite batch writer task failed during shutdown"),
             Err(_) => {

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -2705,7 +2705,63 @@ pub(crate) async fn flush_pending_batch(
     };
     accounting.p2_attempted();
 
-    let deferred_batch = match flush_pending_batch_inner(
+    // A deterministic failure in a derived write must not retain unrelated
+    // system-task completions forever. Flush those completions separately so
+    // their final state is durable even when another P2 write is discarded.
+    let system_task_batch = if !batch.system_task_finishes.is_empty()
+        && batch.logical_rows() > batch.system_task_finishes.len()
+    {
+        let mut system_task_batch = PendingBatch {
+            oldest_at: batch.oldest_at,
+            ..PendingBatch::default()
+        };
+        system_task_batch.system_task_finishes = std::mem::take(&mut batch.system_task_finishes);
+        system_task_batch.recalculate_estimates();
+        system_task_batch.enqueued_rows = system_task_batch.logical_rows();
+        batch.recalculate_estimates();
+        Some(system_task_batch)
+    } else {
+        None
+    };
+
+    let mut deferred_batch = PendingBatch::default();
+    if let Some(system_task_batch) = system_task_batch {
+        match flush_pending_batch_inner(
+            pool,
+            &system_task_batch,
+            pricing_catalog,
+            prompt_cache_conversation_cache,
+            terminal_runtime_store,
+            dashboard_activity_snapshot_cache,
+            terminal_projection_hub,
+            dashboard_reconcile_gate,
+        )
+        .await
+        {
+            Ok(system_task_deferred) => deferred_batch.merge_p2(system_task_deferred),
+            Err(err) => {
+                crate::db_pressure::global_db_pressure_gate()
+                    .record_error("sqlite_batch_writer_p2", &err);
+                warn!(
+                    error = %err,
+                    flush_priority = "P2",
+                    p2_deferred_count = system_task_batch.logical_rows(),
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    flush_reason,
+                    system_task_scope = %summarize_system_task_batch_scope(&system_task_batch),
+                    "sqlite batch writer P2 system-task flush failed"
+                );
+                drop(permit);
+                return Some(RetainedBatch::p2_failed(
+                    system_task_batch,
+                    true,
+                    is_sqlite_lock_error(&err),
+                ));
+            }
+        }
+    }
+
+    match flush_pending_batch_inner(
         pool,
         &batch,
         pricing_catalog,
@@ -2717,7 +2773,7 @@ pub(crate) async fn flush_pending_batch(
     )
     .await
     {
-        Ok(deferred_batch) => deferred_batch,
+        Ok(main_deferred) => deferred_batch.merge_p2(main_deferred),
         Err(err) => {
             crate::db_pressure::global_db_pressure_gate()
                 .record_error("sqlite_batch_writer_p2", &err);
@@ -2730,15 +2786,13 @@ pub(crate) async fn flush_pending_batch(
                 "sqlite batch writer P2 flush failed"
             );
             drop(permit);
-            let retryable_failure = crate::db_pressure::is_db_pressure_error(&err)
-                || !batch.system_task_finishes.is_empty();
             return Some(RetainedBatch::p2_failed(
                 batch,
-                retryable_failure,
+                crate::db_pressure::is_db_pressure_error(&err),
                 is_sqlite_lock_error(&err),
             ));
         }
-    };
+    }
     drop(write_permit);
     drop(permit);
 

--- a/src/sqlite_batch_writer.rs
+++ b/src/sqlite_batch_writer.rs
@@ -378,6 +378,12 @@ impl PendingQueueAccounting {
         self.subtract(&self.pending_bytes, bytes, "release", "pending_bytes");
     }
 
+    fn clear_after_shutdown(&self) -> (usize, usize) {
+        let pending_depth = self.pending_depth.swap(0, Ordering::SeqCst);
+        let pending_bytes = self.pending_bytes.swap(0, Ordering::SeqCst);
+        (pending_depth, pending_bytes)
+    }
+
     pub(crate) fn snapshot(&self) -> PendingQueueAccountingSnapshot {
         let last_invariant_violation = self
             .last_invariant_violation
@@ -1727,6 +1733,15 @@ impl SqliteBatchWriter {
                 let _ = handle.await;
             }
         }
+        let (abandoned_depth, abandoned_bytes) = self.accounting.clear_after_shutdown();
+        self.queued_p1_count.store(0, Ordering::SeqCst);
+        if abandoned_depth > 0 || abandoned_bytes > 0 {
+            warn!(
+                abandoned_depth,
+                abandoned_bytes,
+                "sqlite batch writer cleared accounting for shutdown-owned queued work; journal/P2 recovery remains authoritative"
+            );
+        }
         self.journal_sync_shutdown.cancel();
         if let Some(mut handle) = self.journal_sync_handle.lock().await.take() {
             match timeout_at(
@@ -2048,17 +2063,25 @@ pub(crate) async fn run_sqlite_batch_writer(
                         let shutdown_deadline = Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE;
                         loop {
                             if Instant::now() >= shutdown_deadline {
-                                let _ = drain_queued_batch_writes(
+                                let drained = drain_queued_batch_writes(
                                     &mut write_receiver,
                                     &mut pending,
                                     &accounting,
-                                    usize::MAX,
+                                    SQLITE_BATCH_MAX_ROWS,
                                     &queued_p1_count,
                                 );
+                                drain_terminal_journal_deferred_writes(
+                                    &terminal_journal,
+                                    &mut pending,
+                                    &accounting,
+                                    SQLITE_BATCH_MAX_ROWS,
+                                    &queued_p1_count,
+                                );
+                                let abandoned = std::mem::take(&mut pending);
                                 let _ = release_shutdown_pending_batch(
                                     &accounting,
                                     &terminal_journal,
-                                    &pending,
+                                    &abandoned,
                                     "shutdown drain deadline exceeded",
                                 )
                                 .map_err(|err| {
@@ -2066,6 +2089,10 @@ pub(crate) async fn run_sqlite_batch_writer(
                                         "sqlite batch writer shutdown quarantine failed: {err:#}"
                                     ));
                                 });
+                                warn!(
+                                    drained,
+                                    "sqlite batch writer bounded shutdown drain abandoned remaining queued work"
+                                );
                                 break;
                             }
                             let drained = drain_queued_batch_writes(
@@ -2091,6 +2118,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                             let flush_batch = take_next_bounded_batch(&mut pending);
                             let flush_rows = flush_batch.logical_rows();
                             let flush_bytes = flush_batch.estimated_memory_bytes();
+                            let shutdown_quarantine = shutdown_system_task_batch(&flush_batch);
                             let retained = match timeout_at(
                                 shutdown_deadline.into(),
                                 flush_pending_batch_accounted(
@@ -2112,6 +2140,15 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 Ok(Some(retained)) => retained,
                                 Ok(None) => continue,
                                 Err(_) => {
+                                    if let Some(quarantine) = shutdown_quarantine.as_ref()
+                                        && let Err(err) = quarantine_shutdown_batch(
+                                            &terminal_journal,
+                                            quarantine,
+                                            "shutdown flush deadline exceeded",
+                                        )
+                                    {
+                                        warn!(error = %err, "shutdown system-task quarantine failed after flush timeout");
+                                    }
                                     accounting.release(flush_rows, flush_bytes);
                                     result = Err(format!(
                                         "sqlite batch writer shutdown flush exceeded deadline with {flush_rows} rows"
@@ -2190,6 +2227,19 @@ pub(crate) async fn run_sqlite_batch_writer(
                                 logical_rows,
                                 "sqlite batch writer completed shutdown drain"
                             );
+                        }
+                        if !pending.is_empty() {
+                            let abandoned = std::mem::take(&mut pending);
+                            if let Err(err) = release_shutdown_pending_batch(
+                                &accounting,
+                                &terminal_journal,
+                                &abandoned,
+                                "shutdown drain stopped after flush timeout",
+                            ) {
+                                result = Err(format!(
+                                    "sqlite batch writer shutdown quarantine failed: {err:#}"
+                                ));
+                            }
                         }
                         let _ = responder.send(result);
                         return;
@@ -2337,10 +2387,11 @@ pub(crate) async fn run_sqlite_batch_writer(
                     let shutdown_deadline = Instant::now() + SQLITE_SHUTDOWN_DRAIN_DEADLINE;
                     loop {
                         if Instant::now() >= shutdown_deadline {
+                            let abandoned = std::mem::take(&mut pending);
                             let _ = release_shutdown_pending_batch(
                                 &accounting,
                                 &terminal_journal,
-                                &pending,
+                                &abandoned,
                                 "receiver shutdown drain deadline exceeded",
                             )
                             .map_err(|err| {
@@ -2361,6 +2412,7 @@ pub(crate) async fn run_sqlite_batch_writer(
                         let flush_batch = take_next_bounded_batch(&mut pending);
                         let flush_rows = flush_batch.logical_rows();
                         let flush_bytes = flush_batch.estimated_memory_bytes();
+                        let shutdown_quarantine = shutdown_system_task_batch(&flush_batch);
                         let retained = match timeout_at(
                             shutdown_deadline.into(),
                             flush_pending_batch_accounted(
@@ -2382,6 +2434,15 @@ pub(crate) async fn run_sqlite_batch_writer(
                             Ok(Some(retained)) => retained,
                             Ok(None) => continue,
                             Err(_) => {
+                                if let Some(quarantine) = shutdown_quarantine.as_ref()
+                                    && let Err(err) = quarantine_shutdown_batch(
+                                        &terminal_journal,
+                                        quarantine,
+                                        "receiver shutdown flush deadline exceeded",
+                                    )
+                                {
+                                    warn!(error = %err, "receiver shutdown system-task quarantine failed after flush timeout");
+                                }
                                 accounting.release(flush_rows, flush_bytes);
                                 warn!(
                                     flush_rows,
@@ -2458,6 +2519,17 @@ pub(crate) async fn run_sqlite_batch_writer(
                             continue;
                         }
                         break;
+                    }
+                    if !pending.is_empty() {
+                        let abandoned = std::mem::take(&mut pending);
+                        if let Err(err) = release_shutdown_pending_batch(
+                            &accounting,
+                            &terminal_journal,
+                            &abandoned,
+                            "receiver shutdown drain stopped after flush timeout",
+                        ) {
+                            warn!(error = %err, "receiver shutdown quarantine failed after flush timeout");
+                        }
                     }
                     return;
                 };
@@ -2870,10 +2942,44 @@ fn quarantine_system_task_batch(
         .as_mut()
         .ok_or_else(|| anyhow::anyhow!("terminal journal unavailable for quarantine"))?;
     let error = format!("{error:#}");
-    for finish in batch.system_task_finishes.values() {
-        journal.quarantine_system_task_finish(finish, &error)?;
-    }
+    let finishes = batch.system_task_finishes.values().collect::<Vec<_>>();
+    journal.quarantine_system_task_finishes(&finishes, &error)?;
     Ok(batch.system_task_finishes.len())
+}
+
+fn shutdown_system_task_batch(batch: &PendingBatch) -> Option<PendingBatch> {
+    if batch.system_task_finishes.is_empty() {
+        return None;
+    }
+    let mut quarantine = PendingBatch {
+        system_task_finishes: batch.system_task_finishes.clone(),
+        ..PendingBatch::default()
+    };
+    quarantine.recalculate_estimates();
+    quarantine.enqueued_rows = quarantine.logical_rows();
+    Some(quarantine)
+}
+
+fn quarantine_shutdown_batch(
+    terminal_journal: &Arc<std::sync::Mutex<Option<TerminalJournal>>>,
+    batch: &PendingBatch,
+    error: &str,
+) -> Result<()> {
+    if batch.terminal_invocations.is_empty() && batch.system_task_finishes.is_empty() {
+        return Ok(());
+    }
+    let mut journal = terminal_journal
+        .lock()
+        .map_err(|_| anyhow::anyhow!("terminal journal lock poisoned"))?;
+    let journal = journal
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("terminal journal unavailable for shutdown quarantine"))?;
+    let error = anyhow!(error.to_string());
+    let terminals = batch.terminal_invocations.values().collect::<Vec<_>>();
+    journal.quarantine_terminals(&terminals, &format!("{error:#}"))?;
+    let finishes = batch.system_task_finishes.values().collect::<Vec<_>>();
+    journal.quarantine_system_task_finishes(&finishes, &format!("{error:#}"))?;
+    Ok(())
 }
 
 fn release_shutdown_pending_batch(
@@ -2882,13 +2988,7 @@ fn release_shutdown_pending_batch(
     batch: &PendingBatch,
     reason: &str,
 ) -> Result<()> {
-    let mut quarantine_error = None;
-    if !batch.system_task_finishes.is_empty() {
-        let error = anyhow::anyhow!(reason.to_string());
-        if let Err(err) = quarantine_system_task_batch(terminal_journal, batch, &error) {
-            quarantine_error = Some(err);
-        }
-    }
+    let quarantine_error = quarantine_shutdown_batch(terminal_journal, batch, reason).err();
     accounting.release(batch.logical_rows(), batch.estimated_memory_bytes());
     quarantine_error.map_or(Ok(()), Err)
 }

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -165,7 +165,13 @@ impl TerminalJournal {
             })?
             .filter_map(|entry| entry.ok())
             .map(|entry| entry.path())
-            .filter(|path| path.extension().is_some_and(|ext| ext == "jsonl"))
+            .filter(|path| {
+                path.extension().is_some_and(|ext| ext == "jsonl")
+                    && path
+                        .file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .is_some_and(|stem| stem.starts_with("terminal-"))
+            })
             .collect::<Vec<_>>();
         paths.sort();
 

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     fs::{self, File, OpenOptions},
-    io::{BufRead, BufReader, Seek, SeekFrom, Write},
+    io::{BufReader, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -20,6 +20,8 @@ pub(crate) const TERMINAL_JOURNAL_SEGMENT_BYTES: u64 = 16 * 1024 * 1024;
 pub(crate) const TERMINAL_JOURNAL_MAX_BYTES: u64 = 512 * 1024 * 1024;
 pub(crate) const TERMINAL_JOURNAL_SYNC_INTERVAL: Duration = Duration::from_millis(20);
 const TERMINAL_JOURNAL_REPLAY_MAX_BYTES: usize = 4 * 1024 * 1024;
+const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES: usize = 4 * 1024 * 1024;
+const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES: usize = 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalJournalDurabilityMode {
@@ -121,6 +123,7 @@ pub(crate) struct TerminalJournal {
     replay_segments: VecDeque<JournalReplayCursor>,
     replay_count: usize,
     deferred_writes: VecDeque<BatchedTerminalInvocationWrite>,
+    system_task_quarantine_ids: HashSet<i64>,
     last_sync_at: Instant,
     last_checkpoint_at: Instant,
     overflowed: bool,
@@ -131,6 +134,14 @@ impl TerminalJournal {
     pub(crate) fn quarantine(
         &mut self,
         terminal: &BatchedTerminalInvocationWrite,
+        error: &str,
+    ) -> Result<()> {
+        self.quarantine_terminals(std::slice::from_ref(&terminal), error)
+    }
+
+    pub(crate) fn quarantine_terminals(
+        &mut self,
+        terminals: &[&BatchedTerminalInvocationWrite],
         error: &str,
     ) -> Result<()> {
         #[derive(Serialize)]
@@ -148,24 +159,37 @@ impl TerminalJournal {
             .append(true)
             .open(&path)
             .with_context(|| format!("failed to open terminal quarantine {}", path.display()))?;
-        let entry = QuarantineEntry {
-            invoke_id: &terminal.record.invoke_id,
-            occurred_at: &terminal.record.occurred_at,
-            raw_capture: terminal.raw_capture,
-            error,
-            record: &terminal.record,
-        };
-        serde_json::to_writer(&mut file, &entry).context("failed to encode terminal quarantine")?;
-        file.write_all(b"\n")
-            .context("failed to append terminal quarantine delimiter")?;
-        file.sync_data()
-            .context("failed to sync terminal quarantine")?;
+        for terminal in terminals {
+            let entry = QuarantineEntry {
+                invoke_id: &terminal.record.invoke_id,
+                occurred_at: &terminal.record.occurred_at,
+                raw_capture: terminal.raw_capture,
+                error,
+                record: &terminal.record,
+            };
+            serde_json::to_writer(&mut file, &entry)
+                .context("failed to encode terminal quarantine")?;
+            file.write_all(b"\n")
+                .context("failed to append terminal quarantine delimiter")?;
+        }
+        if !terminals.is_empty() {
+            file.sync_data()
+                .context("failed to sync terminal quarantine")?;
+        }
         Ok(())
     }
 
     pub(crate) fn quarantine_system_task_finish(
         &mut self,
         finish: &BatchedSystemTaskFinish,
+        error: &str,
+    ) -> Result<()> {
+        self.quarantine_system_task_finishes(std::slice::from_ref(&finish), error)
+    }
+
+    pub(crate) fn quarantine_system_task_finishes(
+        &mut self,
+        finishes: &[&BatchedSystemTaskFinish],
         error: &str,
     ) -> Result<()> {
         #[derive(Serialize)]
@@ -182,41 +206,41 @@ impl TerminalJournal {
         }
 
         let path = self.directory.join("system-task-quarantine.jsonl");
-        #[derive(Deserialize)]
-        struct ExistingQuarantineEntry {
-            run_id: i64,
-        }
-        if let Ok(existing) = fs::read_to_string(&path)
-            && existing.lines().any(|line| {
-                serde_json::from_str::<ExistingQuarantineEntry>(line)
-                    .ok()
-                    .is_some_and(|entry| entry.run_id == finish.run_id)
-            })
-        {
-            return Ok(());
-        }
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&path)
             .with_context(|| format!("failed to open system-task quarantine {}", path.display()))?;
-        let entry = QuarantineEntry {
-            run_id: finish.run_id,
-            task_kind: finish.task_kind.as_str(),
-            trigger_kind: &finish.trigger_kind,
-            status: finish.status.as_str(),
-            summary: &finish.summary,
-            detail: &finish.detail,
-            finished_at: &finish.finished_at,
-            duration_ms: finish.duration_ms,
-            error,
-        };
-        serde_json::to_writer(&mut file, &entry)
-            .context("failed to encode system-task quarantine")?;
-        file.write_all(b"\n")
-            .context("failed to append system-task quarantine delimiter")?;
-        file.sync_data()
-            .context("failed to sync system-task quarantine")?;
+        let mut appended = false;
+        for finish in finishes {
+            if !self.system_task_quarantine_ids.insert(finish.run_id) {
+                continue;
+            }
+            let entry = QuarantineEntry {
+                run_id: finish.run_id,
+                task_kind: finish.task_kind.as_str(),
+                trigger_kind: &finish.trigger_kind,
+                status: finish.status.as_str(),
+                summary: &finish.summary,
+                detail: &finish.detail,
+                finished_at: &finish.finished_at,
+                duration_ms: finish.duration_ms,
+                error,
+            };
+            if let Err(err) = serde_json::to_writer(&mut file, &entry) {
+                self.system_task_quarantine_ids.remove(&finish.run_id);
+                return Err(err).context("failed to append system-task quarantine");
+            }
+            if let Err(err) = file.write_all(b"\n") {
+                self.system_task_quarantine_ids.remove(&finish.run_id);
+                return Err(err).context("failed to append system-task quarantine delimiter");
+            }
+            appended = true;
+        }
+        if appended {
+            file.sync_data()
+                .context("failed to sync system-task quarantine")?;
+        }
         Ok(())
     }
 
@@ -318,6 +342,14 @@ impl TerminalJournal {
             .expect("current terminal journal segment exists")
             .path
             .clone();
+        let system_task_quarantine_ids =
+            fs::read_to_string(directory.join("system-task-quarantine.jsonl"))
+                .ok()
+                .into_iter()
+                .flat_map(|contents| contents.lines().map(str::to_owned).collect::<Vec<_>>())
+                .filter_map(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
+                .filter_map(|value| value.get("run_id").and_then(serde_json::Value::as_i64))
+                .collect();
         Ok(Self {
             directory,
             current_file: open_append_file(&current_path)?,
@@ -328,6 +360,7 @@ impl TerminalJournal {
             replay_segments,
             replay_count,
             deferred_writes: VecDeque::new(),
+            system_task_quarantine_ids,
             last_sync_at: Instant::now(),
             last_checkpoint_at: Instant::now(),
             overflowed: pending_bytes >= TERMINAL_JOURNAL_MAX_BYTES,
@@ -521,6 +554,8 @@ impl TerminalJournal {
     ) -> Vec<BatchedTerminalInvocationWrite> {
         let mut writes = Vec::new();
         let mut estimated_bytes = 0_usize;
+        let mut scanned_bytes = 0_usize;
+        let mut scanned_lines = 0_usize;
         while writes.len() < max_writes {
             let Some(cursor) = self.replay_segments.front_mut() else {
                 break;
@@ -536,32 +571,50 @@ impl TerminalJournal {
             if reader.seek(SeekFrom::Start(cursor.byte_offset)).is_err() {
                 break;
             }
-            let mut line_bytes = Vec::new();
             let mut reached_end = false;
             let mut produced = None;
             loop {
-                let line_start = cursor.byte_offset;
-                line_bytes.clear();
-                let Ok(read) = reader.read_until(b'\n', &mut line_bytes) else {
+                let stream_start = cursor.byte_offset;
+                let mut stream =
+                    serde_json::Deserializer::from_reader(&mut reader).into_iter::<JournalLine>();
+                let parsed = stream.next();
+                drop(stream);
+                let Ok(stream_end) = reader.stream_position() else {
                     break;
                 };
-                if read == 0 {
+                if stream_end == stream_start {
                     reached_end = true;
                     break;
                 }
-                cursor.byte_offset = cursor.byte_offset.saturating_add(read as u64);
-                let Ok(line) =
-                    std::str::from_utf8(line_bytes.strip_suffix(b"\n").unwrap_or(&line_bytes))
-                else {
-                    continue;
-                };
-                let Ok(parsed) = serde_json::from_str::<JournalLine>(line) else {
+                scanned_bytes = scanned_bytes.saturating_add(
+                    stream_end
+                        .saturating_sub(stream_start)
+                        .min(usize::MAX as u64) as usize,
+                );
+                scanned_lines = scanned_lines.saturating_add(1);
+                cursor.byte_offset = stream_end;
+                let Some(Ok(parsed)) = parsed else {
+                    if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
+                        || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
+                    {
+                        break;
+                    }
                     continue;
                 };
                 let Some(entry) = parsed.entry else {
+                    if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
+                        || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
+                    {
+                        break;
+                    }
                     continue;
                 };
                 if segment.acknowledged.contains(&entry.sequence) {
+                    if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
+                        || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
+                    {
+                        break;
+                    }
                     continue;
                 }
                 let record = entry.record;
@@ -580,7 +633,7 @@ impl TerminalJournal {
                 };
                 let write_bytes = write.estimated_memory_bytes();
                 if !writes.is_empty() && estimated_bytes.saturating_add(write_bytes) > max_bytes {
-                    cursor.byte_offset = line_start;
+                    cursor.byte_offset = stream_start;
                     reached_end = false;
                     break;
                 }
@@ -595,6 +648,11 @@ impl TerminalJournal {
             if reached_end {
                 self.replay_segments.pop_front();
                 continue;
+            }
+            if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
+                || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
+            {
+                break;
             }
             break;
         }

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -22,8 +22,6 @@ pub(crate) const TERMINAL_JOURNAL_SYNC_INTERVAL: Duration = Duration::from_milli
 const TERMINAL_JOURNAL_REPLAY_MAX_BYTES: usize = 4 * 1024 * 1024;
 const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES: usize = 4 * 1024 * 1024;
 const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES: usize = 1024;
-const SYSTEM_TASK_QUARANTINE_INDEX_MAX_BYTES: usize = 4 * 1024 * 1024;
-const SYSTEM_TASK_QUARANTINE_INDEX_MAX_LINES: usize = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalJournalDurabilityMode {
@@ -685,36 +683,19 @@ impl TerminalJournal {
             let mut produced = None;
             loop {
                 let stream_start = cursor.byte_offset;
-                let (mut parsed, budget_exhausted) = {
+                let parsed = {
                     let mut budget_reader = ReplayBudgetReader {
                         reader: &mut reader,
                         remaining: TERMINAL_JOURNAL_REPLAY_MAX_BYTES,
                     };
                     let mut stream = serde_json::Deserializer::from_reader(&mut budget_reader)
                         .into_iter::<JournalLine>();
-                    let parsed = stream.next();
-                    (parsed, budget_reader.remaining == 0)
+                    stream.next()
                 };
-                let mut stream_end = match reader.stream_position() {
+                let stream_end = match reader.stream_position() {
                     Ok(stream_end) => stream_end,
                     Err(_) => break,
                 };
-                let mut oversized_record = false;
-                if parsed.as_ref().is_some_and(Result::is_err) && budget_exhausted {
-                    if reader.seek(SeekFrom::Start(stream_start)).is_err() {
-                        break;
-                    }
-                    parsed = {
-                        let mut stream = serde_json::Deserializer::from_reader(&mut reader)
-                            .into_iter::<JournalLine>();
-                        stream.next()
-                    };
-                    stream_end = match reader.stream_position() {
-                        Ok(stream_end) => stream_end,
-                        Err(_) => break,
-                    };
-                    oversized_record = parsed.as_ref().is_some_and(Result::is_ok);
-                }
                 if stream_end == stream_start {
                     reached_end = true;
                     break;
@@ -748,14 +729,6 @@ impl TerminalJournal {
                     }
                     continue;
                 };
-                if oversized_record {
-                    warn!(
-                        sequence = entry.sequence,
-                        record_bytes = stream_end.saturating_sub(stream_start),
-                        replay_batch_bytes = TERMINAL_JOURNAL_REPLAY_MAX_BYTES,
-                        "replaying a single terminal journal record larger than the normal batch budget"
-                    );
-                }
                 if segment.acknowledged.contains(&entry.sequence) {
                     if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
                         || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
@@ -936,22 +909,12 @@ fn load_system_task_quarantine_ids(path: &Path) -> HashSet<i64> {
     let mut reader = BufReader::new(file);
     let mut ids = HashSet::new();
     let mut line = String::new();
-    let mut bytes_read = 0_usize;
-    for _ in 0..SYSTEM_TASK_QUARANTINE_INDEX_MAX_LINES {
+    loop {
         line.clear();
         let Ok(read) = reader.read_line(&mut line) else {
             break;
         };
         if read == 0 {
-            break;
-        }
-        bytes_read = bytes_read.saturating_add(read);
-        if bytes_read > SYSTEM_TASK_QUARANTINE_INDEX_MAX_BYTES {
-            warn!(
-                path = %path.display(),
-                max_bytes = SYSTEM_TASK_QUARANTINE_INDEX_MAX_BYTES,
-                "bounded system-task quarantine index reached its startup budget"
-            );
             break;
         }
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line)

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     fs::{self, File, OpenOptions},
-    io::Write,
+    io::{BufRead, BufReader, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -19,6 +19,7 @@ use crate::{
 pub(crate) const TERMINAL_JOURNAL_SEGMENT_BYTES: u64 = 16 * 1024 * 1024;
 pub(crate) const TERMINAL_JOURNAL_MAX_BYTES: u64 = 512 * 1024 * 1024;
 pub(crate) const TERMINAL_JOURNAL_SYNC_INTERVAL: Duration = Duration::from_millis(20);
+const TERMINAL_JOURNAL_REPLAY_MAX_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalJournalDurabilityMode {
@@ -91,8 +92,22 @@ impl JournalSegment {
 #[derive(Debug)]
 struct LoadedJournalSegment {
     segment: JournalSegment,
-    entries: Vec<JournalTerminalRecord>,
+    entries: Vec<JournalEntryMetadata>,
     acknowledgement_sequences: HashSet<u64>,
+}
+
+#[derive(Debug)]
+struct JournalEntryMetadata {
+    sequence: u64,
+    invoke_id: String,
+    occurred_at: String,
+    raw_capture: bool,
+}
+
+#[derive(Debug)]
+struct JournalReplayCursor {
+    first_sequence: u64,
+    byte_offset: u64,
 }
 
 #[derive(Debug)]
@@ -103,7 +118,8 @@ pub(crate) struct TerminalJournal {
     pending_by_key: HashMap<(String, String, bool), Vec<u64>>,
     next_sequence: u64,
     pending_bytes: u64,
-    replay: Vec<JournalTerminalRecord>,
+    replay_segments: VecDeque<JournalReplayCursor>,
+    replay_count: usize,
     deferred_writes: VecDeque<BatchedTerminalInvocationWrite>,
     last_sync_at: Instant,
     last_checkpoint_at: Instant,
@@ -233,7 +249,7 @@ impl TerminalJournal {
         paths.sort();
 
         let mut segments = BTreeMap::new();
-        let mut entries = Vec::new();
+        let mut loaded_segments = Vec::new();
         let mut acknowledged_sequences = HashSet::new();
         let mut next_sequence = 1_u64;
         let mut pending_bytes = 0_u64;
@@ -242,7 +258,7 @@ impl TerminalJournal {
             next_sequence = next_sequence.max(loaded.segment.last_sequence.saturating_add(1));
             pending_bytes = pending_bytes.saturating_add(loaded.segment.bytes);
             acknowledged_sequences.extend(loaded.acknowledgement_sequences);
-            entries.extend(loaded.entries);
+            loaded_segments.push((loaded.segment.first_sequence, loaded.entries));
             segments.insert(loaded.segment.first_sequence, loaded.segment);
         }
 
@@ -270,16 +286,27 @@ impl TerminalJournal {
             );
         }
         let mut pending_by_key = HashMap::new();
-        let mut replay = Vec::new();
-        for entry in entries {
-            if acknowledged_sequences.contains(&entry.sequence) {
-                continue;
+        let mut replay_segments = VecDeque::new();
+        let mut replay_count = 0_usize;
+        for (first_sequence, entries) in loaded_segments {
+            let mut segment_has_replay = false;
+            for entry in entries {
+                if acknowledged_sequences.contains(&entry.sequence) {
+                    continue;
+                }
+                pending_by_key
+                    .entry((entry.invoke_id, entry.occurred_at, entry.raw_capture))
+                    .or_insert_with(Vec::new)
+                    .push(entry.sequence);
+                replay_count = replay_count.saturating_add(1);
+                segment_has_replay = true;
             }
-            pending_by_key
-                .entry(entry_key(&entry))
-                .or_insert_with(Vec::new)
-                .push(entry.sequence);
-            replay.push(entry);
+            if segment_has_replay {
+                replay_segments.push_back(JournalReplayCursor {
+                    first_sequence,
+                    byte_offset: 0,
+                });
+            }
         }
         segments
             .get_mut(&current_start)
@@ -298,7 +325,8 @@ impl TerminalJournal {
             pending_by_key,
             next_sequence,
             pending_bytes,
-            replay,
+            replay_segments,
+            replay_count,
             deferred_writes: VecDeque::new(),
             last_sync_at: Instant::now(),
             last_checkpoint_at: Instant::now(),
@@ -417,6 +445,7 @@ impl TerminalJournal {
             return;
         };
         let mut pending_sequences = Vec::new();
+        let mut acknowledged_replay_count = 0_usize;
         for sequence in sequences {
             let Ok(encoded) = encode_acknowledgement_line(sequence) else {
                 warn!(
@@ -457,6 +486,7 @@ impl TerminalJournal {
                 .expect("current terminal journal segment exists")
                 .bytes = updated_current_bytes;
             self.pending_bytes = self.pending_bytes.saturating_add(encoded.len() as u64);
+            acknowledged_replay_count = acknowledged_replay_count.saturating_add(1);
         }
         if pending_sequences.is_empty() {
             self.pending_by_key.remove(&key);
@@ -464,6 +494,7 @@ impl TerminalJournal {
             self.pending_by_key.insert(key, pending_sequences);
         }
         self.last_checkpoint_at = Instant::now();
+        self.replay_count = self.replay_count.saturating_sub(acknowledged_replay_count);
         self.remove_fully_acknowledged_segments();
         if !self.sync_failed && self.pending_bytes < TERMINAL_JOURNAL_MAX_BYTES * 3 / 5 {
             self.overflowed = false;
@@ -471,16 +502,73 @@ impl TerminalJournal {
     }
 
     pub(crate) fn take_replay(&mut self) -> Vec<BatchedTerminalInvocationWrite> {
-        let replay = std::mem::take(&mut self.replay);
-        replay
-            .into_iter()
-            .map(|entry| {
+        self.take_replay_chunk(usize::MAX, usize::MAX)
+    }
+
+    pub(crate) fn queue_replay_for_dispatch(&mut self, max_writes: usize) {
+        if max_writes == 0 || self.deferred_writes.len() >= max_writes {
+            return;
+        }
+        let available = max_writes.saturating_sub(self.deferred_writes.len());
+        let replay = self.take_replay_chunk(available, TERMINAL_JOURNAL_REPLAY_MAX_BYTES);
+        self.deferred_writes.extend(replay);
+    }
+
+    fn take_replay_chunk(
+        &mut self,
+        max_writes: usize,
+        max_bytes: usize,
+    ) -> Vec<BatchedTerminalInvocationWrite> {
+        let mut writes = Vec::new();
+        let mut estimated_bytes = 0_usize;
+        while writes.len() < max_writes {
+            let Some(cursor) = self.replay_segments.front_mut() else {
+                break;
+            };
+            let Some(segment) = self.segments.get(&cursor.first_sequence) else {
+                self.replay_segments.pop_front();
+                continue;
+            };
+            let Ok(file) = File::open(&segment.path) else {
+                break;
+            };
+            let mut reader = BufReader::new(file);
+            if reader.seek(SeekFrom::Start(cursor.byte_offset)).is_err() {
+                break;
+            }
+            let mut line_bytes = Vec::new();
+            let mut reached_end = false;
+            let mut produced = None;
+            loop {
+                let line_start = cursor.byte_offset;
+                line_bytes.clear();
+                let Ok(read) = reader.read_until(b'\n', &mut line_bytes) else {
+                    break;
+                };
+                if read == 0 {
+                    reached_end = true;
+                    break;
+                }
+                cursor.byte_offset = cursor.byte_offset.saturating_add(read as u64);
+                let Ok(line) =
+                    std::str::from_utf8(line_bytes.strip_suffix(b"\n").unwrap_or(&line_bytes))
+                else {
+                    continue;
+                };
+                let Ok(parsed) = serde_json::from_str::<JournalLine>(line) else {
+                    continue;
+                };
+                let Some(entry) = parsed.entry else {
+                    continue;
+                };
+                if segment.acknowledged.contains(&entry.sequence) {
+                    continue;
+                }
                 let record = entry.record;
                 let startup_backfill_tasks = startup_backfill_tasks_for_terminal(
                     &api_invocation_from_runtime_record(&record),
                 );
-                BatchedTerminalInvocationWrite {
-                    record,
+                let write = BatchedTerminalInvocationWrite {
                     capture_started: entry.capture_elapsed_ms.and_then(|elapsed_ms| {
                         Instant::now().checked_sub(Duration::from_millis(elapsed_ms))
                     }),
@@ -488,9 +576,29 @@ impl TerminalJournal {
                     dashboard_terminal_sequence: None,
                     terminal_projection_event_ids: Vec::new(),
                     startup_backfill_tasks,
+                    record,
+                };
+                let write_bytes = write.estimated_memory_bytes();
+                if !writes.is_empty() && estimated_bytes.saturating_add(write_bytes) > max_bytes {
+                    cursor.byte_offset = line_start;
+                    reached_end = false;
+                    break;
                 }
-            })
-            .collect()
+                estimated_bytes = estimated_bytes.saturating_add(write_bytes);
+                produced = Some(write);
+                break;
+            }
+            if let Some(write) = produced {
+                writes.push(write);
+                continue;
+            }
+            if reached_end {
+                self.replay_segments.pop_front();
+                continue;
+            }
+            break;
+        }
+        writes
     }
 
     pub(crate) fn defer_write(&mut self, write: BatchedTerminalInvocationWrite) -> bool {
@@ -498,9 +606,8 @@ impl TerminalJournal {
         true
     }
 
-    pub(crate) fn queue_replay_for_dispatch(&mut self) {
-        let replay = self.take_replay();
-        self.deferred_writes.extend(replay);
+    pub(crate) fn deferred_write_count(&self) -> usize {
+        self.deferred_writes.len()
     }
 
     pub(crate) fn take_deferred_writes(
@@ -516,7 +623,7 @@ impl TerminalJournal {
             pending_records: self.pending_by_key.len(),
             pending_bytes: self.pending_bytes,
             segment_count: self.segments.len(),
-            replay_count: self.replay.len(),
+            replay_count: self.replay_count,
             checkpoint_lag_ms: self.last_checkpoint_at.elapsed().as_millis() as u64,
             overflowed: self.overflowed,
         }
@@ -655,7 +762,12 @@ fn load_segment(path: &Path) -> Result<LoadedJournalSegment> {
             break;
         }
         match (line.entry, line.acknowledged_sequence) {
-            (Some(entry), None) => entries.push(entry),
+            (Some(entry), None) => entries.push(JournalEntryMetadata {
+                sequence: entry.sequence,
+                invoke_id: entry.record.invoke_id,
+                occurred_at: entry.record.occurred_at,
+                raw_capture: entry.raw_capture,
+            }),
             (None, Some(sequence)) => {
                 acknowledged.insert(sequence);
             }
@@ -766,14 +878,6 @@ fn repair_corrupt_segment_tail(path: &Path, valid_prefix: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn entry_key(entry: &JournalTerminalRecord) -> (String, String, bool) {
-    (
-        entry.record.invoke_id.clone(),
-        entry.record.occurred_at.clone(),
-        entry.raw_capture,
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -814,6 +918,38 @@ mod tests {
         let replayed_after_ack =
             TerminalJournal::open(&database_path).expect("reopen acknowledged journal");
         assert_eq!(replayed_after_ack.stats().replay_count, 0);
+
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn replay_dispatch_is_bounded_by_the_requested_batch_size() {
+        let root =
+            std::env::temp_dir().join(format!("terminal-journal-replay-{}", nanoid::nanoid!()));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let mut journal = TerminalJournal::open(&database_path).expect("open journal");
+        for index in 0..5 {
+            let record = crate::tests::test_proxy_capture_record(
+                &format!("journal-replay-{index}"),
+                &format!("2026-07-29T00:0{index}:00Z"),
+            );
+            journal.append(&record, false, None);
+        }
+        journal.force_sync().expect("sync replay records");
+        drop(journal);
+
+        let mut reopened = TerminalJournal::open(&database_path).expect("reopen journal");
+        reopened.queue_replay_for_dispatch(2);
+        assert_eq!(reopened.deferred_write_count(), 2);
+        let first_batch = reopened.take_deferred_writes(2);
+        assert_eq!(first_batch.len(), 2);
+        reopened.queue_replay_for_dispatch(2);
+        assert_eq!(reopened.deferred_write_count(), 2);
+        let second_batch = reopened.take_deferred_writes(2);
+        assert_eq!(second_batch.len(), 2);
+        reopened.queue_replay_for_dispatch(2);
+        assert_eq!(reopened.deferred_write_count(), 1);
 
         fs::remove_dir_all(root).expect("remove journal test directory");
     }

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -166,6 +166,19 @@ impl TerminalJournal {
         }
 
         let path = self.directory.join("system-task-quarantine.jsonl");
+        #[derive(Deserialize)]
+        struct ExistingQuarantineEntry {
+            run_id: i64,
+        }
+        if let Ok(existing) = fs::read_to_string(&path)
+            && existing.lines().any(|line| {
+                serde_json::from_str::<ExistingQuarantineEntry>(line)
+                    .ok()
+                    .is_some_and(|entry| entry.run_id == finish.run_id)
+            })
+        {
+            return Ok(());
+        }
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -23,6 +23,12 @@ const TERMINAL_JOURNAL_REPLAY_MAX_BYTES: usize = 4 * 1024 * 1024;
 const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES: usize = 4 * 1024 * 1024;
 const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES: usize = 1024;
 
+type ShutdownRecoveryKey = (String, String, bool);
+type LoadedShutdownTerminalRecovery = (
+    HashMap<ShutdownRecoveryKey, ProxyCaptureRecord>,
+    Vec<BatchedTerminalInvocationWrite>,
+);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalJournalDurabilityMode {
     Journal,
@@ -137,6 +143,7 @@ pub(crate) struct TerminalJournal {
     replay_count: usize,
     deferred_writes: VecDeque<BatchedTerminalInvocationWrite>,
     replay_blocked: bool,
+    shutdown_recovery_pending: HashMap<ShutdownRecoveryKey, ProxyCaptureRecord>,
     system_task_quarantine_ids: HashSet<i64>,
     last_sync_at: Instant,
     last_checkpoint_at: Instant,
@@ -455,10 +462,11 @@ impl TerminalJournal {
             .expect("current terminal journal segment exists")
             .path
             .clone();
+        let shutdown_recovery_path = directory.join("shutdown-terminal-quarantine.jsonl");
+        let (shutdown_recovery_pending, recovery_writes) =
+            load_shutdown_terminal_recovery(&shutdown_recovery_path);
         let mut deferred_writes = VecDeque::new();
-        for terminal in
-            load_shutdown_terminal_recovery(&directory.join("shutdown-terminal-quarantine.jsonl"))
-        {
+        for terminal in recovery_writes {
             let key = (
                 terminal.record.invoke_id.clone(),
                 terminal.record.occurred_at.clone(),
@@ -483,6 +491,7 @@ impl TerminalJournal {
             replay_count: replay_count.saturating_add(deferred_writes.len()),
             deferred_writes,
             replay_blocked: false,
+            shutdown_recovery_pending,
             system_task_quarantine_ids,
             last_sync_at: Instant::now(),
             last_checkpoint_at: Instant::now(),
@@ -597,18 +606,31 @@ impl TerminalJournal {
     }
 
     pub(crate) fn acknowledge(&mut self, invoke_id: &str, occurred_at: &str, raw_capture: bool) {
-        if let Err(err) = append_shutdown_terminal_ack(
-            &self.directory.join("shutdown-terminal-quarantine.jsonl"),
-            invoke_id,
-            occurred_at,
-            raw_capture,
-        ) {
-            warn!(error = %err, invoke_id, occurred_at, "failed to checkpoint shutdown terminal recovery acknowledgement");
-        }
         let key = (invoke_id.to_string(), occurred_at.to_string(), raw_capture);
-        let Some(sequences) = self.pending_by_key.get(&key).cloned() else {
+        let recovery_pending = self.shutdown_recovery_pending.contains_key(&key);
+        let Some(sequences) = self
+            .pending_by_key
+            .get(&key)
+            .cloned()
+            .or_else(|| recovery_pending.then_some(Vec::new()))
+        else {
             return;
         };
+        let recovery_only = recovery_pending && sequences.is_empty();
+        if recovery_pending {
+            if let Err(err) = append_shutdown_terminal_ack(
+                &self.directory.join("shutdown-terminal-quarantine.jsonl"),
+                invoke_id,
+                occurred_at,
+                raw_capture,
+            ) {
+                warn!(error = %err, invoke_id, occurred_at, "failed to checkpoint shutdown terminal recovery acknowledgement");
+                self.sync_failed = true;
+                self.overflowed = true;
+                return;
+            }
+            self.shutdown_recovery_pending.remove(&key);
+        }
         let mut pending_sequences = Vec::new();
         let mut written_sequences = Vec::new();
         for sequence in sequences {
@@ -678,10 +700,41 @@ impl TerminalJournal {
             self.pending_by_key.insert(key, pending_sequences);
         }
         self.last_checkpoint_at = Instant::now();
-        self.replay_count = self.replay_count.saturating_sub(acknowledged_replay_count);
+        self.replay_count = self
+            .replay_count
+            .saturating_sub(acknowledged_replay_count + usize::from(recovery_only));
         self.remove_fully_acknowledged_segments();
+        if recovery_pending
+            && let Err(err) = compact_shutdown_terminal_recovery(
+                &self.directory.join("shutdown-terminal-quarantine.jsonl"),
+                &self.shutdown_recovery_pending,
+            )
+        {
+            warn!(error = %err, "failed to compact shutdown terminal recovery sink");
+        }
         if !self.sync_failed && self.pending_bytes < TERMINAL_JOURNAL_MAX_BYTES * 3 / 5 {
             self.overflowed = false;
+        }
+    }
+
+    pub(crate) fn remember_shutdown_recovery(
+        &mut self,
+        terminals: &[&BatchedTerminalInvocationWrite],
+    ) {
+        for terminal in terminals {
+            let key = (
+                terminal.record.invoke_id.clone(),
+                terminal.record.occurred_at.clone(),
+                terminal.raw_capture,
+            );
+            if self
+                .shutdown_recovery_pending
+                .insert(key.clone(), terminal.record.clone())
+                .is_none()
+                && !self.pending_by_key.contains_key(&key)
+            {
+                self.replay_count = self.replay_count.saturating_add(1);
+            }
         }
     }
 
@@ -958,7 +1011,10 @@ fn append_shutdown_terminal_ack(
     raw_capture: bool,
 ) -> Result<()> {
     if !path.exists() {
-        return Ok(());
+        return Err(anyhow::anyhow!(
+            "shutdown terminal recovery file is missing: {}",
+            path.display()
+        ));
     }
     let mut file = OpenOptions::new()
         .append(true)
@@ -1012,16 +1068,18 @@ fn load_system_task_quarantine_ids(path: &Path) -> HashSet<i64> {
     ids
 }
 
-fn load_shutdown_terminal_recovery(path: &Path) -> Vec<BatchedTerminalInvocationWrite> {
+fn load_shutdown_terminal_recovery(path: &Path) -> LoadedShutdownTerminalRecovery {
     let Ok(file) = File::open(path) else {
-        return Vec::new();
+        return (HashMap::new(), Vec::new());
     };
     let mut reader = BufReader::new(file);
     let mut line = String::new();
-    let mut entries = HashMap::<(String, String, bool), Option<ProxyCaptureRecord>>::new();
+    let mut entries = HashMap::<ShutdownRecoveryKey, Option<ProxyCaptureRecord>>::new();
+    let mut corrupt = false;
     loop {
         line.clear();
         let Ok(read) = reader.read_line(&mut line) else {
+            corrupt = true;
             break;
         };
         if read == 0 {
@@ -1029,6 +1087,7 @@ fn load_shutdown_terminal_recovery(path: &Path) -> Vec<BatchedTerminalInvocation
         }
         let Ok(entry) = serde_json::from_str::<ShutdownTerminalRecoveryLine>(&line) else {
             warn!(path = %path.display(), "ignoring corrupt shutdown terminal recovery line");
+            corrupt = true;
             continue;
         };
         let key = (entry.invoke_id, entry.occurred_at, entry.raw_capture);
@@ -1038,26 +1097,82 @@ fn load_shutdown_terminal_recovery(path: &Path) -> Vec<BatchedTerminalInvocation
             entries.insert(key, entry.record);
         }
     }
-    entries
+    let pending = entries
         .into_iter()
         .filter_map(|((invoke_id, occurred_at, raw_capture), record)| {
             let record = record?;
-            Some(BatchedTerminalInvocationWrite {
+            Some(((invoke_id, occurred_at, raw_capture), record))
+        })
+        .collect::<HashMap<_, _>>();
+    let writes = pending
+        .iter()
+        .map(
+            |((invoke_id, occurred_at, raw_capture), record)| BatchedTerminalInvocationWrite {
                 capture_started: None,
-                raw_capture,
+                raw_capture: *raw_capture,
                 dashboard_terminal_sequence: None,
                 terminal_projection_event_ids: Vec::new(),
                 startup_backfill_tasks: startup_backfill_tasks_for_terminal(
-                    &api_invocation_from_runtime_record(&record),
+                    &api_invocation_from_runtime_record(record),
                 ),
                 record: ProxyCaptureRecord {
-                    invoke_id,
-                    occurred_at,
-                    ..record
+                    invoke_id: invoke_id.clone(),
+                    occurred_at: occurred_at.clone(),
+                    ..record.clone()
                 },
-            })
-        })
-        .collect()
+            },
+        )
+        .collect();
+    if !corrupt {
+        let _ = compact_shutdown_terminal_recovery(path, &pending);
+    }
+    (pending, writes)
+}
+
+fn compact_shutdown_terminal_recovery(
+    path: &Path,
+    pending: &HashMap<ShutdownRecoveryKey, ProxyCaptureRecord>,
+) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let temporary_path = path.with_extension("jsonl.tmp");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&temporary_path)
+        .with_context(|| {
+            format!(
+                "failed to open temporary shutdown terminal recovery {}",
+                temporary_path.display()
+            )
+        })?;
+    for ((invoke_id, occurred_at, raw_capture), record) in pending {
+        serde_json::to_writer(
+            &mut file,
+            &ShutdownTerminalRecoveryLine {
+                invoke_id: invoke_id.clone(),
+                occurred_at: occurred_at.clone(),
+                raw_capture: *raw_capture,
+                acknowledged: false,
+                error: Some("recovery snapshot".to_string()),
+                record: Some(record.clone()),
+            },
+        )
+        .context("failed to encode shutdown terminal recovery snapshot")?;
+        file.write_all(b"\n")
+            .context("failed to append shutdown terminal recovery snapshot delimiter")?;
+    }
+    file.sync_data()
+        .context("failed to sync shutdown terminal recovery snapshot")?;
+    fs::rename(&temporary_path, path).with_context(|| {
+        format!(
+            "failed to atomically publish shutdown terminal recovery {}",
+            path.display()
+        )
+    })?;
+    Ok(())
 }
 
 fn segment_path(directory: &Path, first_sequence: u64) -> PathBuf {
@@ -1269,11 +1384,66 @@ mod tests {
         replayed.acknowledge("journal-1", "2026-07-29T00:00:00Z", false);
         replayed.force_sync().expect("sync acknowledgement");
         assert_eq!(replayed.stats().pending_records, 0);
+        assert!(
+            !terminal_journal_directory(&database_path)
+                .join("shutdown-terminal-quarantine.jsonl")
+                .exists()
+        );
         drop(replayed);
 
         let replayed_after_ack =
             TerminalJournal::open(&database_path).expect("reopen acknowledged journal");
         assert_eq!(replayed_after_ack.stats().replay_count, 0);
+
+        fs::remove_dir_all(root).expect("remove journal test directory");
+    }
+
+    #[test]
+    fn shutdown_recovery_replays_and_compacts_after_acknowledgement() {
+        let root = std::env::temp_dir().join(format!(
+            "terminal-journal-shutdown-recovery-{}",
+            nanoid::nanoid!()
+        ));
+        fs::create_dir_all(&root).expect("create journal test directory");
+        let database_path = root.join("monitor.db");
+        let record =
+            crate::tests::test_proxy_capture_record("shutdown-recovery-1", "2026-07-29T00:00:00Z");
+        let terminal = BatchedTerminalInvocationWrite {
+            record: record.clone(),
+            capture_started: None,
+            raw_capture: false,
+            dashboard_terminal_sequence: None,
+            terminal_projection_event_ids: Vec::new(),
+            startup_backfill_tasks: Vec::new(),
+        };
+
+        let journal = TerminalJournal::open(&database_path).expect("open journal");
+        TerminalJournal::quarantine_shutdown_batch_at_database_path(
+            &database_path,
+            &[&terminal],
+            &[],
+            "test recovery",
+        )
+        .expect("write shutdown recovery");
+        drop(journal);
+
+        let mut recovered = TerminalJournal::open(&database_path).expect("reopen recovery journal");
+        assert_eq!(recovered.stats().replay_count, 1);
+        assert_eq!(recovered.take_deferred_writes(1).len(), 1);
+        recovered.acknowledge(&record.invoke_id, &record.occurred_at, false);
+        assert_eq!(recovered.stats().replay_count, 0);
+        drop(recovered);
+
+        let recovery_path =
+            terminal_journal_directory(&database_path).join("shutdown-terminal-quarantine.jsonl");
+        assert!(
+            fs::read_to_string(&recovery_path)
+                .expect("read compacted recovery")
+                .trim()
+                .is_empty()
+        );
+        let reopened = TerminalJournal::open(&database_path).expect("reopen compacted recovery");
+        assert_eq!(reopened.stats().replay_count, 0);
 
         fs::remove_dir_all(root).expect("remove journal test directory");
     }

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -125,6 +125,7 @@ pub(crate) struct TerminalJournal {
     replay_segments: VecDeque<JournalReplayCursor>,
     replay_count: usize,
     deferred_writes: VecDeque<BatchedTerminalInvocationWrite>,
+    replay_blocked: bool,
     system_task_quarantine_ids: HashSet<i64>,
     last_sync_at: Instant,
     last_checkpoint_at: Instant,
@@ -214,10 +215,12 @@ impl TerminalJournal {
             .open(&path)
             .with_context(|| format!("failed to open system-task quarantine {}", path.display()))?;
         let mut appended = false;
+        let mut newly_indexed_ids = Vec::new();
         for finish in finishes {
             if !self.system_task_quarantine_ids.insert(finish.run_id) {
                 continue;
             }
+            newly_indexed_ids.push(finish.run_id);
             let entry = QuarantineEntry {
                 run_id: finish.run_id,
                 task_kind: finish.task_kind.as_str(),
@@ -230,20 +233,122 @@ impl TerminalJournal {
                 error,
             };
             if let Err(err) = serde_json::to_writer(&mut file, &entry) {
-                self.system_task_quarantine_ids.remove(&finish.run_id);
+                for run_id in newly_indexed_ids {
+                    self.system_task_quarantine_ids.remove(&run_id);
+                }
                 return Err(err).context("failed to append system-task quarantine");
             }
             if let Err(err) = file.write_all(b"\n") {
-                self.system_task_quarantine_ids.remove(&finish.run_id);
+                for run_id in newly_indexed_ids {
+                    self.system_task_quarantine_ids.remove(&run_id);
+                }
                 return Err(err).context("failed to append system-task quarantine delimiter");
             }
             appended = true;
         }
         if appended && let Err(err) = file.sync_data() {
-            for finish in finishes {
-                self.system_task_quarantine_ids.remove(&finish.run_id);
+            for run_id in newly_indexed_ids {
+                self.system_task_quarantine_ids.remove(&run_id);
             }
             return Err(err).context("failed to sync system-task quarantine");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn quarantine_shutdown_batch_at_database_path(
+        database_path: &Path,
+        terminals: &[&BatchedTerminalInvocationWrite],
+        finishes: &[&BatchedSystemTaskFinish],
+        error: &str,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        struct TerminalEntry<'a> {
+            invoke_id: &'a str,
+            occurred_at: &'a str,
+            raw_capture: bool,
+            error: &'a str,
+            record: &'a ProxyCaptureRecord,
+        }
+        #[derive(Serialize)]
+        struct SystemTaskEntry<'a> {
+            run_id: i64,
+            task_kind: &'static str,
+            trigger_kind: &'a str,
+            status: &'static str,
+            summary: &'a Option<String>,
+            detail: &'a Option<String>,
+            finished_at: &'a str,
+            duration_ms: i64,
+            error: &'a str,
+        }
+
+        let directory = terminal_journal_directory(database_path);
+        fs::create_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to create independent terminal recovery directory {}",
+                directory.display()
+            )
+        })?;
+        if !terminals.is_empty() {
+            let path = directory.join("shutdown-terminal-quarantine.jsonl");
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .with_context(|| {
+                    format!("failed to open terminal recovery sink {}", path.display())
+                })?;
+            for terminal in terminals {
+                serde_json::to_writer(
+                    &mut file,
+                    &TerminalEntry {
+                        invoke_id: &terminal.record.invoke_id,
+                        occurred_at: &terminal.record.occurred_at,
+                        raw_capture: terminal.raw_capture,
+                        error,
+                        record: &terminal.record,
+                    },
+                )
+                .context("failed to encode terminal recovery entry")?;
+                file.write_all(b"\n")
+                    .context("failed to append terminal recovery delimiter")?;
+            }
+            file.sync_data()
+                .context("failed to sync terminal recovery sink")?;
+        }
+        if !finishes.is_empty() {
+            let path = directory.join("shutdown-system-task-quarantine.jsonl");
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .with_context(|| {
+                    format!(
+                        "failed to open system-task recovery sink {}",
+                        path.display()
+                    )
+                })?;
+            for finish in finishes {
+                serde_json::to_writer(
+                    &mut file,
+                    &SystemTaskEntry {
+                        run_id: finish.run_id,
+                        task_kind: finish.task_kind.as_str(),
+                        trigger_kind: &finish.trigger_kind,
+                        status: finish.status.as_str(),
+                        summary: &finish.summary,
+                        detail: &finish.detail,
+                        finished_at: &finish.finished_at,
+                        duration_ms: finish.duration_ms,
+                        error,
+                    },
+                )
+                .context("failed to encode system-task recovery entry")?;
+                file.write_all(b"\n")
+                    .context("failed to append system-task recovery delimiter")?;
+            }
+            file.sync_data()
+                .context("failed to sync system-task recovery sink")?;
         }
         Ok(())
     }
@@ -358,6 +463,7 @@ impl TerminalJournal {
             replay_segments,
             replay_count,
             deferred_writes: VecDeque::new(),
+            replay_blocked: false,
             system_task_quarantine_ids,
             last_sync_at: Instant::now(),
             last_checkpoint_at: Instant::now(),
@@ -550,6 +656,9 @@ impl TerminalJournal {
         max_writes: usize,
         max_bytes: usize,
     ) -> Vec<BatchedTerminalInvocationWrite> {
+        if self.replay_blocked {
+            return Vec::new();
+        }
         let mut writes = Vec::new();
         let mut estimated_bytes = 0_usize;
         let mut scanned_bytes = 0_usize;
@@ -622,19 +731,13 @@ impl TerminalJournal {
                 );
                 scanned_lines = scanned_lines.saturating_add(1);
                 let Ok(parsed) = parsed else {
-                    let skipped_end = skip_replay_line(&mut reader).unwrap_or(stream_end);
-                    scanned_bytes = scanned_bytes.saturating_add(
-                        skipped_end
-                            .saturating_sub(stream_end)
-                            .min(usize::MAX as u64) as usize,
+                    cursor.byte_offset = stream_start;
+                    self.replay_blocked = true;
+                    warn!(
+                        replay_offset = stream_start,
+                        "terminal journal replay stopped at an unparseable entry; preserving the cursor for recovery"
                     );
-                    cursor.byte_offset = skipped_end;
-                    if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
-                        || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
-                    {
-                        break;
-                    }
-                    continue;
+                    break;
                 };
                 cursor.byte_offset = stream_end;
                 let Some(entry) = parsed.entry else {
@@ -823,21 +926,6 @@ impl Read for ReplayBudgetReader<'_> {
         let read = self.reader.read(&mut buffer[..limit])?;
         self.remaining = self.remaining.saturating_sub(read);
         Ok(read)
-    }
-}
-
-fn skip_replay_line(reader: &mut BufReader<File>) -> io::Result<u64> {
-    loop {
-        let buffer = reader.fill_buf()?;
-        if buffer.is_empty() {
-            return reader.stream_position();
-        }
-        if let Some(newline) = buffer.iter().position(|byte| *byte == b'\n') {
-            reader.consume(newline.saturating_add(1));
-            return reader.stream_position();
-        }
-        let consumed = buffer.len();
-        reader.consume(consumed);
     }
 }
 

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -273,8 +273,33 @@ impl TerminalJournal {
         Ok(())
     }
 
+    pub(crate) fn quarantine_shutdown_batch(
+        &mut self,
+        terminals: &[&BatchedTerminalInvocationWrite],
+        finishes: &[&BatchedSystemTaskFinish],
+        error: &str,
+    ) -> Result<()> {
+        Self::quarantine_shutdown_batch_at_directory(&self.directory, terminals, finishes, error)
+    }
+
     pub(crate) fn quarantine_shutdown_batch_at_database_path(
         database_path: &Path,
+        terminals: &[&BatchedTerminalInvocationWrite],
+        finishes: &[&BatchedSystemTaskFinish],
+        error: &str,
+    ) -> Result<()> {
+        let directory = terminal_journal_directory(database_path);
+        fs::create_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to create independent terminal recovery directory {}",
+                directory.display()
+            )
+        })?;
+        Self::quarantine_shutdown_batch_at_directory(&directory, terminals, finishes, error)
+    }
+
+    fn quarantine_shutdown_batch_at_directory(
+        directory: &Path,
         terminals: &[&BatchedTerminalInvocationWrite],
         finishes: &[&BatchedSystemTaskFinish],
         error: &str,
@@ -292,10 +317,9 @@ impl TerminalJournal {
             error: &'a str,
         }
 
-        let directory = terminal_journal_directory(database_path);
-        fs::create_dir_all(&directory).with_context(|| {
+        fs::create_dir_all(directory).with_context(|| {
             format!(
-                "failed to create independent terminal recovery directory {}",
+                "failed to create terminal journal directory {}",
                 directory.display()
             )
         })?;
@@ -617,6 +641,7 @@ impl TerminalJournal {
             return;
         };
         let recovery_only = recovery_pending && sequences.is_empty();
+        let mut recovery_ack_durable = true;
         if recovery_pending {
             if let Err(err) = append_shutdown_terminal_ack(
                 &self.directory.join("shutdown-terminal-quarantine.jsonl"),
@@ -627,9 +652,13 @@ impl TerminalJournal {
                 warn!(error = %err, invoke_id, occurred_at, "failed to checkpoint shutdown terminal recovery acknowledgement");
                 self.sync_failed = true;
                 self.overflowed = true;
-                return;
+                recovery_ack_durable = false;
+                if recovery_only {
+                    return;
+                }
+            } else {
+                self.shutdown_recovery_pending.remove(&key);
             }
-            self.shutdown_recovery_pending.remove(&key);
         }
         let mut pending_sequences = Vec::new();
         let mut written_sequences = Vec::new();
@@ -705,6 +734,7 @@ impl TerminalJournal {
             .saturating_sub(acknowledged_replay_count + usize::from(recovery_only));
         self.remove_fully_acknowledged_segments();
         if recovery_pending
+            && recovery_ack_durable
             && let Err(err) = compact_shutdown_terminal_recovery(
                 &self.directory.join("shutdown-terminal-quarantine.jsonl"),
                 &self.shutdown_recovery_pending,

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -554,7 +554,10 @@ impl TerminalJournal {
         let mut estimated_bytes = 0_usize;
         let mut scanned_bytes = 0_usize;
         let mut scanned_lines = 0_usize;
-        while writes.len() < max_writes {
+        while writes.len() < max_writes
+            && scanned_bytes < TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
+            && scanned_lines < TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
+        {
             let Some(cursor) = self.replay_segments.front_mut() else {
                 break;
             };
@@ -573,33 +576,51 @@ impl TerminalJournal {
             let mut produced = None;
             loop {
                 let stream_start = cursor.byte_offset;
-                let parsed = {
+                let (mut parsed, budget_exhausted) = {
                     let mut budget_reader = ReplayBudgetReader {
                         reader: &mut reader,
                         remaining: TERMINAL_JOURNAL_REPLAY_MAX_BYTES,
                     };
                     let mut stream = serde_json::Deserializer::from_reader(&mut budget_reader)
                         .into_iter::<JournalLine>();
-                    stream.next()
+                    let parsed = stream.next();
+                    (parsed, budget_reader.remaining == 0)
                 };
-                let Ok(stream_end) = reader.stream_position() else {
-                    break;
+                let mut stream_end = match reader.stream_position() {
+                    Ok(stream_end) => stream_end,
+                    Err(_) => break,
                 };
+                let mut oversized_record = false;
+                if parsed.as_ref().is_some_and(Result::is_err) && budget_exhausted {
+                    if reader.seek(SeekFrom::Start(stream_start)).is_err() {
+                        break;
+                    }
+                    parsed = {
+                        let mut stream = serde_json::Deserializer::from_reader(&mut reader)
+                            .into_iter::<JournalLine>();
+                        stream.next()
+                    };
+                    stream_end = match reader.stream_position() {
+                        Ok(stream_end) => stream_end,
+                        Err(_) => break,
+                    };
+                    oversized_record = parsed.as_ref().is_some_and(Result::is_ok);
+                }
                 if stream_end == stream_start {
                     reached_end = true;
                     break;
                 }
+                let Some(parsed) = parsed else {
+                    cursor.byte_offset = stream_end;
+                    reached_end = true;
+                    break;
+                };
                 scanned_bytes = scanned_bytes.saturating_add(
                     stream_end
                         .saturating_sub(stream_start)
                         .min(usize::MAX as u64) as usize,
                 );
                 scanned_lines = scanned_lines.saturating_add(1);
-                let Some(parsed) = parsed else {
-                    cursor.byte_offset = stream_end;
-                    reached_end = true;
-                    break;
-                };
                 let Ok(parsed) = parsed else {
                     let skipped_end = skip_replay_line(&mut reader).unwrap_or(stream_end);
                     scanned_bytes = scanned_bytes.saturating_add(
@@ -624,6 +645,14 @@ impl TerminalJournal {
                     }
                     continue;
                 };
+                if oversized_record {
+                    warn!(
+                        sequence = entry.sequence,
+                        record_bytes = stream_end.saturating_sub(stream_start),
+                        replay_batch_bytes = TERMINAL_JOURNAL_REPLAY_MAX_BYTES,
+                        "replaying a single terminal journal record larger than the normal batch budget"
+                    );
+                }
                 if segment.acknowledged.contains(&entry.sequence) {
                     if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
                         || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -12,8 +12,8 @@ use sha2::{Digest, Sha256};
 use tracing::warn;
 
 use crate::{
-    BatchedTerminalInvocationWrite, ProxyCaptureRecord, api_invocation_from_runtime_record,
-    startup_backfill_tasks_for_terminal,
+    BatchedSystemTaskFinish, BatchedTerminalInvocationWrite, ProxyCaptureRecord,
+    api_invocation_from_runtime_record, startup_backfill_tasks_for_terminal,
 };
 
 pub(crate) const TERMINAL_JOURNAL_SEGMENT_BYTES: u64 = 16 * 1024 * 1024;
@@ -144,6 +144,50 @@ impl TerminalJournal {
             .context("failed to append terminal quarantine delimiter")?;
         file.sync_data()
             .context("failed to sync terminal quarantine")?;
+        Ok(())
+    }
+
+    pub(crate) fn quarantine_system_task_finish(
+        &mut self,
+        finish: &BatchedSystemTaskFinish,
+        error: &str,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        struct QuarantineEntry<'a> {
+            run_id: i64,
+            task_kind: &'static str,
+            trigger_kind: &'a str,
+            status: &'static str,
+            summary: &'a Option<String>,
+            detail: &'a Option<String>,
+            finished_at: &'a str,
+            duration_ms: i64,
+            error: &'a str,
+        }
+
+        let path = self.directory.join("system-task-quarantine.jsonl");
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("failed to open system-task quarantine {}", path.display()))?;
+        let entry = QuarantineEntry {
+            run_id: finish.run_id,
+            task_kind: finish.task_kind.as_str(),
+            trigger_kind: &finish.trigger_kind,
+            status: finish.status.as_str(),
+            summary: &finish.summary,
+            detail: &finish.detail,
+            finished_at: &finish.finished_at,
+            duration_ms: finish.duration_ms,
+            error,
+        };
+        serde_json::to_writer(&mut file, &entry)
+            .context("failed to encode system-task quarantine")?;
+        file.write_all(b"\n")
+            .context("failed to append system-task quarantine delimiter")?;
+        file.sync_data()
+            .context("failed to sync system-task quarantine")?;
         Ok(())
     }
 

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -74,6 +74,19 @@ struct JournalLine {
     checksum: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct ShutdownTerminalRecoveryLine {
+    invoke_id: String,
+    occurred_at: String,
+    raw_capture: bool,
+    #[serde(default)]
+    acknowledged: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    record: Option<ProxyCaptureRecord>,
+}
+
 #[derive(Debug)]
 struct JournalSegment {
     path: PathBuf,
@@ -260,14 +273,6 @@ impl TerminalJournal {
         error: &str,
     ) -> Result<()> {
         #[derive(Serialize)]
-        struct TerminalEntry<'a> {
-            invoke_id: &'a str,
-            occurred_at: &'a str,
-            raw_capture: bool,
-            error: &'a str,
-            record: &'a ProxyCaptureRecord,
-        }
-        #[derive(Serialize)]
         struct SystemTaskEntry<'a> {
             run_id: i64,
             task_kind: &'static str,
@@ -299,12 +304,13 @@ impl TerminalJournal {
             for terminal in terminals {
                 serde_json::to_writer(
                     &mut file,
-                    &TerminalEntry {
-                        invoke_id: &terminal.record.invoke_id,
-                        occurred_at: &terminal.record.occurred_at,
+                    &ShutdownTerminalRecoveryLine {
+                        invoke_id: terminal.record.invoke_id.clone(),
+                        occurred_at: terminal.record.occurred_at.clone(),
                         raw_capture: terminal.raw_capture,
-                        error,
-                        record: &terminal.record,
+                        acknowledged: false,
+                        error: Some(error.to_string()),
+                        record: Some(terminal.record.clone()),
                     },
                 )
                 .context("failed to encode terminal recovery entry")?;
@@ -449,9 +455,24 @@ impl TerminalJournal {
             .expect("current terminal journal segment exists")
             .path
             .clone();
+        let mut deferred_writes = VecDeque::new();
+        for terminal in
+            load_shutdown_terminal_recovery(&directory.join("shutdown-terminal-quarantine.jsonl"))
+        {
+            let key = (
+                terminal.record.invoke_id.clone(),
+                terminal.record.occurred_at.clone(),
+                terminal.raw_capture,
+            );
+            if pending_by_key.contains_key(&key) {
+                continue;
+            }
+            pending_by_key.insert(key, Vec::new());
+            deferred_writes.push_back(terminal);
+        }
         let system_task_quarantine_ids =
             load_system_task_quarantine_ids(&directory.join("system-task-quarantine.jsonl"));
-        Ok(Self {
+        let journal = Self {
             directory,
             current_file: open_append_file(&current_path)?,
             segments,
@@ -459,15 +480,16 @@ impl TerminalJournal {
             next_sequence,
             pending_bytes,
             replay_segments,
-            replay_count,
-            deferred_writes: VecDeque::new(),
+            replay_count: replay_count.saturating_add(deferred_writes.len()),
+            deferred_writes,
             replay_blocked: false,
             system_task_quarantine_ids,
             last_sync_at: Instant::now(),
             last_checkpoint_at: Instant::now(),
             overflowed: pending_bytes >= TERMINAL_JOURNAL_MAX_BYTES,
             sync_failed: false,
-        })
+        };
+        Ok(journal)
     }
 
     pub(crate) fn append(
@@ -575,12 +597,20 @@ impl TerminalJournal {
     }
 
     pub(crate) fn acknowledge(&mut self, invoke_id: &str, occurred_at: &str, raw_capture: bool) {
+        if let Err(err) = append_shutdown_terminal_ack(
+            &self.directory.join("shutdown-terminal-quarantine.jsonl"),
+            invoke_id,
+            occurred_at,
+            raw_capture,
+        ) {
+            warn!(error = %err, invoke_id, occurred_at, "failed to checkpoint shutdown terminal recovery acknowledgement");
+        }
         let key = (invoke_id.to_string(), occurred_at.to_string(), raw_capture);
         let Some(sequences) = self.pending_by_key.get(&key).cloned() else {
             return;
         };
         let mut pending_sequences = Vec::new();
-        let mut acknowledged_replay_count = 0_usize;
+        let mut written_sequences = Vec::new();
         for sequence in sequences {
             let Ok(encoded) = encode_acknowledgement_line(sequence) else {
                 warn!(
@@ -594,16 +624,6 @@ impl TerminalJournal {
                 warn!(error = %err, sequence, "terminal journal acknowledgement append failed");
                 pending_sequences.push(sequence);
                 continue;
-            }
-            let acknowledgement_target = self.segments.iter().find_map(|(start, segment)| {
-                segment.sequences.contains(&sequence).then_some(*start)
-            });
-            if let Some(start) = acknowledgement_target {
-                self.segments
-                    .get_mut(&start)
-                    .expect("terminal journal acknowledgement target exists")
-                    .acknowledged
-                    .insert(sequence);
             }
             let current_start = self
                 .segments
@@ -621,7 +641,36 @@ impl TerminalJournal {
                 .expect("current terminal journal segment exists")
                 .bytes = updated_current_bytes;
             self.pending_bytes = self.pending_bytes.saturating_add(encoded.len() as u64);
-            acknowledged_replay_count = acknowledged_replay_count.saturating_add(1);
+            written_sequences.push(sequence);
+        }
+        let mut acknowledged_replay_count = 0_usize;
+        if !written_sequences.is_empty() {
+            if let Err(err) = self.current_file.sync_data() {
+                warn!(
+                    error = %err,
+                    count = written_sequences.len(),
+                    "terminal journal acknowledgement checkpoint failed"
+                );
+                self.sync_failed = true;
+                self.overflowed = true;
+                pending_sequences.extend(written_sequences);
+            } else {
+                self.last_sync_at = Instant::now();
+                for sequence in written_sequences {
+                    let acknowledgement_target =
+                        self.segments.iter().find_map(|(start, segment)| {
+                            segment.sequences.contains(&sequence).then_some(*start)
+                        });
+                    if let Some(start) = acknowledgement_target {
+                        self.segments
+                            .get_mut(&start)
+                            .expect("terminal journal acknowledgement target exists")
+                            .acknowledged
+                            .insert(sequence);
+                    }
+                    acknowledged_replay_count = acknowledged_replay_count.saturating_add(1);
+                }
+            }
         }
         if pending_sequences.is_empty() {
             self.pending_by_key.remove(&key);
@@ -902,6 +951,43 @@ impl Read for ReplayBudgetReader<'_> {
     }
 }
 
+fn append_shutdown_terminal_ack(
+    path: &Path,
+    invoke_id: &str,
+    occurred_at: &str,
+    raw_capture: bool,
+) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(path)
+        .with_context(|| {
+            format!(
+                "failed to open shutdown terminal recovery {}",
+                path.display()
+            )
+        })?;
+    serde_json::to_writer(
+        &mut file,
+        &ShutdownTerminalRecoveryLine {
+            invoke_id: invoke_id.to_string(),
+            occurred_at: occurred_at.to_string(),
+            raw_capture,
+            acknowledged: true,
+            error: None,
+            record: None,
+        },
+    )
+    .context("failed to encode shutdown terminal recovery acknowledgement")?;
+    file.write_all(b"\n")
+        .context("failed to append shutdown terminal recovery acknowledgement")?;
+    file.sync_data()
+        .context("failed to sync shutdown terminal recovery acknowledgement")?;
+    Ok(())
+}
+
 fn load_system_task_quarantine_ids(path: &Path) -> HashSet<i64> {
     let Ok(file) = File::open(path) else {
         return HashSet::new();
@@ -924,6 +1010,54 @@ fn load_system_task_quarantine_ids(path: &Path) -> HashSet<i64> {
         }
     }
     ids
+}
+
+fn load_shutdown_terminal_recovery(path: &Path) -> Vec<BatchedTerminalInvocationWrite> {
+    let Ok(file) = File::open(path) else {
+        return Vec::new();
+    };
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let mut entries = HashMap::<(String, String, bool), Option<ProxyCaptureRecord>>::new();
+    loop {
+        line.clear();
+        let Ok(read) = reader.read_line(&mut line) else {
+            break;
+        };
+        if read == 0 {
+            break;
+        }
+        let Ok(entry) = serde_json::from_str::<ShutdownTerminalRecoveryLine>(&line) else {
+            warn!(path = %path.display(), "ignoring corrupt shutdown terminal recovery line");
+            continue;
+        };
+        let key = (entry.invoke_id, entry.occurred_at, entry.raw_capture);
+        if entry.acknowledged {
+            entries.insert(key, None);
+        } else if entry.record.is_some() {
+            entries.insert(key, entry.record);
+        }
+    }
+    entries
+        .into_iter()
+        .filter_map(|((invoke_id, occurred_at, raw_capture), record)| {
+            let record = record?;
+            Some(BatchedTerminalInvocationWrite {
+                capture_started: None,
+                raw_capture,
+                dashboard_terminal_sequence: None,
+                terminal_projection_event_ids: Vec::new(),
+                startup_backfill_tasks: startup_backfill_tasks_for_terminal(
+                    &api_invocation_from_runtime_record(&record),
+                ),
+                record: ProxyCaptureRecord {
+                    invoke_id,
+                    occurred_at,
+                    ..record
+                },
+            })
+        })
+        .collect()
 }
 
 fn segment_path(directory: &Path, first_sequence: u64) -> PathBuf {

--- a/src/terminal_journal.rs
+++ b/src/terminal_journal.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     fs::{self, File, OpenOptions},
-    io::{BufReader, Seek, SeekFrom, Write},
+    io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -22,6 +22,8 @@ pub(crate) const TERMINAL_JOURNAL_SYNC_INTERVAL: Duration = Duration::from_milli
 const TERMINAL_JOURNAL_REPLAY_MAX_BYTES: usize = 4 * 1024 * 1024;
 const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES: usize = 4 * 1024 * 1024;
 const TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES: usize = 1024;
+const SYSTEM_TASK_QUARANTINE_INDEX_MAX_BYTES: usize = 4 * 1024 * 1024;
+const SYSTEM_TASK_QUARANTINE_INDEX_MAX_LINES: usize = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalJournalDurabilityMode {
@@ -237,9 +239,11 @@ impl TerminalJournal {
             }
             appended = true;
         }
-        if appended {
-            file.sync_data()
-                .context("failed to sync system-task quarantine")?;
+        if appended && let Err(err) = file.sync_data() {
+            for finish in finishes {
+                self.system_task_quarantine_ids.remove(&finish.run_id);
+            }
+            return Err(err).context("failed to sync system-task quarantine");
         }
         Ok(())
     }
@@ -343,13 +347,7 @@ impl TerminalJournal {
             .path
             .clone();
         let system_task_quarantine_ids =
-            fs::read_to_string(directory.join("system-task-quarantine.jsonl"))
-                .ok()
-                .into_iter()
-                .flat_map(|contents| contents.lines().map(str::to_owned).collect::<Vec<_>>())
-                .filter_map(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
-                .filter_map(|value| value.get("run_id").and_then(serde_json::Value::as_i64))
-                .collect();
+            load_system_task_quarantine_ids(&directory.join("system-task-quarantine.jsonl"));
         Ok(Self {
             directory,
             current_file: open_append_file(&current_path)?,
@@ -575,10 +573,15 @@ impl TerminalJournal {
             let mut produced = None;
             loop {
                 let stream_start = cursor.byte_offset;
-                let mut stream =
-                    serde_json::Deserializer::from_reader(&mut reader).into_iter::<JournalLine>();
-                let parsed = stream.next();
-                drop(stream);
+                let parsed = {
+                    let mut budget_reader = ReplayBudgetReader {
+                        reader: &mut reader,
+                        remaining: TERMINAL_JOURNAL_REPLAY_MAX_BYTES,
+                    };
+                    let mut stream = serde_json::Deserializer::from_reader(&mut budget_reader)
+                        .into_iter::<JournalLine>();
+                    stream.next()
+                };
                 let Ok(stream_end) = reader.stream_position() else {
                     break;
                 };
@@ -592,8 +595,19 @@ impl TerminalJournal {
                         .min(usize::MAX as u64) as usize,
                 );
                 scanned_lines = scanned_lines.saturating_add(1);
-                cursor.byte_offset = stream_end;
-                let Some(Ok(parsed)) = parsed else {
+                let Some(parsed) = parsed else {
+                    cursor.byte_offset = stream_end;
+                    reached_end = true;
+                    break;
+                };
+                let Ok(parsed) = parsed else {
+                    let skipped_end = skip_replay_line(&mut reader).unwrap_or(stream_end);
+                    scanned_bytes = scanned_bytes.saturating_add(
+                        skipped_end
+                            .saturating_sub(stream_end)
+                            .min(usize::MAX as u64) as usize,
+                    );
+                    cursor.byte_offset = skipped_end;
                     if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
                         || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
                     {
@@ -601,6 +615,7 @@ impl TerminalJournal {
                     }
                     continue;
                 };
+                cursor.byte_offset = stream_end;
                 let Some(entry) = parsed.entry else {
                     if scanned_bytes >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_BYTES
                         || scanned_lines >= TERMINAL_JOURNAL_REPLAY_SCAN_MAX_LINES
@@ -760,6 +775,75 @@ impl TerminalJournal {
             }
         }
     }
+}
+
+struct ReplayBudgetReader<'a> {
+    reader: &'a mut BufReader<File>,
+    remaining: usize,
+}
+
+impl Read for ReplayBudgetReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if self.remaining == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "terminal journal replay record exceeds the bounded input budget",
+            ));
+        }
+        let limit = buffer.len().min(self.remaining);
+        let read = self.reader.read(&mut buffer[..limit])?;
+        self.remaining = self.remaining.saturating_sub(read);
+        Ok(read)
+    }
+}
+
+fn skip_replay_line(reader: &mut BufReader<File>) -> io::Result<u64> {
+    loop {
+        let buffer = reader.fill_buf()?;
+        if buffer.is_empty() {
+            return reader.stream_position();
+        }
+        if let Some(newline) = buffer.iter().position(|byte| *byte == b'\n') {
+            reader.consume(newline.saturating_add(1));
+            return reader.stream_position();
+        }
+        let consumed = buffer.len();
+        reader.consume(consumed);
+    }
+}
+
+fn load_system_task_quarantine_ids(path: &Path) -> HashSet<i64> {
+    let Ok(file) = File::open(path) else {
+        return HashSet::new();
+    };
+    let mut reader = BufReader::new(file);
+    let mut ids = HashSet::new();
+    let mut line = String::new();
+    let mut bytes_read = 0_usize;
+    for _ in 0..SYSTEM_TASK_QUARANTINE_INDEX_MAX_LINES {
+        line.clear();
+        let Ok(read) = reader.read_line(&mut line) else {
+            break;
+        };
+        if read == 0 {
+            break;
+        }
+        bytes_read = bytes_read.saturating_add(read);
+        if bytes_read > SYSTEM_TASK_QUARANTINE_INDEX_MAX_BYTES {
+            warn!(
+                path = %path.display(),
+                max_bytes = SYSTEM_TASK_QUARANTINE_INDEX_MAX_BYTES,
+                "bounded system-task quarantine index reached its startup budget"
+            );
+            break;
+        }
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line)
+            && let Some(run_id) = value.get("run_id").and_then(serde_json::Value::as_i64)
+        {
+            ids.insert(run_id);
+        }
+    }
+    ids
 }
 
 fn segment_path(directory: &Path, first_sequence: u64) -> PathBuf {


### PR DESCRIPTION
## Summary
- Queue terminal-triggered startup backfill wakes as P2 work and execute them through the existing coordinator and pressure gate.
- Drive P2 work from its deadline or background eligibility notifications while preserving P1 priority and lock retry backoff.
- Cover direct-P1 wake isolation, pressure deadline waiting, eligibility wake, and normal P2 flushes.

## Verification
- `cargo test --locked sqlite_batch_writer::tests:: -- --test-threads=1`
- `cargo fmt --check`
- `cargo check --locked`

## Initiative Repair
- PR role: child
- Repair classification: behavioral
- Evidence: deferred-to-aggregate
- Integration target: `prd/typed-runtime-event-bus`