### PR TITLE
fix(ci): extend backend test timeout budget

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -204,7 +204,7 @@ jobs:
   storybook-accessibility-tests:
     name: Storybook Accessibility Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -458,7 +458,7 @@ jobs:
     if: always()
     name: Backend Tests (Lightweight)
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -488,7 +488,7 @@ jobs:
     if: always()
     name: Backend Tests (Stateful SQLite)
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -518,7 +518,7 @@ jobs:
     if: always()
     name: Backend Tests (Archive / File I/O)
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -292,7 +292,7 @@ jobs:
   storybook-accessibility-tests:
     name: Storybook Accessibility Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -558,7 +558,7 @@ jobs:
     if: always()
     name: Backend Tests (Lightweight)
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -588,7 +588,7 @@ jobs:
     if: always()
     name: Backend Tests (Stateful SQLite)
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -618,7 +618,7 @@ jobs:
     if: always()
     name: Backend Tests (Archive / File I/O)
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- extend Storybook and backend profile job timeouts to 35 minutes
- keep CI PR and CI Main timeout budgets symmetric
- preserve all job commands, dependencies, and release gates

## Delivery

- Delivery role: direct
- Spec: -
- Spec Disposition: not_needed
- Solutions: -
- Project Docs: -

## Validation

- actionlint .github/workflows/ci-main.yml
- python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final
- timeout symmetry assertion for the four targeted jobs
- git diff --check

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->