### PR TITLE
fix(schema): persist raw codec backfill completion

### DIFF
--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/HISTORY.md
@@ -20,5 +20,6 @@
 - file-backed pool replay 的路由投影收口为单次读取与单次 JSON parse；解析结果限定为路由所需的紧凑字段，保留既有 sticky key 类型错误和重复字段降级语义，避免大请求在同一准备阶段重复打开临时文件。
 - Response raw storage distinguishes wire encoding from storage encoding: identity content is stored with Zstd, while pre-compressed wire bytes remain untouched. A saturated writer uses a CRC-framed local spool so enabled response capture is not silently discarded.
 - Paired pool response capture writes one finalized payload and stores independent invocation/attempt links. Durable spool capacity failure is explicit `capture_unavailable`, avoiding a second in-memory queue and duplicate response compression.
+- Raw codec inference records its own completion marker atomically with legacy backfill. The pre-existing raw-blob link seed marker is accepted only as compatibility proof because schema startup has already completed codec inference before that seed is recorded.
 
 - response raw 的内存归因与物理文件指标分开：writer occupancy 通过现有 semaphore 和有界队列估算，spool 只作为持久化/磁盘指标；不会因为 raw 文件总量或 `liveInvocationsCount` 直接判定 RSS 根因。

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/IMPLEMENTATION.md
@@ -4,6 +4,7 @@
 
 - Canonical spec: `docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md`
 - Implementation summary: 已完成
+- Legacy invocation raw codec inference is now an atomic one-time schema migration. Its persistent marker eliminates repeated full-table UPDATE scans on completed databases, while the older raw-blob link seed marker remains a verified compatibility completion proof.
 - 最新收口：`proxy capture follow-up` 已改成 subscriber-aware，`receiver_count()==0` 且非 shutdown flush 时不会再消耗 follow-up seq 或触发 summary/quota / rollup refresh；active subscriber 与 shutdown tail flush 语义已回归验证。
 - Response raw capture stores identity bytes as Zstd, retains pre-compressed wire bytes without a second compression pass, and uses a CRC-framed persistent overflow spool when the bounded writer pool is saturated. Incomplete spool files are retained for inspection; complete files replay during startup.
 - Overflow spools rotate at 16 MiB and reserve a 512 MiB directory budget. If a new spool cannot be admitted, capture records `capture_unavailable:spool_capacity`; it does not create a second in-memory overflow queue or delay downstream forwarding. The paired pool invocation and attempt share one finalized response raw blob with independent persistent links.

--- a/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
+++ b/docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md
@@ -35,6 +35,7 @@
 
 - Response raw capture must preserve an already content-encoded wire response as-is; it must not decode and recompress `gzip`, `zstd`, or `deflate` on the proxy request path.
 - Identity payload storage defaults to Zstd. Existing `.gz` captures remain readable and expire through normal retention; no bulk migration is permitted.
+- Raw codec inference for legacy invocation rows must run as a persistent, atomic one-time migration. Completed databases may read only its completion marker at startup; historical raw-blob link seed completion is valid compatibility proof because it was recorded after codec inference.
 - A saturated raw writer queues enabled capture work in the durable spool. Compression concurrency is bounded by `PROXY_RAW_ZSTD_MAX_CONCURRENT_WRITERS` or `clamp(available_parallelism / 2, 2, 8)`. If the spool hard limit cannot accept a capture, the invocation records `capture_unavailable:*`; it never falls back to an unbounded memory queue.
 - A paired pool response stream uses one bounded ingress and one encoder worker. Invocation and attempt metadata may link to the same published response raw path, while retention keeps that path until both independent owners have released it.
 - `src/config.rs` / `src/app_state.rs` / `src/runtime.rs` 中 whole-proxy admission gate 的移除、纯观测型 in-flight 指标与 deprecated 配置告警。
@@ -74,6 +75,7 @@
 
 - `codex-testbox` 上 100 个同时发起的 `/v1/*` 代理请求不会出现任何本地 `503 proxy concurrency limit reached; retry later`。
 - response raw append 不再位于 chunk 转发之前；request raw 写盘不再阻塞上游发送。
+- Given a legacy SQLite database without raw codec completion proof, When schema startup infers raw codecs, Then both codec fields and the completion marker commit atomically; subsequent completed startups do not scan `codex_invocations`.
 - 大于小体积阈值的 pool request body 不再默认整包内存物化；sticky 探测仅依赖前缀窗口或 replay snapshot 前缀。
 - capture 大 body 读取会产生 file-backed replay snapshot；超限/超时/客户端断开时仅保留有界 partial body 证据，不得因为切换 snapshot 控制面而丢 raw failure context，也不得把成功读取的大 body 同时整包留在内存。
 - capture pool outbound 与 route-selection prebuffer fallback 的大 body failover snapshot kind 必须为 `file`；11MB/21MB/62MB 等请求不得在正常临时文件可用时继续以 `snapshot_kind="memory"` 进入上游 timeout / failover 日志。

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -10,6 +10,8 @@ pub(crate) const PROMPT_CACHE_WORKING_SET_WINDOW_SECONDS: i64 = 300;
 pub(crate) const SHANGHAI_NOW_SQL: &str = "datetime('now', '+8 hours')";
 const INVOCATION_ROLLUP_TOKEN_COMPONENT_RECONCILIATION_DATASET: &str =
     "invocation_rollup_hourly_token_components_v1";
+const INVOCATION_RAW_CODEC_MIGRATION_NAME: &str = "backfill_raw_codecs_v1";
+const LEGACY_RAW_BLOB_LINK_SEED_MIGRATION_NAME: &str = "seed_existing_raw_blob_links_v1";
 
 pub(crate) fn ensure_schema_lock_key(pool: &Pool<Sqlite>) -> String {
     let connect_options = pool.connect_options();
@@ -1193,6 +1195,115 @@ pub(crate) async fn reopen_upstream_account_stats_rollup_archives(
     Ok(())
 }
 
+async fn ensure_invocation_raw_codec_backfill(pool: &Pool<Sqlite>) -> Result<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS codex_invocation_raw_codec_migrations (
+            migration_name TEXT PRIMARY KEY,
+            completed_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure raw codec migration marker table")?;
+
+    let already_completed = sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS(SELECT 1 FROM codex_invocation_raw_codec_migrations WHERE migration_name = ?1)",
+    )
+    .bind(INVOCATION_RAW_CODEC_MIGRATION_NAME)
+    .fetch_one(pool)
+    .await?
+        != 0;
+    if already_completed {
+        return Ok(());
+    }
+
+    let mut tx = pool
+        .begin_with("BEGIN IMMEDIATE")
+        .await
+        .context("failed to begin raw codec backfill migration")?;
+    let already_completed = sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS(SELECT 1 FROM codex_invocation_raw_codec_migrations WHERE migration_name = ?1)",
+    )
+    .bind(INVOCATION_RAW_CODEC_MIGRATION_NAME)
+    .fetch_one(tx.as_mut())
+    .await?
+        != 0;
+    if already_completed {
+        tx.commit()
+            .await
+            .context("failed to commit raw codec migration marker check")?;
+        return Ok(());
+    }
+
+    if !legacy_raw_blob_link_seed_completed(&mut tx).await? {
+        sqlx::query(
+            r#"
+            UPDATE codex_invocations
+            SET request_raw_codec = CASE
+                    WHEN request_raw_path IS NOT NULL AND request_raw_path LIKE '%.gz' THEN 'gzip'
+                    ELSE 'identity'
+                END
+            WHERE COALESCE(TRIM(request_raw_codec), '') = ''
+               OR (request_raw_codec = 'identity' AND request_raw_path LIKE '%.gz')
+            "#,
+        )
+        .execute(tx.as_mut())
+        .await
+        .context("failed to backfill codex_invocations request_raw_codec")?;
+
+        sqlx::query(
+            r#"
+            UPDATE codex_invocations
+            SET response_raw_codec = CASE
+                    WHEN response_raw_path IS NOT NULL AND response_raw_path LIKE '%.gz' THEN 'gzip'
+                    ELSE 'identity'
+                END
+            WHERE COALESCE(TRIM(response_raw_codec), '') = ''
+               OR (response_raw_codec = 'identity' AND response_raw_path LIKE '%.gz')
+            "#,
+        )
+        .execute(tx.as_mut())
+        .await
+        .context("failed to backfill codex_invocations response_raw_codec")?;
+    }
+
+    sqlx::query("INSERT INTO codex_invocation_raw_codec_migrations (migration_name) VALUES (?1)")
+        .bind(INVOCATION_RAW_CODEC_MIGRATION_NAME)
+        .execute(tx.as_mut())
+        .await
+        .context("failed to record raw codec backfill completion")?;
+    tx.commit()
+        .await
+        .context("failed to commit raw codec backfill migration")?;
+
+    Ok(())
+}
+
+async fn legacy_raw_blob_link_seed_completed(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+) -> Result<bool> {
+    let migration_table_exists = sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+    )
+    .bind("proxy_raw_payload_blob_link_migrations")
+    .fetch_one(tx.as_mut())
+    .await?
+        != 0;
+    if !migration_table_exists {
+        return Ok(false);
+    }
+
+    Ok(sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS(SELECT 1 FROM proxy_raw_payload_blob_link_migrations WHERE migration_name = ?1)",
+    )
+    .bind(LEGACY_RAW_BLOB_LINK_SEED_MIGRATION_NAME)
+    .fetch_one(tx.as_mut())
+    .await?
+        != 0)
+}
+
 pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     let schema_lock = ensure_schema_lock(pool);
     let _schema_guard = schema_lock.lock_owned().await;
@@ -1264,35 +1375,7 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
         }
     }
 
-    sqlx::query(
-        r#"
-        UPDATE codex_invocations
-        SET request_raw_codec = CASE
-                WHEN request_raw_path IS NOT NULL AND request_raw_path LIKE '%.gz' THEN 'gzip'
-                ELSE 'identity'
-            END
-        WHERE COALESCE(TRIM(request_raw_codec), '') = ''
-           OR (request_raw_codec = 'identity' AND request_raw_path LIKE '%.gz')
-        "#,
-    )
-    .execute(pool)
-    .await
-    .context("failed to backfill codex_invocations request_raw_codec")?;
-
-    sqlx::query(
-        r#"
-        UPDATE codex_invocations
-        SET response_raw_codec = CASE
-                WHEN response_raw_path IS NOT NULL AND response_raw_path LIKE '%.gz' THEN 'gzip'
-                ELSE 'identity'
-            END
-        WHERE COALESCE(TRIM(response_raw_codec), '') = ''
-           OR (response_raw_codec = 'identity' AND response_raw_path LIKE '%.gz')
-        "#,
-    )
-    .execute(pool)
-    .await
-    .context("failed to backfill codex_invocations response_raw_codec")?;
+    ensure_invocation_raw_codec_backfill(pool).await?;
 
     // Speed up time-range scans and ordering on the stats endpoints
     sqlx::query(
@@ -4419,11 +4502,10 @@ async fn ensure_proxy_raw_payload_blob_link_schema(pool: &Pool<Sqlite>) -> Resul
 }
 
 async fn seed_legacy_proxy_raw_payload_blob_links(pool: &Pool<Sqlite>) -> Result<()> {
-    const MIGRATION_NAME: &str = "seed_existing_raw_blob_links_v1";
     let already_seeded = sqlx::query_scalar::<_, i64>(
         "SELECT EXISTS(SELECT 1 FROM proxy_raw_payload_blob_link_migrations WHERE migration_name = ?1)",
     )
-    .bind(MIGRATION_NAME)
+    .bind(LEGACY_RAW_BLOB_LINK_SEED_MIGRATION_NAME)
     .fetch_one(pool)
     .await?
         != 0;
@@ -4467,7 +4549,7 @@ async fn seed_legacy_proxy_raw_payload_blob_links(pool: &Pool<Sqlite>) -> Result
     .execute(tx.as_mut())
     .await?;
     sqlx::query("INSERT INTO proxy_raw_payload_blob_link_migrations (migration_name) VALUES (?1)")
-        .bind(MIGRATION_NAME)
+        .bind(LEGACY_RAW_BLOB_LINK_SEED_MIGRATION_NAME)
         .execute(tx.as_mut())
         .await?;
     tx.commit().await?;

--- a/src/tests/lightweight/forward_proxy_config_and_storage.rs
+++ b/src/tests/lightweight/forward_proxy_config_and_storage.rs
@@ -3268,6 +3268,31 @@ async fn ensure_schema_backfills_raw_codecs_and_manifest_tables() {
     );
     assert_eq!(row.get::<String, _>("response_raw_codec"), RAW_CODEC_GZIP);
 
+    let completed_migrations: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM codex_invocation_raw_codec_migrations WHERE migration_name = 'backfill_raw_codecs_v1'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load raw codec migration marker");
+    assert_eq!(completed_migrations, 1);
+
+    sqlx::query("UPDATE codex_invocations SET response_raw_codec = ?1 WHERE invoke_id = ?2")
+        .bind(RAW_CODEC_IDENTITY)
+        .bind("legacy-codec-row")
+        .execute(&pool)
+        .await
+        .expect("simulate a post-migration row");
+    ensure_schema(&pool)
+        .await
+        .expect("completed codec migration should be idempotent");
+    let response_codec: String =
+        sqlx::query_scalar("SELECT response_raw_codec FROM codex_invocations WHERE invoke_id = ?1")
+            .bind("legacy-codec-row")
+            .fetch_one(&pool)
+            .await
+            .expect("load idempotent codec row");
+    assert_eq!(response_codec, RAW_CODEC_IDENTITY);
+
     let archive_batch_columns = load_sqlite_table_columns(&pool, "archive_batches")
         .await
         .expect("load archive batch columns");
@@ -3278,6 +3303,174 @@ async fn ensure_schema_backfills_raw_codecs_and_manifest_tables() {
     assert!(manifest_columns.contains("archive_batch_id"));
     assert!(manifest_columns.contains("account_id"));
     assert!(manifest_columns.contains("last_activity_at"));
+}
+
+#[tokio::test]
+async fn ensure_schema_commits_raw_codec_backfill_and_marker_atomically() {
+    let db_id = NEXT_PROXY_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    let db_url = format!("sqlite:file:raw-codec-atomic-{db_id}?mode=memory&cache=shared");
+    let pool = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&db_url)
+        .await
+        .expect("connect schema sqlite");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE codex_invocations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            invoke_id TEXT NOT NULL,
+            occurred_at TEXT NOT NULL,
+            raw_response TEXT NOT NULL,
+            request_raw_path TEXT,
+            request_raw_codec TEXT NOT NULL DEFAULT 'identity',
+            response_raw_path TEXT,
+            response_raw_codec TEXT NOT NULL DEFAULT 'identity',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(invoke_id, occurred_at)
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy codex_invocations");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id,
+            occurred_at,
+            raw_response,
+            request_raw_path,
+            response_raw_path
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+    )
+    .bind("atomic-codec-row")
+    .bind("2026-03-01 08:00:00")
+    .bind("{}")
+    .bind("proxy_raw_payloads/request.bin.gz")
+    .bind("proxy_raw_payloads/response.bin.gz")
+    .execute(&pool)
+    .await
+    .expect("insert legacy codec row");
+    sqlx::query(
+        r#"
+        CREATE TRIGGER fail_response_raw_codec_backfill
+        BEFORE UPDATE OF response_raw_codec ON codex_invocations
+        WHEN NEW.response_raw_codec = 'gzip'
+        BEGIN
+            SELECT RAISE(ABORT, 'forced raw codec backfill failure');
+        END
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("install raw codec failure trigger");
+
+    let error = ensure_schema(&pool)
+        .await
+        .expect_err("response codec failure should abort the migration");
+    assert!(
+        format!("{error:#}").contains("failed to backfill codex_invocations response_raw_codec"),
+        "unexpected migration error: {error:#}"
+    );
+
+    let row = sqlx::query(
+        "SELECT request_raw_codec, response_raw_codec FROM codex_invocations WHERE invoke_id = ?1",
+    )
+    .bind("atomic-codec-row")
+    .fetch_one(&pool)
+    .await
+    .expect("load rolled-back codec row");
+    assert_eq!(
+        row.get::<String, _>("request_raw_codec"),
+        RAW_CODEC_IDENTITY
+    );
+    assert_eq!(
+        row.get::<String, _>("response_raw_codec"),
+        RAW_CODEC_IDENTITY
+    );
+    let completed_migrations: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM codex_invocation_raw_codec_migrations WHERE migration_name = 'backfill_raw_codecs_v1'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load raw codec migration marker after rollback");
+    assert_eq!(completed_migrations, 0);
+}
+
+#[tokio::test]
+async fn ensure_schema_honors_legacy_raw_blob_seed_marker_for_raw_codecs() {
+    let db_id = NEXT_PROXY_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    let db_url = format!("sqlite:file:raw-codec-legacy-marker-{db_id}?mode=memory&cache=shared");
+    let pool = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&db_url)
+        .await
+        .expect("connect schema sqlite");
+
+    ensure_schema(&pool)
+        .await
+        .expect("initialize schema and raw blob seed marker");
+    sqlx::query(
+        "DELETE FROM codex_invocation_raw_codec_migrations WHERE migration_name = 'backfill_raw_codecs_v1'",
+    )
+    .execute(&pool)
+    .await
+    .expect("remove new codec marker to simulate an upgraded legacy database");
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (
+            invoke_id,
+            occurred_at,
+            raw_response,
+            response_raw_path,
+            response_raw_codec
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+    )
+    .bind("legacy-seed-proof-row")
+    .bind("2026-03-01 08:00:00")
+    .bind("{}")
+    .bind("proxy_raw_payloads/response.bin.gz")
+    .bind(RAW_CODEC_IDENTITY)
+    .execute(&pool)
+    .await
+    .expect("insert row that would expose a repeated codec scan");
+    sqlx::query(
+        r#"
+        CREATE TRIGGER fail_repeated_response_raw_codec_backfill
+        BEFORE UPDATE OF response_raw_codec ON codex_invocations
+        WHEN NEW.response_raw_codec = 'gzip'
+        BEGIN
+            SELECT RAISE(ABORT, 'repeated raw codec backfill');
+        END
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("install repeated-backfill failure trigger");
+
+    ensure_schema(&pool)
+        .await
+        .expect("legacy raw blob seed marker should skip codec scans");
+
+    let response_codec: String =
+        sqlx::query_scalar("SELECT response_raw_codec FROM codex_invocations WHERE invoke_id = ?1")
+            .bind("legacy-seed-proof-row")
+            .fetch_one(&pool)
+            .await
+            .expect("load untouched codec row");
+    assert_eq!(response_codec, RAW_CODEC_IDENTITY);
+    let completed_migrations: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM codex_invocation_raw_codec_migrations WHERE migration_name = 'backfill_raw_codecs_v1'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load restored raw codec migration marker");
+    assert_eq!(completed_migrations, 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Persist legacy invocation raw-codec inference as one atomic SQLite migration.
- Reuse the historical raw-blob link seed marker only as verified compatibility proof.
- Add migration, idempotency, rollback, and legacy-marker regression coverage.

## Delivery Metadata

- Delivery role: direct
- Spec: `docs/specs/q8h3n-proxy-hot-path-streaming-stability/SPEC.md`
- Spec Disposition: update
- Solutions: -
- Project Docs: -
- Spec sync: passed; no drift
- Visual evidence: not applicable (schema and tests only)

## Validation

- `cargo test ensure_schema_ -- --nocapture`
- `bun run verify:rust`

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
