### PR TITLE
fix(sqlite): index sticky preview lookups

### DIFF
--- a/docs/specs/pbgwc-prompt-cache-conversation-bindings/IMPLEMENTATION.md
+++ b/docs/specs/pbgwc-prompt-cache-conversation-bindings/IMPLEMENTATION.md
@@ -5,6 +5,10 @@
 - Status: implemented
 - Canonical spec: `docs/specs/pbgwc-prompt-cache-conversation-bindings/SPEC.md`
 
+## Sticky Preview Query Plan
+
+- Account-scoped Sticky invocation previews retain the exact JSON compatibility semantics for `upstreamAccountId` and `stickyKey` with `promptCacheKey` fallback. Startup schema maintenance creates a matching composite expression index ending in `occurred_at DESC, id DESC`, so the per-key recent window avoids a SQLite temporary sort; response ordering remains deterministic in the route layer.
+
 ## Calls card projection
 
 The shared conversation Calls view uses `InvocationCardList` (the compatibility export remains `InvocationTable`) so Live and conversation drawers consume the same card projection. The projection is presentation-only: terminal timing still comes from the persisted invocation fields, while one shared one-second clock supplies elapsed values only for in-flight rows. Virtual rows retain stable invocation keys and mount the existing `InvocationWorkflowDetailPanel` in the expanded card region.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1438,6 +1438,24 @@ pub(crate) async fn ensure_schema(pool: &Pool<Sqlite>) -> Result<()> {
     .await
     .context("failed to ensure index idx_codex_invocations_upstream_account_occurred_at")?;
 
+    // The account Sticky-key preview ranks recent invocations within each key. Keep
+    // the JSON compatibility expressions identical to that query so SQLite can use
+    // the index for both predicates and the window ordering.
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_codex_invocations_account_sticky_key_recent
+        ON codex_invocations (
+            (CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.upstreamAccountId') AS INTEGER) END),
+            (CASE WHEN json_valid(payload) THEN TRIM(COALESCE(CAST(json_extract(payload, '$.stickyKey') AS TEXT), CAST(json_extract(payload, '$.promptCacheKey') AS TEXT))) END),
+            occurred_at DESC,
+            id DESC
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("failed to ensure index idx_codex_invocations_account_sticky_key_recent")?;
+
     // The records analytics page compares trimmed lowercase text for exact-match filters.
     // Mirror those expressions in dedicated indexes so high-volume searches avoid full index scans.
     sqlx::query(

--- a/src/upstream_accounts/routing/sticky_routes.rs
+++ b/src/upstream_accounts/routing/sticky_routes.rs
@@ -327,6 +327,33 @@ pub(crate) async fn query_account_sticky_key_recent_invocations(
         return Ok(Vec::new());
     }
 
+    let mut query = build_account_sticky_key_recent_invocations_query(
+        account_id,
+        selected_keys,
+        limit_per_key,
+        range_start_bound,
+    );
+    let mut rows = query
+        .build_query_as::<AccountStickyKeyInvocationPreviewRow>()
+        .fetch_all(pool)
+        .await?;
+    // The composite expression index already supplies the window order. Keep the
+    // response's historical deterministic order without asking SQLite to sort it again.
+    rows.sort_by(|left, right| {
+        left.sticky_key
+            .cmp(&right.sticky_key)
+            .then_with(|| right.occurred_at.cmp(&left.occurred_at))
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    Ok(rows)
+}
+
+pub(crate) fn build_account_sticky_key_recent_invocations_query<'args>(
+    account_id: i64,
+    selected_keys: &'args [String],
+    limit_per_key: i64,
+    range_start_bound: Option<&'args str>,
+) -> QueryBuilder<'args, Sqlite> {
     let mut query =
         QueryBuilder::<Sqlite>::new("WITH ranked AS (SELECT id, invoke_id, occurred_at, ");
     query
@@ -426,19 +453,7 @@ pub(crate) async fn query_account_sticky_key_recent_invocations(
         .push(")) SELECT sticky_key, id, invoke_id, occurred_at, status, failure_class, route_mode, model, request_model, response_model, total_tokens, cost, source, input_tokens, output_tokens, cache_input_tokens, reasoning_tokens, reasoning_effort, error_message, downstream_status_code, downstream_error_message, failure_kind, is_actionable, proxy_display_name, upstream_account_id, upstream_account_name, response_content_encoding, request_compression_algorithm, transport, requested_service_tier, service_tier, billing_service_tier, t_req_read_ms, t_req_parse_ms, t_upstream_connect_ms, t_upstream_ttfb_ms, first_token_ms, t_upstream_stream_ms, t_resp_parse_ms, t_persist_ms, t_total_ms, endpoint, compaction_request_kind, compaction_response_kind, image_intent FROM ranked WHERE row_number <= ")
         .push_bind(limit_per_key);
 
-    let mut rows = query
-        .build_query_as::<AccountStickyKeyInvocationPreviewRow>()
-        .fetch_all(pool)
-        .await?;
-    // The composite expression index already supplies the window order. Keep the
-    // response's historical deterministic order without asking SQLite to sort it again.
-    rows.sort_by(|left, right| {
-        left.sticky_key
-            .cmp(&right.sticky_key)
-            .then_with(|| right.occurred_at.cmp(&left.occurred_at))
-            .then_with(|| right.id.cmp(&left.id))
-    });
-    Ok(rows)
+    query
 }
 
 pub(crate) async fn load_sticky_route(

--- a/src/upstream_accounts/routing/sticky_routes.rs
+++ b/src/upstream_accounts/routing/sticky_routes.rs
@@ -424,14 +424,21 @@ pub(crate) async fn query_account_sticky_key_recent_invocations(
 
     query
         .push(")) SELECT sticky_key, id, invoke_id, occurred_at, status, failure_class, route_mode, model, request_model, response_model, total_tokens, cost, source, input_tokens, output_tokens, cache_input_tokens, reasoning_tokens, reasoning_effort, error_message, downstream_status_code, downstream_error_message, failure_kind, is_actionable, proxy_display_name, upstream_account_id, upstream_account_name, response_content_encoding, request_compression_algorithm, transport, requested_service_tier, service_tier, billing_service_tier, t_req_read_ms, t_req_parse_ms, t_upstream_connect_ms, t_upstream_ttfb_ms, first_token_ms, t_upstream_stream_ms, t_resp_parse_ms, t_persist_ms, t_total_ms, endpoint, compaction_request_kind, compaction_response_kind, image_intent FROM ranked WHERE row_number <= ")
-        .push_bind(limit_per_key)
-        .push(" ORDER BY sticky_key ASC, occurred_at DESC, id DESC");
+        .push_bind(limit_per_key);
 
-    query
+    let mut rows = query
         .build_query_as::<AccountStickyKeyInvocationPreviewRow>()
         .fetch_all(pool)
-        .await
-        .map_err(Into::into)
+        .await?;
+    // The composite expression index already supplies the window order. Keep the
+    // response's historical deterministic order without asking SQLite to sort it again.
+    rows.sort_by(|left, right| {
+        left.sticky_key
+            .cmp(&right.sticky_key)
+            .then_with(|| right.occurred_at.cmp(&left.occurred_at))
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    Ok(rows)
 }
 
 pub(crate) async fn load_sticky_route(

--- a/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
+++ b/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
@@ -6721,13 +6721,44 @@ async fn sticky_key_recent_preview_uses_compatible_composite_index_without_sql_s
         "sticky preview should not sort in SQLite: {plan}"
     );
 
+    let windowed_query = build_account_sticky_key_recent_invocations_query(
+        account_id,
+        &explain_keys,
+        5,
+        Some("2026-08-20 10:00:00"),
+    );
+    let windowed_sql = windowed_query.sql().to_string();
+    let windowed_plan = sqlx::query(&format!("EXPLAIN QUERY PLAN {windowed_sql}"))
+        .bind(account_id)
+        .bind("2026-08-20 10:00:00")
+        .bind("sticky-primary")
+        .bind("sticky-fallback")
+        .bind(5_i64)
+        .fetch_all(&state.pool)
+        .await
+        .expect("load windowed sticky preview explain plan")
+        .into_iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join(" | ");
+    assert!(
+        windowed_plan.contains("idx_codex_invocations_account_sticky_key_recent"),
+        "unexpected windowed sticky preview plan: {windowed_plan}"
+    );
+    assert!(
+        !windowed_plan.contains("USE TEMP B-TREE"),
+        "windowed sticky preview should not sort in SQLite: {windowed_plan}"
+    );
+
     sqlx::query(
         r#"
         INSERT INTO codex_invocations (invoke_id, occurred_at, source, payload, raw_response)
         VALUES
             ('sticky-primary-old', '2026-08-20 10:00:00', 'proxy', ?1, ''),
-            ('sticky-primary-new', '2026-08-20 10:01:00', 'proxy', ?1, ''),
-            ('sticky-fallback-new', '2026-08-20 10:02:00', 'proxy', ?2, '')
+            ('sticky-primary-tie-old', '2026-08-20 10:01:00', 'proxy', ?1, ''),
+            ('sticky-primary-tie-new', '2026-08-20 10:01:00', 'proxy', ?1, ''),
+            ('sticky-primary-new', '2026-08-20 10:02:00', 'proxy', ?1, ''),
+            ('sticky-fallback-new', '2026-08-20 10:03:00', 'proxy', ?2, '')
         "#,
     )
     .bind(
@@ -6752,16 +6783,18 @@ async fn sticky_key_recent_preview_uses_compatible_composite_index_without_sql_s
         &state.pool,
         account_id,
         &["sticky-primary".to_string(), "sticky-fallback".to_string()],
-        1,
+        3,
         None,
     )
     .await
     .expect("load indexed sticky preview");
-    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.len(), 4);
     assert_eq!(rows[0].sticky_key, "sticky-fallback");
     assert_eq!(rows[0].invoke_id, "sticky-fallback-new");
     assert_eq!(rows[1].sticky_key, "sticky-primary");
     assert_eq!(rows[1].invoke_id, "sticky-primary-new");
+    assert_eq!(rows[2].invoke_id, "sticky-primary-tie-new");
+    assert_eq!(rows[3].invoke_id, "sticky-primary-tie-old");
 }
 
 #[tokio::test]
@@ -6776,7 +6809,29 @@ async fn benchmark_sticky_key_recent_preview_on_three_hundred_thousand_rows() {
         r#"
         CREATE TABLE codex_invocations (
             id INTEGER PRIMARY KEY,
+            invoke_id TEXT,
             occurred_at TEXT NOT NULL,
+            status TEXT,
+            failure_class TEXT,
+            failure_kind TEXT,
+            error_message TEXT,
+            model TEXT,
+            total_tokens INTEGER,
+            cost REAL,
+            source TEXT,
+            input_tokens INTEGER,
+            output_tokens INTEGER,
+            cache_input_tokens INTEGER,
+            reasoning_tokens INTEGER,
+            t_req_read_ms REAL,
+            t_req_parse_ms REAL,
+            t_upstream_connect_ms REAL,
+            t_upstream_ttfb_ms REAL,
+            first_token_ms REAL,
+            t_upstream_stream_ms REAL,
+            t_resp_parse_ms REAL,
+            t_persist_ms REAL,
+            t_total_ms REAL,
             payload TEXT
         )
         "#,
@@ -6784,6 +6839,30 @@ async fn benchmark_sticky_key_recent_preview_on_three_hundred_thousand_rows() {
     .execute(&pool)
     .await
     .expect("create sticky preview benchmark table");
+    sqlx::query(
+        r#"
+        CREATE TABLE pool_upstream_request_attempts (
+            id INTEGER PRIMARY KEY,
+            invoke_id TEXT,
+            occurred_at TEXT,
+            status TEXT,
+            upstream_request_compression_algorithm TEXT,
+            attempt_index INTEGER
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create sticky preview benchmark attempts table");
+    sqlx::query(
+        r#"
+        CREATE INDEX idx_pool_upstream_request_attempts_invoke_attempt
+        ON pool_upstream_request_attempts (invoke_id, attempt_index)
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create sticky preview benchmark attempts index");
     let account_id = 42_i64;
     sqlx::query(
         r#"
@@ -6798,13 +6877,15 @@ async fn benchmark_sticky_key_recent_preview_on_three_hundred_thousand_rows() {
                 UNION ALL
                 SELECT value + 1 FROM hundreds WHERE value < 299
             )
-        INSERT INTO codex_invocations (id, occurred_at, payload)
+        INSERT INTO codex_invocations (id, invoke_id, occurred_at, source, payload)
         SELECT
             thousands.value * 300 + hundreds.value + 1,
+            printf('sticky-benchmark-%06d', thousands.value * 300 + hundreds.value + 1),
             datetime('2026-08-20 00:00:00', printf('+%d seconds', thousands.value * 300 + hundreds.value)),
+            'proxy',
             json_object(
                 'upstreamAccountId', CASE WHEN (thousands.value * 300 + hundreds.value) % 10 = 0 THEN ?1 ELSE ?1 + 1 END,
-                CASE WHEN (thousands.value * 300 + hundreds.value) % 2 = 0 THEN 'stickyKey' ELSE 'promptCacheKey' END,
+                CASE WHEN (thousands.value * 300 + hundreds.value) % 20 = 0 THEN 'stickyKey' ELSE 'promptCacheKey' END,
                 printf('sticky-%02d', (thousands.value * 300 + hundreds.value) % 12)
             )
         FROM thousands
@@ -6829,35 +6910,15 @@ async fn benchmark_sticky_key_recent_preview_on_three_hundred_thousand_rows() {
     .execute(&pool)
     .await
     .expect("create sticky preview benchmark index");
-
-    let query = r#"
-        WITH ranked AS (
-            SELECT
-                id,
-                occurred_at,
-                CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
-                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
-                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
-                )) END AS sticky_key,
-                ROW_NUMBER() OVER (
-                    PARTITION BY CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
-                        CAST(json_extract(payload, '$.stickyKey') AS TEXT),
-                        CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
-                    )) END
-                    ORDER BY occurred_at DESC, id DESC
-                ) AS row_number
-            FROM codex_invocations
-            WHERE CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.upstreamAccountId') AS INTEGER) END = ?1
-              AND CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
-                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
-                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
-                  )) END IN (?2, ?3, ?4)
-        )
-        SELECT sticky_key, id
-        FROM ranked
-        WHERE row_number <= 5
-        "#;
-    let plan = sqlx::query(&format!("EXPLAIN QUERY PLAN {query}"))
+    let selected_keys = vec![
+        "sticky-00".to_string(),
+        "sticky-02".to_string(),
+        "sticky-04".to_string(),
+    ];
+    let explain_query =
+        build_account_sticky_key_recent_invocations_query(account_id, &selected_keys, 5, None);
+    let explain_sql = explain_query.sql().to_string();
+    let plan = sqlx::query(&format!("EXPLAIN QUERY PLAN {explain_sql}"))
         .bind(account_id)
         .bind("sticky-00")
         .bind("sticky-02")
@@ -6878,25 +6939,17 @@ async fn benchmark_sticky_key_recent_preview_on_three_hundred_thousand_rows() {
         "300k sticky preview should not sort in SQLite: {plan}"
     );
 
-    let rows = sqlx::query(query)
-        .bind(account_id)
-        .bind("sticky-00")
-        .bind("sticky-02")
-        .bind("sticky-04")
-        .fetch_all(&pool)
-        .await
-        .expect("warm indexed sticky preview");
+    let rows =
+        query_account_sticky_key_recent_invocations(&pool, account_id, &selected_keys, 5, None)
+            .await
+            .expect("warm indexed sticky preview");
     assert_eq!(rows.len(), 15);
 
     let started_at = std::time::Instant::now();
-    let rows = sqlx::query(query)
-        .bind(account_id)
-        .bind("sticky-00")
-        .bind("sticky-02")
-        .bind("sticky-04")
-        .fetch_all(&pool)
-        .await
-        .expect("load indexed sticky preview");
+    let rows =
+        query_account_sticky_key_recent_invocations(&pool, account_id, &selected_keys, 5, None)
+            .await
+            .expect("load indexed sticky preview");
     let elapsed = started_at.elapsed();
 
     assert_eq!(rows.len(), 15);

--- a/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
+++ b/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
@@ -6923,6 +6923,7 @@ async fn benchmark_sticky_key_recent_preview_on_three_hundred_thousand_rows() {
         .bind("sticky-00")
         .bind("sticky-02")
         .bind("sticky-04")
+        .bind(5_i64)
         .fetch_all(&pool)
         .await
         .expect("load 300k sticky preview explain plan")

--- a/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
+++ b/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
@@ -6674,3 +6674,259 @@ async fn sticky_key_preview_uses_the_final_attempt_request_compression() {
         Some("zstd")
     );
 }
+
+#[tokio::test]
+async fn sticky_key_recent_preview_uses_compatible_composite_index_without_sql_sort() {
+    let state = test_app_state_with_usage_base("http://127.0.0.1:9").await;
+    let account_id = insert_api_key_account(&state.pool, "Sticky preview index").await;
+    let index_sql = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'index'
+          AND name = 'idx_codex_invocations_account_sticky_key_recent'
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load sticky preview index");
+    assert!(index_sql.contains("$.upstreamAccountId"));
+    assert!(index_sql.contains("$.stickyKey"));
+    assert!(index_sql.contains("$.promptCacheKey"));
+    assert!(index_sql.contains("occurred_at DESC"));
+    assert!(index_sql.contains("id DESC"));
+
+    let plan = sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        WITH ranked AS (
+            SELECT
+                id,
+                occurred_at,
+                CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
+                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
+                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
+                )) END AS sticky_key,
+                ROW_NUMBER() OVER (
+                    PARTITION BY CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
+                        CAST(json_extract(payload, '$.stickyKey') AS TEXT),
+                        CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
+                    )) END
+                    ORDER BY occurred_at DESC, id DESC
+                ) AS row_number
+            FROM codex_invocations
+            WHERE CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.upstreamAccountId') AS INTEGER) END = ?1
+              AND CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
+                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
+                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
+                  )) END IN (?2, ?3)
+        )
+        SELECT sticky_key, id
+        FROM ranked
+        WHERE row_number <= 5
+        "#,
+    )
+    .bind(account_id)
+    .bind("sticky-primary")
+    .bind("sticky-fallback")
+    .fetch_all(&state.pool)
+    .await
+    .expect("load sticky preview explain plan")
+    .into_iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join(" | ");
+    assert!(
+        plan.contains("idx_codex_invocations_account_sticky_key_recent"),
+        "unexpected sticky preview plan: {plan}"
+    );
+    assert!(
+        !plan.contains("USE TEMP B-TREE"),
+        "sticky preview should not sort in SQLite: {plan}"
+    );
+
+    sqlx::query(
+        r#"
+        INSERT INTO codex_invocations (invoke_id, occurred_at, source, payload, raw_response)
+        VALUES
+            ('sticky-primary-old', '2026-08-20 10:00:00', 'proxy', ?1, ''),
+            ('sticky-primary-new', '2026-08-20 10:01:00', 'proxy', ?1, ''),
+            ('sticky-fallback-new', '2026-08-20 10:02:00', 'proxy', ?2, '')
+        "#,
+    )
+    .bind(
+        json!({
+            "upstreamAccountId": account_id,
+            "stickyKey": "sticky-primary",
+        })
+        .to_string(),
+    )
+    .bind(
+        json!({
+            "upstreamAccountId": account_id,
+            "promptCacheKey": "sticky-fallback",
+        })
+        .to_string(),
+    )
+    .execute(&state.pool)
+    .await
+    .expect("insert sticky preview invocations");
+
+    let rows = query_account_sticky_key_recent_invocations(
+        &state.pool,
+        account_id,
+        &["sticky-primary".to_string(), "sticky-fallback".to_string()],
+        1,
+        None,
+    )
+    .await
+    .expect("load indexed sticky preview");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].sticky_key, "sticky-fallback");
+    assert_eq!(rows[0].invoke_id, "sticky-fallback-new");
+    assert_eq!(rows[1].sticky_key, "sticky-primary");
+    assert_eq!(rows[1].invoke_id, "sticky-primary-new");
+}
+
+#[tokio::test]
+#[ignore = "manual benchmark: measures indexed sticky previews on an isolated 300k fixture"]
+async fn benchmark_sticky_key_recent_preview_on_three_hundred_thousand_rows() {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("open sticky preview benchmark sqlite");
+    sqlx::query(
+        r#"
+        CREATE TABLE codex_invocations (
+            id INTEGER PRIMARY KEY,
+            occurred_at TEXT NOT NULL,
+            payload TEXT
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create sticky preview benchmark table");
+    let account_id = 42_i64;
+    sqlx::query(
+        r#"
+        WITH RECURSIVE
+            thousands(value) AS (
+                VALUES(0)
+                UNION ALL
+                SELECT value + 1 FROM thousands WHERE value < 999
+            ),
+            hundreds(value) AS (
+                VALUES(0)
+                UNION ALL
+                SELECT value + 1 FROM hundreds WHERE value < 299
+            )
+        INSERT INTO codex_invocations (id, occurred_at, payload)
+        SELECT
+            thousands.value * 300 + hundreds.value + 1,
+            datetime('2026-08-20 00:00:00', printf('+%d seconds', thousands.value * 300 + hundreds.value)),
+            json_object(
+                'upstreamAccountId', CASE WHEN (thousands.value * 300 + hundreds.value) % 10 = 0 THEN ?1 ELSE ?1 + 1 END,
+                CASE WHEN (thousands.value * 300 + hundreds.value) % 2 = 0 THEN 'stickyKey' ELSE 'promptCacheKey' END,
+                printf('sticky-%02d', (thousands.value * 300 + hundreds.value) % 12)
+            )
+        FROM thousands
+        CROSS JOIN hundreds
+        "#,
+    )
+    .bind(account_id)
+    .execute(&pool)
+    .await
+    .expect("seed 300k sticky preview fixture");
+    sqlx::query(
+        r#"
+        CREATE INDEX idx_codex_invocations_account_sticky_key_recent
+        ON codex_invocations (
+            (CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.upstreamAccountId') AS INTEGER) END),
+            (CASE WHEN json_valid(payload) THEN TRIM(COALESCE(CAST(json_extract(payload, '$.stickyKey') AS TEXT), CAST(json_extract(payload, '$.promptCacheKey') AS TEXT))) END),
+            occurred_at DESC,
+            id DESC
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create sticky preview benchmark index");
+
+    let query = r#"
+        WITH ranked AS (
+            SELECT
+                id,
+                occurred_at,
+                CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
+                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
+                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
+                )) END AS sticky_key,
+                ROW_NUMBER() OVER (
+                    PARTITION BY CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
+                        CAST(json_extract(payload, '$.stickyKey') AS TEXT),
+                        CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
+                    )) END
+                    ORDER BY occurred_at DESC, id DESC
+                ) AS row_number
+            FROM codex_invocations
+            WHERE CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.upstreamAccountId') AS INTEGER) END = ?1
+              AND CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
+                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
+                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
+                  )) END IN (?2, ?3, ?4)
+        )
+        SELECT sticky_key, id
+        FROM ranked
+        WHERE row_number <= 5
+        "#;
+    let plan = sqlx::query(&format!("EXPLAIN QUERY PLAN {query}"))
+        .bind(account_id)
+        .bind("sticky-00")
+        .bind("sticky-02")
+        .bind("sticky-04")
+        .fetch_all(&pool)
+        .await
+        .expect("load 300k sticky preview explain plan")
+        .into_iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join(" | ");
+    assert!(
+        plan.contains("idx_codex_invocations_account_sticky_key_recent"),
+        "unexpected 300k sticky preview plan: {plan}"
+    );
+    assert!(
+        !plan.contains("USE TEMP B-TREE"),
+        "300k sticky preview should not sort in SQLite: {plan}"
+    );
+
+    let rows = sqlx::query(query)
+        .bind(account_id)
+        .bind("sticky-00")
+        .bind("sticky-02")
+        .bind("sticky-04")
+        .fetch_all(&pool)
+        .await
+        .expect("warm indexed sticky preview");
+    assert_eq!(rows.len(), 15);
+
+    let started_at = std::time::Instant::now();
+    let rows = sqlx::query(query)
+        .bind(account_id)
+        .bind("sticky-00")
+        .bind("sticky-02")
+        .bind("sticky-04")
+        .fetch_all(&pool)
+        .await
+        .expect("load indexed sticky preview");
+    let elapsed = started_at.elapsed();
+
+    assert_eq!(rows.len(), 15);
+    assert!(
+        elapsed < std::time::Duration::from_secs(1),
+        "indexed sticky preview exceeded one second on the 300k-row fixture: {elapsed:?}"
+    );
+    eprintln!("indexed 300k sticky preview completed in {elapsed:?}");
+}

--- a/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
+++ b/src/upstream_accounts/tests/stateful_sqlite/maintenance_scheduler_and_schema.rs
@@ -6696,46 +6696,22 @@ async fn sticky_key_recent_preview_uses_compatible_composite_index_without_sql_s
     assert!(index_sql.contains("occurred_at DESC"));
     assert!(index_sql.contains("id DESC"));
 
-    let plan = sqlx::query(
-        r#"
-        EXPLAIN QUERY PLAN
-        WITH ranked AS (
-            SELECT
-                id,
-                occurred_at,
-                CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
-                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
-                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
-                )) END AS sticky_key,
-                ROW_NUMBER() OVER (
-                    PARTITION BY CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
-                        CAST(json_extract(payload, '$.stickyKey') AS TEXT),
-                        CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
-                    )) END
-                    ORDER BY occurred_at DESC, id DESC
-                ) AS row_number
-            FROM codex_invocations
-            WHERE CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.upstreamAccountId') AS INTEGER) END = ?1
-              AND CASE WHEN json_valid(payload) THEN TRIM(COALESCE(
-                    CAST(json_extract(payload, '$.stickyKey') AS TEXT),
-                    CAST(json_extract(payload, '$.promptCacheKey') AS TEXT)
-                  )) END IN (?2, ?3)
-        )
-        SELECT sticky_key, id
-        FROM ranked
-        WHERE row_number <= 5
-        "#,
-    )
-    .bind(account_id)
-    .bind("sticky-primary")
-    .bind("sticky-fallback")
-    .fetch_all(&state.pool)
-    .await
-    .expect("load sticky preview explain plan")
-    .into_iter()
-    .map(|row| row.get::<String, _>("detail"))
-    .collect::<Vec<_>>()
-    .join(" | ");
+    let explain_keys = vec!["sticky-primary".to_string(), "sticky-fallback".to_string()];
+    let explain_query =
+        build_account_sticky_key_recent_invocations_query(account_id, &explain_keys, 5, None);
+    let explain_sql = explain_query.sql().to_string();
+    let plan = sqlx::query(&format!("EXPLAIN QUERY PLAN {explain_sql}"))
+        .bind(account_id)
+        .bind("sticky-primary")
+        .bind("sticky-fallback")
+        .bind(5_i64)
+        .fetch_all(&state.pool)
+        .await
+        .expect("load sticky preview explain plan")
+        .into_iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join(" | ");
     assert!(
         plan.contains("idx_codex_invocations_account_sticky_key_recent"),
         "unexpected sticky preview plan: {plan}"


### PR DESCRIPTION
## Summary
- Add an idempotent composite expression index for account-scoped sticky-key recent invocation previews.
- Reuse the production query builder in EXPLAIN and 300k load coverage while preserving deterministic response ordering in Rust.
- Preserve stickyKey/promptCacheKey fallback and upstreamAccountId JSON compatibility semantics.

## Scope
Only src/upstream_accounts/routing/sticky_routes.rs, the required schema index, direct stateful SQLite tests, and the associated implementation spec changed. subscriptions.rs, C2/Summary, and long-term projection were not touched.

## Validation
- Isolated full backend runner passed: lightweight 792, stateful-sqlite 1294, archive-file-io 226 (338 seconds total); sync explicitly excluded .env*.
- cargo fmt --all -- --check, cargo check --locked --all-targets --all-features, and cargo clippy --locked --all-targets --all-features -- -D warnings passed.
- Production QueryBuilder EXPLAIN coverage proves the composite index is selected without a SQLite temporary B-tree for both unbounded and windowed previews.
- Ignored 300k-row fixture uses the complete production preview projection, mixes target-account stickyKey and promptCacheKey rows, and passed in 595.9 ms.
- Four independent current-HEAD read-only reviews completed; the one benchmark-bind finding was fixed and re-reviewed cleanly.

## Notes
The index is created with IF NOT EXISTS. The query retains existing JSON compatibility behavior and performs only the historical deterministic final ordering in memory.