### PR TITLE
fix(ci): isolate PR metadata workflow runs reliably

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -458,7 +458,7 @@ def validate_ci_pr(path: Path, contract: ContractModel) -> None:
     assert_event_types(merge_group_config, {"checks_requested"}, "ci-pr.yml.on.merge_group")
 
     concurrency = require_mapping(workflow.get("concurrency"), "ci-pr.yml.concurrency")
-    require(concurrency.get("group") == "ci-pr-${{ github.event.pull_request.number || github.ref }}", "ci-pr.yml.concurrency.group drifted")
+    require(concurrency.get("group") == "ci-pr-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.ref }}", "ci-pr.yml.concurrency.group drifted")
     require(concurrency.get("cancel-in-progress") is True, "ci-pr.yml.concurrency.cancel-in-progress must stay true")
 
     permissions = require_mapping(workflow.get("permissions"), "ci-pr.yml.permissions")
@@ -804,7 +804,7 @@ def validate_label_gate(path: Path, contract: ContractModel) -> None:
     require(permissions.get("issues") == "read", "label-gate.yml.permissions.issues must stay read")
 
     concurrency = require_mapping(workflow.get("concurrency"), "label-gate.yml.concurrency")
-    require(concurrency.get("group") == "label-gate-${{ github.event.pull_request.number || github.run_id }}", "label-gate.yml.concurrency.group drifted")
+    require(concurrency.get("group") == "label-gate-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.run_id }}", "label-gate.yml.concurrency.group drifted")
     require(concurrency.get("cancel-in-progress") is True, "label-gate.yml.concurrency.cancel-in-progress must stay true")
 
     job = named_job_config(workflow, "validate-pr-labels", expected_jobs, "label-gate.yml")
@@ -895,7 +895,7 @@ def validate_review_policy(path: Path, contract: ContractModel) -> None:
     require(permissions.get("pull-requests") == "read", "review-policy.yml.permissions.pull-requests must stay read")
 
     concurrency = require_mapping(workflow.get("concurrency"), "review-policy.yml.concurrency")
-    require(concurrency.get("group") == "review-policy-${{ github.event.pull_request.number || github.run_id }}", "review-policy.yml.concurrency.group drifted")
+    require(concurrency.get("group") == "review-policy-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.run_id }}", "review-policy.yml.concurrency.group drifted")
     require(concurrency.get("cancel-in-progress") is True, "review-policy.yml.concurrency.cancel-in-progress must stay true")
 
     job = named_job_config(workflow, "review-policy", expected_jobs, "review-policy.yml")

--- a/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-pr.yml
@@ -13,7 +13,7 @@ on:
       - checks_requested
 
 concurrency:
-  group: ci-pr-${{ github.event.pull_request.number || github.ref }}
+  group: ci-pr-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/scripts/fixtures/quality-gates-contract/label-gate.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/label-gate.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, edited]
 
 concurrency:
-  group: label-gate-${{ github.event.pull_request.number || github.run_id }}
+  group: label-gate-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/scripts/fixtures/quality-gates-contract/review-policy.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/review-policy.yml
@@ -16,7 +16,7 @@ on:
       - edited
 
 concurrency:
-  group: review-policy-${{ github.event.pull_request.number || github.run_id }}
+  group: review-policy-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/label-gate.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/label-gate.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, edited]
 
 concurrency:
-  group: label-gate-${{ github.event.pull_request.number || github.run_id }}
+  group: label-gate-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -136,10 +136,10 @@ import sys
 repo = Path(sys.argv[1])
 path = repo / ".github/workflows/label-gate.yml"
 text = path.read_text()
-needle = "  group: label-gate-${{ github.event.pull_request.number || github.run_id }}\n"
-replacement = "  group: label-gate-static\n"
+needle = "github.event_name == 'pull_request' && github.event.action == 'edited'"
+replacement = "github.event.action == 'edited'"
 if needle not in text:
-    raise SystemExit("failed to rewrite label-gate concurrency group")
+    raise SystemExit("failed to rewrite label-gate metadata selector")
 path.write_text(text.replace(needle, replacement, 1))
 PY
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,7 +13,7 @@ on:
       - checks_requested
 
 concurrency:
-  group: ci-pr-${{ github.event.pull_request.number || github.ref }}
+  group: ci-pr-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/label-gate.yml
+++ b/.github/workflows/label-gate.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, edited]
 
 concurrency:
-  group: label-gate-${{ github.event.pull_request.number || github.run_id }}
+  group: label-gate-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -16,7 +16,7 @@ on:
       - edited
 
 concurrency:
-  group: review-policy-${{ github.event.pull_request.number || github.run_id }}
+  group: review-policy-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && format('metadata-{0}-{1}', github.event.pull_request.number, github.run_id) || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -11853,7 +11853,7 @@ mod tests {
             "stats.parallel-work.current",
             "stats.timeseries.open-window",
         ];
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         let mut stream = response.into_body().into_data_stream();
         let mut buffered = Vec::new();
         let mut events: BTreeMap<String, Value> = BTreeMap::new();
@@ -12196,18 +12196,11 @@ mod tests {
             .subscription_hub
             .handle_runtime_mutation_batch(state.clone(), parallel_work_mutations)
             .await;
-        tokio::time::sleep(PARALLEL_WORK_TOPIC_MATERIALIZATION_DEBOUNCE * 2).await;
         let parallel_topic = SubscriptionTopic::ParallelWorkCurrent {
             range: "1d".to_string(),
             time_zone: SUBSCRIPTION_DEFAULT_TIME_ZONE.to_string(),
             bucket: Some("1m".to_string()),
             upstream_account_id: None,
-        };
-        let projected_parallel = {
-            let guard = state.subscription_hub.state.lock().await;
-            guard.topics[&parallel_topic.cache_key().expect("parallel-work topic key")]
-                .snapshot_frame
-                .payload_value()
         };
         let exact_parallel = load_parallel_work_stats_response(
             &state,
@@ -12227,6 +12220,41 @@ mod tests {
                 .single()
                 .expect("construct fallback minute"),
         );
+        let exact_point = exact_parallel
+            .current
+            .points
+            .iter()
+            .find(|point| point.bucket_start == fallback_bucket_start)
+            .expect("exact fallback point");
+        let projection_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let projected_parallel = loop {
+            let projected_parallel = {
+                let guard = state.subscription_hub.state.lock().await;
+                guard.topics[&parallel_topic.cache_key().expect("parallel-work topic key")]
+                    .snapshot_frame
+                    .payload_value()
+            };
+            let materialized_point =
+                projected_parallel["current"]["points"]
+                    .as_array()
+                    .and_then(|points| {
+                        points.iter().find(|point| {
+                            point["bucketStart"].as_str() == Some(fallback_bucket_start.as_str())
+                        })
+                    });
+            if materialized_point
+                .is_some_and(|point| point["parallelCount"] == json!(exact_point.parallel_count))
+            {
+                break projected_parallel;
+            }
+            let remaining =
+                projection_deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "parallel-work projection did not materialize the expected bucket"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
         let projected_point = projected_parallel["current"]["points"]
             .as_array()
             .and_then(|points| {
@@ -12235,12 +12263,6 @@ mod tests {
                 })
             })
             .expect("projected fallback point");
-        let exact_point = exact_parallel
-            .current
-            .points
-            .iter()
-            .find(|point| point.bucket_start == fallback_bucket_start)
-            .expect("exact fallback point");
         assert_eq!(
             projected_point["parallelCount"],
             json!(exact_point.parallel_count),


### PR DESCRIPTION
## Summary
- isolate pull_request.edited metadata runs with run-specific concurrency namespaces
- preserve candidate cancellation, trusted-base checkout, and quality gate contracts

## Validation
- bash .github/scripts/test-quality-gates-contract.sh

Labels: type:docs, channel:stable