### PR TITLE
fix(projection): defer expensive maintenance work

### DIFF
--- a/src/long_term_stats.rs
+++ b/src/long_term_stats.rs
@@ -1416,10 +1416,13 @@ fn long_term_projection_repair_due(
     next_repair_at: Option<Instant>,
     now: Instant,
 ) -> bool {
-    has_persisted_work
-        || has_due_dirty_bucket
-        || runtime_state_is_empty
-        || next_repair_at.is_some_and(|retry_at| retry_at <= now)
+    // A scheduled repair owns the expensive rebuild deadline. Persisted terminal
+    // deltas still use the bounded terminal pass, but must not pull this rebuild
+    // forward before the deadline.
+    next_repair_at.map_or(
+        has_persisted_work || has_due_dirty_bucket || runtime_state_is_empty,
+        |retry_at| retry_at <= now,
+    )
 }
 
 async fn defer_long_term_projection_terminal_repair(state: &AppState, defer_reason: &'static str) {
@@ -6179,6 +6182,13 @@ mod tests {
             false,
             false,
             false,
+            Some(now + Duration::from_secs(1)),
+            now,
+        ));
+        assert!(!long_term_projection_repair_due(
+            true,
+            true,
+            true,
             Some(now + Duration::from_secs(1)),
             now,
         ));

--- a/src/long_term_stats.rs
+++ b/src/long_term_stats.rs
@@ -1330,13 +1330,20 @@ pub(crate) fn spawn_long_term_projection_supervisor(
                     }
                 }
                 _ = repair_ticker.tick() => {
-                    if long_term_projection_repair_needed(&state).await {
-                        if let Err(error) = flush_long_term_projection(&state, "repair_deadline").await {
-                            mark_long_term_projection_failure(&state, &error).await;
-                            warn!(error = %error, projection = "long_term", trigger = "repair_deadline", "long-term projection repair failed");
+                    match long_term_projection_repair_needed(&state).await {
+                        Ok(true) => {
+                            if let Err(error) = flush_long_term_projection(&state, "repair_deadline").await {
+                                mark_long_term_projection_failure(&state, &error).await;
+                                warn!(error = %error, projection = "long_term", trigger = "repair_deadline", "long-term projection repair failed");
+                            }
                         }
-                    } else {
-                        debug!(projection = "long_term", trigger = "repair_deadline", flush_outcome = "noop_suppressed", "skipping idle long-term repair");
+                        Ok(false) => {
+                            debug!(projection = "long_term", trigger = "repair_deadline", flush_outcome = "noop_suppressed", "skipping idle long-term repair");
+                        }
+                        Err(error) => {
+                            mark_long_term_projection_failure(&state, &error).await;
+                            warn!(error = %error, projection = "long_term", trigger = "repair_deadline", "failed to inspect long-term projection repair work");
+                        }
                     }
                 }
                 _ = daily_verify_ticker.tick() => {
@@ -1362,12 +1369,51 @@ async fn long_term_projection_terminal_flush_needed(state: &AppState) -> bool {
                 .is_none_or(|retry_at| retry_at <= Instant::now()))
 }
 
-async fn long_term_projection_repair_needed(state: &AppState) -> bool {
-    if state.terminal_projection_hub.has_persisted_work() {
-        return true;
+async fn long_term_projection_repair_needed(state: &AppState) -> Result<bool> {
+    let has_persisted_work = state.terminal_projection_hub.has_persisted_work();
+    let (runtime_state_is_empty, next_repair_at) = {
+        let runtime = state.long_term_projection_runtime.lock().await;
+        (runtime.state.is_empty(), runtime.next_repair_at)
+    };
+    let now = Instant::now();
+    if long_term_projection_repair_due(
+        has_persisted_work,
+        false,
+        runtime_state_is_empty,
+        next_repair_at,
+        now,
+    ) {
+        return Ok(true);
     }
-    let runtime = state.long_term_projection_runtime.lock().await;
-    runtime.state.is_empty() || runtime.dirty_bucket_count > 0
+
+    // Correction and archive triggers write durable dirty markers without touching the
+    // in-memory runtime state. Probe them only on the bounded repair cadence.
+    let has_due_dirty_bucket = sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS(SELECT 1 FROM long_term_projection_dirty_buckets WHERE next_attempt_at IS NULL OR datetime(next_attempt_at) <= datetime('now'))",
+    )
+    .fetch_one(&state.pool)
+    .await?
+        != 0;
+    Ok(long_term_projection_repair_due(
+        has_persisted_work,
+        has_due_dirty_bucket,
+        runtime_state_is_empty,
+        next_repair_at,
+        now,
+    ))
+}
+
+fn long_term_projection_repair_due(
+    has_persisted_work: bool,
+    has_due_dirty_bucket: bool,
+    runtime_state_is_empty: bool,
+    next_repair_at: Option<Instant>,
+    now: Instant,
+) -> bool {
+    has_persisted_work
+        || has_due_dirty_bucket
+        || runtime_state_is_empty
+        || next_repair_at.is_some_and(|retry_at| retry_at <= now)
 }
 
 async fn defer_long_term_projection_terminal_repair(state: &AppState, defer_reason: &'static str) {
@@ -1398,6 +1444,7 @@ async fn mark_long_term_projection_failure(state: &AppState, error: &anyhow::Err
     let mut runtime = state.long_term_projection_runtime.lock().await;
     runtime.state = "dirty_last_good".to_string();
     runtime.last_error_kind = Some(error_kind.to_string());
+    runtime.next_repair_at = Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL);
 }
 
 async fn queue_long_term_projection_daily_verify(pool: &Pool<Sqlite>) -> Result<()> {
@@ -6106,6 +6153,29 @@ mod tests {
             "repair_deadline"
         ));
         assert!(long_term_projection_runs_hourly_retention("daily_verify"));
+    }
+
+    #[test]
+    fn long_term_projection_repair_retries_deferred_and_persisted_dirty_work() {
+        let now = Instant::now();
+
+        assert!(long_term_projection_repair_due(
+            false, true, false, None, now,
+        ));
+        assert!(long_term_projection_repair_due(
+            false,
+            false,
+            false,
+            Some(now - Duration::from_millis(1)),
+            now,
+        ));
+        assert!(!long_term_projection_repair_due(
+            false,
+            false,
+            false,
+            Some(now + Duration::from_secs(1)),
+            now,
+        ));
     }
 
     async fn create_long_term_test_invocations(pool: &Pool<Sqlite>) {

--- a/src/long_term_stats.rs
+++ b/src/long_term_stats.rs
@@ -200,6 +200,7 @@ pub(crate) struct LongTermProjectionRuntime {
     pub(crate) last_repair_scope: Option<String>,
     pub(crate) last_defer_reason: Option<String>,
     pub(crate) last_error_kind: Option<String>,
+    next_repair_at: Option<Instant>,
     interval_index: HashMap<LongTermProjectionIntervalKey, LongTermProjectionIntervalUnion>,
     loaded_interval_dates: HashSet<String>,
 }
@@ -1023,6 +1024,7 @@ pub(crate) async fn ensure_long_term_stats_schema(pool: &Pool<Sqlite>) -> Result
 
 const LONG_TERM_PROJECTION_CONSUMER: &str = "long_term_v1";
 const LONG_TERM_PROJECTION_FLUSH_INTERVAL: Duration = Duration::from_secs(60);
+const LONG_TERM_PROJECTION_REPAIR_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const LONG_TERM_PROJECTION_DAILY_VERIFY_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const LONG_TERM_PROJECTION_MAX_BUCKETS_PER_FLUSH: i64 = 1;
 const LONG_TERM_PROJECTION_MAX_EVENTS_PER_FLUSH: i64 = 2_000;
@@ -1304,6 +1306,9 @@ pub(crate) fn spawn_long_term_projection_supervisor(
         let mut flush_ticker = interval(LONG_TERM_PROJECTION_FLUSH_INTERVAL);
         flush_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         flush_ticker.tick().await;
+        let mut repair_ticker = interval(LONG_TERM_PROJECTION_REPAIR_INTERVAL);
+        repair_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        repair_ticker.tick().await;
         let mut daily_verify_ticker = interval(LONG_TERM_PROJECTION_DAILY_VERIFY_INTERVAL);
         daily_verify_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         daily_verify_ticker.tick().await;
@@ -1315,9 +1320,23 @@ pub(crate) fn spawn_long_term_projection_supervisor(
                     debug!(projection = "long_term", trigger = "terminal_p1_ack", "long-term projection marked dirty by terminal persistence");
                 }
                 _ = flush_ticker.tick() => {
-                    if let Err(error) = flush_long_term_projection(&state, "terminal_deadline").await {
-                        mark_long_term_projection_failure(&state, &error).await;
-                        warn!(error = %error, projection = "long_term", trigger = "terminal_deadline", "long-term projection flush failed");
+                    if long_term_projection_terminal_flush_needed(&state).await {
+                        if let Err(error) = flush_long_term_projection(&state, "terminal_deadline").await {
+                            mark_long_term_projection_failure(&state, &error).await;
+                            warn!(error = %error, projection = "long_term", trigger = "terminal_deadline", "long-term projection flush failed");
+                        }
+                    } else {
+                        debug!(projection = "long_term", trigger = "terminal_deadline", flush_outcome = "noop_suppressed", "skipping idle long-term projection flush");
+                    }
+                }
+                _ = repair_ticker.tick() => {
+                    if long_term_projection_repair_needed(&state).await {
+                        if let Err(error) = flush_long_term_projection(&state, "repair_deadline").await {
+                            mark_long_term_projection_failure(&state, &error).await;
+                            warn!(error = %error, projection = "long_term", trigger = "repair_deadline", "long-term projection repair failed");
+                        }
+                    } else {
+                        debug!(projection = "long_term", trigger = "repair_deadline", flush_outcome = "noop_suppressed", "skipping idle long-term repair");
                     }
                 }
                 _ = daily_verify_ticker.tick() => {
@@ -1331,6 +1350,39 @@ pub(crate) fn spawn_long_term_projection_supervisor(
             }
         }
     })
+}
+
+async fn long_term_projection_terminal_flush_needed(state: &AppState) -> bool {
+    let has_persisted_work = state.terminal_projection_hub.has_persisted_work();
+    let runtime = state.long_term_projection_runtime.lock().await;
+    runtime.state.is_empty()
+        || (has_persisted_work
+            && runtime
+                .next_repair_at
+                .is_none_or(|retry_at| retry_at <= Instant::now()))
+}
+
+async fn long_term_projection_repair_needed(state: &AppState) -> bool {
+    if state.terminal_projection_hub.has_persisted_work() {
+        return true;
+    }
+    let runtime = state.long_term_projection_runtime.lock().await;
+    runtime.state.is_empty() || runtime.dirty_bucket_count > 0
+}
+
+async fn defer_long_term_projection_terminal_repair(state: &AppState, defer_reason: &'static str) {
+    let mut runtime = state.long_term_projection_runtime.lock().await;
+    runtime.state = "dirty_last_good".to_string();
+    runtime.last_defer_reason = Some(defer_reason.to_string());
+    runtime.next_repair_at = Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL);
+}
+
+fn long_term_projection_allows_expensive_repair(trigger: &str) -> bool {
+    trigger != "terminal_deadline"
+}
+
+fn long_term_projection_runs_hourly_retention(trigger: &str) -> bool {
+    trigger == "daily_verify"
 }
 
 async fn mark_long_term_projection_failure(state: &AppState, error: &anyhow::Error) {
@@ -1576,6 +1628,7 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
             let mut runtime = state.long_term_projection_runtime.lock().await;
             runtime.state = "deferred".to_string();
             runtime.last_defer_reason = Some("writer_pressure".to_string());
+            runtime.next_repair_at = Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL);
             debug!(projection = "long_term", trigger, gate_outcome = "deferred", defer_reason = "writer_pressure", reason = %reason, "long-term projection flush deferred by database pressure gate");
             return Ok(0);
         }
@@ -1683,58 +1736,76 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
         }
         if let Some(event) = repair_event {
             let repair_dates = event.bucket_dates.into_iter().collect::<Vec<_>>();
-            ensure_long_term_projection_repairs(&state.pool, &repair_dates, "interval_baseline")
-                .await?;
-            let repair_dirty =
-                load_long_term_projection_dirty_buckets(&state.pool, &repair_dates).await?;
-            if long_term_projection_repairs_are_deferred(&state.pool, &repair_dates).await? {
+            if !long_term_projection_allows_expensive_repair(trigger) {
                 deferred_repair_count = deferred_repair_count.saturating_add(repair_dates.len());
                 deferred_repair_backoff_count =
                     deferred_repair_backoff_count.saturating_add(repair_dates.len());
                 debug!(
                     projection = "long_term",
                     repair_scope = ?repair_dates,
-                    defer_reason = "repair_backoff",
-                    "long-term cursor repair retained until its retry deadline"
+                    defer_reason = "terminal_hot_path",
+                    "long-term cursor repair deferred to the bounded repair window"
                 );
+                defer_long_term_projection_terminal_repair(state, "terminal_hot_path").await;
             } else {
-                let mut rebuilds = Vec::with_capacity(repair_dates.len());
-                let mut rebuild_error = None;
-                for date in &repair_dates {
-                    match build_long_term_projection_date_rebuild(&state.pool, date).await {
-                        Ok(rebuild) => {
-                            loaded_row_count =
-                                loaded_row_count.saturating_add(rebuild.source_row_count);
-                            rebuilds.push(rebuild);
-                        }
-                        Err(error) => {
-                            rebuild_error = Some(error);
-                            break;
-                        }
-                    }
-                }
-                if let Some(error) = rebuild_error {
-                    defer_long_term_projection_repairs(&state.pool, &repair_dates).await?;
+                ensure_long_term_projection_repairs(
+                    &state.pool,
+                    &repair_dates,
+                    "interval_baseline",
+                )
+                .await?;
+                let repair_dirty =
+                    load_long_term_projection_dirty_buckets(&state.pool, &repair_dates).await?;
+                if long_term_projection_repairs_are_deferred(&state.pool, &repair_dates).await? {
                     deferred_repair_count =
                         deferred_repair_count.saturating_add(repair_dates.len());
-                    warn!(
-                        error = %error,
+                    deferred_repair_backoff_count =
+                        deferred_repair_backoff_count.saturating_add(repair_dates.len());
+                    debug!(
                         projection = "long_term",
                         repair_scope = ?repair_dates,
-                        retry_after_ms = 300_000_u64,
-                        "long-term cursor repair deferred after an unavailable source"
+                        defer_reason = "repair_backoff",
+                        "long-term cursor repair retained until its retry deadline"
                     );
                 } else {
-                    commit_long_term_projection_date_rebuilds(
-                        &state.pool,
-                        &rebuilds,
-                        Some(event.row_id),
-                        &repair_dirty,
-                        false,
-                    )
-                    .await?;
-                    repaired.extend(repair_dates);
-                    cursor = event.row_id;
+                    let mut rebuilds = Vec::with_capacity(repair_dates.len());
+                    let mut rebuild_error = None;
+                    for date in &repair_dates {
+                        match build_long_term_projection_date_rebuild(&state.pool, date).await {
+                            Ok(rebuild) => {
+                                loaded_row_count =
+                                    loaded_row_count.saturating_add(rebuild.source_row_count);
+                                rebuilds.push(rebuild);
+                            }
+                            Err(error) => {
+                                rebuild_error = Some(error);
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(error) = rebuild_error {
+                        defer_long_term_projection_repairs(&state.pool, &repair_dates).await?;
+                        deferred_repair_count =
+                            deferred_repair_count.saturating_add(repair_dates.len());
+                        warn!(
+                            error = %error,
+                            projection = "long_term",
+                            repair_scope = ?repair_dates,
+                            retry_after_ms = 300_000_u64,
+                            "long-term cursor repair deferred after an unavailable source"
+                        );
+                    } else {
+                        commit_long_term_projection_date_rebuilds(
+                            &state.pool,
+                            &rebuilds,
+                            Some(event.row_id),
+                            &repair_dirty,
+                            false,
+                        )
+                        .await?;
+                        repaired.extend(repair_dates);
+                        cursor = event.row_id;
+                    }
                 }
             }
         }
@@ -1744,12 +1815,16 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
         invalidate_long_term_projection_interval_cache(state).await;
     }
 
-    let dirty_dates = sqlx::query_as::<_, LongTermProjectionDirtyBucket>(
-        "SELECT bucket_date, generation FROM long_term_projection_dirty_buckets WHERE next_attempt_at IS NULL OR datetime(next_attempt_at) <= datetime('now') ORDER BY queued_at ASC, bucket_date ASC LIMIT ?1",
-    )
-    .bind(LONG_TERM_PROJECTION_MAX_BUCKETS_PER_FLUSH)
-    .fetch_all(&state.pool)
-    .await?;
+    let dirty_dates = if !long_term_projection_allows_expensive_repair(trigger) {
+        Vec::new()
+    } else {
+        sqlx::query_as::<_, LongTermProjectionDirtyBucket>(
+            "SELECT bucket_date, generation FROM long_term_projection_dirty_buckets WHERE next_attempt_at IS NULL OR datetime(next_attempt_at) <= datetime('now') ORDER BY queued_at ASC, bucket_date ASC LIMIT ?1",
+        )
+        .bind(LONG_TERM_PROJECTION_MAX_BUCKETS_PER_FLUSH)
+        .fetch_all(&state.pool)
+        .await?
+    };
     for dirty in dirty_dates {
         let date = dirty.bucket_date.clone();
         if repaired.contains(&date) {
@@ -1786,11 +1861,15 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
     }
 
     let (retention_pruned_hourly_rows, retention_pruned_interval_rows) =
-        prune_long_term_projection_hourly_retention(
-            &state.pool,
-            state.config.long_term_stats_hourly_retention_days,
-        )
-        .await?;
+        if long_term_projection_runs_hourly_retention(trigger) {
+            prune_long_term_projection_hourly_retention(
+                &state.pool,
+                state.config.long_term_stats_hourly_retention_days,
+            )
+            .await?
+        } else {
+            (0, 0)
+        };
 
     let dirty_bucket_count =
         sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM long_term_projection_dirty_buckets")
@@ -1811,7 +1890,9 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
     let projection_health = state.terminal_projection_hub.health();
     let elapsed_ms = started.elapsed().as_millis() as u64;
     let mut runtime = state.long_term_projection_runtime.lock().await;
-    runtime.state = if dirty_bucket_count == 0 {
+    runtime.state = if deferred_repair_count > 0 {
+        "dirty_last_good"
+    } else if dirty_bucket_count == 0 {
         "healthy"
     } else {
         "repairing"
@@ -1823,14 +1904,24 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
     runtime.last_flush_elapsed_ms = Some(elapsed_ms);
     runtime.last_flush_at = Some(Instant::now());
     runtime.last_repair_scope = (!repaired.is_empty()).then(|| repaired.join(","));
-    runtime.last_defer_reason = if deferred_repair_backoff_count > 0 {
+    let terminal_hot_path_deferred =
+        !long_term_projection_allows_expensive_repair(trigger) && deferred_repair_count > 0;
+    runtime.last_defer_reason = if terminal_hot_path_deferred {
+        Some("terminal_hot_path".to_string())
+    } else if deferred_repair_backoff_count > 0 {
         Some("repair_backoff".to_string())
     } else if deferred_repair_count > 0 {
         Some("repair_source_unavailable".to_string())
     } else {
         None
     };
-    runtime.last_error_kind = (deferred_repair_count > 0).then(|| "targeted_repair".to_string());
+    runtime.last_error_kind = (!terminal_hot_path_deferred && deferred_repair_count > 0)
+        .then(|| "targeted_repair".to_string());
+    runtime.next_repair_at = if deferred_repair_count > 0 {
+        Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL)
+    } else {
+        None
+    };
     let interval_bytes = runtime
         .interval_index
         .iter()
@@ -5997,6 +6088,25 @@ fn internal_error_tuple(error: anyhow::Error) -> (StatusCode, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terminal_projection_flush_defers_expensive_repairs_and_retention() {
+        assert!(!long_term_projection_allows_expensive_repair(
+            "terminal_deadline"
+        ));
+        assert!(long_term_projection_allows_expensive_repair(
+            "repair_deadline"
+        ));
+        assert!(long_term_projection_allows_expensive_repair("daily_verify"));
+
+        assert!(!long_term_projection_runs_hourly_retention(
+            "terminal_deadline"
+        ));
+        assert!(!long_term_projection_runs_hourly_retention(
+            "repair_deadline"
+        ));
+        assert!(long_term_projection_runs_hourly_retention("daily_verify"));
+    }
 
     async fn create_long_term_test_invocations(pool: &Pool<Sqlite>) {
         sqlx::query(

--- a/src/long_term_stats.rs
+++ b/src/long_term_stats.rs
@@ -1429,7 +1429,20 @@ async fn defer_long_term_projection_terminal_repair(state: &AppState, defer_reas
     let mut runtime = state.long_term_projection_runtime.lock().await;
     runtime.state = "dirty_last_good".to_string();
     runtime.last_defer_reason = Some(defer_reason.to_string());
-    runtime.next_repair_at = Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL);
+    runtime.next_repair_at = Some(long_term_projection_repair_deadline(
+        runtime.next_repair_at,
+        Instant::now(),
+    ));
+}
+
+fn long_term_projection_repair_deadline(
+    existing_deadline: Option<Instant>,
+    now: Instant,
+) -> Instant {
+    // Repeated terminal flushes and pressure deferrals may arrive while a
+    // targeted repair is pending. Keep the first deadline so they cannot
+    // postpone recovery indefinitely.
+    existing_deadline.unwrap_or(now + LONG_TERM_PROJECTION_REPAIR_INTERVAL)
 }
 
 fn long_term_projection_allows_expensive_repair(trigger: &str) -> bool {
@@ -1453,7 +1466,10 @@ async fn mark_long_term_projection_failure(state: &AppState, error: &anyhow::Err
     let mut runtime = state.long_term_projection_runtime.lock().await;
     runtime.state = "dirty_last_good".to_string();
     runtime.last_error_kind = Some(error_kind.to_string());
-    runtime.next_repair_at = Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL);
+    runtime.next_repair_at = Some(long_term_projection_repair_deadline(
+        runtime.next_repair_at,
+        Instant::now(),
+    ));
 }
 
 async fn queue_long_term_projection_daily_verify(pool: &Pool<Sqlite>) -> Result<()> {
@@ -1684,7 +1700,10 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
             let mut runtime = state.long_term_projection_runtime.lock().await;
             runtime.state = "deferred".to_string();
             runtime.last_defer_reason = Some("writer_pressure".to_string());
-            runtime.next_repair_at = Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL);
+            runtime.next_repair_at = Some(long_term_projection_repair_deadline(
+                runtime.next_repair_at,
+                Instant::now(),
+            ));
             debug!(projection = "long_term", trigger, gate_outcome = "deferred", defer_reason = "writer_pressure", reason = %reason, "long-term projection flush deferred by database pressure gate");
             return Ok(0);
         }
@@ -1974,7 +1993,10 @@ async fn flush_long_term_projection_inner(state: &AppState, trigger: &'static st
     runtime.last_error_kind = (!terminal_hot_path_deferred && deferred_repair_count > 0)
         .then(|| "targeted_repair".to_string());
     runtime.next_repair_at = if deferred_repair_count > 0 {
-        Some(Instant::now() + LONG_TERM_PROJECTION_REPAIR_INTERVAL)
+        Some(long_term_projection_repair_deadline(
+            runtime.next_repair_at,
+            Instant::now(),
+        ))
     } else {
         None
     };
@@ -6185,6 +6207,11 @@ mod tests {
             Some(now + Duration::from_secs(1)),
             now,
         ));
+    }
+
+    #[test]
+    fn long_term_projection_repair_respects_a_future_deadline_with_pending_work() {
+        let now = Instant::now();
         assert!(!long_term_projection_repair_due(
             true,
             true,
@@ -6192,6 +6219,21 @@ mod tests {
             Some(now + Duration::from_secs(1)),
             now,
         ));
+    }
+
+    #[test]
+    fn repeated_terminal_defers_preserve_the_original_repair_deadline() {
+        let now = Instant::now();
+        let original = now + Duration::from_secs(30);
+        assert_eq!(
+            long_term_projection_repair_deadline(Some(original), now),
+            original
+        );
+        let overdue = now - Duration::from_secs(1);
+        assert_eq!(
+            long_term_projection_repair_deadline(Some(overdue), now),
+            overdue
+        );
     }
 
     #[test]

--- a/src/long_term_stats.rs
+++ b/src/long_term_stats.rs
@@ -1362,11 +1362,17 @@ pub(crate) fn spawn_long_term_projection_supervisor(
 async fn long_term_projection_terminal_flush_needed(state: &AppState) -> bool {
     let has_persisted_work = state.terminal_projection_hub.has_persisted_work();
     let runtime = state.long_term_projection_runtime.lock().await;
-    runtime.state.is_empty()
-        || (has_persisted_work
-            && runtime
-                .next_repair_at
-                .is_none_or(|retry_at| retry_at <= Instant::now()))
+    long_term_projection_terminal_flush_due(has_persisted_work, runtime.state.is_empty())
+}
+
+fn long_term_projection_terminal_flush_due(
+    has_persisted_work: bool,
+    runtime_state_is_empty: bool,
+) -> bool {
+    // A deferred date rebuild must not suppress the bounded terminal delta pass.
+    // The pass can still advance any ready prefix while the repair ticker owns
+    // the expensive rebuild deadline.
+    has_persisted_work || runtime_state_is_empty
 }
 
 async fn long_term_projection_repair_needed(state: &AppState) -> Result<bool> {
@@ -6176,6 +6182,13 @@ mod tests {
             Some(now + Duration::from_secs(1)),
             now,
         ));
+    }
+
+    #[test]
+    fn terminal_projection_flush_does_not_share_the_repair_backoff() {
+        assert!(long_term_projection_terminal_flush_due(true, false));
+        assert!(long_term_projection_terminal_flush_due(false, true));
+        assert!(!long_term_projection_terminal_flush_due(false, false));
     }
 
     async fn create_long_term_test_invocations(pool: &Pool<Sqlite>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,8 @@ const STARTUP_BACKFILL_TASK_POOL_ATTEMPT_PUBLIC_ID_ARCHIVES: &str =
     "pool_attempt_public_id_archives_v1";
 const STARTUP_BACKFILL_TASK_POOL_UPSTREAM_NODE_HEALTH_ARCHIVES: &str =
     "pool_upstream_node_health_archives_v1";
+const STARTUP_BACKFILL_TASK_ACCOUNT_ACTIVITY_V2_COVERAGE: &str =
+    "account_activity_v2_coverage_repair_v1";
 const STARTUP_BACKFILL_TASK_HISTORICAL_ROLLUPS: &str = "historical_rollup_materialization_v1";
 const DEFAULT_PROXY_RAW_MAX_BYTES: Option<usize> = None;
 const DEFAULT_PROXY_PRICING_CATALOG_PATH: &str = "config/model-pricing.json";

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -11,17 +11,37 @@ const LEGACY_MATERIALIZED_UPSTREAM_ACCOUNT_ARCHIVE_REPLAY_TARGETS: [&str; 3] = [
     HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_MINUTE,
 ];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HourlyRollupRefreshScope {
+    Full,
+    SkipActiveAccountActivityV2CoverageRepair,
+}
+
 pub(crate) async fn sync_hourly_rollups_from_live_tables(pool: &Pool<Sqlite>) -> Result<()> {
-    sync_hourly_rollups_from_live_tables_with_parallel_work_coverage(pool, None).await
+    sync_hourly_rollups_from_live_tables_with_scope(pool, None, HourlyRollupRefreshScope::Full)
+        .await
 }
 
 pub(crate) async fn sync_hourly_rollups_from_live_tables_with_parallel_work_coverage(
     pool: &Pool<Sqlite>,
     invocation_live_days: Option<u64>,
 ) -> Result<()> {
+    sync_hourly_rollups_from_live_tables_with_scope(
+        pool,
+        invocation_live_days,
+        HourlyRollupRefreshScope::Full,
+    )
+    .await
+}
+
+async fn sync_hourly_rollups_from_live_tables_with_scope(
+    pool: &Pool<Sqlite>,
+    invocation_live_days: Option<u64>,
+    scope: HourlyRollupRefreshScope,
+) -> Result<()> {
     let mut attempt = 1_u32;
     loop {
-        match sync_hourly_rollups_from_live_tables_once(pool, invocation_live_days).await {
+        match sync_hourly_rollups_from_live_tables_once(pool, invocation_live_days, scope).await {
             Ok(()) => return Ok(()),
             Err(err)
                 if attempt < LIVE_ROLLUP_LOCK_RETRY_MAX_ATTEMPTS
@@ -52,8 +72,11 @@ pub(crate) async fn sync_hourly_rollups_from_live_tables_with_parallel_work_cove
 async fn sync_hourly_rollups_from_live_tables_once(
     pool: &Pool<Sqlite>,
     invocation_live_days: Option<u64>,
+    scope: HourlyRollupRefreshScope,
 ) -> Result<()> {
-    repair_active_account_activity_v2_coverage(pool).await?;
+    if scope == HourlyRollupRefreshScope::Full {
+        repair_active_account_activity_v2_coverage(pool).await?;
+    }
     loop {
         let updated = replay_live_invocation_hourly_rollups(pool).await?;
         if updated == 0 {
@@ -2040,7 +2063,14 @@ pub(crate) async fn bootstrap_hourly_rollups_with_parallel_work_coverage(
 }
 
 pub(crate) async fn refresh_hourly_rollups_for_read_surfaces(pool: &Pool<Sqlite>) -> Result<()> {
-    sync_hourly_rollups_from_live_tables(pool).await?;
+    refresh_hourly_rollups_for_read_surfaces_with_scope(pool, HourlyRollupRefreshScope::Full).await
+}
+
+async fn refresh_hourly_rollups_for_read_surfaces_with_scope(
+    pool: &Pool<Sqlite>,
+    scope: HourlyRollupRefreshScope,
+) -> Result<()> {
+    sync_hourly_rollups_from_live_tables_with_scope(pool, None, scope).await?;
     ensure_invocation_summary_rollups_ready_best_effort(pool).await?;
     Ok(())
 }
@@ -2058,6 +2088,7 @@ pub(crate) async fn refresh_hourly_rollups_for_read_surfaces_best_effort(
     pool: &Pool<Sqlite>,
     hourly_rollup_sync_lock: &Mutex<()>,
     reason: &'static str,
+    scope: HourlyRollupRefreshScope,
 ) {
     let gate = crate::db_pressure::global_db_pressure_gate();
     let _permit = match gate.try_begin_background("hourly_rollup_refresh") {
@@ -2073,7 +2104,7 @@ pub(crate) async fn refresh_hourly_rollups_for_read_surfaces_best_effort(
     };
     let _guard = hourly_rollup_sync_lock.lock().await;
 
-    if let Err(err) = refresh_hourly_rollups_for_read_surfaces(pool).await {
+    if let Err(err) = refresh_hourly_rollups_for_read_surfaces_with_scope(pool, scope).await {
         gate.record_error("hourly_rollup_refresh", &err);
         warn!(
             error = %err,

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -1958,6 +1958,14 @@ mod hourly_rollup_budget_tests {
     }
 
     #[test]
+    fn runtime_startup_bootstrap_leaves_active_coverage_to_the_dedicated_task() {
+        assert_eq!(
+            runtime_startup_hourly_rollup_refresh_scope(),
+            HourlyRollupRefreshScope::SkipActiveAccountActivityV2CoverageRepair
+        );
+    }
+
+    #[test]
     fn historical_rollup_elapsed_budget_reached_respects_unbounded_mode() {
         assert!(!historical_rollup_elapsed_budget_reached(
             Instant::now(),
@@ -2039,12 +2047,34 @@ pub(crate) async fn bootstrap_hourly_rollups_with_parallel_work_coverage(
     pool: &Pool<Sqlite>,
     invocation_full_detail_days: Option<u64>,
 ) -> Result<()> {
-    repair_live_invocation_usage_breakdown_rollups(pool).await?;
-    sync_hourly_rollups_from_live_tables_with_parallel_work_coverage(
+    bootstrap_hourly_rollups_with_scope(
         pool,
         invocation_full_detail_days,
+        HourlyRollupRefreshScope::Full,
     )
-    .await?;
+    .await
+}
+
+pub(crate) async fn bootstrap_hourly_rollups_for_runtime_startup(
+    pool: &Pool<Sqlite>,
+    invocation_full_detail_days: Option<u64>,
+) -> Result<()> {
+    bootstrap_hourly_rollups_with_scope(
+        pool,
+        invocation_full_detail_days,
+        runtime_startup_hourly_rollup_refresh_scope(),
+    )
+    .await
+}
+
+async fn bootstrap_hourly_rollups_with_scope(
+    pool: &Pool<Sqlite>,
+    invocation_full_detail_days: Option<u64>,
+    scope: HourlyRollupRefreshScope,
+) -> Result<()> {
+    repair_live_invocation_usage_breakdown_rollups(pool).await?;
+    sync_hourly_rollups_from_live_tables_with_scope(pool, invocation_full_detail_days, scope)
+        .await?;
     repair_materialized_invocation_archive_usage_breakdown_backfill_state(pool).await?;
     repair_materialized_upstream_account_archive_markers(pool).await?;
     let account_stats_hourly_count: i64 =
@@ -2060,6 +2090,12 @@ pub(crate) async fn bootstrap_hourly_rollups_with_parallel_work_coverage(
         repair_materialized_upstream_account_archive_markers(pool).await?;
     }
     Ok(())
+}
+
+fn runtime_startup_hourly_rollup_refresh_scope() -> HourlyRollupRefreshScope {
+    // The dedicated startup task owns active-window coverage and its backoff.
+    // Bootstrap still catches up rollups, but must not run that planner twice.
+    HourlyRollupRefreshScope::SkipActiveAccountActivityV2CoverageRepair
 }
 
 pub(crate) async fn refresh_hourly_rollups_for_read_surfaces(pool: &Pool<Sqlite>) -> Result<()> {

--- a/src/maintenance/hourly_rollups.rs
+++ b/src/maintenance/hourly_rollups.rs
@@ -81,7 +81,7 @@ async fn sync_hourly_rollups_from_live_tables_once(
         }
     }
     let repaired_activity_v2_rows = repair_live_invocation_account_activity_v2_once(pool).await?;
-    wake_historical_rollups_for_live_activity_v2_coverage(pool, repaired_activity_v2_rows).await?;
+    wake_account_activity_v2_coverage_repair(pool, repaired_activity_v2_rows).await?;
     if let Some(days) = invocation_live_days {
         maintain_parallel_work_rollups(pool, Some(shanghai_retention_cutoff(days).timestamp()))
             .await?;
@@ -89,17 +89,13 @@ async fn sync_hourly_rollups_from_live_tables_once(
     Ok(())
 }
 
-pub(crate) async fn wake_historical_rollups_for_live_activity_v2_coverage(
+pub(crate) async fn wake_account_activity_v2_coverage_repair(
     pool: &Pool<Sqlite>,
     repaired_activity_v2_rows: u64,
 ) -> Result<()> {
     if repaired_activity_v2_rows > 0 {
-        wake_startup_backfill_tasks(
-            pool,
-            &[StartupBackfillTask::HistoricalRollups],
-            "live_account_activity_v2_coverage_updated",
-        )
-        .await?;
+        wake_startup_backfill_coverage_repair(pool, "live_account_activity_v2_coverage_updated")
+            .await?;
     }
     Ok(())
 }

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -2,6 +2,7 @@ use super::*;
 
 const STARTUP_HISTORICAL_ROLLUP_PRIORITY_BATCH_LIMIT: u64 = 2;
 const STARTUP_HISTORICAL_ROLLUP_PRIORITY_BUDGET_SECS: u64 = 6;
+const COVERAGE_REPAIR_RETRY_DELAYS_SECS: [u64; 4] = [15, 60, 5 * 60, 15 * 60];
 
 pub(crate) fn push_backfill_sample(samples: &mut Vec<String>, sample: String) {
     if samples.len() < STARTUP_BACKFILL_LOG_SAMPLE_LIMIT {
@@ -882,6 +883,54 @@ pub(crate) async fn defer_startup_backfill_task(
     Ok(())
 }
 
+pub(crate) fn coverage_repair_retry_delay(retry_generation: u32) -> Duration {
+    let index = retry_generation.saturating_sub(1) as usize;
+    Duration::from_secs(
+        COVERAGE_REPAIR_RETRY_DELAYS_SECS[index.min(COVERAGE_REPAIR_RETRY_DELAYS_SECS.len() - 1)],
+    )
+}
+
+pub(crate) async fn defer_startup_backfill_coverage_repair(state: &AppState) -> Result<()> {
+    let task = StartupBackfillTask::HistoricalRollups;
+    let task_name = startup_backfill_task_progress_key(state, task).await;
+    let progress = load_startup_backfill_progress(&state.pool, &task_name).await?;
+    let retry_generation = progress.zero_update_streak.saturating_add(1);
+    let delay = coverage_repair_retry_delay(retry_generation);
+    let retry_after = Utc::now() + ChronoDuration::from_std(delay).unwrap_or_default();
+    let retry_after = format_utc_iso(retry_after);
+    save_startup_backfill_progress(
+        &state.pool,
+        &task_name,
+        StartupBackfillProgressUpdate {
+            cursor_id: progress.cursor_id,
+            scanned: progress.last_scanned,
+            updated: progress.last_updated,
+            zero_update_streak: retry_generation,
+            next_run_after: &retry_after,
+            status: &progress.last_status,
+            suspension_reason: progress.suspension_reason.as_deref(),
+        },
+    )
+    .await?;
+    let retry_at = parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now);
+    STARTUP_BACKFILL_SCHEDULER.record_next_due(task, retry_at);
+    let backoff_stage = match delay.as_secs() {
+        0..=15 => "15s",
+        16..=60 => "1m",
+        61..=300 => "5m",
+        _ => "15m",
+    };
+    info!(
+        task = task.log_label(),
+        next_retry_after = %retry_after,
+        retry_generation,
+        backoff_stage,
+        wake_reason = "coverage_repair_retry",
+        "startup backfill coverage repair retry scheduled"
+    );
+    Ok(())
+}
+
 pub(crate) async fn run_startup_backfill_maintenance_pass(
     state: Arc<AppState>,
     cancel: &CancellationToken,
@@ -1004,14 +1053,7 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             | ActiveAccountActivityV2RepairResult::Failed) => {
                 let failed = matches!(outcome, ActiveAccountActivityV2RepairResult::Failed);
                 had_failure |= failed;
-                if let Err(err) = defer_startup_backfill_task(
-                    state.as_ref(),
-                    StartupBackfillTask::HistoricalRollups,
-                    Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS),
-                    "coverage_repair_retry",
-                )
-                .await
-                {
+                if let Err(err) = defer_startup_backfill_coverage_repair(state.as_ref()).await {
                     had_failure = true;
                     STARTUP_BACKFILL_SCHEDULER.record_task_result(
                         StartupBackfillTask::HistoricalRollups,

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -931,6 +931,58 @@ pub(crate) async fn defer_startup_backfill_coverage_repair(state: &AppState) -> 
     Ok(())
 }
 
+pub(crate) async fn record_startup_backfill_coverage_repair_progress(
+    state: &AppState,
+    outcome: ActiveAccountActivityV2RepairOutcome,
+) -> Result<()> {
+    if outcome.repaired_bucket_count == 0 {
+        return Ok(());
+    }
+
+    let task = StartupBackfillTask::HistoricalRollups;
+    let task_name = startup_backfill_task_progress_key(state, task).await;
+    let progress = load_startup_backfill_progress(&state.pool, &task_name).await?;
+    if progress.last_status == STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE {
+        debug!(
+            task = task.log_label(),
+            coverage_priority_bucket_count = outcome.priority_bucket_count,
+            repaired_bucket_count = outcome.repaired_bucket_count,
+            "coverage repair made progress without waking a source-unavailable historical backfill"
+        );
+        return Ok(());
+    }
+    let retry_after = format_utc_iso(
+        Utc::now() + ChronoDuration::seconds(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS as i64),
+    );
+    save_startup_backfill_progress(
+        &state.pool,
+        &task_name,
+        StartupBackfillProgressUpdate {
+            cursor_id: progress.cursor_id,
+            scanned: progress.last_scanned,
+            updated: progress.last_updated,
+            zero_update_streak: 0,
+            next_run_after: &retry_after,
+            status: STARTUP_BACKFILL_STATUS_OK,
+            suspension_reason: None,
+        },
+    )
+    .await?;
+    let retry_at = parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now);
+    STARTUP_BACKFILL_SCHEDULER.record_next_due(task, retry_at);
+    info!(
+        task = task.log_label(),
+        coverage_priority_bucket_count = outcome.priority_bucket_count,
+        repaired_bucket_count = outcome.repaired_bucket_count,
+        next_retry_after = %retry_after,
+        retry_generation = 0_u32,
+        backoff_stage = "15s",
+        wake_reason = "coverage_repair_progress",
+        "startup backfill coverage repair progress reset its retry backoff"
+    );
+    Ok(())
+}
+
 pub(crate) async fn run_startup_backfill_maintenance_pass(
     state: Arc<AppState>,
     cancel: &CancellationToken,
@@ -1042,12 +1094,27 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
         match repair_outcome {
             ActiveAccountActivityV2RepairResult::Repaired(outcome) => {
                 ran_actionable_task |= outcome.repaired_bucket_count > 0;
-                STARTUP_BACKFILL_SCHEDULER.record_coverage_repair_success(
-                    StartupBackfillTask::HistoricalRollups,
-                    historical_rollup_task_completed,
-                    historical_rollup_task_failed,
-                    historical_rollup_task_deferred,
-                );
+                match record_startup_backfill_coverage_repair_progress(state.as_ref(), outcome)
+                    .await
+                {
+                    Ok(()) => STARTUP_BACKFILL_SCHEDULER.record_coverage_repair_success(
+                        StartupBackfillTask::HistoricalRollups,
+                        historical_rollup_task_completed,
+                        historical_rollup_task_failed,
+                        historical_rollup_task_deferred,
+                    ),
+                    Err(err) => {
+                        had_failure = true;
+                        STARTUP_BACKFILL_SCHEDULER.record_task_result(
+                            StartupBackfillTask::HistoricalRollups,
+                            true,
+                            false,
+                        );
+                        crate::db_pressure::global_db_pressure_gate()
+                            .record_error("startup_backfill_coverage_progress", &err);
+                        warn!(error = %err, "failed to persist startup backfill coverage repair progress");
+                    }
+                }
             }
             outcome @ (ActiveAccountActivityV2RepairResult::Deferred
             | ActiveAccountActivityV2RepairResult::Failed) => {

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -960,6 +960,20 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
 ) -> Result<u64> {
     let task = StartupBackfillTask::AccountActivityV2Coverage;
     let task_name = task.name();
+    let progress = load_startup_backfill_progress(pool, task_name).await?;
+    let backoff_preserved = progress.zero_update_streak > 0 && !progress.is_due(Utc::now());
+    if backoff_preserved {
+        STARTUP_BACKFILL_SCHEDULER.record_next_due(task, startup_backfill_progress_due(&progress));
+        info!(
+            task = task.log_label(),
+            wake_reason,
+            backoff_preserved,
+            retry_generation = progress.zero_update_streak,
+            "kept account activity v2 coverage repair on its active retry deadline"
+        );
+        return Ok(progress.wake_generation);
+    }
+
     sqlx::query(
         r#"
         INSERT INTO startup_backfill_progress (
@@ -997,12 +1011,7 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
     .await?;
 
     let progress = load_startup_backfill_progress(pool, task_name).await?;
-    let backoff_preserved = progress.zero_update_streak > 0 && !progress.is_due(Utc::now());
-    if backoff_preserved {
-        STARTUP_BACKFILL_SCHEDULER.record_next_due(task, startup_backfill_progress_due(&progress));
-    } else {
-        STARTUP_BACKFILL_SCHEDULER.wake(task);
-    }
+    STARTUP_BACKFILL_SCHEDULER.wake(task);
     info!(
         task = task.log_label(),
         wake_reason,
@@ -1011,6 +1020,16 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
         "woke account activity v2 coverage repair"
     );
     Ok(progress.wake_generation)
+}
+
+fn startup_backfill_hourly_rollup_refresh_scope(
+    ran_account_activity_v2_coverage_repair: bool,
+) -> HourlyRollupRefreshScope {
+    if ran_account_activity_v2_coverage_repair {
+        HourlyRollupRefreshScope::SkipActiveAccountActivityV2CoverageRepair
+    } else {
+        HourlyRollupRefreshScope::Full
+    }
 }
 
 async fn run_startup_backfill_coverage_repair_if_due(
@@ -1114,6 +1133,7 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
 ) -> StartupBackfillMaintenancePass {
     let mut had_failure = false;
     let mut ran_actionable_task = false;
+    let mut ran_account_activity_v2_coverage_repair = false;
     let mut had_deferred_task = false;
     let tasks = match selected_tasks {
         Some(tasks) => tasks,
@@ -1146,6 +1166,8 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             Ok(outcome) => {
                 STARTUP_BACKFILL_SCHEDULER.record_next_due(*task, outcome.next_due);
                 ran_actionable_task |= outcome.actionable;
+                ran_account_activity_v2_coverage_repair |=
+                    *task == StartupBackfillTask::AccountActivityV2Coverage && outcome.actionable;
                 had_failure |= outcome.failed;
                 had_deferred_task |= outcome.deferred;
                 if outcome.completed {
@@ -1172,10 +1194,13 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
     }
 
     if ran_actionable_task {
+        let refresh_scope =
+            startup_backfill_hourly_rollup_refresh_scope(ran_account_activity_v2_coverage_repair);
         refresh_hourly_rollups_for_read_surfaces_best_effort(
             &state.pool,
             state.hourly_rollup_sync_lock.as_ref(),
             "startup backfill maintenance pass",
+            refresh_scope,
         )
         .await;
         if !cancel.is_cancelled() {
@@ -2084,6 +2109,18 @@ mod startup_backfill_tests {
         assert_eq!(health.state, "degraded");
         assert_eq!(health.failed_task_count, 1);
         assert_eq!(health.pressure_defer_count, 1);
+    }
+
+    #[test]
+    fn coverage_repair_does_not_repeat_its_planner_in_the_following_hourly_refresh() {
+        assert_eq!(
+            startup_backfill_hourly_rollup_refresh_scope(true),
+            HourlyRollupRefreshScope::SkipActiveAccountActivityV2CoverageRepair
+        );
+        assert_eq!(
+            startup_backfill_hourly_rollup_refresh_scope(false),
+            HourlyRollupRefreshScope::Full
+        );
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -961,15 +961,16 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
     let task = StartupBackfillTask::AccountActivityV2Coverage;
     let task_name = task.name();
     let progress = load_startup_backfill_progress(pool, task_name).await?;
-    let backoff_preserved = progress.zero_update_streak > 0 && !progress.is_due(Utc::now());
-    if backoff_preserved {
+    let deadline_preserved = !progress.is_due(Utc::now())
+        && (progress.zero_update_streak > 0 || progress.last_status == STARTUP_BACKFILL_STATUS_OK);
+    if deadline_preserved {
         STARTUP_BACKFILL_SCHEDULER.record_next_due(task, startup_backfill_progress_due(&progress));
         info!(
             task = task.log_label(),
             wake_reason,
-            backoff_preserved,
+            deadline_preserved,
             retry_generation = progress.zero_update_streak,
-            "kept account activity v2 coverage repair on its active retry deadline"
+            "kept account activity v2 coverage repair on its active follow-up deadline"
         );
         return Ok(progress.wake_generation);
     }
@@ -1015,21 +1016,17 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
     info!(
         task = task.log_label(),
         wake_reason,
-        backoff_preserved,
+        deadline_preserved,
         retry_generation = progress.zero_update_streak,
         "woke account activity v2 coverage repair"
     );
     Ok(progress.wake_generation)
 }
 
-fn startup_backfill_hourly_rollup_refresh_scope(
-    ran_account_activity_v2_coverage_repair: bool,
-) -> HourlyRollupRefreshScope {
-    if ran_account_activity_v2_coverage_repair {
-        HourlyRollupRefreshScope::SkipActiveAccountActivityV2CoverageRepair
-    } else {
-        HourlyRollupRefreshScope::Full
-    }
+fn startup_backfill_hourly_rollup_refresh_scope() -> HourlyRollupRefreshScope {
+    // The dedicated coverage task owns the active-window planner and its retry
+    // deadline. Generic backfill refreshes must never re-enter that planner.
+    HourlyRollupRefreshScope::SkipActiveAccountActivityV2CoverageRepair
 }
 
 async fn run_startup_backfill_coverage_repair_if_due(
@@ -1133,7 +1130,6 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
 ) -> StartupBackfillMaintenancePass {
     let mut had_failure = false;
     let mut ran_actionable_task = false;
-    let mut ran_account_activity_v2_coverage_repair = false;
     let mut had_deferred_task = false;
     let tasks = match selected_tasks {
         Some(tasks) => tasks,
@@ -1166,8 +1162,6 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             Ok(outcome) => {
                 STARTUP_BACKFILL_SCHEDULER.record_next_due(*task, outcome.next_due);
                 ran_actionable_task |= outcome.actionable;
-                ran_account_activity_v2_coverage_repair |=
-                    *task == StartupBackfillTask::AccountActivityV2Coverage && outcome.actionable;
                 had_failure |= outcome.failed;
                 had_deferred_task |= outcome.deferred;
                 if outcome.completed {
@@ -1194,13 +1188,11 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
     }
 
     if ran_actionable_task {
-        let refresh_scope =
-            startup_backfill_hourly_rollup_refresh_scope(ran_account_activity_v2_coverage_repair);
         refresh_hourly_rollups_for_read_surfaces_best_effort(
             &state.pool,
             state.hourly_rollup_sync_lock.as_ref(),
             "startup backfill maintenance pass",
-            refresh_scope,
+            startup_backfill_hourly_rollup_refresh_scope(),
         )
         .await;
         if !cancel.is_cancelled() {
@@ -2114,12 +2106,8 @@ mod startup_backfill_tests {
     #[test]
     fn coverage_repair_does_not_repeat_its_planner_in_the_following_hourly_refresh() {
         assert_eq!(
-            startup_backfill_hourly_rollup_refresh_scope(true),
+            startup_backfill_hourly_rollup_refresh_scope(),
             HourlyRollupRefreshScope::SkipActiveAccountActivityV2CoverageRepair
-        );
-        assert_eq!(
-            startup_backfill_hourly_rollup_refresh_scope(false),
-            HourlyRollupRefreshScope::Full
         );
     }
 

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -24,6 +24,7 @@ pub(crate) enum StartupBackfillTask {
     UpstreamActivityLive,
     UpstreamActivityArchives,
     PoolUpstreamNodeHealthArchives,
+    AccountActivityV2Coverage,
     HistoricalRollups,
 }
 
@@ -158,21 +159,6 @@ impl StartupBackfillScheduler {
         self.noop_suppressed_count.fetch_add(1, Ordering::Relaxed);
     }
 
-    fn record_coverage_repair_success(
-        &self,
-        task: StartupBackfillTask,
-        task_completed_in_current_pass: bool,
-        task_failed_in_current_pass: bool,
-        task_deferred_in_current_pass: bool,
-    ) {
-        if task_completed_in_current_pass
-            && !task_failed_in_current_pass
-            && !task_deferred_in_current_pass
-        {
-            self.record_task_result(task, false, false);
-        }
-    }
-
     fn health_snapshot(&self) -> StartupBackfillHealthSnapshot {
         let woken_task_count = self
             .woken_tasks
@@ -281,6 +267,7 @@ impl StartupBackfillTask {
             Self::UpstreamActivityLive,
             Self::UpstreamActivityArchives,
             Self::PoolUpstreamNodeHealthArchives,
+            Self::AccountActivityV2Coverage,
             Self::HistoricalRollups,
         ]
     }
@@ -303,6 +290,7 @@ impl StartupBackfillTask {
             Self::PoolUpstreamNodeHealthArchives => {
                 STARTUP_BACKFILL_TASK_POOL_UPSTREAM_NODE_HEALTH_ARCHIVES
             }
+            Self::AccountActivityV2Coverage => STARTUP_BACKFILL_TASK_ACCOUNT_ACTIVITY_V2_COVERAGE,
             Self::HistoricalRollups => STARTUP_BACKFILL_TASK_HISTORICAL_ROLLUPS,
         }
     }
@@ -321,6 +309,7 @@ impl StartupBackfillTask {
             Self::UpstreamActivityLive => "upstream activity live rows",
             Self::UpstreamActivityArchives => "upstream activity archives",
             Self::PoolUpstreamNodeHealthArchives => "pool upstream node health archives",
+            Self::AccountActivityV2Coverage => "account activity v2 coverage repair",
             Self::HistoricalRollups => "historical rollup materialization",
         }
     }
@@ -837,17 +826,6 @@ pub(crate) struct StartupBackfillMaintenancePass {
     pub(crate) had_failure: bool,
 }
 
-fn selected_task_includes(
-    selected_tasks: Option<&[StartupBackfillTask]>,
-    task: StartupBackfillTask,
-) -> bool {
-    let tasks = match selected_tasks {
-        Some(tasks) => tasks,
-        None => StartupBackfillTask::ordered_tasks(),
-    };
-    tasks.contains(&task)
-}
-
 pub(crate) async fn defer_startup_backfill_task(
     state: &AppState,
     task: StartupBackfillTask,
@@ -890,8 +868,10 @@ pub(crate) fn coverage_repair_retry_delay(retry_generation: u32) -> Duration {
     )
 }
 
-pub(crate) async fn defer_startup_backfill_coverage_repair(state: &AppState) -> Result<()> {
-    let task = StartupBackfillTask::HistoricalRollups;
+pub(crate) async fn defer_startup_backfill_coverage_repair(
+    state: &AppState,
+) -> Result<DateTime<Utc>> {
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
     let task_name = startup_backfill_task_progress_key(state, task).await;
     let progress = load_startup_backfill_progress(&state.pool, &task_name).await?;
     let retry_generation = progress.zero_update_streak.saturating_add(1);
@@ -928,29 +908,20 @@ pub(crate) async fn defer_startup_backfill_coverage_repair(state: &AppState) -> 
         wake_reason = "coverage_repair_retry",
         "startup backfill coverage repair retry scheduled"
     );
-    Ok(())
+    Ok(retry_at)
 }
 
 pub(crate) async fn record_startup_backfill_coverage_repair_progress(
     state: &AppState,
     outcome: ActiveAccountActivityV2RepairOutcome,
-) -> Result<()> {
+) -> Result<DateTime<Utc>> {
     if outcome.repaired_bucket_count == 0 {
-        return Ok(());
+        return Ok(Utc::now());
     }
 
-    let task = StartupBackfillTask::HistoricalRollups;
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
     let task_name = startup_backfill_task_progress_key(state, task).await;
     let progress = load_startup_backfill_progress(&state.pool, &task_name).await?;
-    if progress.last_status == STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE {
-        debug!(
-            task = task.log_label(),
-            coverage_priority_bucket_count = outcome.priority_bucket_count,
-            repaired_bucket_count = outcome.repaired_bucket_count,
-            "coverage repair made progress without waking a source-unavailable historical backfill"
-        );
-        return Ok(());
-    }
     let retry_after = format_utc_iso(
         Utc::now() + ChronoDuration::seconds(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS as i64),
     );
@@ -980,7 +951,160 @@ pub(crate) async fn record_startup_backfill_coverage_repair_progress(
         wake_reason = "coverage_repair_progress",
         "startup backfill coverage repair progress reset its retry backoff"
     );
-    Ok(())
+    Ok(retry_at)
+}
+
+pub(crate) async fn wake_startup_backfill_coverage_repair(
+    pool: &Pool<Sqlite>,
+    wake_reason: &'static str,
+) -> Result<u64> {
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
+    let task_name = task.name();
+    sqlx::query(
+        r#"
+        INSERT INTO startup_backfill_progress (
+            task_name,
+            cursor_id,
+            next_run_after,
+            zero_update_streak,
+            last_started_at,
+            last_finished_at,
+            last_scanned,
+            last_updated,
+            last_status,
+            suspension_reason,
+            next_probe_at,
+            wake_generation
+        )
+        VALUES (?1, 0, NULL, 0, NULL, NULL, 0, 0, ?2, NULL, NULL, 1)
+        ON CONFLICT(task_name) DO UPDATE SET
+            next_run_after = CASE
+                WHEN startup_backfill_progress.zero_update_streak > 0
+                    THEN startup_backfill_progress.next_run_after
+                ELSE NULL
+            END,
+            last_status = CASE
+                WHEN startup_backfill_progress.zero_update_streak > 0
+                    THEN startup_backfill_progress.last_status
+                ELSE ?2
+            END,
+            wake_generation = startup_backfill_progress.wake_generation + 1
+        "#,
+    )
+    .bind(task_name)
+    .bind(STARTUP_BACKFILL_STATUS_IDLE)
+    .execute(pool)
+    .await?;
+
+    let progress = load_startup_backfill_progress(pool, task_name).await?;
+    let backoff_preserved = progress.zero_update_streak > 0 && !progress.is_due(Utc::now());
+    if backoff_preserved {
+        STARTUP_BACKFILL_SCHEDULER.record_next_due(task, startup_backfill_progress_due(&progress));
+    } else {
+        STARTUP_BACKFILL_SCHEDULER.wake(task);
+    }
+    info!(
+        task = task.log_label(),
+        wake_reason,
+        backoff_preserved,
+        retry_generation = progress.zero_update_streak,
+        "woke account activity v2 coverage repair"
+    );
+    Ok(progress.wake_generation)
+}
+
+async fn run_startup_backfill_coverage_repair_if_due(
+    state: &Arc<AppState>,
+) -> Result<StartupBackfillTaskRunOutcome> {
+    let repair_outcome = repair_active_account_activity_v2_coverage_best_effort(
+        &state.pool,
+        state.hourly_rollup_sync_lock.as_ref(),
+        "startup backfill account-activity coverage repair",
+    )
+    .await;
+    match repair_outcome {
+        ActiveAccountActivityV2RepairResult::Repaired(outcome)
+            if outcome.repaired_bucket_count > 0 =>
+        {
+            let next_due =
+                record_startup_backfill_coverage_repair_progress(state.as_ref(), outcome).await?;
+            Ok(StartupBackfillTaskRunOutcome {
+                actionable: true,
+                failed: false,
+                deferred: false,
+                completed: true,
+                next_due,
+            })
+        }
+        ActiveAccountActivityV2RepairResult::Repaired(outcome)
+            if outcome.priority_bucket_count > 0 =>
+        {
+            let next_due = defer_startup_backfill_coverage_repair(state.as_ref()).await?;
+            Ok(StartupBackfillTaskRunOutcome {
+                actionable: false,
+                failed: false,
+                deferred: true,
+                completed: true,
+                next_due,
+            })
+        }
+        ActiveAccountActivityV2RepairResult::Repaired(_) => {
+            let task = StartupBackfillTask::AccountActivityV2Coverage;
+            let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
+            let progress = load_startup_backfill_progress(&state.pool, &task_name).await?;
+            let next_retry_after = format_utc_iso(
+                Utc::now() + ChronoDuration::seconds(STARTUP_BACKFILL_IDLE_INTERVAL_SECS as i64),
+            );
+            save_startup_backfill_progress(
+                &state.pool,
+                &task_name,
+                StartupBackfillProgressUpdate {
+                    cursor_id: progress.cursor_id,
+                    scanned: progress.last_scanned,
+                    updated: progress.last_updated,
+                    zero_update_streak: 0,
+                    next_run_after: &next_retry_after,
+                    status: STARTUP_BACKFILL_STATUS_IDLE,
+                    suspension_reason: None,
+                },
+            )
+            .await?;
+            let next_due = parse_to_utc_datetime(&next_retry_after).unwrap_or_else(Utc::now);
+            STARTUP_BACKFILL_SCHEDULER.record_next_due(task, next_due);
+            debug!(
+                task = task.log_label(),
+                next_retry_after = %next_retry_after,
+                "account activity v2 coverage repair is idle"
+            );
+            Ok(StartupBackfillTaskRunOutcome {
+                actionable: false,
+                failed: false,
+                deferred: false,
+                completed: true,
+                next_due,
+            })
+        }
+        ActiveAccountActivityV2RepairResult::Deferred => {
+            let next_due = defer_startup_backfill_coverage_repair(state.as_ref()).await?;
+            Ok(StartupBackfillTaskRunOutcome {
+                actionable: false,
+                failed: false,
+                deferred: true,
+                completed: true,
+                next_due,
+            })
+        }
+        ActiveAccountActivityV2RepairResult::Failed => {
+            let next_due = defer_startup_backfill_coverage_repair(state.as_ref()).await?;
+            Ok(StartupBackfillTaskRunOutcome {
+                actionable: false,
+                failed: true,
+                deferred: false,
+                completed: true,
+                next_due,
+            })
+        }
+    }
 }
 
 pub(crate) async fn run_startup_backfill_maintenance_pass(
@@ -991,9 +1115,6 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
     let mut had_failure = false;
     let mut ran_actionable_task = false;
     let mut had_deferred_task = false;
-    let mut historical_rollup_task_completed = false;
-    let mut historical_rollup_task_failed = false;
-    let mut historical_rollup_task_deferred = false;
     let tasks = match selected_tasks {
         Some(tasks) => tasks,
         None => StartupBackfillTask::ordered_tasks(),
@@ -1027,11 +1148,6 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
                 ran_actionable_task |= outcome.actionable;
                 had_failure |= outcome.failed;
                 had_deferred_task |= outcome.deferred;
-                if *task == StartupBackfillTask::HistoricalRollups {
-                    historical_rollup_task_completed |= outcome.completed;
-                    historical_rollup_task_failed |= outcome.failed;
-                    historical_rollup_task_deferred |= outcome.deferred;
-                }
                 if outcome.completed {
                     STARTUP_BACKFILL_SCHEDULER.record_task_result(
                         *task,
@@ -1042,9 +1158,6 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             }
             Err(err) => {
                 had_failure = true;
-                if *task == StartupBackfillTask::HistoricalRollups {
-                    historical_rollup_task_failed = true;
-                }
                 STARTUP_BACKFILL_SCHEDULER.record_task_result(*task, true, false);
                 STARTUP_BACKFILL_SCHEDULER.record_next_due(
                     *task,
@@ -1076,74 +1189,6 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
                 crate::db_pressure::global_db_pressure_gate()
                     .record_error("parallel_work_rollup_maintenance", &err);
                 warn!(error = %err, "parallel-work rollup maintenance pass failed");
-            }
-        }
-    }
-
-    // Coverage repair belongs to the historical-rollup task. It remains bounded to two buckets
-    // and runs only during the initial pass or when that task is explicitly due or woken.
-    if !cancel.is_cancelled()
-        && selected_task_includes(selected_tasks, StartupBackfillTask::HistoricalRollups)
-    {
-        let repair_outcome = repair_active_account_activity_v2_coverage_best_effort(
-            &state.pool,
-            state.hourly_rollup_sync_lock.as_ref(),
-            "startup backfill historical-rollup coverage repair",
-        )
-        .await;
-        match repair_outcome {
-            ActiveAccountActivityV2RepairResult::Repaired(outcome) => {
-                ran_actionable_task |= outcome.repaired_bucket_count > 0;
-                match record_startup_backfill_coverage_repair_progress(state.as_ref(), outcome)
-                    .await
-                {
-                    Ok(()) => STARTUP_BACKFILL_SCHEDULER.record_coverage_repair_success(
-                        StartupBackfillTask::HistoricalRollups,
-                        historical_rollup_task_completed,
-                        historical_rollup_task_failed,
-                        historical_rollup_task_deferred,
-                    ),
-                    Err(err) => {
-                        had_failure = true;
-                        STARTUP_BACKFILL_SCHEDULER.record_task_result(
-                            StartupBackfillTask::HistoricalRollups,
-                            true,
-                            false,
-                        );
-                        crate::db_pressure::global_db_pressure_gate()
-                            .record_error("startup_backfill_coverage_progress", &err);
-                        warn!(error = %err, "failed to persist startup backfill coverage repair progress");
-                    }
-                }
-            }
-            outcome @ (ActiveAccountActivityV2RepairResult::Deferred
-            | ActiveAccountActivityV2RepairResult::Failed) => {
-                let failed = matches!(outcome, ActiveAccountActivityV2RepairResult::Failed);
-                had_failure |= failed;
-                if let Err(err) = defer_startup_backfill_coverage_repair(state.as_ref()).await {
-                    had_failure = true;
-                    STARTUP_BACKFILL_SCHEDULER.record_task_result(
-                        StartupBackfillTask::HistoricalRollups,
-                        true,
-                        false,
-                    );
-                    crate::db_pressure::global_db_pressure_gate()
-                        .record_error("startup_backfill_coverage_retry", &err);
-                    warn!(error = %err, "failed to schedule startup backfill coverage retry");
-                } else if failed {
-                    STARTUP_BACKFILL_SCHEDULER.record_task_result(
-                        StartupBackfillTask::HistoricalRollups,
-                        true,
-                        false,
-                    );
-                } else {
-                    had_deferred_task = true;
-                    STARTUP_BACKFILL_SCHEDULER.record_task_result(
-                        StartupBackfillTask::HistoricalRollups,
-                        false,
-                        true,
-                    );
-                }
             }
         }
     }
@@ -1258,6 +1303,10 @@ async fn run_startup_backfill_task_if_due_outcome(
             completed: false,
             next_due: startup_backfill_progress_due(&progress),
         });
+    }
+
+    if task == StartupBackfillTask::AccountActivityV2Coverage {
+        return run_startup_backfill_coverage_repair_if_due(state).await;
     }
 
     let _permit = match gate.try_begin_background("startup_backfill") {
@@ -1758,6 +1807,9 @@ pub(crate) async fn run_startup_backfill_task(
                 ),
             ))
         }
+        StartupBackfillTask::AccountActivityV2Coverage => Err(anyhow!(
+            "account activity v2 coverage repair must use its dedicated scheduler path"
+        )),
         StartupBackfillTask::HistoricalRollups => {
             let historical_elapsed_budget = startup_backfill_run_budget(source_unavailable_probe);
             let before =
@@ -2022,63 +2074,11 @@ mod startup_backfill_tests {
     }
 
     #[test]
-    fn coverage_repair_cannot_clear_a_same_pass_historical_rollup_failure() {
+    fn coverage_repair_health_is_independent_from_historical_rollups() {
         let scheduler = StartupBackfillScheduler::default();
         scheduler.record_task_result(StartupBackfillTask::HistoricalRollups, true, false);
 
-        scheduler.record_coverage_repair_success(
-            StartupBackfillTask::HistoricalRollups,
-            true,
-            true,
-            false,
-        );
-
-        let health = scheduler.health_snapshot();
-        assert_eq!(health.state, "degraded");
-        assert_eq!(health.failed_task_count, 1);
-    }
-
-    #[test]
-    fn coverage_repair_cannot_clear_a_same_pass_historical_rollup_deferral() {
-        let scheduler = StartupBackfillScheduler::default();
-        scheduler.record_task_result(StartupBackfillTask::HistoricalRollups, false, true);
-
-        scheduler.record_coverage_repair_success(
-            StartupBackfillTask::HistoricalRollups,
-            true,
-            false,
-            true,
-        );
-
-        let health = scheduler.health_snapshot();
-        assert_eq!(health.state, "deferred");
-        assert_eq!(health.deferred_task_count, 1);
-        assert_eq!(health.pressure_defer_count, 1);
-    }
-
-    #[test]
-    fn coverage_repair_cannot_clear_a_prior_historical_rollup_failure_when_not_due() {
-        let scheduler = StartupBackfillScheduler::default();
-        scheduler.record_task_result(StartupBackfillTask::HistoricalRollups, true, false);
-
-        scheduler.record_coverage_repair_success(
-            StartupBackfillTask::HistoricalRollups,
-            false,
-            false,
-            false,
-        );
-
-        let health = scheduler.health_snapshot();
-        assert_eq!(health.state, "degraded");
-        assert_eq!(health.failed_task_count, 1);
-    }
-
-    #[test]
-    fn deferred_coverage_repair_cannot_clear_an_active_historical_rollup_failure() {
-        let scheduler = StartupBackfillScheduler::default();
-        scheduler.record_task_result(StartupBackfillTask::HistoricalRollups, true, false);
-
-        scheduler.record_task_result(StartupBackfillTask::HistoricalRollups, false, true);
+        scheduler.record_task_result(StartupBackfillTask::AccountActivityV2Coverage, false, true);
 
         let health = scheduler.health_snapshot();
         assert_eq!(health.state, "degraded");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -49,11 +49,8 @@ pub(crate) async fn run() -> Result<()> {
     }
     if should_run_blocking_startup_hourly_rollup_bootstrap(&cli) {
         let rollup_bootstrap_started_at = Instant::now();
-        bootstrap_hourly_rollups_with_parallel_work_coverage(
-            &pool,
-            Some(config.invocation_max_days),
-        )
-        .await?;
+        bootstrap_hourly_rollups_for_runtime_startup(&pool, Some(config.invocation_max_days))
+            .await?;
         ensure_invocation_summary_rollups_ready_best_effort(&pool).await?;
         log_startup_phase("hourly_rollup_bootstrap", rollup_bootstrap_started_at);
     }

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1422,6 +1422,10 @@ async fn live_activity_v2_coverage_wake_preserves_an_active_retry_backoff() {
     .await
     .expect("seed active coverage retry backoff");
 
+    let before = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load active coverage retry before the live update");
+
     wake_account_activity_v2_coverage_repair(&state.pool, 1)
         .await
         .expect("record live coverage progress without bypassing the retry deadline");
@@ -1435,7 +1439,7 @@ async fn live_activity_v2_coverage_wake_preserves_an_active_retry_backoff() {
         Some(deferred_until.as_str())
     );
     assert!(!progress.is_due(Utc::now()));
-    assert!(progress.wake_generation > 0);
+    assert_eq!(progress.wake_generation, before.wake_generation);
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1232,14 +1232,9 @@ async fn coverage_repair_defer_persists_the_historical_retry_deadline() {
     .await;
     let task = StartupBackfillTask::HistoricalRollups;
 
-    defer_startup_backfill_task(
-        state.as_ref(),
-        task,
-        Duration::from_secs(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS),
-        "test_coverage_repair_retry",
-    )
-    .await
-    .expect("schedule the coverage repair retry");
+    defer_startup_backfill_coverage_repair(state.as_ref())
+        .await
+        .expect("schedule the coverage repair retry");
 
     let progress = load_startup_backfill_progress(&state.pool, task.name())
         .await
@@ -1252,6 +1247,19 @@ async fn coverage_repair_defer_persists_the_historical_retry_deadline() {
     assert!(retry_at > Utc::now());
     assert!(retry_at <= Utc::now() + ChronoDuration::seconds(30));
     assert!(!progress.is_due(Utc::now()));
+    assert_eq!(progress.zero_update_streak, 1);
+}
+
+#[test]
+fn coverage_repair_retry_backoff_is_bounded_and_exponential() {
+    assert_eq!(coverage_repair_retry_delay(1), Duration::from_secs(15));
+    assert_eq!(coverage_repair_retry_delay(2), Duration::from_secs(60));
+    assert_eq!(coverage_repair_retry_delay(3), Duration::from_secs(5 * 60));
+    assert_eq!(coverage_repair_retry_delay(4), Duration::from_secs(15 * 60));
+    assert_eq!(
+        coverage_repair_retry_delay(20),
+        Duration::from_secs(15 * 60)
+    );
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1250,6 +1250,104 @@ async fn coverage_repair_defer_persists_the_historical_retry_deadline() {
     assert_eq!(progress.zero_update_streak, 1);
 }
 
+#[tokio::test]
+async fn coverage_repair_progress_resets_the_historical_retry_backoff() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::HistoricalRollups;
+    let deferred_until = format_utc_iso(Utc::now() + ChronoDuration::minutes(15));
+    save_startup_backfill_progress(
+        &state.pool,
+        task.name(),
+        StartupBackfillProgressUpdate {
+            cursor_id: 7,
+            scanned: 11,
+            updated: 0,
+            zero_update_streak: 4,
+            next_run_after: &deferred_until,
+            status: STARTUP_BACKFILL_STATUS_OK,
+            suspension_reason: None,
+        },
+    )
+    .await
+    .expect("seed a deferred historical coverage repair");
+
+    record_startup_backfill_coverage_repair_progress(
+        state.as_ref(),
+        ActiveAccountActivityV2RepairOutcome {
+            priority_bucket_count: 2,
+            repaired_bucket_count: 2,
+            elapsed_ms: 1,
+        },
+    )
+    .await
+    .expect("record coverage repair progress");
+
+    let progress = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load coverage repair progress");
+    let retry_at = progress
+        .next_run_after
+        .as_deref()
+        .and_then(parse_to_utc_datetime)
+        .expect("coverage follow-up deadline");
+    assert_eq!(progress.zero_update_streak, 0);
+    assert_eq!(progress.last_status, STARTUP_BACKFILL_STATUS_OK);
+    assert!(retry_at > Utc::now());
+    assert!(retry_at <= Utc::now() + ChronoDuration::seconds(30));
+}
+
+#[tokio::test]
+async fn coverage_repair_progress_keeps_source_unavailable_backfill_suspended() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::HistoricalRollups;
+    let suspended_until = format_utc_iso(Utc::now() + ChronoDuration::hours(24));
+    save_startup_backfill_progress(
+        &state.pool,
+        task.name(),
+        StartupBackfillProgressUpdate {
+            cursor_id: 7,
+            scanned: 11,
+            updated: 0,
+            zero_update_streak: 4,
+            next_run_after: &suspended_until,
+            status: STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE,
+            suspension_reason: Some("source_unavailable"),
+        },
+    )
+    .await
+    .expect("seed a source-unavailable historical backfill");
+
+    record_startup_backfill_coverage_repair_progress(
+        state.as_ref(),
+        ActiveAccountActivityV2RepairOutcome {
+            priority_bucket_count: 2,
+            repaired_bucket_count: 2,
+            elapsed_ms: 1,
+        },
+    )
+    .await
+    .expect("retain the source-unavailable backfill suspension");
+
+    let progress = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load source-unavailable historical backfill");
+    assert_eq!(progress.zero_update_streak, 4);
+    assert_eq!(
+        progress.last_status,
+        STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE
+    );
+    assert_eq!(
+        progress.next_run_after.as_deref(),
+        Some(suspended_until.as_str())
+    );
+}
+
 #[test]
 fn coverage_repair_retry_backoff_is_bounded_and_exponential() {
     assert_eq!(coverage_repair_retry_delay(1), Duration::from_secs(15));

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1225,12 +1225,12 @@ async fn startup_backfill_pressure_defer_persists_a_retry_deadline() {
 }
 
 #[tokio::test]
-async fn coverage_repair_defer_persists_the_historical_retry_deadline() {
+async fn coverage_repair_defer_persists_its_own_retry_deadline() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
     )
     .await;
-    let task = StartupBackfillTask::HistoricalRollups;
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
 
     defer_startup_backfill_coverage_repair(state.as_ref())
         .await
@@ -1251,12 +1251,12 @@ async fn coverage_repair_defer_persists_the_historical_retry_deadline() {
 }
 
 #[tokio::test]
-async fn coverage_repair_progress_resets_the_historical_retry_backoff() {
+async fn coverage_repair_progress_resets_its_own_retry_backoff() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
     )
     .await;
-    let task = StartupBackfillTask::HistoricalRollups;
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
     let deferred_until = format_utc_iso(Utc::now() + ChronoDuration::minutes(15));
     save_startup_backfill_progress(
         &state.pool,
@@ -1272,7 +1272,7 @@ async fn coverage_repair_progress_resets_the_historical_retry_backoff() {
         },
     )
     .await
-    .expect("seed a deferred historical coverage repair");
+    .expect("seed a deferred coverage repair");
 
     record_startup_backfill_coverage_repair_progress(
         state.as_ref(),
@@ -1300,16 +1300,17 @@ async fn coverage_repair_progress_resets_the_historical_retry_backoff() {
 }
 
 #[tokio::test]
-async fn coverage_repair_progress_keeps_source_unavailable_backfill_suspended() {
+async fn coverage_repair_progress_does_not_wake_source_unavailable_historical_backfill() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
     )
     .await;
-    let task = StartupBackfillTask::HistoricalRollups;
+    let historical_task = StartupBackfillTask::HistoricalRollups;
+    let coverage_task = StartupBackfillTask::AccountActivityV2Coverage;
     let suspended_until = format_utc_iso(Utc::now() + ChronoDuration::hours(24));
     save_startup_backfill_progress(
         &state.pool,
-        task.name(),
+        historical_task.name(),
         StartupBackfillProgressUpdate {
             cursor_id: 7,
             scanned: 11,
@@ -1334,18 +1335,25 @@ async fn coverage_repair_progress_keeps_source_unavailable_backfill_suspended() 
     .await
     .expect("retain the source-unavailable backfill suspension");
 
-    let progress = load_startup_backfill_progress(&state.pool, task.name())
+    let historical_progress = load_startup_backfill_progress(&state.pool, historical_task.name())
         .await
         .expect("load source-unavailable historical backfill");
-    assert_eq!(progress.zero_update_streak, 4);
+    assert_eq!(historical_progress.zero_update_streak, 4);
     assert_eq!(
-        progress.last_status,
+        historical_progress.last_status,
         STARTUP_BACKFILL_STATUS_SOURCE_UNAVAILABLE
     );
     assert_eq!(
-        progress.next_run_after.as_deref(),
+        historical_progress.next_run_after.as_deref(),
         Some(suspended_until.as_str())
     );
+
+    let coverage_progress = load_startup_backfill_progress(&state.pool, coverage_task.name())
+        .await
+        .expect("load independent coverage repair progress");
+    assert_eq!(coverage_progress.zero_update_streak, 0);
+    assert_eq!(coverage_progress.last_status, STARTUP_BACKFILL_STATUS_OK);
+    assert!(!coverage_progress.is_due(Utc::now()));
 }
 
 #[test]
@@ -1361,14 +1369,14 @@ fn coverage_repair_retry_backoff_is_bounded_and_exponential() {
 }
 
 #[tokio::test]
-async fn live_activity_v2_coverage_progress_wakes_historical_rollups() {
+async fn live_activity_v2_coverage_progress_wakes_its_dedicated_repair_task() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
     )
     .await;
-    let task = StartupBackfillTask::HistoricalRollups;
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
 
-    wake_historical_rollups_for_live_activity_v2_coverage(&state.pool, 0)
+    wake_account_activity_v2_coverage_repair(&state.pool, 0)
         .await
         .expect("skip an unchanged live v2 coverage cursor");
     assert_eq!(
@@ -1379,7 +1387,7 @@ async fn live_activity_v2_coverage_progress_wakes_historical_rollups() {
         0
     );
 
-    wake_historical_rollups_for_live_activity_v2_coverage(&state.pool, 1)
+    wake_account_activity_v2_coverage_repair(&state.pool, 1)
         .await
         .expect("wake after live v2 coverage cursor progress");
 
@@ -1388,6 +1396,73 @@ async fn live_activity_v2_coverage_progress_wakes_historical_rollups() {
         .expect("load coverage-woken startup backfill progress");
     assert!(progress.wake_generation > 0);
     assert!(progress.is_due(Utc::now()));
+}
+
+#[tokio::test]
+async fn live_activity_v2_coverage_wake_preserves_an_active_retry_backoff() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
+    let deferred_until = format_utc_iso(Utc::now() + ChronoDuration::minutes(15));
+    save_startup_backfill_progress(
+        &state.pool,
+        task.name(),
+        StartupBackfillProgressUpdate {
+            cursor_id: 9,
+            scanned: 12,
+            updated: 0,
+            zero_update_streak: 4,
+            next_run_after: &deferred_until,
+            status: STARTUP_BACKFILL_STATUS_OK,
+            suspension_reason: None,
+        },
+    )
+    .await
+    .expect("seed active coverage retry backoff");
+
+    wake_account_activity_v2_coverage_repair(&state.pool, 1)
+        .await
+        .expect("record live coverage progress without bypassing the retry deadline");
+
+    let progress = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load preserved coverage retry progress");
+    assert_eq!(progress.zero_update_streak, 4);
+    assert_eq!(
+        progress.next_run_after.as_deref(),
+        Some(deferred_until.as_str())
+    );
+    assert!(!progress.is_due(Utc::now()));
+    assert!(progress.wake_generation > 0);
+}
+
+#[tokio::test]
+async fn idle_coverage_repair_persists_its_next_probe_deadline() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
+
+    let ran = run_startup_backfill_task_if_due(&state, task)
+        .await
+        .expect("run an idle coverage repair pass");
+    assert!(!ran);
+
+    let progress = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load idle coverage repair progress");
+    let next_due = progress
+        .next_run_after
+        .as_deref()
+        .and_then(parse_to_utc_datetime)
+        .expect("persisted idle coverage deadline");
+    assert_eq!(progress.last_status, STARTUP_BACKFILL_STATUS_IDLE);
+    assert_eq!(progress.zero_update_streak, 0);
+    assert!(next_due > Utc::now() + ChronoDuration::hours(5));
+    assert!(next_due <= Utc::now() + ChronoDuration::hours(7));
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -1443,6 +1443,42 @@ async fn live_activity_v2_coverage_wake_preserves_an_active_retry_backoff() {
 }
 
 #[tokio::test]
+async fn live_activity_v2_coverage_wake_preserves_a_success_follow_up_deadline() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::AccountActivityV2Coverage;
+
+    record_startup_backfill_coverage_repair_progress(
+        state.as_ref(),
+        ActiveAccountActivityV2RepairOutcome {
+            priority_bucket_count: 1,
+            repaired_bucket_count: 1,
+            elapsed_ms: 1,
+        },
+    )
+    .await
+    .expect("record successful coverage repair progress");
+    let before = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load scheduled coverage follow-up");
+
+    wake_account_activity_v2_coverage_repair(&state.pool, 1)
+        .await
+        .expect("keep the successful coverage follow-up deadline");
+
+    let progress = load_startup_backfill_progress(&state.pool, task.name())
+        .await
+        .expect("load preserved coverage follow-up");
+    assert_eq!(progress.zero_update_streak, 0);
+    assert_eq!(progress.last_status, STARTUP_BACKFILL_STATUS_OK);
+    assert_eq!(progress.next_run_after, before.next_run_after);
+    assert_eq!(progress.wake_generation, before.wake_generation);
+    assert!(!progress.is_due(Utc::now()));
+}
+
+#[tokio::test]
 async fn idle_coverage_repair_persists_its_next_probe_deadline() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),


### PR DESCRIPTION
## Summary
- Defers long-term dirty-date rebuilds and hourly retention pruning out of the terminal-driven 60-second path.
- Uses a bounded five-minute repair deadline for pending long-term repairs.
- Backs off repeated account activity v2 coverage repairs from 15 seconds to 1 minute, 5 minutes, and then 15 minutes.

## Production Evidence
- The current 101 logs show terminal-triggered long-term flushes reaching 36 seconds and repeated coverage queries every 15 seconds.
- This change targets only those two recurring maintenance paths; it does not change Dashboard, HTTP, SSE, or statistics contracts.

## Validation
- `cargo fmt --check`
- `cargo check --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Shared testbox source build: `.github/scripts/run-backend-tests.sh` (all profiles passed, 292 seconds)

Delivery role: direct

Spec: -
Spec Disposition: none
Solutions: -
Project Docs: -
Document sync: not applicable

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->