### PR TITLE
docs: define dashboard hot topic projection contract

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -45,6 +45,7 @@
 | f2w7m | 请求记录筛选范围控件与诊断维度增强                                        | active    | `f2w7m-records-filter-range-diagnostics/SPEC.md`           | `f2w7m-records-filter-range-diagnostics/IMPLEMENTATION.md`           | topic anchor: records / filters / diagnostics               |
 | zr9jd | API Key 上游按模型路由健康管理                                            | active    | `zr9jd-api-key-model-routing-health/SPEC.md`               | `zr9jd-api-key-model-routing-health/IMPLEMENTATION.md`               | topic anchor: API Key / model routing / health              |
 | 6qe6u | 全项目 TTFT 口径                                                          | active    | `6qe6u-time-to-first-token/SPEC.md`                        | `6qe6u-time-to-first-token/IMPLEMENTATION.md`                        | topic anchor: TTFT / proxy / stats / UI                     |
+| -     | Dashboard Hot Topic 内存投影与 SSE 稳定性                                 | active    | `dashboard-hot-topic-projection/SPEC.md`                   | `dashboard-hot-topic-projection/IMPLEMENTATION.md`                   | topic anchor: dashboard / hot projection / SSE              |
 
 ## Archived Sources
 

--- a/docs/specs/dashboard-hot-topic-projection/HISTORY.md
+++ b/docs/specs/dashboard-hot-topic-projection/HISTORY.md
@@ -1,0 +1,21 @@
+# Dashboard Hot Topic 内存投影与 SSE 稳定性演进历史
+
+> 这里记录会影响 Agent 理解“为什么一步步变成现在这样”的关键演进；单次任务流水账不放这里，规范正文仍以 `./SPEC.md` 为准。
+
+## Decision Trace
+
+- 将 working-conversations、parallel-work 与 open-window timeseries 从通用订阅构建路径中独立出来，定义为必须使用 typed projection 的 Dashboard HotProjection。
+- 将 activity topic 的 `recentLimit` 固定为 16，动态显示数量改由客户端本地截断，避免数据变化触发 SSE descriptor 重建。
+- 将 System Status additive 诊断视为允许的 owner-facing 只读变更；Dashboard 的既有交互和公开数据合同保持不变。
+
+## Key Reasons / Replacements
+
+- 既有 activity、summary 和 network typed materializer 只能证明部分 topic 已收口，不能证明完整 Dashboard 页面不会触发数据库或通用 JSON builder。
+- 生产观测显示 Dashboard 页面活跃与 CPU/SQLx 占用相关；剩余三条通用 topic 是需要单独验收的架构缺口。
+- 本主题使用完整 Dashboard topic bundle、per-topic build/SQL/serialization 计数和页面 A/B 作为完成证明，替代单组件“零 SQL”结论。
+
+## References
+
+- `./SPEC.md`
+- `./IMPLEMENTATION.md`
+- `../high-frequency-runtime-data-plane/HISTORY.md`

--- a/docs/specs/dashboard-hot-topic-projection/IMPLEMENTATION.md
+++ b/docs/specs/dashboard-hot-topic-projection/IMPLEMENTATION.md
@@ -1,0 +1,33 @@
+# Dashboard Hot Topic 内存投影与 SSE 稳定性实现状态
+
+> 当前有效规范仍以 `./SPEC.md` 为准；这里记录实现覆盖、交付进度与 rollout 相关事实，避免这些细节散落到 PR / Git 历史里。
+
+## Current Status
+
+- Implementation: 未开始
+- Lifecycle: active
+- Catalog note: activity、summary 与 network 已有 typed 基础；本主题三条 hot topic 尚未完成迁移
+
+## Coverage / rollout summary
+
+- working-conversations 仍可通过通用 Prompt Cache builder 完整 hydrate。
+- open-range parallel-work 仍可执行当前范围 exact query。
+- open-window timeseries 仍可进入通用 timeseries builder。
+- per-topic hot health 与端到端 Dashboard bundle 性能门禁尚未建立。
+
+## Remaining Gaps
+
+- 建立 topic class 的穷举类型边界。
+- 为三条 hot topic 实现 typed projection/materializer 与 bounded recovery。
+- 稳定 activity `recentLimit` SSE descriptor。
+- 增加 System Status health、浏览器视口证据与线上 A/B 验收。
+
+## Related Changes
+
+- None
+
+## References
+
+- `./SPEC.md`
+- `./HISTORY.md`
+- `../high-frequency-runtime-data-plane/IMPLEMENTATION.md`

--- a/docs/specs/dashboard-hot-topic-projection/SPEC.md
+++ b/docs/specs/dashboard-hot-topic-projection/SPEC.md
@@ -1,0 +1,152 @@
+# Dashboard Hot Topic 内存投影与 SSE 稳定性
+
+> 当前有效规范以本文为准；实现覆盖与当前状态见 `./IMPLEMENTATION.md`，关键演进原因见 `./HISTORY.md`。
+
+## 背景 / 问题陈述
+
+Dashboard 已具备 Runtime/Terminal Projection、共享 SSE frame，以及 activity、summary 和 network topic 的 typed materializer。working-conversations、parallel-work 与 open-window timeseries 仍可能由任意 invocation mutation 触发通用 JSON 或 SQLite builder，导致页面活跃时重复执行完整快照构建、序列化和数据库读取。
+
+本规范将这些持续变化的 Dashboard topic 定义为独立的高频数据面，避免“部分 topic 已内存化”被误认为“Dashboard 已全部脱离通用构建链”。
+
+## 目标 / 非目标
+
+### Goals
+
+- 将订阅 topic 强制分类为 `HotProjection`、`ClosedSnapshot` 或 `BoundedColdHydrate`。
+- 将 working-conversations、parallel-work open range 与 open-window timeseries 迁入 revision-aware typed projection。
+- 保持 Dashboard HTTP/SSE wire shape、topic、排序、range、recent 与 owner-facing 交互不变。
+- 每个 topic revision 只生成一个共享不可变 serialized frame，订阅者数量不增加 builder、serialization 或数据库读取。
+- 通过 additive `runtimePressureHealth.dashboardHotTopics` 准确报告 hot topic 的事实源、负载与退化状态。
+
+### Non-goals
+
+- 不迁移 Live、invocation list、详情或其他非 Dashboard topic。
+- 不迁移 SQLite、不扩大连接池、不调高 slow threshold，也不降低统计精度。
+- 不新建与既有 Prompt Cache、parallel-work 或 timeseries projection 平行的 rollup 表。
+- 不改变 closed-range HTTP 行为或公开 SSE schema epoch。
+- 不改变 Dashboard 的既有交互；System Status 可以增加 additive 只读诊断字段和展示。
+
+## 范围（Scope）
+
+### In scope
+
+- working-conversations 的 active-selection projection。
+- parallel-work 的 open-range projection 与 closed-window 门控。
+- open-window timeseries 的 typed materializer。
+- activity topic 的稳定 `recentLimit` selection。
+- hot topic health、telemetry、System Status 只读诊断与端到端性能门禁。
+
+### Out of scope
+
+- closed-range exact builder 的替换。
+- 非 Dashboard 订阅面和 owner 配置写路径。
+- 数据库、连接池、保留策略或 SSE envelope 的迁移。
+
+## 需求（Requirements）
+
+### MUST
+
+- `HotProjection` 必须提供 typed materializer；穷举分派不得落入通用 `build_payload`、通用 JSON overlay 或健康路径 SQL fallback。
+- working-conversations 首订阅必须建立同一事务 cursor baseline，后续只应用 compact delta；旧 key 重入、metadata 变化和候选补位只允许按 key 或 identity 有界 hydrate。
+- working-conversations 必须保持 5 分钟 working selection、分页排序、blocked binding、账号/owner/sticky metadata、精确 24 小时 points 和每 key 最多 16 条 recent。
+- parallel-work 必须复用既有 minute-key/hourly rollup baseline，并以 current boundary identities 和 runtime overlay 精确维护 `today`、`1d`、`7d`；`yesterday` 必须作为 `ClosedSnapshot`，不受当前 mutation 触发。
+- open-window timeseries 必须复用 `timeseries_minute_projection_v2`，并以 terminal/runtime revisions 更新当前桶；健康发布不得调用通用 timeseries fetch builder。
+- working-conversations 使用固定 `500ms` 合并 deadline；parallel-work 与 timeseries current bucket 使用 `1s`；terminal totals 保持 `5s`；后台精确 reconcile 每 selection 最多 `60s` 一次。
+- activity topic descriptor 必须固定 `recentLimit=16`；动态可见数量仅由客户端本地截断，显式 range、分页和筛选操作仍可改变 descriptor。
+- 每个依赖 revision tuple 最多 materialize 和 serialize 一次，生成一个 `Arc<SerializedTopicFrame>`；内容未变化时不得推进 cursor。
+- 已有 last-good 时，projection 异常不得在订阅请求任务中同步查库或发布部分累计值。
+
+### SHOULD
+
+- 首个 owner subscriber 激活 projection，最后一个 subscriber 离开后停止 payload 构建并释放 active-selection 增量态。
+- bounded hydrate、reconcile 和 dirty recovery 应复用现有 pressure gate，并记录明确触发原因和规模。
+- 高频健康/no-change 日志应保持 debug；hot fallback、live DB read、持续 cadence miss 和 SSE churn 应进入 warning 或 degraded health。
+
+### COULD
+
+- 在不改变外部合同的前提下，复用现有 projection 的 compact expiry、coverage 和 cursor recovery 辅助结构。
+
+## 功能与行为规格（Functional/Behavior Spec）
+
+### Core flows
+
+- Router 根据 topic class 和 active dependency index 产生轻量 work；HotProjection 只消费 typed fact/revision。
+- Materializer 从 typed baseline、compact delta 和 runtime overlay 渲染 payload，并将 immutable frame 交给 cache、replay 和 broadcaster。
+- Cold start、dirty recovery 或 bounded candidate refill 可进入 background hydrate；成功后更新 baseline，失败时保留 last-good。
+- ClosedSnapshot 通过显式请求建立 exact snapshot，不接收无关 current mutation。
+
+### Edge cases / errors
+
+- Cursor gap、容量触限、coverage 缺口或数据库不可用时进入 `dirty_last_good`；不得静默漏计或伪装 healthy。
+- Metadata 变更只影响相关 key/account，不得触发 working full-window hydrate。
+- Timezone、DST、account scope、unassigned 和 conversation spans 必须与既有 exact builder 保持精确一致。
+- SSE selection 只有显式导航、分页、range 或 filter 变化时才允许触发 `topic-change` reconnect；recent 可见数量变化不得改变连接签名。
+
+## 接口契约（Interfaces & Contracts）
+
+### 接口清单（Inventory）
+
+| 接口（Name）                               | 类型（Kind） | 范围（Scope） | 变更（Change） | 契约文档（Contract Doc） | 负责人（Owner）              | 使用方（Consumers） | 备注（Notes）                           |
+| ------------------------------------------ | ------------ | ------------- | -------------- | ------------------------ | ---------------------------- | ------------------- | --------------------------------------- |
+| Dashboard HTTP/SSE contracts               | HTTP/SSE     | external      | None           | None                     | Dashboard runtime data plane | Web App             | Wire shape、topic、排序和 range 不变    |
+| `runtimePressureHealth.dashboardHotTopics` | JSON field   | external      | New            | None                     | System Status                | Web App / operators | Additive，只读，字段缺失按 unknown 兼容 |
+| Hot topic class/materializer               | Rust types   | internal      | New            | None                     | Subscription runtime         | Dashboard producers | HotProjection 编译期禁止通用 fallback   |
+
+### 契约文档（按 Kind 拆分）
+
+- None；外部变更仅为现有 System Status 响应中的 additive 诊断字段。
+
+## 验收标准（Acceptance Criteria）
+
+- Given baseline 已完成且完整 Dashboard topic bundle 激活，When 处理 10,000 次 runtime mutation，Then 三条 HotProjection 的 live DB read 与 generic fallback build 均为零。
+- Given 同一 topic revision，When subscriber 从 1 增至 N，Then builder、serialization、payload clone 和 DB read 次数不增长。
+- Given working、parallel-work 与 timeseries 的代表性 live/terminal/metadata 变化，When 对比 exact builder，Then 字段、排序、分页、P95、timezone/DST 和 account/unassigned 语义一致。
+- Given recent 可见数量在 4 到 16 之间变化，When 用户没有显式导航或筛选，Then SSE connection signature 不变且 `topic-change` reconnect 为零。
+- Given 任一 hot fallback、live DB read、持续 cadence miss 或 SSE churn，When 读取 System Status，Then `dashboardHotTopics` 与总体 runtime health 不得报告 healthy。
+
+## 验收清单（Acceptance checklist）
+
+- [ ] 三条 HotProjection 均具有 typed projection 和 materializer。
+- [ ] HotProjection 穷举分派不能落入通用 SQL/JSON builder。
+- [ ] Wire shape、排序、range、recent 与 cursor 语义保持兼容。
+- [ ] System Status 能准确展示 healthy、deferred、hot-DB-read 与 cadence-miss。
+- [ ] 完整 Dashboard topic bundle 的性能门禁通过。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- Rust stateful/contract tests 覆盖 projection delta、cursor baseline、bounded hydrate、closed-window 门控和 dirty recovery。
+- Subscription topology benchmark 覆盖完整 Dashboard topic bundle、1 到 N subscriber 以及 10,000 mutation。
+- Web tests 覆盖固定 `recentLimit=16`、本地截断和无非预期 SSE reconnect。
+
+### UI / Storybook (if applicable)
+
+- System Status mock states 覆盖 healthy、deferred、hot-DB-read 与 cadence-miss。
+- 使用真实桌面和移动浏览器视口生成 mock-only 视觉证据。
+
+### Quality checks
+
+- `cargo fmt --check`、`cargo check`、相关 targeted tests、`cargo test -q`。
+- Web unit tests、TypeScript check 与 Storybook tests。
+- 线上受控验证包含 15 分钟 Dashboard 关闭基线和 10 分钟单页对照；额外 Dashboard CPU 不超过 10pp，CPU-seconds/request 相对 `v2.58.6` 至少下降 30%。
+
+## Visual Evidence
+
+PR: none
+
+## Related PRs
+
+- None
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：基线恢复或 bounded hydrate 不完整会导致 last-good 长时间 deferred；health 必须显示该状态且后台精确恢复。
+- 假设：既有 Prompt Cache、parallel-work 与 timeseries projection 足以承载迁移，不新增平行 rollup 表。
+- 假设：公开 Dashboard/SSE 合同保持不变，System Status 只增加 additive 诊断。
+
+## 参考（References）
+
+- `../high-frequency-runtime-data-plane/SPEC.md`
+- `../5932d-sse-proxy-live-sync/SPEC.md`
+- `../z6ysw-dashboard-account-activity-tabs/SPEC.md`

--- a/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
+++ b/docs/specs/high-frequency-runtime-data-plane/IMPLEMENTATION.md
@@ -1,5 +1,9 @@
 # High-Frequency Runtime Data Plane Implementation
 
+## Dashboard Hot Topic Coverage
+
+Activity、summary 与 network topic 已有 typed projection/materializer。working-conversations、parallel-work open range 与 open-window timeseries 仍可能进入通用 subscription builder；其迁移、健康判责与完整 Dashboard bundle 性能门禁由 [`dashboard-hot-topic-projection`](../dashboard-hot-topic-projection/IMPLEMENTATION.md) 跟踪。在该规范验收前，高频 Dashboard delivery 不视为全部完成。
+
 ## Typed Runtime Event Bus Boundary
 
 The next delivery boundary is a single typed runtime mutation bus and router. Hot events carry identity, lifecycle, aggregate, and cursor fields only; they do not carry full invocation records, generic JSON values, or mutable topic snapshots. Topic work is selected from active dependency indexes before any materialization. Historical and detail consumers use bounded identity hydration.

--- a/docs/specs/high-frequency-runtime-data-plane/SPEC.md
+++ b/docs/specs/high-frequency-runtime-data-plane/SPEC.md
@@ -45,6 +45,8 @@
 - 首个 owner subscriber 激活 producer；后续 subscriber 只增加引用计数。无 owner subscriber 时停止周期 producer，mutation 只标记 dirty。
 - projection revision 未变化时不推进 cursor，不发送重复 frame。
 
+Activity、summary 与 network topic 已建立上述 typed delivery 基础；working-conversations、parallel-work open range 与 open-window timeseries 的剩余强制迁移由 [`dashboard-hot-topic-projection`](../dashboard-hot-topic-projection/SPEC.md) 规范。跨域数据面不能仅凭前一组 topic 的完成状态宣称整个 Dashboard 高频路径已经收口。
+
 ### Persistence And Reconcile
 
 代理请求热写必须经过统一写协调器。P1 terminal、同步 attempt/route 与 P2 derived 的优先级固定，禁止同一代理生命周期内的多个 helper 独立争抢 SQLite writer。P1 采用有界短批次并在 commit 后 ACK；锁冲突保留完整批次并指数退避，新事件只能合并，不能重置 retry deadline。P2 不得在一个事务内无界追赶 rollup cursor。

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -59,6 +59,7 @@ flowchart LR
 - startup backfill 由 terminal/archive/payload/coverage 事件唤醒并持有动态 `next_due`；无 actionable work 不查询数据库、不写 `system_task_runs`，source-unavailable 任务仅每日做有界复检。
 - `yesterday / previous7d / usage` 与其他 closed-range 查询继续使用 exact DB builder。
 - typed materializer 根据 topic dependency revision tuple 生成一个 `Arc<SerializedTopicFrame>`。delivery 不接收完整业务 snapshot 或通用 JSON overlay；subscriber 数量只增加引用，不增加 builder 或 serialization 次数。
+- Activity、summary 与 network topic 已使用 typed materializer；working-conversations、parallel-work open range 与 open-window timeseries 仍是待迁移的 Dashboard HotProjection。在迁移完成前，它们不得被视为健康高频数据面的已完成部分，具体合同见 [`dashboard-hot-topic-projection`](./specs/dashboard-hot-topic-projection/SPEC.md)。
 - 第一位 owner subscriber 激活 producer；无 owner subscriber 时停止周期构建并标记 dirty，重新订阅时恢复 fresh snapshot/replay 语义。
 
 ## 5. 持久化与历史数据


### PR DESCRIPTION
## Summary

- add the canonical Dashboard hot-topic projection spec, implementation status, and decision history
- define typed hot/closed/bounded topic classes, cadence, recovery, delivery, and health contracts
- correct the cross-domain architecture docs so the remaining working/parallel/timeseries gaps are explicit

## Validation

- `git diff --check`
- relative Markdown link validation
- pre-commit Markdown formatting
- pre-commit Web TypeScript check
- read-only documentation review: clear

## Scope

Documentation only. No runtime, API, schema, or UI implementation changes.