### PR TITLE
test(subscriptions): stabilize lightweight CI fixtures

### DIFF
--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -12306,7 +12306,7 @@ mod tests {
             .iter()
             .find(|point| point.bucket_start == fallback_bucket_start)
             .expect("exact fallback point");
-        let projection_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let projection_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         let projected_parallel = loop {
             let projected_parallel = {
                 let guard = state.subscription_hub.state.lock().await;
@@ -15876,19 +15876,13 @@ mod tests {
             .expect("build empty working conversations baseline");
 
         let now = Utc::now();
-        let first_occurred_at = format_naive(
-            (now - ChronoDuration::minutes(2))
-                .with_timezone(&Shanghai)
-                .naive_local(),
-        );
-        let second_occurred_at = format_naive(
-            (now - ChronoDuration::minutes(1))
-                .with_timezone(&Shanghai)
-                .naive_local(),
-        );
+        // Bounded hydration reads current-hour P1 rows plus materialized prior-hour history.
+        // Keep both fixture rows in the live hour so the contract does not depend on an
+        // hour-rollup boundary while CI happens to run near the top of an hour.
+        let occurred_at = format_naive(now.with_timezone(&Shanghai).naive_local());
         for (invoke_id, occurred_at, total_tokens) in [
-            ("reentered-older", first_occurred_at.as_str(), 11_i64),
-            ("reentered-newer", second_occurred_at.as_str(), 31_i64),
+            ("reentered-older", occurred_at.as_str(), 11_i64),
+            ("reentered-newer", occurred_at.as_str(), 31_i64),
         ] {
             sqlx::query(
                 r#"

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -15906,6 +15906,36 @@ mod tests {
             .await
             .expect("persist reentered working conversation history");
         }
+        // The hydration snapshot is captured after these writes. If CI crosses an hour
+        // boundary in between, account details read the materialized historical bucket
+        // rather than the prior-hour P1 rows, just as production does after rollup.
+        sqlx::query(
+            r#"
+            INSERT INTO prompt_cache_upstream_account_hourly (
+                bucket_start_epoch,
+                source,
+                prompt_cache_key,
+                upstream_account_key,
+                upstream_account_id,
+                upstream_account_name,
+                request_count,
+                success_count,
+                failure_count,
+                total_tokens,
+                total_cost,
+                first_seen_at,
+                last_seen_at,
+                updated_at
+            )
+            VALUES (?1, 'proxy', 'reentered-key', 'id:42|name:Hydrated Account', 42,
+                    'Hydrated Account', 2, 2, 0, 42, 0.5, ?2, ?2, datetime('now'))
+            "#,
+        )
+        .bind(now.timestamp().div_euclid(3_600) * 3_600)
+        .bind(&occurred_at)
+        .execute(&state.pool)
+        .await
+        .expect("materialize reentered working conversation account history");
         sqlx::query(
             r#"
             INSERT INTO prompt_cache_conversation_bindings (


### PR DESCRIPTION
## Summary
- Give the shared parallel-work projection a CI-tolerant materialization window.
- Keep the bounded reentered-conversation fixture within its current-hour source boundary.

## Delivery
- Delivery role: direct
- Spec: -
- Spec Disposition: not_needed
- Solutions: -
- Project Docs: -

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- Backend lightweight profile: shared-testbox environment unavailable because its root volume was full before test execution; required GitHub CI is pending.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->