### PR TITLE
fix: govern system task run retention

### DIFF
--- a/docs/specs/9aucy-db-retention-archive/IMPLEMENTATION.md
+++ b/docs/specs/9aucy-db-retention-archive/IMPLEMENTATION.md
@@ -27,6 +27,7 @@
 - Note: startup persistent preparation does not hold a global background permit around nested retention writers. Each writer acquires its own maintenance admission, and a deferred pass remains eligible for the prompt retry schedule instead of being recorded as complete.
 - Note: raw-metrics inventory reset is resumable. The inventory worker checks for an interrupted `resetting` state and advances one pressure-gated reset batch before resuming normal inventory, so a restart or defer cannot strand the snapshot indefinitely.
 - Note: archive publication paths include a process-local monotonic suffix in addition to PID and timestamp, preventing parallel test or worker collisions when timestamp resolution is coarse.
+- Note: `system_task_runs` retention is part of the existing retention pass. It preserves running rows and the latest 200 rows per `(task_kind, status)`, deletes terminal history in 500-row transactions with a 5000-row pass ceiling, and uses a dedicated five-minute SQLite-pressure backoff without changing startup backfill scheduling.
 
 ## Verification
 

--- a/docs/specs/9aucy-db-retention-archive/SPEC.md
+++ b/docs/specs/9aucy-db-retention-archive/SPEC.md
@@ -31,6 +31,7 @@
 - retention 主库写入仲裁、可恢复微批与压力期公平调度，确保归档不会长期占用 SQLite 单写者。
 - 调用明细 30/90 天分层、月度 `sqlite.gz` 归档、manifest 校验、主库 purge、raw file 删除与 orphan sweep。
 - `forward_proxy_attempts` 与 `codex_quota_snapshots` 的在线保留、离线归档与压缩策略。
+- `system_task_runs` 的有界在线历史：运行中的行永不删除；每个 `(task_kind, status)` 的最新 200 行始终保留；`success`/`skipped` 保留 30 天且每类最多 5000 行，`failed` 保留 180 天且每类最多 10000 行。
 - `summary?window=all` / 总量统计的初始 `invocation_rollup_daily` 承接方案，以及后续迁移到 hourly rollups 前的兼容边界。
 - `README.md`、`docs/deployment.md`、`docs/specs/README.md` 与前端 `InvocationTable` 的契约更新。
 
@@ -129,6 +130,7 @@
 - live DB 与新创建 archive DB 均不再包含 `raw_expires_at`；历史 archive 文件保持只读兼容，不在本轮做离线 schema 重写。
 - 不得更改既有 `prompt_cache_rollup_hourly` 与 `prompt_cache_upstream_account_hourly` 的生命周期或会话查询语义；它们不是 parallel-work 活动分钟日均的分母来源。
 - 常驻任务只执行 `PRAGMA wal_checkpoint(PASSIVE)` 与 `PRAGMA optimize`；`VACUUM` 不放进周期任务，由 101 首次 backlog cleanup 完成后的维护窗口人工执行一次。
+- `system_task_runs` 只由 retention 主流程清理，不新增或改变 startup backfill 调度。每个删除事务最多 500 行、每个 pass 最多 5000 行，pass 间隔至少 15 秒；SQLite busy/locked 时该清理链退避 5 分钟。禁止对该表执行全量 `DELETE` 或 `VACUUM`。
 
 ## 验收标准（Acceptance Criteria）
 

--- a/docs/specs/s7m3q-system-workspace/IMPLEMENTATION.md
+++ b/docs/specs/s7m3q-system-workspace/IMPLEMENTATION.md
@@ -10,6 +10,7 @@
 - 新增 `system` 顶层工作区与四个子页：`状态 / 任务 / 设置 / 代理`。
 - 顶层导航由 `设置` 改为 `系统`，旧 `#/settings` 改为兼容跳转。
 - 新增系统状态接口与系统后台任务记录接口。
+- 系统任务列表保持既有 page/pageSize 语义，并增加以 `(startedAt, id)` 为锚点的 additive cursor 翻页；查询直接比较 UTC ISO 时间文本，schema 同时提供默认时间排序和 task/status 组合筛选排序索引。
 - 原 settings 页按职责拆分为通用设置页与 forward-proxy 页，同时继续复用现有设置数据模型与写接口。
 - 系统状态页 raw 统计已切换为真实磁盘文件口径，并拆分为 `raw / request / response` 三组指标。
 - raw 指标已改为持久化增量快照：legacy path 由有界 cursor 补齐，启动时一次性回填旧 invocation/attempt owner link，新写入通过 response/request blob link 增量发现；状态页请求只读快照，不再枚举全部 raw 路径或逐文件读取元数据。pressure defer 或后台失败状态保留在内存 health override，避免诊断写抢占 SQLite。

--- a/docs/specs/s7m3q-system-workspace/SPEC.md
+++ b/docs/specs/s7m3q-system-workspace/SPEC.md
@@ -107,6 +107,7 @@
   - `forward_proxy_subscription_refresh`
 - retention 任务摘要必须包含 raw compression / archive / prune 等关键计数，避免再拆单独任务调度器。
 - 列表至少支持任务类型、结果状态与时间范围的基础筛选。
+- 默认按 `startedAt DESC, id DESC` 排序。`GET /api/system/tasks` 保持 page/pageSize 响应和总数语义，additive 提供 `nextCursor`；cursor 是 base64url 编码的 `{startedAt,id}`，用于稳定的 keyset 翻页。cursor 不能与 `page > 1` 同时使用。
 
 ### `系统/设置`
 
@@ -139,6 +140,7 @@
 - Given 用户访问 `#/settings`，When 路由解析，Then 重定向到 `#/system/settings`。
 - Given `系统/状态` 页面加载，When 数据返回，Then 页面展示顶部项目磁盘总览、数据库记录概况、归档与逻辑体量三个结构，并包含刷新时间反馈。
 - Given `系统/任务` 页面加载，When 查询返回，Then 页面展示系统后台任务记录且不混入账号池维护事件。
+- Given 任务记录通过 page 或 cursor 连续翻页，When 记录开始时间相同，Then 以 `id` 打破顺序并且不重复、不漏项。
 - Given 用户进入 `系统/设置`，When 调整原有常规设置，Then 保存行为与旧设置页一致。
 - Given 用户进入 `系统/代理`，When 操作 forward proxy，Then 现有校验、测速、刷新订阅能力保持可用。
 

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -1,4 +1,5 @@
 use super::*;
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use tracing::{debug, warn};
@@ -260,6 +261,8 @@ pub(crate) struct SystemTaskRunsListResponse {
     pub(crate) total: u64,
     pub(crate) page: u32,
     pub(crate) page_size: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) next_cursor: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -272,6 +275,14 @@ pub(crate) struct SystemTaskRunsQuery {
     pub(crate) limit: Option<u32>,
     pub(crate) page: Option<u32>,
     pub(crate) page_size: Option<u32>,
+    pub(crate) cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SystemTaskRunCursor {
+    started_at: String,
+    id: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -377,6 +388,46 @@ pub(crate) fn parse_system_task_run_bound(
         .map_err(ApiError::bad_request)?
         .with_timezone(&Utc);
     Ok(Some(format_utc_iso(parsed)))
+}
+
+fn parse_system_task_run_cursor(
+    raw: Option<&str>,
+) -> Result<Option<SystemTaskRunCursor>, ApiError> {
+    let Some(raw_value) = normalize_query_text(raw) else {
+        return Ok(None);
+    };
+    let decoded = URL_SAFE_NO_PAD
+        .decode(raw_value)
+        .context("invalid cursor encoding")
+        .map_err(ApiError::bad_request)?;
+    let cursor = serde_json::from_slice::<SystemTaskRunCursor>(&decoded)
+        .context("invalid cursor payload")
+        .map_err(ApiError::bad_request)?;
+    if cursor.id < 1 {
+        return Err(ApiError::bad_request(anyhow!("invalid cursor id")));
+    }
+    let started_at = DateTime::parse_from_rfc3339(&cursor.started_at)
+        .context("invalid cursor startedAt")
+        .map_err(ApiError::bad_request)?
+        .with_timezone(&Utc);
+    Ok(Some(SystemTaskRunCursor {
+        started_at: format_utc_iso(started_at),
+        id: cursor.id,
+    }))
+}
+
+fn encode_system_task_run_cursor(row: &SystemTaskRunRow) -> Result<String, ApiError> {
+    let started_at = DateTime::parse_from_rfc3339(&row.started_at)
+        .context("system task run has a non-ISO started_at")
+        .map_err(ApiError::Internal)
+        .map(|value| format_utc_iso(value.with_timezone(&Utc)))?;
+    let payload = serde_json::to_vec(&SystemTaskRunCursor {
+        started_at,
+        id: row.id,
+    })
+    .context("failed to encode system task cursor")
+    .map_err(ApiError::Internal)?;
+    Ok(URL_SAFE_NO_PAD.encode(payload))
 }
 
 pub(crate) fn count_file_size(path: &Path) -> u64 {
@@ -1218,6 +1269,12 @@ pub(crate) async fn list_system_task_runs(
     let started_at_from =
         parse_system_task_run_bound(query.started_at_from.as_deref(), "startedAtFrom")?;
     let started_at_to = parse_system_task_run_bound(query.started_at_to.as_deref(), "startedAtTo")?;
+    let cursor = parse_system_task_run_cursor(query.cursor.as_deref())?;
+    if cursor.is_some() && query.page.unwrap_or(1) > 1 {
+        return Err(ApiError::bad_request(anyhow!(
+            "cursor cannot be combined with page greater than 1"
+        )));
+    }
     let page_size = query
         .page_size
         .unwrap_or(query.limit.unwrap_or(20))
@@ -1246,22 +1303,28 @@ pub(crate) async fn list_system_task_runs(
     }
     if let Some(started_at_from) = started_at_from.as_deref() {
         builder
-            .push(" AND datetime(started_at) >= datetime(")
-            .push_bind(started_at_from)
-            .push(")");
+            .push(" AND started_at >= ")
+            .push_bind(started_at_from);
     }
     if let Some(started_at_to) = started_at_to.as_deref() {
+        builder.push(" AND started_at <= ").push_bind(started_at_to);
+    }
+    if let Some(cursor) = cursor.as_ref() {
         builder
-            .push(" AND datetime(started_at) <= datetime(")
-            .push_bind(started_at_to)
-            .push(")");
+            .push(" AND (started_at < ")
+            .push_bind(&cursor.started_at)
+            .push(" OR (started_at = ")
+            .push_bind(&cursor.started_at)
+            .push(" AND id < ")
+            .push_bind(cursor.id)
+            .push("))");
     }
     builder
         .push(" ORDER BY started_at DESC, id DESC LIMIT ")
-        .push_bind(limit)
+        .push_bind(limit + 1)
         .push(" OFFSET ")
         .push_bind(offset);
-    let rows = builder
+    let mut rows = builder
         .build_query_as::<SystemTaskRunRow>()
         .fetch_all(&state.pool)
         .await?;
@@ -1286,26 +1349,34 @@ pub(crate) async fn list_system_task_runs(
     }
     if let Some(started_at_from) = started_at_from.as_deref() {
         count_builder
-            .push(" AND datetime(started_at) >= datetime(")
-            .push_bind(started_at_from)
-            .push(")");
+            .push(" AND started_at >= ")
+            .push_bind(started_at_from);
     }
     if let Some(started_at_to) = started_at_to.as_deref() {
         count_builder
-            .push(" AND datetime(started_at) <= datetime(")
-            .push_bind(started_at_to)
-            .push(")");
+            .push(" AND started_at <= ")
+            .push_bind(started_at_to);
     }
     let total = count_builder
         .build_query_scalar::<i64>()
         .fetch_one(&state.pool)
         .await?;
 
+    let has_next_page = rows.len() > page_size as usize;
+    if has_next_page {
+        rows.pop();
+    }
+    let next_cursor = has_next_page
+        .then(|| rows.last().map(encode_system_task_run_cursor))
+        .flatten()
+        .transpose()?;
+
     Ok(Json(SystemTaskRunsListResponse {
         items: rows.into_iter().map(Into::into).collect(),
         total: total.max(0) as u64,
         page,
         page_size,
+        next_cursor,
     }))
 }
 
@@ -1313,15 +1384,16 @@ pub(crate) fn summarize_retention_run_for_system_task(
     summary: &RetentionRunSummary,
 ) -> (String, String) {
     let brief = format!(
-        "compressed={} archived_invocations={} pruned_details={} model_routes_pruned={} orphan_raw_removed={}",
+        "compressed={} archived_invocations={} pruned_details={} model_routes_pruned={} task_runs_pruned={} orphan_raw_removed={}",
         summary.raw_files_compressed,
         summary.invocation_rows_archived,
         summary.invocation_details_pruned,
         summary.model_route_rows_pruned,
+        summary.system_task_run_rows_pruned,
         summary.orphan_raw_files_removed
     );
     let detail = format!(
-        "dry_run={} raw_candidates={} raw_compressed={} raw_bytes_before={} raw_bytes_after={} details_pruned={} invocation_rows_archived={} forward_proxy_attempt_rows_archived={} pool_attempt_rows_archived={} quota_rows_archived={} archive_batches_touched={} archive_batches_deleted={} raw_files_removed={} model_routes_pruned={} orphan_raw_files_removed={}",
+        "dry_run={} raw_candidates={} raw_compressed={} raw_bytes_before={} raw_bytes_after={} details_pruned={} invocation_rows_archived={} forward_proxy_attempt_rows_archived={} pool_attempt_rows_archived={} quota_rows_archived={} archive_batches_touched={} archive_batches_deleted={} raw_files_removed={} model_routes_pruned={} task_runs_pruned={} orphan_raw_files_removed={}",
         summary.dry_run,
         summary.raw_files_compression_candidates,
         summary.raw_files_compressed,
@@ -1336,6 +1408,7 @@ pub(crate) fn summarize_retention_run_for_system_task(
         summary.archive_batches_deleted,
         summary.raw_files_removed,
         summary.model_route_rows_pruned,
+        summary.system_task_run_rows_pruned,
         summary.orphan_raw_files_removed
     );
     (brief, detail)

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -1299,6 +1299,9 @@ pub(crate) async fn list_system_task_runs(
     {
         builder.push(" AND status = ").push_bind(status);
     }
+    if started_at_from.is_some() || started_at_to.is_some() {
+        builder.push(" AND started_at GLOB '????-??-??T??:??:??.???Z'");
+    }
     if let Some(started_at_from) = started_at_from.as_deref() {
         builder
             .push(" AND started_at >= ")
@@ -1344,6 +1347,9 @@ pub(crate) async fn list_system_task_runs(
         .filter(|value| !value.is_empty())
     {
         count_builder.push(" AND status = ").push_bind(status);
+    }
+    if started_at_from.is_some() || started_at_to.is_some() {
+        count_builder.push(" AND started_at GLOB '????-??-??T??:??:??.???Z'");
     }
     if let Some(started_at_from) = started_at_from.as_deref() {
         count_builder

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -407,20 +407,18 @@ fn parse_system_task_run_cursor(
         return Err(ApiError::bad_request(anyhow!("invalid cursor id")));
     }
     let started_at = DateTime::parse_from_rfc3339(&cursor.started_at)
-        .context("invalid cursor startedAt")
-        .map_err(ApiError::bad_request)?
-        .with_timezone(&Utc);
+        .map(|value| format_utc_iso_millis(value.with_timezone(&Utc)))
+        .unwrap_or(cursor.started_at);
     Ok(Some(SystemTaskRunCursor {
-        started_at: format_utc_iso_millis(started_at),
+        started_at,
         id: cursor.id,
     }))
 }
 
 fn encode_system_task_run_cursor(row: &SystemTaskRunRow) -> Result<String, ApiError> {
     let started_at = DateTime::parse_from_rfc3339(&row.started_at)
-        .context("system task run has a non-ISO started_at")
-        .map_err(ApiError::Internal)
-        .map(|value| format_utc_iso_millis(value.with_timezone(&Utc)))?;
+        .map(|value| format_utc_iso_millis(value.with_timezone(&Utc)))
+        .unwrap_or_else(|_| row.started_at.clone());
     let payload = serde_json::to_vec(&SystemTaskRunCursor {
         started_at,
         id: row.id,

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -1300,7 +1300,7 @@ pub(crate) async fn list_system_task_runs(
         builder.push(" AND status = ").push_bind(status);
     }
     if started_at_from.is_some() || started_at_to.is_some() {
-        builder.push(" AND started_at GLOB '????-??-??T??:??:??.???Z'");
+        builder.push(" AND strftime('%Y-%m-%dT%H:%M:%fZ', started_at) = started_at");
     }
     if let Some(started_at_from) = started_at_from.as_deref() {
         builder
@@ -1349,7 +1349,7 @@ pub(crate) async fn list_system_task_runs(
         count_builder.push(" AND status = ").push_bind(status);
     }
     if started_at_from.is_some() || started_at_to.is_some() {
-        count_builder.push(" AND started_at GLOB '????-??-??T??:??:??.???Z'");
+        count_builder.push(" AND strftime('%Y-%m-%dT%H:%M:%fZ', started_at) = started_at");
     }
     if let Some(started_at_from) = started_at_from.as_deref() {
         count_builder

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -387,7 +387,7 @@ pub(crate) fn parse_system_task_run_bound(
         .with_context(|| format!("invalid {field_name}: {raw_value}"))
         .map_err(ApiError::bad_request)?
         .with_timezone(&Utc);
-    Ok(Some(format_utc_iso(parsed)))
+    Ok(Some(format_utc_iso_millis(parsed)))
 }
 
 fn parse_system_task_run_cursor(
@@ -411,7 +411,7 @@ fn parse_system_task_run_cursor(
         .map_err(ApiError::bad_request)?
         .with_timezone(&Utc);
     Ok(Some(SystemTaskRunCursor {
-        started_at: format_utc_iso(started_at),
+        started_at: format_utc_iso_millis(started_at),
         id: cursor.id,
     }))
 }
@@ -420,7 +420,7 @@ fn encode_system_task_run_cursor(row: &SystemTaskRunRow) -> Result<String, ApiEr
     let started_at = DateTime::parse_from_rfc3339(&row.started_at)
         .context("system task run has a non-ISO started_at")
         .map_err(ApiError::Internal)
-        .map(|value| format_utc_iso(value.with_timezone(&Utc)))?;
+        .map(|value| format_utc_iso_millis(value.with_timezone(&Utc)))?;
     let payload = serde_json::to_vec(&SystemTaskRunCursor {
         started_at,
         id: row.id,
@@ -1149,7 +1149,7 @@ pub(crate) async fn begin_system_task_run(
     trigger_kind: impl Into<String>,
     summary: Option<String>,
 ) -> Result<SystemTaskRunHandle> {
-    let started_at = format_utc_iso(Utc::now());
+    let started_at = format_utc_iso_millis(Utc::now());
     let trigger_kind = trigger_kind.into();
     let id = sqlx::query_scalar::<_, i64>(
         r#"
@@ -1187,7 +1187,7 @@ pub(crate) async fn finish_system_task_run(
     summary: Option<String>,
     detail: Option<String>,
 ) {
-    let finished_at = format_utc_iso(Utc::now());
+    let finished_at = format_utc_iso_millis(Utc::now());
     let duration_ms = handle
         .started_at
         .elapsed()
@@ -1229,7 +1229,7 @@ pub(crate) async fn finish_system_task_run_batched(
     summary: Option<String>,
     detail: Option<String>,
 ) {
-    let finished_at = format_utc_iso(Utc::now());
+    let finished_at = format_utc_iso_millis(Utc::now());
     let duration_ms = handle
         .started_at
         .elapsed()

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -564,7 +564,7 @@ pub(crate) fn reset_system_task_run_retention_schedule() {
     SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS.store(0, Ordering::Release);
 }
 
-fn system_task_run_retention_handle_pressure(error: &anyhow::Error) -> bool {
+pub(crate) fn system_task_run_retention_handle_pressure(error: &anyhow::Error) -> bool {
     if !crate::db_pressure::is_db_pressure_error(error) {
         return false;
     }
@@ -573,6 +573,7 @@ fn system_task_run_retention_handle_pressure(error: &anyhow::Error) -> bool {
         now_epoch_ms,
         SYSTEM_TASK_RUN_RETENTION_PRESSURE_BACKOFF,
     );
+    retention_record_defer("system_task_run_retention", "sqlite_pressure");
     crate::db_pressure::global_db_pressure_gate().record_error("system_task_run_retention", error);
     retention_record_error("system_task_run_retention", error);
     warn!(error = %error, "system task run retention deferred after SQLite pressure");

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -1659,6 +1659,7 @@ pub(crate) async fn run_data_retention_maintenance(
     dry_run_override: Option<bool>,
     shutdown: Option<&CancellationToken>,
 ) -> Result<RetentionRunSummary> {
+    let dry_run = dry_run_override.unwrap_or(config.retention_dry_run);
     let defer_generation = retention_defer_generation();
     let result = if let Some(shutdown) = shutdown {
         RETENTION_SHUTDOWN
@@ -1675,10 +1676,24 @@ pub(crate) async fn run_data_retention_maintenance(
     } else {
         run_data_retention_maintenance_inner(pool, config, dry_run_override, None).await
     };
-    result.map(|mut summary| {
-        summary.deferred = retention_defer_generation() != defer_generation;
-        summary
-    })
+    // This janitor must run even when an earlier archive stage fails. Otherwise every
+    // failed pass adds a task-run record while the retention policy that bounds those
+    // records is unreachable until the unrelated failure clears.
+    let task_run_prune = prune_system_task_runs(pool, dry_run).await;
+    match result {
+        Ok(mut summary) => {
+            summary.system_task_run_rows_pruned +=
+                task_run_prune.context("failed to prune expired system task runs")?;
+            summary.deferred = retention_defer_generation() != defer_generation;
+            Ok(summary)
+        }
+        Err(error) => {
+            if let Err(prune_error) = task_run_prune {
+                warn!(error = %prune_error, "failed to prune system task runs after retention failure");
+            }
+            Err(error)
+        }
+    }
 }
 
 async fn run_data_retention_maintenance_inner(
@@ -1888,10 +1903,6 @@ async fn run_data_retention_maintenance_inner(
     if should_stop_data_retention_maintenance(shutdown) {
         return Ok(summary);
     }
-
-    summary.system_task_run_rows_pruned += prune_system_task_runs(pool, dry_run)
-        .await
-        .context("failed to prune expired system task runs")?;
 
     if !dry_run && summary.touched_anything() {
         run_best_effort_retention_pragma(

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -579,14 +579,23 @@ fn system_task_run_retention_handle_pressure(error: &anyhow::Error) -> bool {
     true
 }
 
+fn system_task_run_retention_admission_requires_pressure_backoff(
+    reason: Option<crate::db_pressure::DbPressureDenyReason>,
+) -> bool {
+    matches!(
+        reason,
+        Some(crate::db_pressure::DbPressureDenyReason::PressureCooldown { .. })
+    )
+}
+
 pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -> Result<usize> {
     let now_epoch_ms = system_task_run_retention_now_epoch_ms();
     if !system_task_run_retention_pass_is_due(now_epoch_ms) {
         return Ok(0);
     }
 
-    let success_cutoff = format_utc_iso(Utc::now() - ChronoDuration::days(30));
-    let failed_cutoff = format_utc_iso(Utc::now() - ChronoDuration::days(180));
+    let success_cutoff = format_utc_iso_millis(Utc::now() - ChronoDuration::days(30));
+    let failed_cutoff = format_utc_iso_millis(Utc::now() - ChronoDuration::days(180));
     if dry_run {
         let candidates: i64 = sqlx::query_scalar(
             r#"
@@ -680,6 +689,16 @@ pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -
     for candidates in candidates.chunks(SYSTEM_TASK_RUN_RETENTION_TERMINAL_BATCH_ROWS) {
         let Some(admission) = acquire_retention_write_admission("system_task_run_retention").await
         else {
+            // Admission can be denied before a SQL call observes the pressure error. A
+            // cooldown is distinct from shutdown or a normally busy background slot.
+            if system_task_run_retention_admission_requires_pressure_backoff(
+                crate::db_pressure::global_db_pressure_gate().background_deny_reason(),
+            ) {
+                system_task_run_retention_schedule_next(
+                    system_task_run_retention_now_epoch_ms(),
+                    SYSTEM_TASK_RUN_RETENTION_PRESSURE_BACKOFF,
+                );
+            }
             break;
         };
         let execute_started = Instant::now();
@@ -3685,6 +3704,21 @@ mod retention_write_budget_tests {
         let selected =
             take_retention_micro_batch(vec![2 * RETENTION_WRITE_MAX_BYTES, 128], |value| *value);
         assert_eq!(selected, vec![2 * RETENTION_WRITE_MAX_BYTES]);
+    }
+
+    #[test]
+    fn system_task_run_retention_only_backs_off_for_pressure_cooldown() {
+        assert!(
+            system_task_run_retention_admission_requires_pressure_backoff(Some(
+                crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms: 1 }
+            ))
+        );
+        assert!(
+            !system_task_run_retention_admission_requires_pressure_backoff(Some(
+                crate::db_pressure::DbPressureDenyReason::BackgroundBusy
+            ))
+        );
+        assert!(!system_task_run_retention_admission_requires_pressure_backoff(None));
     }
 }
 

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -1545,7 +1545,7 @@ pub(crate) async fn run_data_retention_maintenance_best_effort(
                 return false;
             }
             let touched_anything = summary.touched_anything();
-            if touched_anything {
+            if touched_anything && !summary.dry_run {
                 let task_run = begin_system_task_run(
                     &state.pool,
                     SystemTaskKind::RetentionArchive,
@@ -1613,23 +1613,25 @@ pub(crate) async fn run_data_retention_maintenance_best_effort(
             let pressure_error = crate::db_pressure::global_db_pressure_gate()
                 .record_error("data_retention_maintenance", &err);
             retention_record_error("data_retention_maintenance", &err);
-            let task_run = begin_system_task_run(
-                &state.pool,
-                SystemTaskKind::RetentionArchive,
-                trigger,
-                Some("retention maintenance failed".to_string()),
-            )
-            .await
-            .ok();
-            if let Some(handle) = task_run.as_ref() {
-                finish_system_task_run_batched(
-                    state.as_ref(),
-                    handle,
-                    SystemTaskStatus::Failed,
+            if !state.config.retention_dry_run {
+                let task_run = begin_system_task_run(
+                    &state.pool,
+                    SystemTaskKind::RetentionArchive,
+                    trigger,
                     Some("retention maintenance failed".to_string()),
-                    Some(err.to_string()),
                 )
-                .await;
+                .await
+                .ok();
+                if let Some(handle) = task_run.as_ref() {
+                    finish_system_task_run_batched(
+                        state.as_ref(),
+                        handle,
+                        SystemTaskStatus::Failed,
+                        Some("retention maintenance failed".to_string()),
+                        Some(err.to_string()),
+                    )
+                    .await;
+                }
             }
             warn!(trigger, error = %err, retry_soon = pressure_error, "failed to run retention maintenance");
             return !pressure_error;
@@ -1659,13 +1661,12 @@ pub(crate) async fn run_data_retention_maintenance(
     dry_run_override: Option<bool>,
     shutdown: Option<&CancellationToken>,
 ) -> Result<RetentionRunSummary> {
-    let dry_run = dry_run_override.unwrap_or(config.retention_dry_run);
     let defer_generation = retention_defer_generation();
     let result = if let Some(shutdown) = shutdown {
         RETENTION_SHUTDOWN
             .scope(
                 shutdown.clone(),
-                run_data_retention_maintenance_inner(
+                run_data_retention_maintenance_with_task_run_prune(
                     pool,
                     config,
                     dry_run_override,
@@ -1674,17 +1675,36 @@ pub(crate) async fn run_data_retention_maintenance(
             )
             .await
     } else {
-        run_data_retention_maintenance_inner(pool, config, dry_run_override, None).await
+        run_data_retention_maintenance_with_task_run_prune(pool, config, dry_run_override, None)
+            .await
     };
+    result.map(|mut summary| {
+        summary.deferred = retention_defer_generation() != defer_generation;
+        summary
+    })
+}
+
+async fn run_data_retention_maintenance_with_task_run_prune(
+    pool: &Pool<Sqlite>,
+    config: &AppConfig,
+    dry_run_override: Option<bool>,
+    shutdown: Option<&CancellationToken>,
+) -> Result<RetentionRunSummary> {
+    let dry_run = dry_run_override.unwrap_or(config.retention_dry_run);
+    let result =
+        run_data_retention_maintenance_inner(pool, config, dry_run_override, shutdown).await;
     // This janitor must run even when an earlier archive stage fails. Otherwise every
     // failed pass adds a task-run record while the retention policy that bounds those
     // records is unreachable until the unrelated failure clears.
-    let task_run_prune = prune_system_task_runs(pool, dry_run).await;
+    let task_run_prune = if should_stop_data_retention_maintenance(shutdown) {
+        Ok(0)
+    } else {
+        prune_system_task_runs(pool, dry_run).await
+    };
     match result {
         Ok(mut summary) => {
             summary.system_task_run_rows_pruned +=
                 task_run_prune.context("failed to prune expired system task runs")?;
-            summary.deferred = retention_defer_generation() != defer_generation;
             Ok(summary)
         }
         Err(error) => {

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -19,6 +19,7 @@ const SYSTEM_TASK_RUN_RETENTION_PASS_INTERVAL: Duration = Duration::from_secs(15
 const SYSTEM_TASK_RUN_RETENTION_PRESSURE_BACKOFF: Duration = Duration::from_secs(5 * 60);
 
 static SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS: AtomicU64 = AtomicU64::new(0);
+static SYSTEM_TASK_RUN_RETENTION_SCHEDULE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 tokio::task_local! {
     static RETENTION_SHUTDOWN: CancellationToken;
@@ -541,6 +542,9 @@ fn system_task_run_retention_schedule_next(now_epoch_ms: u64, delay: Duration) {
 }
 
 fn system_task_run_retention_pass_is_due(now_epoch_ms: u64) -> bool {
+    let _schedule_guard = SYSTEM_TASK_RUN_RETENTION_SCHEDULE_LOCK
+        .lock()
+        .expect("system task retention schedule lock");
     let next = SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS.load(Ordering::Acquire);
     if next > now_epoch_ms {
         return false;
@@ -561,6 +565,9 @@ fn system_task_run_retention_pass_is_due(now_epoch_ms: u64) -> bool {
 
 #[cfg(test)]
 pub(crate) fn reset_system_task_run_retention_schedule() {
+    let _schedule_guard = SYSTEM_TASK_RUN_RETENTION_SCHEDULE_LOCK
+        .lock()
+        .expect("system task retention schedule lock");
     SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS.store(0, Ordering::Release);
 }
 

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -587,13 +587,49 @@ pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -
 
     let success_cutoff = format_utc_iso(Utc::now() - ChronoDuration::days(30));
     let failed_cutoff = format_utc_iso(Utc::now() - ChronoDuration::days(180));
-    let mut pruned = 0usize;
-
-    while pruned < SYSTEM_TASK_RUN_RETENTION_MAX_ROWS_PER_PASS {
-        let batch_limit = SYSTEM_TASK_RUN_RETENTION_TERMINAL_BATCH_ROWS
-            .min(SYSTEM_TASK_RUN_RETENTION_MAX_ROWS_PER_PASS.saturating_sub(pruned));
-        let candidates = match sqlx::query_as::<_, SystemTaskRunRetentionCandidate>(
+    if dry_run {
+        let candidates: i64 = sqlx::query_scalar(
             r#"
+            WITH ranked AS (
+                SELECT
+                    task_kind,
+                    status,
+                    started_at,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY task_kind, status
+                        ORDER BY started_at DESC, id DESC
+                    ) AS retention_rank
+                FROM system_task_runs
+                WHERE status IN ('success', 'skipped', 'failed')
+            )
+            SELECT COUNT(*)
+            FROM ranked
+            WHERE retention_rank > ?1
+              AND (
+                  (status IN ('success', 'skipped')
+                    AND (started_at < ?2 OR retention_rank > 5000))
+                  OR (status = 'failed'
+                    AND (started_at < ?3 OR retention_rank > 10000))
+              )
+            "#,
+        )
+        .bind(SYSTEM_TASK_RUN_RETENTION_KEEP_RECENT)
+        .bind(&success_cutoff)
+        .bind(&failed_cutoff)
+        .fetch_one(pool)
+        .await
+        .map_err(anyhow::Error::from)
+        .or_else(|error| {
+            if system_task_run_retention_handle_pressure(&error) {
+                Ok(0)
+            } else {
+                Err(error.context("failed to count system task retention candidates"))
+            }
+        })?;
+        return Ok((candidates.max(0) as usize).min(SYSTEM_TASK_RUN_RETENTION_MAX_ROWS_PER_PASS));
+    }
+    let candidates = match sqlx::query_as::<_, SystemTaskRunRetentionCandidate>(
+        r#"
             WITH ranked AS (
                 SELECT
                     id,
@@ -619,34 +655,29 @@ pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -
             ORDER BY started_at ASC, id ASC
             LIMIT ?4
             "#,
-        )
-        .bind(SYSTEM_TASK_RUN_RETENTION_KEEP_RECENT)
-        .bind(&success_cutoff)
-        .bind(&failed_cutoff)
-        .bind(batch_limit as i64)
-        .fetch_all(pool)
-        .await
-        {
-            Ok(candidates) => candidates,
-            Err(error) => {
-                let error = anyhow::Error::from(error);
-                if system_task_run_retention_handle_pressure(&error) {
-                    return Ok(pruned);
-                }
-                return Err(error).context("failed to select system task retention candidates");
+    )
+    .bind(SYSTEM_TASK_RUN_RETENTION_KEEP_RECENT)
+    .bind(&success_cutoff)
+    .bind(&failed_cutoff)
+    .bind(SYSTEM_TASK_RUN_RETENTION_MAX_ROWS_PER_PASS as i64)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            let error = anyhow::Error::from(error);
+            if system_task_run_retention_handle_pressure(&error) {
+                return Ok(0);
             }
-        };
-        if candidates.is_empty() {
-            break;
+            return Err(error).context("failed to select system task retention candidates");
         }
-        if dry_run {
-            pruned += candidates.len();
-            if candidates.len() < batch_limit {
-                break;
-            }
-            continue;
-        }
+    };
+    if candidates.is_empty() {
+        return Ok(0);
+    }
 
+    let mut pruned = 0usize;
+    for candidates in candidates.chunks(SYSTEM_TASK_RUN_RETENTION_TERMINAL_BATCH_ROWS) {
         let Some(admission) = acquire_retention_write_admission("system_task_run_retention").await
         else {
             break;
@@ -699,10 +730,10 @@ pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -
             execute_started.elapsed(),
             Duration::ZERO,
             admission.p1_waiter_count(),
-            usize::from(candidates.len() >= batch_limit),
+            usize::from(candidates.len() == SYSTEM_TASK_RUN_RETENTION_TERMINAL_BATCH_ROWS),
         );
         pruned += deleted;
-        if candidates.len() < batch_limit || deleted < candidates.len() {
+        if deleted < candidates.len() {
             break;
         }
     }

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -1,11 +1,24 @@
 use super::*;
 
+use sqlx::FromRow;
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
 const RETENTION_FAIRNESS_INTERVAL: Duration = Duration::from_secs(15);
 const RETENTION_WRITE_TARGET: Duration = Duration::from_millis(200);
 const RETENTION_WRITE_WARNING: Duration = Duration::from_millis(250);
 const RETENTION_WRITE_INITIAL_ROWS: usize = 4;
 pub(super) const RETENTION_WRITE_MAX_ROWS: usize = 64;
 const RETENTION_WRITE_MAX_BYTES: usize = 1024 * 1024;
+const SYSTEM_TASK_RUN_RETENTION_KEEP_RECENT: i64 = 200;
+const SYSTEM_TASK_RUN_RETENTION_TERMINAL_BATCH_ROWS: usize = 500;
+const SYSTEM_TASK_RUN_RETENTION_MAX_ROWS_PER_PASS: usize = 5_000;
+const SYSTEM_TASK_RUN_RETENTION_PASS_INTERVAL: Duration = Duration::from_secs(15);
+const SYSTEM_TASK_RUN_RETENTION_PRESSURE_BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+static SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS: AtomicU64 = AtomicU64::new(0);
 
 tokio::task_local! {
     static RETENTION_SHUTDOWN: CancellationToken;
@@ -478,6 +491,7 @@ pub(crate) struct RetentionRunSummary {
     pub(crate) raw_files_removed: usize,
     pub(crate) orphan_raw_files_removed: usize,
     pub(crate) model_route_rows_pruned: usize,
+    pub(crate) system_task_run_rows_pruned: usize,
 }
 
 impl RetentionRunSummary {
@@ -493,7 +507,207 @@ impl RetentionRunSummary {
             || self.raw_files_removed > 0
             || self.orphan_raw_files_removed > 0
             || self.model_route_rows_pruned > 0
+            || self.system_task_run_rows_pruned > 0
     }
+}
+
+#[derive(Debug, FromRow)]
+struct SystemTaskRunRetentionCandidate {
+    id: i64,
+}
+
+fn system_task_run_retention_now_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u64::MAX as u128) as u64
+}
+
+fn system_task_run_retention_schedule_next(now_epoch_ms: u64, delay: Duration) {
+    let next = now_epoch_ms.saturating_add(delay.as_millis().min(u64::MAX as u128) as u64);
+    let mut current = SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS.load(Ordering::Acquire);
+    while next > current {
+        match SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS.compare_exchange(
+            current,
+            next,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => return,
+            Err(actual) => current = actual,
+        }
+    }
+}
+
+fn system_task_run_retention_pass_is_due(now_epoch_ms: u64) -> bool {
+    let next = SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS.load(Ordering::Acquire);
+    if next > now_epoch_ms {
+        return false;
+    }
+    SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS
+        .compare_exchange(
+            next,
+            now_epoch_ms.saturating_add(
+                SYSTEM_TASK_RUN_RETENTION_PASS_INTERVAL
+                    .as_millis()
+                    .min(u64::MAX as u128) as u64,
+            ),
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        )
+        .is_ok()
+}
+
+#[cfg(test)]
+pub(crate) fn reset_system_task_run_retention_schedule() {
+    SYSTEM_TASK_RUN_RETENTION_NEXT_PASS_EPOCH_MS.store(0, Ordering::Release);
+}
+
+fn system_task_run_retention_handle_pressure(error: &anyhow::Error) -> bool {
+    if !crate::db_pressure::is_db_pressure_error(error) {
+        return false;
+    }
+    let now_epoch_ms = system_task_run_retention_now_epoch_ms();
+    system_task_run_retention_schedule_next(
+        now_epoch_ms,
+        SYSTEM_TASK_RUN_RETENTION_PRESSURE_BACKOFF,
+    );
+    crate::db_pressure::global_db_pressure_gate().record_error("system_task_run_retention", error);
+    retention_record_error("system_task_run_retention", error);
+    warn!(error = %error, "system task run retention deferred after SQLite pressure");
+    true
+}
+
+pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -> Result<usize> {
+    let now_epoch_ms = system_task_run_retention_now_epoch_ms();
+    if !system_task_run_retention_pass_is_due(now_epoch_ms) {
+        return Ok(0);
+    }
+
+    let success_cutoff = format_utc_iso(Utc::now() - ChronoDuration::days(30));
+    let failed_cutoff = format_utc_iso(Utc::now() - ChronoDuration::days(180));
+    let mut pruned = 0usize;
+
+    while pruned < SYSTEM_TASK_RUN_RETENTION_MAX_ROWS_PER_PASS {
+        let batch_limit = SYSTEM_TASK_RUN_RETENTION_TERMINAL_BATCH_ROWS
+            .min(SYSTEM_TASK_RUN_RETENTION_MAX_ROWS_PER_PASS.saturating_sub(pruned));
+        let candidates = match sqlx::query_as::<_, SystemTaskRunRetentionCandidate>(
+            r#"
+            WITH ranked AS (
+                SELECT
+                    id,
+                    task_kind,
+                    status,
+                    started_at,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY task_kind, status
+                        ORDER BY started_at DESC, id DESC
+                    ) AS retention_rank
+                FROM system_task_runs
+                WHERE status IN ('success', 'skipped', 'failed')
+            )
+            SELECT id
+            FROM ranked
+            WHERE retention_rank > ?1
+              AND (
+                  (status IN ('success', 'skipped')
+                    AND (started_at < ?2 OR retention_rank > 5000))
+                  OR (status = 'failed'
+                    AND (started_at < ?3 OR retention_rank > 10000))
+              )
+            ORDER BY started_at ASC, id ASC
+            LIMIT ?4
+            "#,
+        )
+        .bind(SYSTEM_TASK_RUN_RETENTION_KEEP_RECENT)
+        .bind(&success_cutoff)
+        .bind(&failed_cutoff)
+        .bind(batch_limit as i64)
+        .fetch_all(pool)
+        .await
+        {
+            Ok(candidates) => candidates,
+            Err(error) => {
+                let error = anyhow::Error::from(error);
+                if system_task_run_retention_handle_pressure(&error) {
+                    return Ok(pruned);
+                }
+                return Err(error).context("failed to select system task retention candidates");
+            }
+        };
+        if candidates.is_empty() {
+            break;
+        }
+        if dry_run {
+            pruned += candidates.len();
+            if candidates.len() < batch_limit {
+                break;
+            }
+            continue;
+        }
+
+        let Some(admission) = acquire_retention_write_admission("system_task_run_retention").await
+        else {
+            break;
+        };
+        let execute_started = Instant::now();
+        let ids = candidates
+            .iter()
+            .map(|candidate| candidate.id)
+            .collect::<Vec<_>>();
+        let mut delete = QueryBuilder::<Sqlite>::new("DELETE FROM system_task_runs WHERE id IN (");
+        let mut separated = delete.separated(", ");
+        for id in &ids {
+            separated.push_bind(id);
+        }
+        separated.push_unseparated(")");
+        let mut transaction = match pool.begin().await {
+            Ok(transaction) => transaction,
+            Err(error) => {
+                let error = anyhow::Error::from(error);
+                if system_task_run_retention_handle_pressure(&error) {
+                    return Ok(pruned);
+                }
+                return Err(error).context("failed to begin system task retention batch");
+            }
+        };
+        let deleted = match delete.build().execute(&mut *transaction).await {
+            Ok(result) => result.rows_affected() as usize,
+            Err(error) => {
+                let error = anyhow::Error::from(error);
+                if system_task_run_retention_handle_pressure(&error) {
+                    return Ok(pruned);
+                }
+                return Err(error).context("failed to delete system task retention batch");
+            }
+        };
+        if let Err(error) = transaction.commit().await {
+            let error = anyhow::Error::from(error);
+            if system_task_run_retention_handle_pressure(&error) {
+                return Ok(pruned);
+            }
+            return Err(error).context("failed to commit system task retention batch");
+        }
+        retention_record_commit!(
+            "system_task_run_retention",
+            admission.admission_mode(),
+            deleted,
+            deleted.saturating_mul(128),
+            Duration::ZERO,
+            admission.lock_wait(),
+            execute_started.elapsed(),
+            Duration::ZERO,
+            admission.p1_waiter_count(),
+            usize::from(candidates.len() >= batch_limit),
+        );
+        pruned += deleted;
+        if candidates.len() < batch_limit || deleted < candidates.len() {
+            break;
+        }
+    }
+
+    Ok(pruned)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1624,6 +1838,10 @@ async fn run_data_retention_maintenance_inner(
     if should_stop_data_retention_maintenance(shutdown) {
         return Ok(summary);
     }
+
+    summary.system_task_run_rows_pruned += prune_system_task_runs(pool, dry_run)
+        .await
+        .context("failed to prune expired system task runs")?;
 
     if !dry_run && summary.touched_anything() {
         run_best_effort_retention_pragma(

--- a/src/maintenance/retention.rs
+++ b/src/maintenance/retention.rs
@@ -618,6 +618,7 @@ pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -
                     ) AS retention_rank
                 FROM system_task_runs
                 WHERE status IN ('success', 'skipped', 'failed')
+                  AND strftime('%Y-%m-%dT%H:%M:%fZ', started_at) = started_at
             )
             SELECT COUNT(*)
             FROM ranked
@@ -659,6 +660,7 @@ pub(crate) async fn prune_system_task_runs(pool: &Pool<Sqlite>, dry_run: bool) -
                     ) AS retention_rank
                 FROM system_task_runs
                 WHERE status IN ('success', 'skipped', 'failed')
+                  AND strftime('%Y-%m-%dT%H:%M:%fZ', started_at) = started_at
             )
             SELECT id
             FROM ranked

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4111,6 +4111,30 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
 
     sqlx::query(
         r#"
+        UPDATE system_task_runs
+        SET
+            started_at = COALESCE(
+                strftime('%Y-%m-%dT%H:%M:%SZ', started_at),
+                started_at
+            ),
+            finished_at = CASE
+                WHEN finished_at IS NULL THEN NULL
+                ELSE COALESCE(strftime('%Y-%m-%dT%H:%M:%SZ', finished_at), finished_at)
+            END
+        WHERE
+            (strftime('%Y-%m-%dT%H:%M:%SZ', started_at) IS NOT NULL
+                AND started_at <> strftime('%Y-%m-%dT%H:%M:%SZ', started_at))
+            OR (finished_at IS NOT NULL
+                AND strftime('%Y-%m-%dT%H:%M:%SZ', finished_at) IS NOT NULL
+                AND finished_at <> strftime('%Y-%m-%dT%H:%M:%SZ', finished_at))
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to normalize system_task_runs timestamps to UTC ISO")?;
+
+    sqlx::query(
+        r#"
         CREATE INDEX IF NOT EXISTS idx_system_task_runs_task_time
         ON system_task_runs (task_kind, started_at DESC, id DESC)
         "#,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4156,11 +4156,13 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         WHERE
             (started_at NOT GLOB '????-??-??T??:??:??.???Z'
                 AND date(substr(started_at, 1, 10)) = substr(started_at, 1, 10)
-                AND time(substr(started_at, 12, 8)) = substr(started_at, 12, 8))
+                AND time(substr(started_at, 12, 8)) = substr(started_at, 12, 8)
+                AND strftime('%Y-%m-%dT%H:%M:%fZ', started_at) IS NOT NULL)
             OR (finished_at IS NOT NULL
                 AND finished_at NOT GLOB '????-??-??T??:??:??.???Z'
                 AND date(substr(finished_at, 1, 10)) = substr(finished_at, 1, 10)
-                AND time(substr(finished_at, 12, 8)) = substr(finished_at, 12, 8))
+                AND time(substr(finished_at, 12, 8)) = substr(finished_at, 12, 8)
+                AND strftime('%Y-%m-%dT%H:%M:%fZ', finished_at) IS NOT NULL)
         "#,
     )
     .execute(pool)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4154,9 +4154,13 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
                 ELSE finished_at
             END
         WHERE
-            started_at NOT GLOB '????-??-??T??:??:??.???Z'
+            (started_at NOT GLOB '????-??-??T??:??:??.???Z'
+                AND date(substr(started_at, 1, 10)) = substr(started_at, 1, 10)
+                AND time(substr(started_at, 12, 8)) = substr(started_at, 12, 8))
             OR (finished_at IS NOT NULL
-                AND finished_at NOT GLOB '????-??-??T??:??:??.???Z')
+                AND finished_at NOT GLOB '????-??-??T??:??:??.???Z'
+                AND date(substr(finished_at, 1, 10)) = substr(finished_at, 1, 10)
+                AND time(substr(finished_at, 12, 8)) = substr(finished_at, 12, 8))
         "#,
     )
     .execute(pool)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4115,29 +4115,43 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         SET
             started_at = CASE
                 -- Pre-ISO task rows used the application's Shanghai-local timestamp convention.
-                WHEN started_at GLOB '????-??-?? ??:??:??*'
+                WHEN date(substr(started_at, 1, 10)) = substr(started_at, 1, 10)
+                    AND time(substr(started_at, 12, 8)) = substr(started_at, 12, 8)
+                    AND started_at GLOB '????-??-?? ??:??:??*'
                     AND (started_at GLOB '????-??-?? ??:??:??*Z'
                         OR started_at GLOB '????-??-?? ??:??:??*[-+]??:??')
                     THEN COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', started_at), started_at)
-                WHEN started_at GLOB '????-??-?? ??:??:??*'
+                WHEN date(substr(started_at, 1, 10)) = substr(started_at, 1, 10)
+                    AND time(substr(started_at, 12, 8)) = substr(started_at, 12, 8)
+                    AND started_at GLOB '????-??-?? ??:??:??*'
                     THEN COALESCE(
                         strftime('%Y-%m-%dT%H:%M:%fZ', started_at, '-8 hours'),
                         started_at
                     )
-                ELSE COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', started_at), started_at)
+                WHEN date(substr(started_at, 1, 10)) = substr(started_at, 1, 10)
+                    AND time(substr(started_at, 12, 8)) = substr(started_at, 12, 8)
+                    THEN COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', started_at), started_at)
+                ELSE started_at
             END,
             finished_at = CASE
                 WHEN finished_at IS NULL THEN NULL
-                WHEN finished_at GLOB '????-??-?? ??:??:??*'
+                WHEN date(substr(finished_at, 1, 10)) = substr(finished_at, 1, 10)
+                    AND time(substr(finished_at, 12, 8)) = substr(finished_at, 12, 8)
+                    AND finished_at GLOB '????-??-?? ??:??:??*'
                     AND (finished_at GLOB '????-??-?? ??:??:??*Z'
                         OR finished_at GLOB '????-??-?? ??:??:??*[-+]??:??')
                     THEN COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', finished_at), finished_at)
-                WHEN finished_at GLOB '????-??-?? ??:??:??*'
+                WHEN date(substr(finished_at, 1, 10)) = substr(finished_at, 1, 10)
+                    AND time(substr(finished_at, 12, 8)) = substr(finished_at, 12, 8)
+                    AND finished_at GLOB '????-??-?? ??:??:??*'
                     THEN COALESCE(
                         strftime('%Y-%m-%dT%H:%M:%fZ', finished_at, '-8 hours'),
                         finished_at
                     )
-                ELSE COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', finished_at), finished_at)
+                WHEN date(substr(finished_at, 1, 10)) = substr(finished_at, 1, 10)
+                    AND time(substr(finished_at, 12, 8)) = substr(finished_at, 12, 8)
+                    THEN COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', finished_at), finished_at)
+                ELSE finished_at
             END
         WHERE
             started_at NOT GLOB '????-??-??T??:??:??.???Z'

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4116,6 +4116,10 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
             started_at = CASE
                 -- Pre-ISO task rows used the application's Shanghai-local timestamp convention.
                 WHEN started_at GLOB '????-??-?? ??:??:??*'
+                    AND (started_at GLOB '????-??-?? ??:??:??*Z'
+                        OR started_at GLOB '????-??-?? ??:??:??*[-+]??:??')
+                    THEN COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', started_at), started_at)
+                WHEN started_at GLOB '????-??-?? ??:??:??*'
                     THEN COALESCE(
                         strftime('%Y-%m-%dT%H:%M:%fZ', started_at, '-8 hours'),
                         started_at
@@ -4124,6 +4128,10 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
             END,
             finished_at = CASE
                 WHEN finished_at IS NULL THEN NULL
+                WHEN finished_at GLOB '????-??-?? ??:??:??*'
+                    AND (finished_at GLOB '????-??-?? ??:??:??*Z'
+                        OR finished_at GLOB '????-??-?? ??:??:??*[-+]??:??')
+                    THEN COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', finished_at), finished_at)
                 WHEN finished_at GLOB '????-??-?? ??:??:??*'
                     THEN COALESCE(
                         strftime('%Y-%m-%dT%H:%M:%fZ', finished_at, '-8 hours'),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4131,6 +4131,26 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
 
     sqlx::query(
         r#"
+        CREATE INDEX IF NOT EXISTS idx_system_task_runs_started_at_id
+        ON system_task_runs (started_at DESC, id DESC)
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure index idx_system_task_runs_started_at_id")?;
+
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_system_task_runs_task_status_time
+        ON system_task_runs (task_kind, status, started_at DESC, id DESC)
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure index idx_system_task_runs_task_status_time")?;
+
+    sqlx::query(
+        r#"
         CREATE TABLE IF NOT EXISTS system_raw_payload_metrics (
             singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
             inventory_state TEXT NOT NULL DEFAULT 'preparing',

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4113,20 +4113,28 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         r#"
         UPDATE system_task_runs
         SET
-            started_at = COALESCE(
-                strftime('%Y-%m-%dT%H:%M:%SZ', started_at),
-                started_at
-            ),
+            started_at = CASE
+                -- Pre-ISO task rows used the application's Shanghai-local timestamp convention.
+                WHEN started_at GLOB '????-??-?? ??:??:??*'
+                    THEN COALESCE(
+                        strftime('%Y-%m-%dT%H:%M:%fZ', started_at, '-8 hours'),
+                        started_at
+                    )
+                ELSE COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', started_at), started_at)
+            END,
             finished_at = CASE
                 WHEN finished_at IS NULL THEN NULL
-                ELSE COALESCE(strftime('%Y-%m-%dT%H:%M:%SZ', finished_at), finished_at)
+                WHEN finished_at GLOB '????-??-?? ??:??:??*'
+                    THEN COALESCE(
+                        strftime('%Y-%m-%dT%H:%M:%fZ', finished_at, '-8 hours'),
+                        finished_at
+                    )
+                ELSE COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', finished_at), finished_at)
             END
         WHERE
-            (strftime('%Y-%m-%dT%H:%M:%SZ', started_at) IS NOT NULL
-                AND started_at <> strftime('%Y-%m-%dT%H:%M:%SZ', started_at))
+            started_at NOT GLOB '????-??-??T??:??:??.???Z'
             OR (finished_at IS NOT NULL
-                AND strftime('%Y-%m-%dT%H:%M:%SZ', finished_at) IS NOT NULL
-                AND finished_at <> strftime('%Y-%m-%dT%H:%M:%SZ', finished_at))
+                AND finished_at NOT GLOB '????-??-??T??:??:??.???Z')
         "#,
     )
     .execute(pool)

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -496,8 +496,8 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     )
     .await;
     sqlx::query("UPDATE system_task_runs SET started_at = ?1, finished_at = ?2 WHERE id = ?3")
-        .bind("2026-06-22 08:45:00")
-        .bind("2026-06-22 08:45:01")
+        .bind("2026-06-22T08:45:00Z")
+        .bind("2026-06-22T08:45:01Z")
         .bind(startup_handle.id)
         .execute(&state.pool)
         .await
@@ -520,8 +520,8 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     )
     .await;
     sqlx::query("UPDATE system_task_runs SET started_at = ?1, finished_at = ?2 WHERE id = ?3")
-        .bind("2026-06-22 09:15:00")
-        .bind("2026-06-22 09:15:02")
+        .bind("2026-06-22T09:15:00Z")
+        .bind("2026-06-22T09:15:02Z")
         .bind(retention_handle.id)
         .execute(&state.pool)
         .await
@@ -537,6 +537,7 @@ async fn system_task_runs_filter_and_routes_serve_json() {
             limit: Some(10),
             page: None,
             page_size: None,
+            cursor: None,
         }),
     )
     .await
@@ -566,6 +567,7 @@ async fn system_task_runs_filter_and_routes_serve_json() {
             limit: Some(10),
             page: None,
             page_size: None,
+            cursor: None,
         }),
     )
     .await
@@ -589,6 +591,7 @@ async fn system_task_runs_filter_and_routes_serve_json() {
             limit: None,
             page: Some(2),
             page_size: Some(1),
+            cursor: None,
         }),
     )
     .await
@@ -611,6 +614,7 @@ async fn system_task_runs_filter_and_routes_serve_json() {
             limit: Some(10),
             page: None,
             page_size: None,
+            cursor: None,
         }),
     )
     .await
@@ -620,6 +624,49 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     assert_eq!(ranged.total, 1);
     assert_eq!(ranged.items.len(), 1);
     assert_eq!(ranged.items[0].task_kind, "retention_archive");
+
+    let first_cursor_page = list_system_task_runs(
+        State(state.clone()),
+        Query(SystemTaskRunsQuery {
+            task_kind: None,
+            status: None,
+            started_at_from: None,
+            started_at_to: None,
+            limit: None,
+            page: None,
+            page_size: Some(1),
+            cursor: None,
+        }),
+    )
+    .await
+    .expect("list first cursor page")
+    .0;
+    let cursor = first_cursor_page
+        .next_cursor
+        .clone()
+        .expect("first cursor page should expose a continuation");
+    let second_cursor_page = list_system_task_runs(
+        State(state.clone()),
+        Query(SystemTaskRunsQuery {
+            task_kind: None,
+            status: None,
+            started_at_from: None,
+            started_at_to: None,
+            limit: None,
+            page: None,
+            page_size: Some(1),
+            cursor: Some(cursor),
+        }),
+    )
+    .await
+    .expect("list second cursor page")
+    .0;
+    assert_eq!(first_cursor_page.total, paged.total);
+    assert_eq!(second_cursor_page.items[0].id, paged.items[0].id);
+    assert_ne!(
+        first_cursor_page.items[0].id,
+        second_cursor_page.items[0].id
+    );
 
     let app = build_app_router(state.clone());
     let response = app
@@ -644,6 +691,18 @@ async fn system_task_runs_filter_and_routes_serve_json() {
         payload["items"][0]["taskKind"].as_str(),
         Some("retention_archive")
     );
+
+    let cursor_with_page_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/system/tasks?cursor=eyJzdGFydGVkQXQiOiIyMDI2LTA2LTIyVDA5OjE1OjAwWiIsImlkIjoyfQ&page=2")
+                .body(Body::empty())
+                .expect("build invalid cursor and page request"),
+        )
+        .await
+        .expect("serve invalid cursor and page request");
+    assert_eq!(cursor_with_page_response.status(), StatusCode::BAD_REQUEST);
 
     let invalid_range_response = app
         .clone()
@@ -677,6 +736,150 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     assert!(payload.get("completedArchiveBatchesCount").is_some());
     assert!(payload.get("databaseBytes").is_some());
     assert!(payload.get("refreshedAt").is_some());
+}
+
+#[tokio::test]
+async fn system_task_runs_schema_indexes_support_time_queries() {
+    let pool = test_current_schema_pool().await;
+    ensure_schema(&pool)
+        .await
+        .expect("apply current system task run schema");
+    sqlx::query(
+        r#"
+        WITH RECURSIVE
+            hundreds(value) AS (
+                VALUES(0)
+                UNION ALL
+                SELECT value + 1 FROM hundreds WHERE value < 999
+            ),
+            blocks(value) AS (
+                VALUES(0)
+                UNION ALL
+                SELECT value + 1 FROM blocks WHERE value < 399
+            )
+        INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at)
+        SELECT
+            CASE WHEN (hundreds.value + blocks.value) % 2 = 0
+                THEN 'retention_archive' ELSE 'startup_backfill' END,
+            'fixture',
+            CASE WHEN hundreds.value % 3 = 0 THEN 'success' ELSE 'failed' END,
+            printf(
+                '2026-06-%02dT%02d:%02d:%02dZ',
+                1 + ((hundreds.value * 400 + blocks.value) / 86400),
+                ((hundreds.value * 400 + blocks.value) / 3600) % 24,
+                ((hundreds.value * 400 + blocks.value) / 60) % 60,
+                (hundreds.value * 400 + blocks.value) % 60
+            )
+        FROM hundreds CROSS JOIN blocks
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("seed 400k system task runs");
+
+    let default_plan: Vec<String> = sqlx::query(
+        "EXPLAIN QUERY PLAN SELECT id FROM system_task_runs ORDER BY started_at DESC, id DESC LIMIT 100",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("explain default system task query")
+    .into_iter()
+    .map(|row| row.get("detail"))
+    .collect();
+    assert!(
+        default_plan
+            .iter()
+            .any(|detail| detail.contains("idx_system_task_runs_started_at_id")),
+        "default time query must use its ordering index: {default_plan:?}"
+    );
+
+    let filtered_plan: Vec<String> = sqlx::query(
+        "EXPLAIN QUERY PLAN SELECT id FROM system_task_runs WHERE task_kind = 'retention_archive' AND status = 'success' AND started_at >= '2026-06-02T00:00:00Z' ORDER BY started_at DESC, id DESC LIMIT 100",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("explain combined system task query")
+    .into_iter()
+    .map(|row| row.get("detail"))
+    .collect();
+    assert!(
+        filtered_plan
+            .iter()
+            .any(|detail| detail.contains("idx_system_task_runs_task_status_time")),
+        "combined filter and sort query must use its index: {filtered_plan:?}"
+    );
+}
+
+#[tokio::test]
+async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
+    reset_system_task_run_retention_schedule();
+    let pool = test_current_schema_pool().await;
+    ensure_schema(&pool)
+        .await
+        .expect("apply current system task run schema");
+    sqlx::query(
+        r#"
+        WITH RECURSIVE
+            hundreds(value) AS (
+                VALUES(0)
+                UNION ALL
+                SELECT value + 1 FROM hundreds WHERE value < 999
+            ),
+            blocks(value) AS (
+                VALUES(0)
+                UNION ALL
+                SELECT value + 1 FROM blocks WHERE value < 5
+            )
+        INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at)
+        SELECT 'retention_archive', 'fixture', 'success', '2020-01-01T00:00:00Z'
+        FROM hundreds CROSS JOIN blocks
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("seed expired terminal task runs");
+    sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at) VALUES ('retention_archive', 'fixture', 'running', '2019-01-01T00:00:00Z')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed running task run");
+
+    let pruned = prune_system_task_runs(&pool, false)
+        .await
+        .expect("prune expired task runs");
+    assert_eq!(pruned, 5_000, "one retention pass has a hard delete cap");
+    let terminal_remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'retention_archive' AND status = 'success'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count remaining terminal task runs");
+    assert_eq!(terminal_remaining, 1_000);
+    let oldest_retained_id: i64 = sqlx::query_scalar(
+        "SELECT MIN(id) FROM system_task_runs WHERE task_kind = 'retention_archive' AND status = 'success'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("find oldest retained terminal task run");
+    assert_eq!(
+        oldest_retained_id, 5_001,
+        "the pass deletes the oldest records before newer equal-timestamp ties"
+    );
+    let running_remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM system_task_runs WHERE status = 'running'")
+            .fetch_one(&pool)
+            .await
+            .expect("count running task runs");
+    assert_eq!(running_remaining, 1, "running task runs are never pruned");
+    assert_eq!(
+        prune_system_task_runs(&pool, false)
+            .await
+            .expect("immediate retention pass should be throttled"),
+        0,
+        "retention passes are spaced by at least 15 seconds"
+    );
+    reset_system_task_run_retention_schedule();
 }
 
 pub(crate) fn write_backfill_response_payload_with_terminal_service_tier(

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -811,6 +811,29 @@ async fn system_task_runs_schema_indexes_support_time_queries() {
 }
 
 #[tokio::test]
+async fn ensure_schema_normalizes_legacy_system_task_run_timestamps() {
+    let pool = test_current_schema_pool().await;
+    sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at, finished_at) VALUES ('startup_backfill', 'fixture', 'success', '2026-06-22 08:45:00', '2026-06-22T17:15:00+08:00')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed legacy system task timestamp");
+
+    ensure_schema(&pool)
+        .await
+        .expect("normalize legacy system task timestamps");
+    let (started_at, finished_at): (String, Option<String>) = sqlx::query_as(
+        "SELECT started_at, finished_at FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load normalized task timestamps");
+    assert_eq!(started_at, "2026-06-22T08:45:00Z");
+    assert_eq!(finished_at.as_deref(), Some("2026-06-22T09:15:00Z"));
+}
+
+#[tokio::test]
 async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
     reset_system_task_run_retention_schedule();
     let pool = test_current_schema_pool().await;
@@ -878,6 +901,14 @@ async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
             .expect("immediate retention pass should be throttled"),
         0,
         "retention passes are spaced by at least 15 seconds"
+    );
+    reset_system_task_run_retention_schedule();
+    assert_eq!(
+        prune_system_task_runs(&pool, true)
+            .await
+            .expect("count remaining retention candidates"),
+        800,
+        "dry run counts each eligible row once and respects the per-pass cap"
     );
     reset_system_task_run_retention_schedule();
 }

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -818,7 +818,7 @@ async fn system_task_runs_cursor_preserves_invalid_legacy_timestamp() {
         .expect("invalid legacy timestamp still yields a cursor");
 
     let second_page = list_system_task_runs(
-        State(state),
+        State(state.clone()),
         Query(SystemTaskRunsQuery {
             page_size: Some(1),
             cursor: Some(cursor),
@@ -830,6 +830,20 @@ async fn system_task_runs_cursor_preserves_invalid_legacy_timestamp() {
     .0;
     assert_eq!(second_page.items[0].task_kind, "older_canonical_timestamp");
     assert!(second_page.next_cursor.is_none());
+
+    let ranged_page = list_system_task_runs(
+        State(state),
+        Query(SystemTaskRunsQuery {
+            started_at_from: Some("2026-02-01T00:00:00Z".to_string()),
+            started_at_to: Some("2026-03-01T00:00:00Z".to_string()),
+            ..SystemTaskRunsQuery::default()
+        }),
+    )
+    .await
+    .expect("exclude invalid legacy timestamp from time range")
+    .0;
+    assert_eq!(ranged_page.total, 0);
+    assert!(ranged_page.items.is_empty());
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -831,6 +831,27 @@ async fn ensure_schema_normalizes_legacy_system_task_run_timestamps() {
     .expect("load normalized task timestamps");
     assert_eq!(started_at, "2026-06-22T00:45:00.125Z");
     assert_eq!(finished_at.as_deref(), Some("2026-06-22T09:15:00.000Z"));
+
+    sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at, finished_at) VALUES ('startup_backfill_with_offset', 'fixture', 'success', '2026-06-22 08:45:00.125+08:00', '2026-06-22 17:15:00+08:00')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed space timestamps with explicit offsets");
+    ensure_schema(&pool)
+        .await
+        .expect("normalize offset timestamps");
+    let (offset_started_at, offset_finished_at): (String, Option<String>) = sqlx::query_as(
+        "SELECT started_at, finished_at FROM system_task_runs WHERE task_kind = 'startup_backfill_with_offset'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load normalized offset timestamps");
+    assert_eq!(offset_started_at, "2026-06-22T00:45:00.125Z");
+    assert_eq!(
+        offset_finished_at.as_deref(),
+        Some("2026-06-22T09:15:00.000Z")
+    );
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -814,7 +814,7 @@ async fn system_task_runs_schema_indexes_support_time_queries() {
 async fn ensure_schema_normalizes_legacy_system_task_run_timestamps() {
     let pool = test_current_schema_pool().await;
     sqlx::query(
-        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at, finished_at) VALUES ('startup_backfill', 'fixture', 'success', '2026-06-22 08:45:00', '2026-06-22T17:15:00+08:00')",
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at, finished_at) VALUES ('startup_backfill', 'fixture', 'success', '2026-06-22 08:45:00.125', '2026-06-22T17:15:00+08:00')",
     )
     .execute(&pool)
     .await
@@ -829,8 +829,8 @@ async fn ensure_schema_normalizes_legacy_system_task_run_timestamps() {
     .fetch_one(&pool)
     .await
     .expect("load normalized task timestamps");
-    assert_eq!(started_at, "2026-06-22T08:45:00Z");
-    assert_eq!(finished_at.as_deref(), Some("2026-06-22T09:15:00Z"));
+    assert_eq!(started_at, "2026-06-22T00:45:00.125Z");
+    assert_eq!(finished_at.as_deref(), Some("2026-06-22T09:15:00.000Z"));
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -496,8 +496,8 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     )
     .await;
     sqlx::query("UPDATE system_task_runs SET started_at = ?1, finished_at = ?2 WHERE id = ?3")
-        .bind("2026-06-22T08:45:00Z")
-        .bind("2026-06-22T08:45:01Z")
+        .bind("2026-06-22T08:45:00.000Z")
+        .bind("2026-06-22T08:45:01.000Z")
         .bind(startup_handle.id)
         .execute(&state.pool)
         .await
@@ -520,12 +520,36 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     )
     .await;
     sqlx::query("UPDATE system_task_runs SET started_at = ?1, finished_at = ?2 WHERE id = ?3")
-        .bind("2026-06-22T09:15:00Z")
-        .bind("2026-06-22T09:15:02Z")
+        .bind("2026-06-22T09:15:00.000Z")
+        .bind("2026-06-22T09:15:02.000Z")
         .bind(retention_handle.id)
         .execute(&state.pool)
         .await
         .expect("pin retention task timestamps");
+
+    let tied_handle = begin_system_task_run(
+        &state.pool,
+        SystemTaskKind::StartupBackfill,
+        "manual",
+        Some("same timestamp cursor tie".to_string()),
+    )
+    .await
+    .expect("insert tied cursor task");
+    finish_system_task_run(
+        &state.pool,
+        &tied_handle,
+        SystemTaskStatus::Success,
+        Some("tied cursor task completed".to_string()),
+        None,
+    )
+    .await;
+    sqlx::query("UPDATE system_task_runs SET started_at = ?1, finished_at = ?2 WHERE id = ?3")
+        .bind("2026-06-22T09:15:00.000Z")
+        .bind("2026-06-22T09:15:03.000Z")
+        .bind(tied_handle.id)
+        .execute(&state.pool)
+        .await
+        .expect("pin tied cursor task timestamps");
 
     let filtered = list_system_task_runs(
         State(state.clone()),
@@ -574,12 +598,13 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     .expect("list all system tasks")
     .0;
 
-    assert_eq!(all.total, 2);
+    assert_eq!(all.total, 3);
     assert_eq!(all.page, 1);
     assert_eq!(all.page_size, 10);
-    assert_eq!(all.items.len(), 2);
-    assert_eq!(all.items[0].task_kind, "retention_archive");
-    assert_eq!(all.items[1].task_kind, "startup_backfill");
+    assert_eq!(all.items.len(), 3);
+    assert_eq!(all.items[0].id, tied_handle.id);
+    assert_eq!(all.items[1].id, retention_handle.id);
+    assert_eq!(all.items[2].id, startup_handle.id);
 
     let paged = list_system_task_runs(
         State(state.clone()),
@@ -598,11 +623,11 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     .expect("list paged system tasks")
     .0;
 
-    assert_eq!(paged.total, 2);
+    assert_eq!(paged.total, 3);
     assert_eq!(paged.page, 2);
     assert_eq!(paged.page_size, 1);
     assert_eq!(paged.items.len(), 1);
-    assert_eq!(paged.items[0].task_kind, "startup_backfill");
+    assert_eq!(paged.items[0].id, retention_handle.id);
 
     let ranged = list_system_task_runs(
         State(state.clone()),
@@ -621,9 +646,10 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     .expect("list ranged system tasks")
     .0;
 
-    assert_eq!(ranged.total, 1);
-    assert_eq!(ranged.items.len(), 1);
-    assert_eq!(ranged.items[0].task_kind, "retention_archive");
+    assert_eq!(ranged.total, 2);
+    assert_eq!(ranged.items.len(), 2);
+    assert_eq!(ranged.items[0].id, tied_handle.id);
+    assert_eq!(ranged.items[1].id, retention_handle.id);
 
     let first_cursor_page = list_system_task_runs(
         State(state.clone()),
@@ -661,12 +687,27 @@ async fn system_task_runs_filter_and_routes_serve_json() {
     .await
     .expect("list second cursor page")
     .0;
+    let third_cursor_page = list_system_task_runs(
+        State(state.clone()),
+        Query(SystemTaskRunsQuery {
+            task_kind: None,
+            status: None,
+            started_at_from: None,
+            started_at_to: None,
+            limit: None,
+            page: None,
+            page_size: Some(1),
+            cursor: second_cursor_page.next_cursor.clone(),
+        }),
+    )
+    .await
+    .expect("list third cursor page")
+    .0;
     assert_eq!(first_cursor_page.total, paged.total);
-    assert_eq!(second_cursor_page.items[0].id, paged.items[0].id);
-    assert_ne!(
-        first_cursor_page.items[0].id,
-        second_cursor_page.items[0].id
-    );
+    assert_eq!(first_cursor_page.items[0].id, tied_handle.id);
+    assert_eq!(second_cursor_page.items[0].id, retention_handle.id);
+    assert_eq!(third_cursor_page.items[0].id, startup_handle.id);
+    assert!(third_cursor_page.next_cursor.is_none());
 
     let app = build_app_router(state.clone());
     let response = app
@@ -851,6 +892,27 @@ async fn ensure_schema_normalizes_legacy_system_task_run_timestamps() {
     assert_eq!(
         offset_finished_at.as_deref(),
         Some("2026-06-22T09:15:00.000Z")
+    );
+
+    sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at, finished_at) VALUES ('invalid_legacy_task_timestamp', 'fixture', 'success', '2026-02-30 08:45:00', '2026-02-30 17:15:00+08:00')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed invalid legacy task timestamps");
+    ensure_schema(&pool)
+        .await
+        .expect("preserve invalid task timestamps");
+    let (invalid_started_at, invalid_finished_at): (String, Option<String>) = sqlx::query_as(
+        "SELECT started_at, finished_at FROM system_task_runs WHERE task_kind = 'invalid_legacy_task_timestamp'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load preserved invalid timestamps");
+    assert_eq!(invalid_started_at, "2026-02-30 08:45:00");
+    assert_eq!(
+        invalid_finished_at.as_deref(),
+        Some("2026-02-30 17:15:00+08:00")
     );
 }
 

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -780,6 +780,56 @@ async fn system_task_runs_filter_and_routes_serve_json() {
 }
 
 #[tokio::test]
+async fn system_task_runs_cursor_preserves_invalid_legacy_timestamp() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    for (task_kind, started_at) in [
+        ("invalid_legacy_timestamp", "2026-02-30 08:45:00"),
+        ("older_canonical_timestamp", "2025-01-01T00:00:00.000Z"),
+    ] {
+        sqlx::query(
+            "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at) VALUES (?1, 'fixture', 'success', ?2)",
+        )
+        .bind(task_kind)
+        .bind(started_at)
+        .execute(&state.pool)
+        .await
+        .expect("seed cursor timestamp fixture");
+    }
+
+    let first_page = list_system_task_runs(
+        State(state.clone()),
+        Query(SystemTaskRunsQuery {
+            page_size: Some(1),
+            ..SystemTaskRunsQuery::default()
+        }),
+    )
+    .await
+    .expect("list invalid timestamp cursor page")
+    .0;
+    assert_eq!(first_page.items[0].task_kind, "invalid_legacy_timestamp");
+    let cursor = first_page
+        .next_cursor
+        .expect("invalid legacy timestamp still yields a cursor");
+
+    let second_page = list_system_task_runs(
+        State(state),
+        Query(SystemTaskRunsQuery {
+            page_size: Some(1),
+            cursor: Some(cursor),
+            ..SystemTaskRunsQuery::default()
+        }),
+    )
+    .await
+    .expect("continue after invalid timestamp cursor")
+    .0;
+    assert_eq!(second_page.items[0].task_kind, "older_canonical_timestamp");
+    assert!(second_page.next_cursor.is_none());
+}
+
+#[tokio::test]
 async fn system_task_runs_schema_indexes_support_time_queries() {
     let pool = test_current_schema_pool().await;
     ensure_schema(&pool)

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -945,6 +945,23 @@ async fn ensure_schema_normalizes_legacy_system_task_run_timestamps() {
     );
 
     sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at) VALUES ('legacy_rfc3339_without_millis', 'fixture', 'success', '2026-06-22T08:45:00Z')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed legacy RFC3339 timestamp without milliseconds");
+    ensure_schema(&pool)
+        .await
+        .expect("normalize legacy RFC3339 timestamp without milliseconds");
+    let legacy_rfc3339_started_at: String = sqlx::query_scalar(
+        "SELECT started_at FROM system_task_runs WHERE task_kind = 'legacy_rfc3339_without_millis'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load normalized legacy RFC3339 timestamp");
+    assert_eq!(legacy_rfc3339_started_at, "2026-06-22T08:45:00.000Z");
+
+    sqlx::query(
         "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at, finished_at) VALUES ('invalid_legacy_task_timestamp', 'fixture', 'success', '2026-02-30 08:45:00', '2026-02-30 17:15:00+08:00')",
     )
     .execute(&pool)

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -847,6 +847,34 @@ async fn system_task_runs_cursor_preserves_invalid_legacy_timestamp() {
 }
 
 #[tokio::test]
+async fn system_task_runs_time_ranges_exclude_canonical_shaped_invalid_dates() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at) VALUES ('invalid_canonical_timestamp', 'fixture', 'success', '2026-02-30T08:45:00.000Z')",
+    )
+    .execute(&state.pool)
+    .await
+    .expect("seed canonical-shaped invalid timestamp");
+
+    let ranged_page = list_system_task_runs(
+        State(state),
+        Query(SystemTaskRunsQuery {
+            started_at_from: Some("2026-02-01T00:00:00Z".to_string()),
+            started_at_to: Some("2026-03-01T00:00:00Z".to_string()),
+            ..SystemTaskRunsQuery::default()
+        }),
+    )
+    .await
+    .expect("exclude canonical-shaped invalid timestamp from time range")
+    .0;
+    assert_eq!(ranged_page.total, 0);
+    assert!(ranged_page.items.is_empty());
+}
+
+#[tokio::test]
 async fn system_task_runs_schema_indexes_support_time_queries() {
     let pool = test_current_schema_pool().await;
     ensure_schema(&pool)
@@ -872,7 +900,7 @@ async fn system_task_runs_schema_indexes_support_time_queries() {
             'fixture',
             CASE WHEN hundreds.value % 3 = 0 THEN 'success' ELSE 'failed' END,
             printf(
-                '2026-06-%02dT%02d:%02d:%02dZ',
+                '2026-06-%02dT%02d:%02d:%02d.000Z',
                 1 + ((hundreds.value * 400 + blocks.value) / 86400),
                 ((hundreds.value * 400 + blocks.value) / 3600) % 24,
                 ((hundreds.value * 400 + blocks.value) / 60) % 60,
@@ -1044,7 +1072,7 @@ async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
                 SELECT value + 1 FROM blocks WHERE value < 5
             )
         INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at)
-        SELECT 'retention_archive', 'fixture', 'success', '2020-01-01T00:00:00Z'
+        SELECT 'retention_archive', 'fixture', 'success', '2020-01-01T00:00:00.000Z'
         FROM hundreds CROSS JOIN blocks
         "#,
     )
@@ -1052,11 +1080,17 @@ async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
     .await
     .expect("seed expired terminal task runs");
     sqlx::query(
-        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at) VALUES ('retention_archive', 'fixture', 'running', '2019-01-01T00:00:00Z')",
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at) VALUES ('retention_archive', 'fixture', 'running', '2019-01-01T00:00:00.000Z')",
     )
     .execute(&pool)
     .await
     .expect("seed running task run");
+    sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at) VALUES ('retention_archive', 'fixture', 'success', '2026-02-30T08:45:00.000Z')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed canonical-shaped invalid retention timestamp");
 
     let pruned = prune_system_task_runs(&pool, false)
         .await
@@ -1068,7 +1102,7 @@ async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
     .fetch_one(&pool)
     .await
     .expect("count remaining terminal task runs");
-    assert_eq!(terminal_remaining, 1_000);
+    assert_eq!(terminal_remaining, 1_001);
     let oldest_retained_id: i64 = sqlx::query_scalar(
         "SELECT MIN(id) FROM system_task_runs WHERE task_kind = 'retention_archive' AND status = 'success'",
     )
@@ -1079,6 +1113,13 @@ async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
         oldest_retained_id, 5_001,
         "the pass deletes the oldest records before newer equal-timestamp ties"
     );
+    let invalid_timestamp_remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'retention_archive' AND status = 'success' AND started_at = '2026-02-30T08:45:00.000Z'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count preserved invalid retention timestamp");
+    assert_eq!(invalid_timestamp_remaining, 1);
     let running_remaining: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM system_task_runs WHERE status = 'running'")
             .fetch_one(&pool)

--- a/src/tests/stateful_sqlite/system_status_and_account_roster.rs
+++ b/src/tests/stateful_sqlite/system_status_and_account_roster.rs
@@ -10,6 +10,9 @@ pub(crate) const STATEFUL_SCHEMA_TEMPLATE_PATH_ENV: &str =
 pub(crate) const ARCHIVE_SCHEMA_TEMPLATE_PATH_ENV: &str =
     "CODEX_VIBE_MONITOR_ARCHIVE_SCHEMA_TEMPLATE_PATH";
 
+static SYSTEM_TASK_RUN_RETENTION_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
 pub(crate) fn write_backfill_response_payload_with_service_tier(
     path: &Path,
     service_tier: Option<&str>,
@@ -981,10 +984,33 @@ async fn ensure_schema_normalizes_legacy_system_task_run_timestamps() {
         invalid_finished_at.as_deref(),
         Some("2026-02-30 17:15:00+08:00")
     );
+
+    sqlx::query(
+        "INSERT INTO system_task_runs (task_kind, trigger_kind, status, started_at, finished_at) VALUES ('invalid_legacy_task_timestamp_suffix', 'fixture', 'success', '2026-06-22 08:45:00foo', '2026-06-22 17:15:00+08:00foo')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed invalid legacy task timestamp suffixes");
+    ensure_schema(&pool)
+        .await
+        .expect("preserve invalid task timestamp suffixes");
+    let (invalid_suffix_started_at, invalid_suffix_finished_at): (String, Option<String>) =
+        sqlx::query_as(
+            "SELECT started_at, finished_at FROM system_task_runs WHERE task_kind = 'invalid_legacy_task_timestamp_suffix'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("load preserved invalid timestamp suffixes");
+    assert_eq!(invalid_suffix_started_at, "2026-06-22 08:45:00foo");
+    assert_eq!(
+        invalid_suffix_finished_at.as_deref(),
+        Some("2026-06-22 17:15:00+08:00foo")
+    );
 }
 
 #[tokio::test]
 async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
+    let _schedule_guard = SYSTEM_TASK_RUN_RETENTION_TEST_LOCK.lock().await;
     reset_system_task_run_retention_schedule();
     let pool = test_current_schema_pool().await;
     ensure_schema(&pool)
@@ -1059,6 +1085,19 @@ async fn system_task_run_retention_preserves_recent_rows_and_bounds_deletes() {
             .expect("count remaining retention candidates"),
         800,
         "dry run counts each eligible row once and respects the per-pass cap"
+    );
+    reset_system_task_run_retention_schedule();
+}
+
+#[tokio::test]
+async fn system_task_run_retention_pressure_marks_the_maintenance_pass_deferred() {
+    let _schedule_guard = SYSTEM_TASK_RUN_RETENTION_TEST_LOCK.lock().await;
+    let generation_before = retention_defer_generation();
+    let pressure_error = anyhow::anyhow!("pool timed out while waiting for an open connection");
+    assert!(system_task_run_retention_handle_pressure(&pressure_error));
+    assert!(
+        retention_defer_generation() > generation_before,
+        "pressure must wake the five-minute maintenance retry path"
     );
     reset_system_task_run_retention_schedule();
 }

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -18,6 +18,7 @@ import {
   fetchPromptCacheConversations,
   fetchSettings,
   fetchSummary,
+  fetchSystemTaskRuns,
   fetchTimeseries,
   fetchUpstreamAccountActivity,
   fetchUpstreamAccountAttempts,
@@ -313,6 +314,40 @@ describe("model routing read models", () => {
     expect(live.groups[0]?.accounts[0]).not.toHaveProperty("accountGroupName");
     expect(live.records[0]).not.toHaveProperty("accountGroupName");
     expect(history.items[0]).not.toHaveProperty("accountGroupName");
+  });
+});
+
+describe("fetchSystemTaskRuns", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves the additive cursor contract", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        requestedUrls.push(String(input));
+        return new Response(
+          JSON.stringify({
+            items: [],
+            total: 2,
+            page: 1,
+            pageSize: 1,
+            nextCursor: "eyJzdGFydGVkQXQiOiIyMDI2LTA2LTIyVDA5OjE1OjAwWiIsImlkIjoyfQ",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as typeof fetch,
+    );
+
+    const response = await fetchSystemTaskRuns({
+      cursor: "cursor-token",
+      pageSize: 1,
+    });
+
+    expect(requestedUrls).toEqual(["/api/system/tasks?pageSize=1&cursor=cursor-token"]);
+    expect(response.nextCursor).toBe("eyJzdGFydGVkQXQiOiIyMDI2LTA2LTIyVDA5OjE1OjAwWiIsImlkIjoyfQ");
   });
 });
 

--- a/web/src/lib/api/core-foundation.ts
+++ b/web/src/lib/api/core-foundation.ts
@@ -2443,6 +2443,7 @@ export interface SystemTaskRunsResponse {
   total: number;
   page: number;
   pageSize: number;
+  nextCursor?: string;
 }
 
 export interface ExternalApiKeySummary {
@@ -4640,6 +4641,7 @@ function normalizeSystemTaskRunsResponse(raw: unknown): SystemTaskRunsResponse {
     total: normalizeFiniteNumber(payload.total) ?? 0,
     page: normalizeFiniteNumber(payload.page) ?? 1,
     pageSize: normalizeFiniteNumber(payload.pageSize) ?? 20,
+    nextCursor: typeof payload.nextCursor === "string" ? payload.nextCursor : undefined,
   };
 }
 
@@ -4719,6 +4721,7 @@ export async function fetchSystemTaskRuns(params?: {
   limit?: number;
   page?: number;
   pageSize?: number;
+  cursor?: string;
 }): Promise<SystemTaskRunsResponse> {
   const query = new URLSearchParams();
   if (params?.taskKind) query.set("taskKind", params.taskKind);
@@ -4728,6 +4731,7 @@ export async function fetchSystemTaskRuns(params?: {
   if (params?.limit != null) query.set("limit", String(params.limit));
   if (params?.page != null) query.set("page", String(params.page));
   if (params?.pageSize != null) query.set("pageSize", String(params.pageSize));
+  if (params?.cursor) query.set("cursor", params.cursor);
   const suffix = query.toString() ? `?${query.toString()}` : "";
   const response = await fetchJson<unknown>(`/api/system/tasks${suffix}`);
   return normalizeSystemTaskRunsResponse(response);


### PR DESCRIPTION
## Summary
- Govern `system_task_runs` growth with canonical timestamp ordering, composite indexes, and bounded retention.
- Add additive cursor pagination for `/api/system/tasks` while preserving legacy page responses.
- Normalize legacy timestamps using the existing Shanghai-local convention and apply SQLite pressure backoff without changing startup backfill scheduling.

## Delivery role
Direct PR targeting `main`.

## Spec
- `docs/specs/9aucy-db-retention-archive/SPEC.md`
- `docs/specs/s7m3q-system-workspace/SPEC.md`

## Spec Disposition
Implemented the Lane D system task run schema, cursor API, retention policy, and integration coverage. No owner-facing UI changes.

## Solutions
-

## Project Docs
-

## Sync Results
- Spec: synchronized
- Solutions: not applicable
- Project Docs: not applicable
- Visual evidence: not applicable for backend/API-only changes

## Validation
- Serial backend: `2234 passed / 45 ignored / 0 failed`
- Full Web: `1424 passed / 6 skipped`
- Rust `fmt --check`, `cargo check`, and Clippy `-D warnings`: passed
- Four final read-only review lanes: clear

<!-- CUSTOM_NOTES_START -->
Current validated head: `cc32e78d67a031e22bb5ef6de2e2f5fd359b2ea1`.
<!-- CUSTOM_NOTES_END -->
