### PR TITLE
fix(timeseries): yield minute projection writes to terminal traffic

### DIFF
--- a/docs/specs/dashboard-hot-topic-projection/SPEC.md
+++ b/docs/specs/dashboard-hot-topic-projection/SPEC.md
@@ -51,6 +51,7 @@ Dashboard 已具备 Runtime/Terminal Projection、共享 SSE frame，以及 acti
 - working-conversations 必须保持 5 分钟 working selection、分页排序、blocked binding、账号/owner/sticky metadata、精确 24 小时 points 和每 key 最多 16 条 recent。
 - parallel-work 必须复用既有 minute-key/hourly rollup baseline，并以 current boundary identities 和 runtime overlay 精确维护 `today`、`1d`、`7d`；`yesterday` 必须作为 `ClosedSnapshot`，不受当前 mutation 触发。
 - open-window timeseries 必须复用 `timeseries_minute_projection_v2`，并以 terminal/runtime revisions 更新当前桶；健康发布不得调用通用 timeseries fetch builder。
+- minute projection 的后台写入必须以 `P2Derived` 通过共享 SQLite 写协调器和 pressure gate；coverage invalidation 与 key 更新必须是有界事务、片段间让出执行权，并在 P1 terminal 写入等待或持有时保留 delta 以便重试。
 - working-conversations 使用固定 `500ms` 合并 deadline；parallel-work 与 timeseries current bucket 使用 `1s`；terminal totals 保持 `5s`；后台精确 reconcile 每 selection 最多 `60s` 一次。
 - activity topic descriptor 必须固定 `recentLimit=16`；动态可见数量仅由客户端本地截断，显式 range、分页和筛选操作仍可改变 descriptor。
 - 每个依赖 revision tuple 最多 materialize 和 serialize 一次，生成一个 `Arc<SerializedTopicFrame>`；内容未变化时不得推进 cursor。

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -508,6 +508,10 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
             upstream_account_key: upstream_account_id.unwrap_or(-1),
         })
         .collect::<Vec<_>>();
+    let projection_selection = TimeseriesProjectionSelection {
+        source_scope: timeseries_projection_scope(source_scope),
+        upstream_account_id,
+    };
 
     for key_batch in keys.chunks(TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT) {
         if terminal_projection_hub.timeseries_coverage_generation() != coverage_generation
@@ -604,6 +608,13 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
                 TimeseriesMinuteProjectionDeferred { retry_after: None },
             ));
         }
+        let projection_snapshot_records = source_records
+            .iter()
+            .filter(|record| {
+                !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
+            })
+            .map(timeseries_projection_snapshot_record)
+            .collect::<Vec<_>>();
         let mut aggregates = HashMap::<i64, BucketAggregate>::new();
         let mut max_row_ids = HashMap::<i64, i64>::new();
         for record in source_records {
@@ -632,6 +643,8 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
                 .await?;
         }
         tx.commit().await?;
+        let coverage_ack_count = terminal_projection_hub
+            .mark_timeseries_warm_coverage(projection_selection, &projection_snapshot_records);
         debug!(
             route = "timeseries_projection",
             builder = "minute_projection_v2",
@@ -639,8 +652,9 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
             transaction_phase = "exact_warm",
             transaction_key_limit = TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT,
             transaction_key_count = key_batch.len(),
+            coverage_ack_count,
             elapsed_ms = transaction_started.elapsed().as_millis() as u64,
-            "materialized a bounded exact-fallback minute projection slice"
+            "materialized and acknowledged a bounded exact-fallback minute projection slice"
         );
         drop(admission);
         tokio::task::yield_now().await;
@@ -1017,7 +1031,36 @@ impl TimeseriesTopicMaterializedBase {
                         bucket_seconds,
                         reporting_tz,
                     )?;
-                    aggregates
+                    if timeseries_minute_projection_v2_coverage_is_ready(
+                        &state.pool,
+                        start,
+                        end,
+                        source_scope,
+                        params.upstream_account_id,
+                    )
+                    .await?
+                    {
+                        aggregates
+                    } else {
+                        debug!(
+                            route = "timeseries_topic",
+                            builder = "minute_projection_v2",
+                            projection_cursor,
+                            "minute projection coverage changed while building a hot topic; falling back to exact records"
+                        );
+                        build_exact_timeseries_topic_baseline(
+                            state,
+                            start,
+                            end,
+                            source_scope,
+                            snapshot_id,
+                            params.upstream_account_id,
+                            bucket_seconds,
+                            reporting_tz,
+                            true,
+                        )
+                        .await?
+                    }
                 } else {
                     build_exact_timeseries_topic_baseline(
                         state,
@@ -1231,18 +1274,7 @@ async fn build_exact_timeseries_topic_baseline(
     .await?;
     if let Some(coverage_generation) = warm_coverage_generation {
         let pool = state.pool.clone();
-        let projection_snapshot_records = records
-            .iter()
-            .filter(|record| {
-                !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
-            })
-            .map(timeseries_projection_snapshot_record)
-            .collect::<Vec<_>>();
         let terminal_projection_hub = state.terminal_projection_hub.clone();
-        let projection_selection = TimeseriesProjectionSelection {
-            source_scope: timeseries_projection_scope(source_scope),
-            upstream_account_id,
-        };
         tokio::spawn(async move {
             match store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
                 &pool,
@@ -1256,12 +1288,7 @@ async fn build_exact_timeseries_topic_baseline(
             )
             .await
             {
-                Ok(TimeseriesMinuteProjectionWarmOutcome::Stored) => {
-                    terminal_projection_hub.mark_timeseries_warm_coverage(
-                        projection_selection,
-                        &projection_snapshot_records,
-                    );
-                }
+                Ok(TimeseriesMinuteProjectionWarmOutcome::Stored) => {}
                 Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(_)) => {
                     debug!(
                         route = "timeseries_projection",
@@ -1389,28 +1416,6 @@ fn timeseries_projection_snapshot_record(
         row_id: record.id,
         invoke_id: record.invoke_id.clone(),
         occurred_at: record.occurred_at.clone(),
-        delta: TimeseriesTerminalDelta {
-            occurred_at: record.occurred_at.clone(),
-            source: String::new(),
-            upstream_account_id: None,
-            status: record.status.clone(),
-            error_message: record.error_message.clone(),
-            failure_kind: record.failure_kind.clone(),
-            failure_class: record.failure_class.clone(),
-            is_actionable: record.is_actionable.map(|value| value != 0),
-            total_tokens: record.total_tokens,
-            input_tokens: record.input_tokens,
-            output_tokens: record.output_tokens,
-            cache_input_tokens: record.cache_input_tokens,
-            reasoning_tokens: record.reasoning_tokens,
-            cost: record.cost,
-            t_total_ms: record.t_total_ms,
-            t_req_read_ms: record.t_req_read_ms,
-            t_req_parse_ms: record.t_req_parse_ms,
-            t_upstream_connect_ms: record.t_upstream_connect_ms,
-            t_upstream_ttfb_ms: record.t_upstream_ttfb_ms,
-            first_token_ms: record.first_token_ms,
-        },
     }
 }
 
@@ -3097,18 +3102,7 @@ pub(crate) async fn fetch_timeseries(
             // Projection persistence is P2 work. Never make a read request wait for a SQLite
             // writer when a first-time exact fallback already produced a valid response.
             let projection_pool = state.pool.clone();
-            let projection_snapshot_records = records
-                .iter()
-                .filter(|record| {
-                    !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
-                })
-                .map(timeseries_projection_snapshot_record)
-                .collect::<Vec<_>>();
             let terminal_projection_hub = state.terminal_projection_hub.clone();
-            let projection_selection = TimeseriesProjectionSelection {
-                source_scope: timeseries_projection_scope(source_scope),
-                upstream_account_id: None,
-            };
             tokio::spawn(async move {
                 match store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
                     &projection_pool,
@@ -3122,12 +3116,7 @@ pub(crate) async fn fetch_timeseries(
                 )
                 .await
                 {
-                    Ok(TimeseriesMinuteProjectionWarmOutcome::Stored) => {
-                        terminal_projection_hub.mark_timeseries_warm_coverage(
-                            projection_selection,
-                            &projection_snapshot_records,
-                        );
-                    }
+                    Ok(TimeseriesMinuteProjectionWarmOutcome::Stored) => {}
                     Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(_)) => {
                         debug!(
                             route = "timeseries_projection",
@@ -3524,58 +3513,21 @@ pub(crate) async fn fetch_timeseries_for_account(
         let projection_pool = state.pool.clone();
         let terminal_projection_hub = state.terminal_projection_hub.clone();
         let warm_coverage_generation = terminal_projection_hub.timeseries_coverage_generation();
-        let projection_selection = TimeseriesProjectionSelection {
-            source_scope: timeseries_projection_scope(source_scope),
-            upstream_account_id: Some(upstream_account_id),
-        };
         tokio::spawn(async move {
-            let records = query_invocation_aggregate_records_from_live_range_for_account(
+            match store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
                 &projection_pool,
-                ExactUtcRange {
-                    start: start_dt,
-                    end: end_dt,
-                },
+                start_dt,
+                end_dt,
                 source_scope,
-                None,
-                Some(snapshot_id),
-                upstream_account_id,
+                Some(upstream_account_id),
+                terminal_projection_hub.as_ref(),
+                warm_coverage_generation,
+                "account_exact_fallback",
             )
-            .await;
-            let result = match records {
-                Ok(records) => {
-                    let projection_snapshot_records = records
-                        .iter()
-                        .filter(|record| {
-                            !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
-                        })
-                        .map(timeseries_projection_snapshot_record)
-                        .collect::<Vec<_>>();
-                    store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
-                        &projection_pool,
-                        start_dt,
-                        end_dt,
-                        source_scope,
-                        Some(upstream_account_id),
-                        terminal_projection_hub.as_ref(),
-                        warm_coverage_generation,
-                        "account_exact_fallback",
-                    )
-                    .await
-                    .map(|outcome| (outcome, projection_snapshot_records))
-                }
-                Err(error) => Err(error),
-            };
-            match result {
-                Ok((
-                    TimeseriesMinuteProjectionWarmOutcome::Stored,
-                    projection_snapshot_records,
-                )) => {
-                    terminal_projection_hub.mark_timeseries_warm_coverage(
-                        projection_selection,
-                        &projection_snapshot_records,
-                    );
-                }
-                Ok((TimeseriesMinuteProjectionWarmOutcome::Deferred(_), _)) => {
+            .await
+            {
+                Ok(TimeseriesMinuteProjectionWarmOutcome::Stored) => {}
+                Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(_)) => {
                     debug!(
                         route = "timeseries_projection",
                         upstream_account_id,

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -33,6 +33,7 @@ struct TimeseriesMinuteProjectionV2Row {
 }
 
 const TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT: usize = 64;
+const TIMESERIES_MINUTE_PROJECTION_WRITE_DELTA_BATCH_LIMIT: usize = 512;
 const TIMESERIES_MINUTE_PROJECTION_INVALIDATION_ROW_BATCH_LIMIT: i64 = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1456,10 +1457,31 @@ pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
                 key.upstream_account_key,
             )
         });
+        let mut work_batches = Vec::<Vec<_>>::new();
+        let mut work_batch = Vec::new();
+        let mut work_batch_delta_count = 0usize;
+        for (key, mut deltas) in grouped {
+            deltas.sort_by_key(|(row_id, _)| *row_id);
+            for delta_batch in deltas.chunks(TIMESERIES_MINUTE_PROJECTION_WRITE_DELTA_BATCH_LIMIT) {
+                if !work_batch.is_empty()
+                    && (work_batch.len() >= TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT
+                        || work_batch_delta_count + delta_batch.len()
+                            > TIMESERIES_MINUTE_PROJECTION_WRITE_DELTA_BATCH_LIMIT)
+                {
+                    work_batches.push(std::mem::take(&mut work_batch));
+                    work_batch_delta_count = 0;
+                }
+                work_batch.push((key.clone(), delta_batch.to_vec()));
+                work_batch_delta_count += delta_batch.len();
+            }
+        }
+        if !work_batch.is_empty() {
+            work_batches.push(work_batch);
+        }
         let mut written_key_count = 0usize;
         let mut exact_fallback_minute_count = 0usize;
         let mut transaction_count = 0usize;
-        for key_batch in grouped.chunks_mut(TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT) {
+        for key_batch in work_batches {
             let Some(admission) = try_acquire_timeseries_minute_projection_write(
                 coordinator,
                 trigger,
@@ -1473,25 +1495,29 @@ pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
 
             let transaction_started = Instant::now();
             let mut tx = state.pool.begin().await?;
-            for (key, deltas) in &mut *key_batch {
-                deltas.sort_by_key(|(row_id, _)| *row_id);
+            let transaction_key_count = key_batch.len();
+            let transaction_delta_count = key_batch
+                .iter()
+                .map(|(_, deltas)| deltas.len())
+                .sum::<usize>();
+            for (key, deltas) in key_batch {
                 let (aggregate, max_row_id) = if let Some((aggregate, existing_max_row_id)) =
-                    load_timeseries_minute_projection_v2_key_tx(tx.as_mut(), key).await?
+                    load_timeseries_minute_projection_v2_key_tx(tx.as_mut(), &key).await?
                 {
-                    if timeseries_projection_requires_exact_rebuild(deltas, existing_max_row_id) {
+                    if timeseries_projection_requires_exact_rebuild(&deltas, existing_max_row_id) {
                         // A terminal record can update an older running row. Its row ID is not a
                         // change cursor, and repeated pending events can share the same row ID.
                         // Either case needs an exact rebuild rather than another incremental add.
                         exact_fallback_minute_count += 1;
                         let (aggregate, max_row_id, source_row_count) =
-                            rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), key)
+                            rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), &key)
                                 .await?;
                         loaded_row_count = loaded_row_count.saturating_add(source_row_count);
                         (aggregate, max_row_id)
                     } else {
                         let mut aggregate = aggregate;
                         let mut max_row_id = existing_max_row_id;
-                        for (row_id, delta) in deltas {
+                        for (row_id, delta) in &deltas {
                             add_timeseries_terminal_delta_to_aggregate(&mut aggregate, delta);
                             max_row_id = max_row_id.max(*row_id);
                         }
@@ -1503,13 +1529,13 @@ pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
                     // minute before publishing it as ready, rather than storing a partial total.
                     exact_fallback_minute_count += 1;
                     let (aggregate, max_row_id, source_row_count) =
-                        rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), key).await?;
+                        rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), &key).await?;
                     loaded_row_count = loaded_row_count.saturating_add(source_row_count);
                     (aggregate, max_row_id)
                 };
                 upsert_timeseries_minute_projection_v2_key_tx(
                     tx.as_mut(),
-                    key,
+                    &key,
                     &aggregate,
                     max_row_id,
                 )
@@ -1524,7 +1550,9 @@ pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
                 trigger,
                 transaction_phase = "minute_projection_keys",
                 transaction_key_limit = TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT,
-                transaction_key_count = key_batch.len(),
+                transaction_key_count,
+                transaction_delta_limit = TIMESERIES_MINUTE_PROJECTION_WRITE_DELTA_BATCH_LIMIT,
+                transaction_delta_count,
                 elapsed_ms = transaction_started.elapsed().as_millis() as u64,
                 "flushed a bounded minute projection key slice"
             );

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -324,7 +324,6 @@ async fn store_timeseries_minute_projection_v2_warm(
     end: DateTime<Utc>,
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
-    records: &[InvocationAggregateRecord],
     terminal_projection_hub: &TerminalProjectionHub,
     coverage_generation: u64,
     trigger: &'static str,
@@ -335,7 +334,6 @@ async fn store_timeseries_minute_projection_v2_warm(
         end,
         source_scope,
         upstream_account_id,
-        records,
         terminal_projection_hub,
         coverage_generation,
         trigger,
@@ -350,7 +348,6 @@ async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
     end: DateTime<Utc>,
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
-    records: &[InvocationAggregateRecord],
     terminal_projection_hub: &TerminalProjectionHub,
     coverage_generation: u64,
     trigger: &'static str,
@@ -363,7 +360,6 @@ async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
         end,
         source_scope,
         upstream_account_id,
-        records,
         terminal_projection_hub,
         coverage_generation,
         trigger,
@@ -388,7 +384,6 @@ async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
                 end,
                 source_scope,
                 upstream_account_id,
-                records,
                 terminal_projection_hub,
                 coverage_generation,
                 trigger,
@@ -404,7 +399,6 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
     end: DateTime<Utc>,
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
-    records: &[InvocationAggregateRecord],
     terminal_projection_hub: &TerminalProjectionHub,
     coverage_generation: u64,
     trigger: &'static str,
@@ -414,41 +408,16 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
     if minute_end <= minute_start {
         return Ok(TimeseriesMinuteProjectionWarmOutcome::Stored);
     }
-    let mut by_minute: HashMap<i64, BucketAggregate> = HashMap::new();
-    let mut max_row_ids = HashMap::new();
-    for record in records {
-        if prompt_shared::invocation_status_is_in_flight(record.status.as_deref()) {
-            continue;
-        }
-        let Some(occurred) = parse_to_utc_datetime(&record.occurred_at) else {
-            continue;
-        };
-        let minute = occurred.timestamp().div_euclid(60) * 60;
-        if minute < minute_start || minute >= minute_end {
-            continue;
-        }
-        add_exact_record_to_timeseries_aggregate(by_minute.entry(minute).or_default(), record);
-        max_row_ids
-            .entry(minute)
-            .and_modify(|max_row_id: &mut i64| *max_row_id = (*max_row_id).max(record.id))
-            .or_insert(record.id);
-    }
-    let rows = (minute_start..minute_end)
+    let keys = (minute_start..minute_end)
         .step_by(60_usize)
-        .map(|minute| {
-            (
-                TimeseriesMinuteProjectionKey {
-                    minute_start_epoch: minute,
-                    source_scope: timeseries_projection_scope(source_scope),
-                    upstream_account_key: upstream_account_id.unwrap_or(-1),
-                },
-                by_minute.remove(&minute).unwrap_or_default(),
-                max_row_ids.remove(&minute).unwrap_or(0),
-            )
+        .map(|minute| TimeseriesMinuteProjectionKey {
+            minute_start_epoch: minute,
+            source_scope: timeseries_projection_scope(source_scope),
+            upstream_account_key: upstream_account_id.unwrap_or(-1),
         })
         .collect::<Vec<_>>();
 
-    for key_batch in rows.chunks(TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT) {
+    for key_batch in keys.chunks(TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT) {
         if terminal_projection_hub.timeseries_coverage_generation() != coverage_generation
             || terminal_projection_hub
                 .timeseries_coverage_invalidation_pending()
@@ -470,14 +439,15 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
             coordinator,
             trigger,
             "exact_warm",
-            records.len(),
+            key_batch.len(),
         )
         .await
         else {
             return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
         };
-        // The exact source snapshot was read before admission. Re-check while holding the
-        // shared P2 permit so an invalidation completed in that interval cannot be overwritten.
+        // Hub invalidations cover proxy terminal events. Non-proxy terminal updates invalidate
+        // coverage in SQLite through a trigger, so the source records are rebuilt in the
+        // transaction below rather than reusing the response-time snapshot.
         if terminal_projection_hub.timeseries_coverage_generation() != coverage_generation
             || terminal_projection_hub
                 .timeseries_coverage_invalidation_pending()
@@ -488,24 +458,76 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
         }
         let transaction_started = Instant::now();
         let mut tx = pool.begin().await?;
-        for (key, aggregate, max_row_id) in key_batch {
-            sqlx::query(
-                "INSERT INTO timeseries_minute_projection_v2 (minute_start_epoch, source_scope, upstream_account_key, aggregate_json, total_latency_samples_json, first_byte_samples_json, first_response_byte_total_samples_json, first_token_samples_json, max_row_id, coverage_state, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'ready', datetime('now')) ON CONFLICT(minute_start_epoch, source_scope, upstream_account_key) DO UPDATE SET aggregate_json = excluded.aggregate_json, total_latency_samples_json = excluded.total_latency_samples_json, first_byte_samples_json = excluded.first_byte_samples_json, first_response_byte_total_samples_json = excluded.first_response_byte_total_samples_json, first_token_samples_json = excluded.first_token_samples_json, max_row_id = excluded.max_row_id, coverage_state = 'ready', updated_at = excluded.updated_at WHERE excluded.max_row_id > timeseries_minute_projection_v2.max_row_id OR (timeseries_minute_projection_v2.coverage_state = 'warming' AND excluded.max_row_id = timeseries_minute_projection_v2.max_row_id)",
-            )
-            .bind(key.minute_start_epoch)
-            .bind(key.source_scope)
-            .bind(key.upstream_account_key)
-            .bind(serde_json::to_string(aggregate).map_err(ApiError::from)?)
-            .bind(serde_json::to_string(&aggregate.total_latency_values).map_err(ApiError::from)?)
-            .bind(serde_json::to_string(&aggregate.first_byte_ttfb_values).map_err(ApiError::from)?)
-            .bind(
-                serde_json::to_string(&aggregate.first_response_byte_total_values)
-                    .map_err(ApiError::from)?,
-            )
-            .bind(serde_json::to_string(&aggregate.first_token_values).map_err(ApiError::from)?)
-            .bind(*max_row_id)
-            .execute(tx.as_mut())
-            .await?;
+        let batch_start = Utc
+            .timestamp_opt(key_batch[0].minute_start_epoch, 0)
+            .single()
+            .ok_or_else(|| ApiError::from(anyhow!("invalid minute projection batch start")))?;
+        let batch_end = Utc
+            .timestamp_opt(key_batch[key_batch.len() - 1].minute_start_epoch + 60, 0)
+            .single()
+            .ok_or_else(|| ApiError::from(anyhow!("invalid minute projection batch end")))?;
+        let source_records = match upstream_account_id {
+            Some(upstream_account_id) => {
+                query_invocation_aggregate_records_from_live_range_tx_for_account(
+                    tx.as_mut(),
+                    ExactUtcRange {
+                        start: batch_start,
+                        end: batch_end,
+                    },
+                    source_scope,
+                    None,
+                    None,
+                    upstream_account_id,
+                )
+                .await?
+            }
+            None => {
+                query_invocation_aggregate_records_from_live_range_tx(
+                    tx.as_mut(),
+                    ExactUtcRange {
+                        start: batch_start,
+                        end: batch_end,
+                    },
+                    source_scope,
+                    None,
+                    None,
+                )
+                .await?
+            }
+        };
+        if terminal_projection_hub.timeseries_coverage_generation() != coverage_generation
+            || terminal_projection_hub
+                .timeseries_coverage_invalidation_pending()
+                .is_some()
+        {
+            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+        }
+        let mut aggregates = HashMap::<i64, BucketAggregate>::new();
+        let mut max_row_ids = HashMap::<i64, i64>::new();
+        for record in source_records {
+            if prompt_shared::invocation_status_is_in_flight(record.status.as_deref()) {
+                continue;
+            }
+            let Some(occurred) = parse_to_utc_datetime(&record.occurred_at) else {
+                continue;
+            };
+            let minute = occurred.timestamp().div_euclid(60) * 60;
+            add_exact_record_to_timeseries_aggregate(
+                aggregates.entry(minute).or_default(),
+                &record,
+            );
+            max_row_ids
+                .entry(minute)
+                .and_modify(|max_row_id| *max_row_id = (*max_row_id).max(record.id))
+                .or_insert(record.id);
+        }
+        for key in key_batch {
+            let aggregate = aggregates
+                .remove(&key.minute_start_epoch)
+                .unwrap_or_default();
+            let max_row_id = max_row_ids.remove(&key.minute_start_epoch).unwrap_or(0);
+            upsert_timeseries_minute_projection_v2_key_tx(tx.as_mut(), key, &aggregate, max_row_id)
+                .await?;
         }
         tx.commit().await?;
         debug!(
@@ -1107,8 +1129,7 @@ async fn build_exact_timeseries_topic_baseline(
     .await?;
     if let Some(coverage_generation) = warm_coverage_generation {
         let pool = state.pool.clone();
-        let projection_records = records.clone();
-        let projection_snapshot_records = projection_records
+        let projection_snapshot_records = records
             .iter()
             .filter(|record| {
                 !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
@@ -1127,7 +1148,6 @@ async fn build_exact_timeseries_topic_baseline(
                 end,
                 source_scope,
                 upstream_account_id,
-                &projection_records,
                 terminal_projection_hub.as_ref(),
                 coverage_generation,
                 "topic_exact_fallback",
@@ -1888,7 +1908,8 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
         let pressure_gate = crate::db_pressure::global_db_pressure_gate();
         loop {
             let observed_eligibility_generation = pressure_gate.eligibility_generation();
-            match prepare_timeseries_minute_projection_after_restart(state.as_ref()).await {
+            match prepare_timeseries_minute_projection_after_restart(state.as_ref(), &cancel).await
+            {
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => break,
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred) => {
                     debug!(
@@ -1975,9 +1996,13 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
     })
 }
 
-async fn prepare_timeseries_minute_projection_after_restart(
+pub(crate) async fn prepare_timeseries_minute_projection_after_restart(
     state: &AppState,
+    cancellation: &CancellationToken,
 ) -> Result<TimeseriesMinuteProjectionFlushOutcome, ApiError> {
+    if cancellation.is_cancelled() {
+        return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
+    }
     let coordinator = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator();
     let Some(admission) = try_acquire_timeseries_minute_projection_write(
         &coordinator,
@@ -1989,6 +2014,10 @@ async fn prepare_timeseries_minute_projection_after_restart(
     else {
         return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
     };
+    if cancellation.is_cancelled() {
+        drop(admission);
+        return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
+    }
     let mut tx = state.pool.begin().await?;
     sqlx::query(
         "INSERT INTO timeseries_minute_projection_v2_state (consumer, cursor_row_id, last_flush_at, last_error, updated_at) VALUES ('timeseries_minute_v2', 0, NULL, 'warming', datetime('now')) ON CONFLICT(consumer) DO UPDATE SET last_error = 'warming', updated_at = excluded.updated_at",
@@ -2003,7 +2032,7 @@ async fn prepare_timeseries_minute_projection_after_restart(
         &coordinator,
         "startup_recovery",
         0,
-        None,
+        Some(cancellation),
     )
     .await?
     {
@@ -2026,6 +2055,10 @@ async fn prepare_timeseries_minute_projection_after_restart(
     else {
         return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
     };
+    if cancellation.is_cancelled() {
+        drop(admission);
+        return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
+    }
     let mut tx = state.pool.begin().await?;
     sqlx::query(
         "UPDATE timeseries_minute_projection_v2_state SET last_error = 'ready', updated_at = datetime('now') WHERE consumer = 'timeseries_minute_v2'",
@@ -2839,8 +2872,7 @@ pub(crate) async fn fetch_timeseries(
             // Projection persistence is P2 work. Never make a read request wait for a SQLite
             // writer when a first-time exact fallback already produced a valid response.
             let projection_pool = state.pool.clone();
-            let projection_records = records.clone();
-            let projection_snapshot_records = projection_records
+            let projection_snapshot_records = records
                 .iter()
                 .filter(|record| {
                     !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
@@ -2859,7 +2891,6 @@ pub(crate) async fn fetch_timeseries(
                     end_dt,
                     source_scope,
                     None,
-                    &projection_records,
                     terminal_projection_hub.as_ref(),
                     warm_coverage_generation,
                     "http_exact_fallback",
@@ -3286,7 +3317,6 @@ pub(crate) async fn fetch_timeseries_for_account(
                         end_dt,
                         source_scope,
                         Some(upstream_account_id),
-                        &records,
                         terminal_projection_hub.as_ref(),
                         warm_coverage_generation,
                         "account_exact_fallback",

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -280,6 +280,40 @@ async fn load_timeseries_minute_projection_v2(
     Ok(Some((aggregates, cursor)))
 }
 
+async fn timeseries_minute_projection_v2_coverage_is_ready(
+    pool: &Pool<Sqlite>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+) -> Result<bool, ApiError> {
+    let projection_ready = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT last_error FROM timeseries_minute_projection_v2_state WHERE consumer = 'timeseries_minute_v2'",
+    )
+    .fetch_optional(pool)
+    .await?
+    .flatten()
+    .is_some_and(|state| state == "ready");
+    if !projection_ready {
+        return Ok(false);
+    }
+    let (minute_start, minute_end) = complete_minute_bounds(start, end);
+    let expected = (minute_end - minute_start).div_euclid(60);
+    if expected <= 0 {
+        return Ok(false);
+    }
+    let ready_row_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM timeseries_minute_projection_v2 WHERE minute_start_epoch >= ?1 AND minute_start_epoch < ?2 AND source_scope = ?3 AND upstream_account_key = ?4 AND coverage_state = 'ready'",
+    )
+    .bind(minute_start)
+    .bind(minute_end)
+    .bind(timeseries_projection_scope(source_scope))
+    .bind(upstream_account_id.unwrap_or(-1))
+    .fetch_one(pool)
+    .await?;
+    Ok(ready_row_count == expected)
+}
+
 #[cfg(test)]
 async fn store_timeseries_minute_projection_v2_for_test(
     pool: &Pool<Sqlite>,
@@ -2766,6 +2800,18 @@ mod minute_projection_tests {
             .expect("load invalidated projection")
             .is_none()
         );
+        assert!(
+            !timeseries_minute_projection_v2_coverage_is_ready(
+                &pool,
+                start,
+                end,
+                InvocationSourceScope::All,
+                None,
+            )
+            .await
+            .expect("check invalidated coverage fence"),
+            "a coverage change after the projection read must force an exact fallback"
+        );
         store_timeseries_minute_projection_v2_for_test(
             &pool,
             start,
@@ -2791,6 +2837,17 @@ mod minute_projection_tests {
         .expect("re-warmed minute coverage");
         assert_eq!(cursor, 18);
         assert_eq!(aggregates[&start.timestamp()].total_count, 2);
+        assert!(
+            timeseries_minute_projection_v2_coverage_is_ready(
+                &pool,
+                start,
+                end,
+                InvocationSourceScope::All,
+                None,
+            )
+            .await
+            .expect("check re-warmed coverage fence")
+        );
     }
 
     #[test]
@@ -2868,7 +2925,7 @@ pub(crate) async fn fetch_timeseries(
     let start_str_iso = format_utc_iso(start_dt);
     let use_minute_projection = range_window.duration <= ChronoDuration::days(1);
 
-    let coverage_invalidation_pending = state
+    let mut coverage_invalidation_pending = state
         .terminal_projection_hub
         .timeseries_coverage_invalidation_pending()
         .is_some();
@@ -2978,28 +3035,44 @@ pub(crate) async fn fetch_timeseries(
             reporting_tz,
             &db_runtime_records,
         )?;
-        debug!(
-            route = "timeseries_http_or_topic",
-            builder = "minute_projection_v2",
-            response_source = "minute_projection",
-            minute_rollup_count = aggregates.len(),
-            memory_overlay_count,
-            exact_fallback_minute_count = 2_u8,
-            raw_row_count = db_runtime_records.len(),
-            coverage_state = "covered",
-            projection_cursor,
-            "built open-window timeseries from minute projection"
-        );
-        return build_timeseries_response(
+        if timeseries_minute_projection_v2_coverage_is_ready(
+            &state.pool,
             start_dt,
             end_dt,
-            bucket_seconds,
-            snapshot_id,
-            bucket_selection,
-            aggregates,
-            fill_start_epoch,
-            fill_end_epoch,
-            reporting_tz,
+            source_scope,
+            None,
+        )
+        .await?
+        {
+            debug!(
+                route = "timeseries_http_or_topic",
+                builder = "minute_projection_v2",
+                response_source = "minute_projection",
+                minute_rollup_count = aggregates.len(),
+                memory_overlay_count,
+                exact_fallback_minute_count = 2_u8,
+                raw_row_count = db_runtime_records.len(),
+                coverage_state = "covered",
+                projection_cursor,
+                "built open-window timeseries from minute projection"
+            );
+            return build_timeseries_response(
+                start_dt,
+                end_dt,
+                bucket_seconds,
+                snapshot_id,
+                bucket_selection,
+                aggregates,
+                fill_start_epoch,
+                fill_end_epoch,
+                reporting_tz,
+            );
+        }
+        coverage_invalidation_pending = true;
+        debug!(
+            route = "timeseries_http_or_topic",
+            projection_cursor,
+            "minute projection coverage changed while loading the live tail; falling back to exact records"
         );
     }
 
@@ -3269,7 +3342,7 @@ pub(crate) async fn fetch_timeseries_for_account(
         }
     }
 
-    let coverage_invalidation_pending = state
+    let mut coverage_invalidation_pending = state
         .terminal_projection_hub
         .timeseries_coverage_invalidation_pending()
         .is_some();
@@ -3390,29 +3463,46 @@ pub(crate) async fn fetch_timeseries_for_account(
             reporting_tz,
             &db_runtime_records,
         )?;
-        debug!(
-            route = "timeseries_http_or_topic",
-            builder = "minute_projection_v2",
-            response_source = "minute_projection",
-            upstream_account_id,
-            minute_rollup_count = aggregates.len(),
-            memory_overlay_count,
-            exact_fallback_minute_count = 2_u8,
-            raw_row_count = db_runtime_records.len(),
-            coverage_state = "covered",
-            projection_cursor,
-            "built account open-window timeseries from minute projection"
-        );
-        return build_timeseries_response(
+        if timeseries_minute_projection_v2_coverage_is_ready(
+            &state.pool,
             start_dt,
             end_dt,
-            bucket_seconds,
-            snapshot_id,
-            bucket_selection,
-            aggregates,
-            fill_start_epoch,
-            fill_end_epoch,
-            reporting_tz,
+            source_scope,
+            Some(upstream_account_id),
+        )
+        .await?
+        {
+            debug!(
+                route = "timeseries_http_or_topic",
+                builder = "minute_projection_v2",
+                response_source = "minute_projection",
+                upstream_account_id,
+                minute_rollup_count = aggregates.len(),
+                memory_overlay_count,
+                exact_fallback_minute_count = 2_u8,
+                raw_row_count = db_runtime_records.len(),
+                coverage_state = "covered",
+                projection_cursor,
+                "built account open-window timeseries from minute projection"
+            );
+            return build_timeseries_response(
+                start_dt,
+                end_dt,
+                bucket_seconds,
+                snapshot_id,
+                bucket_selection,
+                aggregates,
+                fill_start_epoch,
+                fill_end_epoch,
+                reporting_tz,
+            );
+        }
+        coverage_invalidation_pending = true;
+        debug!(
+            route = "timeseries_http_or_topic",
+            upstream_account_id,
+            projection_cursor,
+            "account minute projection coverage changed while loading the live tail; falling back to exact records"
         );
     }
 
@@ -3427,10 +3517,7 @@ pub(crate) async fn fetch_timeseries_for_account(
     let snapshot_id = resolve_invocation_snapshot_id(&state.pool, source_scope).await?;
     if bucket_seconds < 3_600
         && range_window.duration <= ChronoDuration::days(1)
-        && state
-            .terminal_projection_hub
-            .timeseries_coverage_invalidation_pending()
-            .is_none()
+        && !coverage_invalidation_pending
     {
         // Account projections include empty minutes, so a first exact fallback must warm
         // the complete selection instead of relying on future terminal events to fill gaps.

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -39,8 +39,18 @@ const TIMESERIES_MINUTE_PROJECTION_INVALIDATION_ROW_BATCH_LIMIT: i64 = 256;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TimeseriesMinuteProjectionFlushOutcome {
     Flushed,
-    Deferred,
+    Deferred(TimeseriesMinuteProjectionDeferred),
     Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TimeseriesMinuteProjectionDeferred {
+    retry_after: Option<Duration>,
+}
+
+enum TimeseriesMinuteProjectionWriteAdmissionOutcome {
+    Acquired(TimeseriesMinuteProjectionWriteAdmission),
+    Deferred(TimeseriesMinuteProjectionDeferred),
 }
 
 struct TimeseriesMinuteProjectionWriteAdmission {
@@ -56,7 +66,7 @@ struct TimeseriesMinuteProjectionCoverageInvalidationStats {
 
 enum TimeseriesMinuteProjectionCoverageInvalidationOutcome {
     Invalidated(TimeseriesMinuteProjectionCoverageInvalidationStats),
-    Deferred,
+    Deferred(TimeseriesMinuteProjectionDeferred),
     Cancelled,
 }
 
@@ -315,7 +325,7 @@ async fn store_timeseries_minute_projection_v2_for_test(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TimeseriesMinuteProjectionWarmOutcome {
     Stored,
-    Deferred,
+    Deferred(TimeseriesMinuteProjectionDeferred),
 }
 
 async fn store_timeseries_minute_projection_v2_warm(
@@ -365,9 +375,9 @@ async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
         trigger,
     )
     .await?;
-    if outcome != TimeseriesMinuteProjectionWarmOutcome::Deferred {
+    let TimeseriesMinuteProjectionWarmOutcome::Deferred(deferred) = outcome else {
         return Ok(outcome);
-    }
+    };
     debug!(
         route = "timeseries_projection",
         builder = "minute_projection_v2",
@@ -389,7 +399,18 @@ async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
                 trigger,
             ).await
         }
-        _ = tokio::time::sleep(Duration::from_secs(5)) => Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred),
+        _ = tokio::time::sleep(deferred.retry_after.unwrap_or(Duration::from_secs(5))) => {
+            store_timeseries_minute_projection_v2_warm(
+                pool,
+                start,
+                end,
+                source_scope,
+                upstream_account_id,
+                terminal_projection_hub,
+                coverage_generation,
+                trigger,
+            ).await
+        }
     }
 }
 
@@ -433,17 +454,23 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
                 coverage_generation,
                 "minute projection warm write deferred for a newer coverage generation"
             );
-            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(
+                TimeseriesMinuteProjectionDeferred { retry_after: None },
+            ));
         }
-        let Some(admission) = try_acquire_timeseries_minute_projection_write(
+        let admission = match try_acquire_timeseries_minute_projection_write(
             coordinator,
+            crate::db_pressure::global_db_pressure_gate(),
             trigger,
             "exact_warm",
             key_batch.len(),
         )
         .await
-        else {
-            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+        {
+            TimeseriesMinuteProjectionWriteAdmissionOutcome::Acquired(admission) => admission,
+            TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(deferred) => {
+                return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(deferred));
+            }
         };
         // Hub invalidations cover proxy terminal events. Non-proxy terminal updates invalidate
         // coverage in SQLite through a trigger, so the source records are rebuilt in the
@@ -454,7 +481,9 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
                 .is_some()
         {
             drop(admission);
-            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(
+                TimeseriesMinuteProjectionDeferred { retry_after: None },
+            ));
         }
         let transaction_started = Instant::now();
         let mut tx = pool.begin().await?;
@@ -500,7 +529,9 @@ pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
                 .timeseries_coverage_invalidation_pending()
                 .is_some()
         {
-            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(
+                TimeseriesMinuteProjectionDeferred { retry_after: None },
+            ));
         }
         let mut aggregates = HashMap::<i64, BucketAggregate>::new();
         let mut max_row_ids = HashMap::<i64, i64>::new();
@@ -1160,7 +1191,7 @@ async fn build_exact_timeseries_topic_baseline(
                         &projection_snapshot_records,
                     );
                 }
-                Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred) => {
+                Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(_)) => {
                     debug!(
                         route = "timeseries_projection",
                         projection_store_outcome = "deferred",
@@ -1548,11 +1579,11 @@ fn timeseries_projection_requires_exact_rebuild(
 
 async fn try_acquire_timeseries_minute_projection_write(
     coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
+    pressure_gate: &crate::db_pressure::DbPressureGate,
     trigger: &'static str,
     transaction_phase: &'static str,
     pending_event_count: usize,
-) -> Option<TimeseriesMinuteProjectionWriteAdmission> {
-    let pressure_gate = crate::db_pressure::global_db_pressure_gate();
+) -> TimeseriesMinuteProjectionWriteAdmissionOutcome {
     let observed_eligibility_generation = pressure_gate.eligibility_generation();
     let Some(mut write_permit) = coordinator
         .try_acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
@@ -1572,21 +1603,28 @@ async fn try_acquire_timeseries_minute_projection_write(
             pending_event_count,
             "minute projection deferred before opening a P2 write transaction"
         );
-        return None;
+        return TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(
+            TimeseriesMinuteProjectionDeferred { retry_after: None },
+        );
     };
 
     match pressure_gate.try_begin_background("timeseries_minute_projection_flush") {
-        Ok(pressure_permit) => Some(TimeseriesMinuteProjectionWriteAdmission {
-            _write_permit: write_permit,
-            _pressure_permit: pressure_permit,
-        }),
+        Ok(pressure_permit) => TimeseriesMinuteProjectionWriteAdmissionOutcome::Acquired(
+            TimeseriesMinuteProjectionWriteAdmission {
+                _write_permit: write_permit,
+                _pressure_permit: pressure_permit,
+            },
+        ),
         Err(reason) => {
-            if matches!(
-                reason,
-                crate::db_pressure::DbPressureDenyReason::BackgroundBusy
-            ) {
-                write_permit.suppress_background_eligibility_wakeup();
-            }
+            let retry_after = match reason {
+                crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => {
+                    Some(Duration::from_millis(remaining_ms.max(1)))
+                }
+                crate::db_pressure::DbPressureDenyReason::BackgroundBusy => None,
+            };
+            // This acquisition never opened a background transaction. Its P2 permit must not
+            // satisfy the retry wait that was registered before this admission attempt.
+            write_permit.suppress_background_eligibility_wakeup();
             drop(write_permit);
             debug!(
                 route = "timeseries_projection",
@@ -1600,7 +1638,9 @@ async fn try_acquire_timeseries_minute_projection_write(
                 %reason,
                 "minute projection deferred before opening a P2 write transaction"
             );
-            None
+            TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(
+                TimeseriesMinuteProjectionDeferred { retry_after },
+            )
         }
     }
 }
@@ -1627,15 +1667,21 @@ async fn invalidate_timeseries_minute_projection_coverage(
             return Ok(TimeseriesMinuteProjectionCoverageInvalidationOutcome::Invalidated(stats));
         }
 
-        let Some(admission) = try_acquire_timeseries_minute_projection_write(
+        let admission = match try_acquire_timeseries_minute_projection_write(
             coordinator,
+            crate::db_pressure::global_db_pressure_gate(),
             trigger,
             "coverage_invalidation",
             pending_event_count,
         )
         .await
-        else {
-            return Ok(TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred);
+        {
+            TimeseriesMinuteProjectionWriteAdmissionOutcome::Acquired(admission) => admission,
+            TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(deferred) => {
+                return Ok(
+                    TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred(deferred),
+                );
+            }
         };
 
         let started = Instant::now();
@@ -1735,8 +1781,8 @@ async fn flush_timeseries_minute_projection_with_coordinator_and_cancellation(
             .await?
             {
                 TimeseriesMinuteProjectionCoverageInvalidationOutcome::Invalidated(stats) => stats,
-                TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred => {
-                    return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+                TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred(deferred) => {
+                    return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred));
                 }
                 TimeseriesMinuteProjectionCoverageInvalidationOutcome::Cancelled => {
                     return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
@@ -1782,15 +1828,19 @@ async fn flush_timeseries_minute_projection_with_coordinator_and_cancellation(
             if timeseries_minute_projection_is_cancelled(cancellation) {
                 return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
             }
-            let Some(admission) = try_acquire_timeseries_minute_projection_write(
+            let admission = match try_acquire_timeseries_minute_projection_write(
                 coordinator,
+                crate::db_pressure::global_db_pressure_gate(),
                 trigger,
                 "minute_projection_keys",
                 flushed_event_ids.len(),
             )
             .await
-            else {
-                return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+            {
+                TimeseriesMinuteProjectionWriteAdmissionOutcome::Acquired(admission) => admission,
+                TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(deferred) => {
+                    return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred));
+                }
             };
 
             let transaction_started = Instant::now();
@@ -1911,7 +1961,7 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
             match prepare_timeseries_minute_projection_after_restart(state.as_ref(), &cancel).await
             {
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => break,
-                Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred) => {
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred)) => {
                     debug!(
                         route = "timeseries_projection",
                         builder = "minute_projection_v2",
@@ -1919,9 +1969,17 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
                         observed_eligibility_generation,
                         "startup minute projection recovery yielded to higher-priority database work"
                     );
-                    tokio::select! {
-                        _ = cancel.cancelled() => return,
-                        _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                    if let Some(retry_after) = deferred.retry_after {
+                        tokio::select! {
+                            _ = cancel.cancelled() => return,
+                            _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                            _ = tokio::time::sleep(retry_after) => {}
+                        }
+                    } else {
+                        tokio::select! {
+                            _ = cancel.cancelled() => return,
+                            _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                        }
                     }
                 }
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled) => return,
@@ -1946,12 +2004,22 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         ticker.tick().await;
         let mut deferred_eligibility_generation = None;
+        let mut deferred_retry_after = None;
         loop {
             if let Some(observed_eligibility_generation) = deferred_eligibility_generation.take() {
-                tokio::select! {
-                    _ = cancel.cancelled() => return,
-                    _ = ticker.tick() => {}
-                    _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                if let Some(retry_after) = deferred_retry_after.take() {
+                    tokio::select! {
+                        _ = cancel.cancelled() => return,
+                        _ = ticker.tick() => {}
+                        _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                        _ = tokio::time::sleep(retry_after) => {}
+                    }
+                } else {
+                    tokio::select! {
+                        _ = cancel.cancelled() => return,
+                        _ = ticker.tick() => {}
+                        _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                    }
                 }
             } else {
                 tokio::select! {
@@ -1970,14 +2038,16 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
             .await
             {
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => {}
-                Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred) => {
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred)) => {
                     deferred_eligibility_generation = Some(observed_eligibility_generation);
+                    deferred_retry_after = deferred.retry_after;
                     debug!(
                         route = "timeseries_projection",
                         builder = "minute_projection_v2",
                         trigger = "terminal_deadline",
                         flush_outcome = "deferred",
                         observed_eligibility_generation,
+                        retry_after_ms = deferred.retry_after.map(|value| value.as_millis() as u64),
                         "minute projection flush yielded to higher-priority database work"
                     );
                 }
@@ -2004,15 +2074,19 @@ pub(crate) async fn prepare_timeseries_minute_projection_after_restart(
         return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
     }
     let coordinator = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator();
-    let Some(admission) = try_acquire_timeseries_minute_projection_write(
+    let admission = match try_acquire_timeseries_minute_projection_write(
         &coordinator,
+        crate::db_pressure::global_db_pressure_gate(),
         "startup_recovery",
         "startup_state_warming",
         0,
     )
     .await
-    else {
-        return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+    {
+        TimeseriesMinuteProjectionWriteAdmissionOutcome::Acquired(admission) => admission,
+        TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(deferred) => {
+            return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred));
+        }
     };
     if cancellation.is_cancelled() {
         drop(admission);
@@ -2037,23 +2111,27 @@ pub(crate) async fn prepare_timeseries_minute_projection_after_restart(
     .await?
     {
         TimeseriesMinuteProjectionCoverageInvalidationOutcome::Invalidated(stats) => stats,
-        TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred => {
-            return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+        TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred(deferred) => {
+            return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred));
         }
         TimeseriesMinuteProjectionCoverageInvalidationOutcome::Cancelled => {
             return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
         }
     };
 
-    let Some(admission) = try_acquire_timeseries_minute_projection_write(
+    let admission = match try_acquire_timeseries_minute_projection_write(
         &coordinator,
+        crate::db_pressure::global_db_pressure_gate(),
         "startup_recovery",
         "startup_state_ready",
         0,
     )
     .await
-    else {
-        return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+    {
+        TimeseriesMinuteProjectionWriteAdmissionOutcome::Acquired(admission) => admission,
+        TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(deferred) => {
+            return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred));
+        }
     };
     if cancellation.is_cancelled() {
         drop(admission);
@@ -2903,7 +2981,7 @@ pub(crate) async fn fetch_timeseries(
                             &projection_snapshot_records,
                         );
                     }
-                    Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred) => {
+                    Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(_)) => {
                         debug!(
                             route = "timeseries_projection",
                             projection_store_outcome = "deferred",
@@ -3336,7 +3414,7 @@ pub(crate) async fn fetch_timeseries_for_account(
                         &projection_snapshot_records,
                     );
                 }
-                Ok((TimeseriesMinuteProjectionWarmOutcome::Deferred, _)) => {
+                Ok((TimeseriesMinuteProjectionWarmOutcome::Deferred(_), _)) => {
                     debug!(
                         route = "timeseries_projection",
                         upstream_account_id,
@@ -4953,5 +5031,39 @@ mod tests {
         assert_eq!(aggregate.reasoning_tokens, 11);
         assert_eq!(aggregate.total_latency_sample_count, 2);
         assert_eq!(aggregate.total_latency_sum_ms, 1_100.0);
+    }
+
+    #[tokio::test]
+    async fn pressure_cooldown_deferral_does_not_wake_its_own_retry_waiter() {
+        let coordinator = Arc::new(
+            crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator::new_for_test(),
+        );
+        let pressure_gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(30));
+        pressure_gate.record_pressure("timeseries_minute_projection_test", "sqlite_lock");
+        let observed_eligibility_generation = pressure_gate.eligibility_generation();
+
+        let outcome = try_acquire_timeseries_minute_projection_write(
+            &coordinator,
+            &pressure_gate,
+            "test",
+            "pressure_cooldown",
+            1,
+        )
+        .await;
+
+        let TimeseriesMinuteProjectionWriteAdmissionOutcome::Deferred(deferred) = outcome else {
+            panic!("pressure cooldown must defer minute projection work");
+        };
+        assert!(
+            deferred
+                .retry_after
+                .is_some_and(|retry_after| retry_after >= Duration::from_secs(29)),
+            "pressure cooldown must provide the retry deadline"
+        );
+        assert_eq!(
+            pressure_gate.eligibility_generation(),
+            observed_eligibility_generation,
+            "releasing a denied P2 permit must not wake its own retry waiter"
+        );
     }
 }

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -125,6 +125,31 @@ fn timeseries_projection_scope(source_scope: InvocationSourceScope) -> &'static 
     }
 }
 
+pub(crate) fn timeseries_minute_projection_has_uncovered_terminal_delta(
+    terminal_projection_hub: &TerminalProjectionHub,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> bool {
+    let (full_minute_start_epoch, full_minute_end_epoch) = complete_minute_bounds(start, end);
+    if full_minute_start_epoch >= full_minute_end_epoch {
+        return false;
+    }
+    let selection = TimeseriesProjectionSelection {
+        source_scope: timeseries_projection_scope(source_scope),
+        upstream_account_id,
+    };
+    // A cursor does not version a row replacement. A persisted terminal delta that has not been
+    // committed into this selection's warm snapshot makes its covered minute unsafe to reuse.
+    terminal_projection_hub.has_pending_timeseries_delta_for_selection(selection, |delta| {
+        parse_to_utc_datetime(&delta.occurred_at).is_none_or(|occurred| {
+            let occurred_epoch = occurred.timestamp();
+            occurred_epoch >= full_minute_start_epoch && occurred_epoch < full_minute_end_epoch
+        })
+    })
+}
+
 fn complete_minute_bounds(start: DateTime<Utc>, end: DateTime<Utc>) -> (i64, i64) {
     let start_epoch = (start.timestamp() + 59).div_euclid(60) * 60;
     let end_epoch = end.timestamp().div_euclid(60) * 60;
@@ -977,12 +1002,22 @@ impl TimeseriesTopicMaterializedBase {
             (baseline.snapshot_id, baseline.aggregates)
         } else {
             let snapshot_id = resolve_invocation_snapshot_id(&state.pool, source_scope).await?;
-            let use_minute_projection = bucket_seconds < 3_600
-                && range_window.duration <= ChronoDuration::days(1)
+            let minute_projection_candidate =
+                bucket_seconds < 3_600 && range_window.duration <= ChronoDuration::days(1);
+            let uncovered_terminal_delta = minute_projection_candidate
+                && timeseries_minute_projection_has_uncovered_terminal_delta(
+                    state.terminal_projection_hub.as_ref(),
+                    source_scope,
+                    params.upstream_account_id,
+                    start,
+                    end,
+                );
+            let use_minute_projection = minute_projection_candidate
                 && state
                     .terminal_projection_hub
                     .timeseries_coverage_invalidation_pending()
-                    .is_none();
+                    .is_none()
+                && !uncovered_terminal_delta;
             let aggregates = if use_minute_projection {
                 if let Some(TimeseriesMinuteProjectionV2Load {
                     aggregates: minute_aggregates,
@@ -1098,6 +1133,14 @@ impl TimeseriesTopicMaterializedBase {
                     .await?
                 }
             } else {
+                if uncovered_terminal_delta {
+                    debug!(
+                        route = "timeseries_topic",
+                        builder = "minute_projection_v2",
+                        response_source = "exact_fallback_pending_terminal_delta",
+                        "minute projection deferred until an uncovered terminal delta is warmed"
+                    );
+                }
                 build_exact_timeseries_topic_baseline(
                     state,
                     start,
@@ -1107,7 +1150,7 @@ impl TimeseriesTopicMaterializedBase {
                     params.upstream_account_id,
                     bucket_seconds,
                     reporting_tz,
-                    false,
+                    uncovered_terminal_delta,
                 )
                 .await?
             };

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -20,7 +20,7 @@ struct TimeseriesMinuteProjectionRow {
     max_row_id: i64,
 }
 
-#[derive(sqlx::FromRow)]
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 struct TimeseriesMinuteProjectionV2Row {
     minute_start_epoch: i64,
     aggregate_json: String,
@@ -30,6 +30,12 @@ struct TimeseriesMinuteProjectionV2Row {
     first_token_samples_json: String,
     max_row_id: i64,
     coverage_state: String,
+}
+
+struct TimeseriesMinuteProjectionV2Load {
+    aggregates: BTreeMap<i64, BucketAggregate>,
+    cursor: i64,
+    coverage_rows: Vec<TimeseriesMinuteProjectionV2Row>,
 }
 
 const TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT: usize = 64;
@@ -228,7 +234,53 @@ async fn load_timeseries_minute_projection_v2(
     end: DateTime<Utc>,
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
-) -> Result<Option<(BTreeMap<i64, BucketAggregate>, i64)>, ApiError> {
+) -> Result<Option<TimeseriesMinuteProjectionV2Load>, ApiError> {
+    let Some(rows) = load_ready_timeseries_minute_projection_v2_rows(
+        pool,
+        start,
+        end,
+        source_scope,
+        upstream_account_id,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let mut aggregates = BTreeMap::new();
+    let mut cursor = 0;
+    for row in &rows {
+        debug_assert_eq!(row.coverage_state, "ready");
+        let mut aggregate = serde_json::from_str::<BucketAggregate>(&row.aggregate_json)
+            .map_err(|err| ApiError::from(anyhow!("invalid v2 minute aggregate: {err}")))?;
+        // Keep the sample payloads independently addressable so a corrupt aggregate payload
+        // cannot silently turn an exact P95 into a histogram approximation.
+        aggregate.total_latency_values = serde_json::from_str(&row.total_latency_samples_json)
+            .map_err(|err| ApiError::from(anyhow!("invalid v2 total-latency samples: {err}")))?;
+        aggregate.first_byte_ttfb_values = serde_json::from_str(&row.first_byte_samples_json)
+            .map_err(|err| ApiError::from(anyhow!("invalid v2 first-byte samples: {err}")))?;
+        aggregate.first_response_byte_total_values =
+            serde_json::from_str(&row.first_response_byte_total_samples_json).map_err(|err| {
+                ApiError::from(anyhow!("invalid v2 first-response samples: {err}"))
+            })?;
+        aggregate.first_token_values = serde_json::from_str(&row.first_token_samples_json)
+            .map_err(|err| ApiError::from(anyhow!("invalid v2 first-token samples: {err}")))?;
+        cursor = cursor.max(row.max_row_id);
+        aggregates.insert(row.minute_start_epoch, aggregate);
+    }
+    Ok(Some(TimeseriesMinuteProjectionV2Load {
+        aggregates,
+        cursor,
+        coverage_rows: rows,
+    }))
+}
+
+async fn load_ready_timeseries_minute_projection_v2_rows(
+    pool: &Pool<Sqlite>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+) -> Result<Option<Vec<TimeseriesMinuteProjectionV2Row>>, ApiError> {
     let projection_ready = sqlx::query_scalar::<_, Option<String>>(
         "SELECT last_error FROM timeseries_minute_projection_v2_state WHERE consumer = 'timeseries_minute_v2'",
     )
@@ -256,62 +308,28 @@ async fn load_timeseries_minute_projection_v2(
     if rows.len() as i64 != expected {
         return Ok(None);
     }
-    let mut aggregates = BTreeMap::new();
-    let mut cursor = 0;
-    for row in rows {
-        debug_assert_eq!(row.coverage_state, "ready");
-        let mut aggregate = serde_json::from_str::<BucketAggregate>(&row.aggregate_json)
-            .map_err(|err| ApiError::from(anyhow!("invalid v2 minute aggregate: {err}")))?;
-        // Keep the sample payloads independently addressable so a corrupt aggregate payload
-        // cannot silently turn an exact P95 into a histogram approximation.
-        aggregate.total_latency_values = serde_json::from_str(&row.total_latency_samples_json)
-            .map_err(|err| ApiError::from(anyhow!("invalid v2 total-latency samples: {err}")))?;
-        aggregate.first_byte_ttfb_values = serde_json::from_str(&row.first_byte_samples_json)
-            .map_err(|err| ApiError::from(anyhow!("invalid v2 first-byte samples: {err}")))?;
-        aggregate.first_response_byte_total_values =
-            serde_json::from_str(&row.first_response_byte_total_samples_json).map_err(|err| {
-                ApiError::from(anyhow!("invalid v2 first-response samples: {err}"))
-            })?;
-        aggregate.first_token_values = serde_json::from_str(&row.first_token_samples_json)
-            .map_err(|err| ApiError::from(anyhow!("invalid v2 first-token samples: {err}")))?;
-        cursor = cursor.max(row.max_row_id);
-        aggregates.insert(row.minute_start_epoch, aggregate);
-    }
-    Ok(Some((aggregates, cursor)))
+    Ok(Some(rows))
 }
 
-async fn timeseries_minute_projection_v2_coverage_is_ready(
+async fn timeseries_minute_projection_v2_snapshot_is_current(
     pool: &Pool<Sqlite>,
     start: DateTime<Utc>,
     end: DateTime<Utc>,
     source_scope: InvocationSourceScope,
     upstream_account_id: Option<i64>,
+    coverage_rows: &[TimeseriesMinuteProjectionV2Row],
 ) -> Result<bool, ApiError> {
-    let projection_ready = sqlx::query_scalar::<_, Option<String>>(
-        "SELECT last_error FROM timeseries_minute_projection_v2_state WHERE consumer = 'timeseries_minute_v2'",
+    // Re-read the payload selected by the loader, not merely its row count. An invalidation can
+    // warm the same primary keys again while a reader is building its live tail.
+    Ok(load_ready_timeseries_minute_projection_v2_rows(
+        pool,
+        start,
+        end,
+        source_scope,
+        upstream_account_id,
     )
-    .fetch_optional(pool)
     .await?
-    .flatten()
-    .is_some_and(|state| state == "ready");
-    if !projection_ready {
-        return Ok(false);
-    }
-    let (minute_start, minute_end) = complete_minute_bounds(start, end);
-    let expected = (minute_end - minute_start).div_euclid(60);
-    if expected <= 0 {
-        return Ok(false);
-    }
-    let ready_row_count = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM timeseries_minute_projection_v2 WHERE minute_start_epoch >= ?1 AND minute_start_epoch < ?2 AND source_scope = ?3 AND upstream_account_key = ?4 AND coverage_state = 'ready'",
-    )
-    .bind(minute_start)
-    .bind(minute_end)
-    .bind(timeseries_projection_scope(source_scope))
-    .bind(upstream_account_id.unwrap_or(-1))
-    .fetch_one(pool)
-    .await?;
-    Ok(ready_row_count == expected)
+    .is_some_and(|current_rows| current_rows == coverage_rows))
 }
 
 #[cfg(test)]
@@ -966,15 +984,18 @@ impl TimeseriesTopicMaterializedBase {
                     .timeseries_coverage_invalidation_pending()
                     .is_none();
             let aggregates = if use_minute_projection {
-                if let Some((minute_aggregates, projection_cursor)) =
-                    load_timeseries_minute_projection_v2(
-                        &state.pool,
-                        start,
-                        end,
-                        source_scope,
-                        params.upstream_account_id,
-                    )
-                    .await?
+                if let Some(TimeseriesMinuteProjectionV2Load {
+                    aggregates: minute_aggregates,
+                    cursor: projection_cursor,
+                    coverage_rows,
+                }) = load_timeseries_minute_projection_v2(
+                    &state.pool,
+                    start,
+                    end,
+                    source_scope,
+                    params.upstream_account_id,
+                )
+                .await?
                 {
                     let mut aggregates = fold_minute_projection_aggregates(
                         minute_aggregates,
@@ -1031,12 +1052,13 @@ impl TimeseriesTopicMaterializedBase {
                         bucket_seconds,
                         reporting_tz,
                     )?;
-                    if timeseries_minute_projection_v2_coverage_is_ready(
+                    if timeseries_minute_projection_v2_snapshot_is_current(
                         &state.pool,
                         start,
                         end,
                         source_scope,
                         params.upstream_account_id,
+                        &coverage_rows,
                     )
                     .await?
                     {
@@ -2457,7 +2479,7 @@ mod minute_projection_tests {
         .await
         .expect("store v2 projection");
 
-        let (aggregates, cursor) = load_timeseries_minute_projection_v2(
+        let projection = load_timeseries_minute_projection_v2(
             &pool,
             start,
             end,
@@ -2467,6 +2489,8 @@ mod minute_projection_tests {
         .await
         .expect("load v2 projection")
         .expect("complete v2 minute coverage");
+        let aggregates = projection.aggregates;
+        let cursor = projection.cursor;
         let minute = start.timestamp();
         let aggregate = aggregates.get(&minute).expect("first minute aggregate");
         assert_eq!(cursor, 18);
@@ -2707,7 +2731,7 @@ mod minute_projection_tests {
         .await
         .expect("warm account projection");
 
-        let (aggregates, cursor) = load_timeseries_minute_projection_v2(
+        let projection = load_timeseries_minute_projection_v2(
             &pool,
             start,
             end,
@@ -2717,6 +2741,8 @@ mod minute_projection_tests {
         .await
         .expect("load account projection")
         .expect("complete account minute coverage");
+        let aggregates = projection.aggregates;
+        let cursor = projection.cursor;
         assert_eq!(cursor, 17);
         assert_eq!(aggregates.len(), 2);
         assert_eq!(
@@ -2726,7 +2752,7 @@ mod minute_projection_tests {
     }
 
     #[tokio::test]
-    async fn minute_projection_warm_snapshot_does_not_replace_a_newer_cursor() {
+    async fn minute_projection_snapshot_fence_rejects_changed_rewarm_with_same_cursor() {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect("sqlite::memory:")
@@ -2776,7 +2802,7 @@ mod minute_projection_tests {
         .await
         .expect("attempt stale warm snapshot");
 
-        let (aggregates, cursor) = load_timeseries_minute_projection_v2(
+        let initial_projection = load_timeseries_minute_projection_v2(
             &pool,
             start,
             end,
@@ -2786,8 +2812,11 @@ mod minute_projection_tests {
         .await
         .expect("load v2 projection")
         .expect("complete minute coverage");
-        assert_eq!(cursor, 18);
-        assert_eq!(aggregates[&start.timestamp()].total_count, 2);
+        assert_eq!(initial_projection.cursor, 18);
+        assert_eq!(
+            initial_projection.aggregates[&start.timestamp()].total_count,
+            2
+        );
 
         sqlx::query("UPDATE timeseries_minute_projection_v2 SET coverage_state = 'warming'")
             .execute(&pool)
@@ -2806,12 +2835,13 @@ mod minute_projection_tests {
             .is_none()
         );
         assert!(
-            !timeseries_minute_projection_v2_coverage_is_ready(
+            !timeseries_minute_projection_v2_snapshot_is_current(
                 &pool,
                 start,
                 end,
                 InvocationSourceScope::All,
                 None,
+                &initial_projection.coverage_rows,
             )
             .await
             .expect("check invalidated coverage fence"),
@@ -2825,12 +2855,28 @@ mod minute_projection_tests {
             None,
             &[
                 record(17, "2026-08-01 08:00:12"),
-                record(18, "2026-08-01 08:00:30"),
+                InvocationAggregateRecord {
+                    status: Some("failed".to_string()),
+                    ..record(18, "2026-08-01 08:00:30")
+                },
             ],
         )
         .await
         .expect("re-warm invalidated projection");
-        let (aggregates, cursor) = load_timeseries_minute_projection_v2(
+        assert!(
+            !timeseries_minute_projection_v2_snapshot_is_current(
+                &pool,
+                start,
+                end,
+                InvocationSourceScope::All,
+                None,
+                &initial_projection.coverage_rows,
+            )
+            .await
+            .expect("check changed re-warmed coverage fence"),
+            "re-warming the same primary keys must not accept stale aggregate payloads"
+        );
+        let re_warmed_projection = load_timeseries_minute_projection_v2(
             &pool,
             start,
             end,
@@ -2840,15 +2886,19 @@ mod minute_projection_tests {
         .await
         .expect("load re-warmed projection")
         .expect("re-warmed minute coverage");
-        assert_eq!(cursor, 18);
-        assert_eq!(aggregates[&start.timestamp()].total_count, 2);
+        assert_eq!(re_warmed_projection.cursor, 18);
+        assert_eq!(
+            re_warmed_projection.aggregates[&start.timestamp()].total_count,
+            2
+        );
         assert!(
-            timeseries_minute_projection_v2_coverage_is_ready(
+            timeseries_minute_projection_v2_snapshot_is_current(
                 &pool,
                 start,
                 end,
                 InvocationSourceScope::All,
                 None,
+                &re_warmed_projection.coverage_rows,
             )
             .await
             .expect("check re-warmed coverage fence")
@@ -2936,7 +2986,11 @@ pub(crate) async fn fetch_timeseries(
         .is_some();
     if use_minute_projection
         && !coverage_invalidation_pending
-        && let Some((minute_aggregates, projection_cursor)) =
+        && let Some(TimeseriesMinuteProjectionV2Load {
+            aggregates: minute_aggregates,
+            cursor: projection_cursor,
+            coverage_rows,
+        }) =
             load_timeseries_minute_projection_v2(&state.pool, start_dt, end_dt, source_scope, None)
                 .await?
     {
@@ -3040,12 +3094,13 @@ pub(crate) async fn fetch_timeseries(
             reporting_tz,
             &db_runtime_records,
         )?;
-        if timeseries_minute_projection_v2_coverage_is_ready(
+        if timeseries_minute_projection_v2_snapshot_is_current(
             &state.pool,
             start_dt,
             end_dt,
             source_scope,
             None,
+            &coverage_rows,
         )
         .await?
         {
@@ -3338,7 +3393,11 @@ pub(crate) async fn fetch_timeseries_for_account(
     if bucket_seconds < 3_600
         && range_window.duration <= ChronoDuration::days(1)
         && !coverage_invalidation_pending
-        && let Some((minute_aggregates, projection_cursor)) = load_timeseries_minute_projection_v2(
+        && let Some(TimeseriesMinuteProjectionV2Load {
+            aggregates: minute_aggregates,
+            cursor: projection_cursor,
+            coverage_rows,
+        }) = load_timeseries_minute_projection_v2(
             &state.pool,
             start_dt,
             end_dt,
@@ -3452,12 +3511,13 @@ pub(crate) async fn fetch_timeseries_for_account(
             reporting_tz,
             &db_runtime_records,
         )?;
-        if timeseries_minute_projection_v2_coverage_is_ready(
+        if timeseries_minute_projection_v2_snapshot_is_current(
             &state.pool,
             start_dt,
             end_dt,
             source_scope,
             Some(upstream_account_id),
+            &coverage_rows,
         )
         .await?
         {

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -1,8 +1,11 @@
 use super::prompt_cache_and_timeseries_shared as prompt_shared;
 use super::*;
 use anyhow::anyhow;
-use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, Instant};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+};
 use tokio::{
     task::JoinHandle,
     time::{MissedTickBehavior, interval},
@@ -27,6 +30,26 @@ struct TimeseriesMinuteProjectionV2Row {
     first_token_samples_json: String,
     max_row_id: i64,
     coverage_state: String,
+}
+
+const TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT: usize = 64;
+const TIMESERIES_MINUTE_PROJECTION_INVALIDATION_ROW_BATCH_LIMIT: i64 = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TimeseriesMinuteProjectionFlushOutcome {
+    Flushed,
+    Deferred,
+}
+
+struct TimeseriesMinuteProjectionWriteAdmission {
+    _write_permit: crate::proxy_sqlite_write_coordinator::ProxySqliteWritePermit,
+    _pressure_permit: crate::db_pressure::DbBackgroundPermit,
+}
+
+#[derive(Debug, Default)]
+struct TimeseriesMinuteProjectionCoverageInvalidationStats {
+    row_count: u64,
+    transaction_count: u64,
 }
 
 fn fold_minute_projection_aggregates(
@@ -1253,10 +1276,142 @@ fn timeseries_projection_requires_exact_rebuild(
         .any(|(row_id, _)| *row_id <= existing_max_row_id || !seen_row_ids.insert(*row_id))
 }
 
+async fn try_acquire_timeseries_minute_projection_write(
+    coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
+    trigger: &'static str,
+    transaction_phase: &'static str,
+    pending_event_count: usize,
+) -> Option<TimeseriesMinuteProjectionWriteAdmission> {
+    let pressure_gate = crate::db_pressure::global_db_pressure_gate();
+    let observed_eligibility_generation = pressure_gate.eligibility_generation();
+    let Some(mut write_permit) = coordinator
+        .try_acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P2Derived)
+    else {
+        let snapshot = coordinator.snapshot().await;
+        debug!(
+            route = "timeseries_projection",
+            builder = "minute_projection_v2",
+            trigger,
+            transaction_phase,
+            admission_outcome = "deferred",
+            defer_reason = "coordinator_priority",
+            active_write_class = snapshot.active_write_class.as_deref().unwrap_or("none"),
+            p1_waiter_count = snapshot.p1_waiter_count,
+            interactive_waiter_count = snapshot.interactive_waiter_count,
+            p2_waiter_count = snapshot.p2_waiter_count,
+            pending_event_count,
+            "minute projection deferred before opening a P2 write transaction"
+        );
+        return None;
+    };
+
+    match pressure_gate.try_begin_background("timeseries_minute_projection_flush") {
+        Ok(pressure_permit) => Some(TimeseriesMinuteProjectionWriteAdmission {
+            _write_permit: write_permit,
+            _pressure_permit: pressure_permit,
+        }),
+        Err(reason) => {
+            if matches!(
+                reason,
+                crate::db_pressure::DbPressureDenyReason::BackgroundBusy
+            ) {
+                write_permit.suppress_background_eligibility_wakeup();
+            }
+            drop(write_permit);
+            debug!(
+                route = "timeseries_projection",
+                builder = "minute_projection_v2",
+                trigger,
+                transaction_phase,
+                admission_outcome = "deferred",
+                defer_reason = "writer_pressure",
+                observed_eligibility_generation,
+                pending_event_count,
+                %reason,
+                "minute projection deferred before opening a P2 write transaction"
+            );
+            None
+        }
+    }
+}
+
+async fn invalidate_timeseries_minute_projection_coverage(
+    state: &AppState,
+    coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
+    trigger: &'static str,
+    pending_event_count: usize,
+) -> Result<Option<TimeseriesMinuteProjectionCoverageInvalidationStats>, ApiError> {
+    let mut stats = TimeseriesMinuteProjectionCoverageInvalidationStats::default();
+    loop {
+        let row_ids = sqlx::query_scalar::<_, i64>(
+            "SELECT rowid FROM timeseries_minute_projection_v2 WHERE coverage_state <> 'warming' ORDER BY rowid LIMIT ?1",
+        )
+        .bind(TIMESERIES_MINUTE_PROJECTION_INVALIDATION_ROW_BATCH_LIMIT)
+        .fetch_all(&state.pool)
+        .await?;
+        if row_ids.is_empty() {
+            return Ok(Some(stats));
+        }
+
+        let Some(admission) = try_acquire_timeseries_minute_projection_write(
+            coordinator,
+            trigger,
+            "coverage_invalidation",
+            pending_event_count,
+        )
+        .await
+        else {
+            return Ok(None);
+        };
+
+        let started = Instant::now();
+        let mut tx = state.pool.begin().await?;
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "UPDATE timeseries_minute_projection_v2 SET coverage_state = 'warming' WHERE rowid IN (",
+        );
+        {
+            let mut separated = query.separated(", ");
+            for row_id in &row_ids {
+                separated.push_bind(row_id);
+            }
+        }
+        query.push(")");
+        let updated_rows = query.build().execute(tx.as_mut()).await?.rows_affected();
+        tx.commit().await?;
+        stats.row_count = stats.row_count.saturating_add(updated_rows);
+        stats.transaction_count = stats.transaction_count.saturating_add(1);
+        debug!(
+            route = "timeseries_projection",
+            builder = "minute_projection_v2",
+            trigger,
+            transaction_phase = "coverage_invalidation",
+            transaction_row_limit = TIMESERIES_MINUTE_PROJECTION_INVALIDATION_ROW_BATCH_LIMIT,
+            transaction_row_count = updated_rows,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "invalidated a bounded minute projection coverage slice"
+        );
+        drop(admission);
+        tokio::task::yield_now().await;
+    }
+}
+
 pub(crate) async fn flush_timeseries_minute_projection(
     state: &AppState,
     trigger: &'static str,
-) -> Result<(), ApiError> {
+) -> Result<TimeseriesMinuteProjectionFlushOutcome, ApiError> {
+    flush_timeseries_minute_projection_with_coordinator(
+        state,
+        trigger,
+        &crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator(),
+    )
+    .await
+}
+
+pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
+    state: &AppState,
+    trigger: &'static str,
+    coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
+) -> Result<TimeseriesMinuteProjectionFlushOutcome, ApiError> {
     let pending = state
         .terminal_projection_hub
         .pending_timeseries_deltas(10_000);
@@ -1264,27 +1419,11 @@ pub(crate) async fn flush_timeseries_minute_projection(
         .terminal_projection_hub
         .timeseries_coverage_invalidation_pending();
     if pending.is_empty() && coverage_invalidation_generation.is_none() {
-        return Ok(());
+        return Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed);
     }
     let memory_baseline = state.memory_diagnostics.begin_operation(state).await;
     let mut loaded_row_count = 0u64;
-    let result: Result<(), ApiError> = async {
-        let gate = crate::db_pressure::global_db_pressure_gate();
-        let _permit = match gate.try_begin_background("timeseries_minute_projection_flush") {
-            Ok(permit) => permit,
-            Err(reason) => {
-                debug!(
-                    route = "timeseries_projection",
-                    builder = "minute_projection_v2",
-                    trigger,
-                    gate_outcome = "deferred",
-                    defer_reason = "writer_pressure",
-                    %reason,
-                    "minute projection flush deferred by database pressure"
-                );
-                return Ok(());
-            }
-        };
+    let result: Result<TimeseriesMinuteProjectionFlushOutcome, ApiError> = async {
         let started = Instant::now();
         let mut grouped = HashMap::new();
         let mut flushed_event_ids = Vec::with_capacity(pending.len());
@@ -1292,59 +1431,107 @@ pub(crate) async fn flush_timeseries_minute_projection(
             flushed_event_ids.push(event_id);
             add_timeseries_delta_projection_keys(&mut grouped, row_id, delta);
         }
-        let mut tx = state.pool.begin().await?;
-        if coverage_invalidation_generation.is_some() {
-            // A Hub admission rejection may have omitted a terminal update for an existing
-            // row. Never keep any minute marked ready until exact fallback has rebuilt it.
-            sqlx::query("UPDATE timeseries_minute_projection_v2 SET coverage_state = 'warming'")
-                .execute(tx.as_mut())
-                .await?;
-        }
+
+        let coverage_invalidation = if coverage_invalidation_generation.is_some() {
+            match invalidate_timeseries_minute_projection_coverage(
+                state,
+                coordinator,
+                trigger,
+                flushed_event_ids.len(),
+            )
+            .await?
+            {
+                Some(stats) => stats,
+                None => return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred),
+            }
+        } else {
+            TimeseriesMinuteProjectionCoverageInvalidationStats::default()
+        };
+
+        let mut grouped = grouped.into_iter().collect::<Vec<_>>();
+        grouped.sort_by_key(|(key, _)| {
+            (
+                key.minute_start_epoch,
+                key.source_scope,
+                key.upstream_account_key,
+            )
+        });
         let mut written_key_count = 0usize;
         let mut exact_fallback_minute_count = 0usize;
-        for (key, mut deltas) in grouped {
-            deltas.sort_by_key(|(row_id, _)| *row_id);
-            let (aggregate, max_row_id) = if let Some((aggregate, existing_max_row_id)) =
-                load_timeseries_minute_projection_v2_key_tx(tx.as_mut(), &key).await?
-            {
-                if timeseries_projection_requires_exact_rebuild(&deltas, existing_max_row_id) {
-                    // A terminal record can update an older running row. Its row ID is not a
-                    // change cursor, and repeated pending events can share the same row ID.
-                    // Either case needs an exact rebuild rather than another incremental add.
+        let mut transaction_count = 0usize;
+        for key_batch in grouped.chunks_mut(TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT) {
+            let Some(admission) = try_acquire_timeseries_minute_projection_write(
+                coordinator,
+                trigger,
+                "minute_projection_keys",
+                flushed_event_ids.len(),
+            )
+            .await
+            else {
+                return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+            };
+
+            let transaction_started = Instant::now();
+            let mut tx = state.pool.begin().await?;
+            for (key, deltas) in &mut *key_batch {
+                deltas.sort_by_key(|(row_id, _)| *row_id);
+                let (aggregate, max_row_id) = if let Some((aggregate, existing_max_row_id)) =
+                    load_timeseries_minute_projection_v2_key_tx(tx.as_mut(), key).await?
+                {
+                    if timeseries_projection_requires_exact_rebuild(deltas, existing_max_row_id) {
+                        // A terminal record can update an older running row. Its row ID is not a
+                        // change cursor, and repeated pending events can share the same row ID.
+                        // Either case needs an exact rebuild rather than another incremental add.
+                        exact_fallback_minute_count += 1;
+                        let (aggregate, max_row_id, source_row_count) =
+                            rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), key)
+                                .await?;
+                        loaded_row_count = loaded_row_count.saturating_add(source_row_count);
+                        (aggregate, max_row_id)
+                    } else {
+                        let mut aggregate = aggregate;
+                        let mut max_row_id = existing_max_row_id;
+                        for (row_id, delta) in deltas {
+                            add_timeseries_terminal_delta_to_aggregate(&mut aggregate, delta);
+                            max_row_id = max_row_id.max(*row_id);
+                        }
+                        (aggregate, max_row_id)
+                    }
+                } else {
+                    // A delta alone cannot prove that a minute is complete: a process can start
+                    // mid-minute or recover after an earlier terminal write. Rebuild only this
+                    // minute before publishing it as ready, rather than storing a partial total.
                     exact_fallback_minute_count += 1;
                     let (aggregate, max_row_id, source_row_count) =
-                        rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), &key).await?;
+                        rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), key).await?;
                     loaded_row_count = loaded_row_count.saturating_add(source_row_count);
                     (aggregate, max_row_id)
-                } else {
-                    let mut aggregate = aggregate;
-                    let mut max_row_id = existing_max_row_id;
-                    for (row_id, delta) in deltas {
-                        add_timeseries_terminal_delta_to_aggregate(&mut aggregate, &delta);
-                        max_row_id = max_row_id.max(row_id);
-                    }
-                    (aggregate, max_row_id)
-                }
-            } else {
-                // A delta alone cannot prove that a minute is complete: a process can start
-                // mid-minute or recover after an earlier terminal write. Rebuild only this
-                // minute before publishing it as ready, rather than storing a partial total.
-                exact_fallback_minute_count += 1;
-                let (aggregate, max_row_id, source_row_count) =
-                    rebuild_timeseries_minute_projection_v2_key_tx(tx.as_mut(), &key).await?;
-                loaded_row_count = loaded_row_count.saturating_add(source_row_count);
-                (aggregate, max_row_id)
-            };
-            upsert_timeseries_minute_projection_v2_key_tx(
-                tx.as_mut(),
-                &key,
-                &aggregate,
-                max_row_id,
-            )
-            .await?;
-            written_key_count += 1;
+                };
+                upsert_timeseries_minute_projection_v2_key_tx(
+                    tx.as_mut(),
+                    key,
+                    &aggregate,
+                    max_row_id,
+                )
+                .await?;
+                written_key_count += 1;
+            }
+            tx.commit().await?;
+            transaction_count += 1;
+            debug!(
+                route = "timeseries_projection",
+                builder = "minute_projection_v2",
+                trigger,
+                transaction_phase = "minute_projection_keys",
+                transaction_key_limit = TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT,
+                transaction_key_count = key_batch.len(),
+                elapsed_ms = transaction_started.elapsed().as_millis() as u64,
+                "flushed a bounded minute projection key slice"
+            );
+            drop(admission);
+            tokio::task::yield_now().await;
         }
-        tx.commit().await?;
+
         if let Some(generation) = coverage_invalidation_generation {
             state
                 .terminal_projection_hub
@@ -1362,11 +1549,14 @@ pub(crate) async fn flush_timeseries_minute_projection(
             minute_rollup_count = written_key_count,
             exact_fallback_minute_count,
             raw_row_count = loaded_row_count,
+            coverage_invalidation_row_count = coverage_invalidation.row_count,
+            coverage_invalidation_transaction_count = coverage_invalidation.transaction_count,
+            write_transaction_count = transaction_count,
             coverage_invalidation_pending = coverage_invalidation_generation.is_some(),
             elapsed_ms = started.elapsed().as_millis() as u64,
             "flushed terminal deltas into minute projection"
         );
-        Ok(())
+        Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed)
     }
     .await;
     state
@@ -1406,14 +1596,26 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
             tokio::select! {
                 _ = cancel.cancelled() => return,
                 _ = ticker.tick() => {
-                    if let Err(error) = flush_timeseries_minute_projection(state.as_ref(), "terminal_deadline").await {
-                        warn!(
-                            route = "timeseries_projection",
-                            builder = "minute_projection_v2",
-                            trigger = "terminal_deadline",
-                            ?error,
-                            "minute projection flush failed"
-                        );
+                    match flush_timeseries_minute_projection(state.as_ref(), "terminal_deadline").await {
+                        Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => {}
+                        Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred) => {
+                            debug!(
+                                route = "timeseries_projection",
+                                builder = "minute_projection_v2",
+                                trigger = "terminal_deadline",
+                                flush_outcome = "deferred",
+                                "minute projection flush yielded to higher-priority database work"
+                            );
+                        }
+                        Err(error) => {
+                            warn!(
+                                route = "timeseries_projection",
+                                builder = "minute_projection_v2",
+                                trigger = "terminal_deadline",
+                                ?error,
+                                "minute projection flush failed"
+                            );
+                        }
                     }
                 }
             }

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -76,6 +76,28 @@ fn timeseries_minute_projection_is_cancelled(
     cancellation.is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
 }
 
+fn timeseries_minute_projection_pressure_deferred(
+    pressure_gate: &crate::db_pressure::DbPressureGate,
+    task: &'static str,
+    error: &ApiError,
+) -> Option<TimeseriesMinuteProjectionDeferred> {
+    let error = match error {
+        ApiError::BadRequest(error) | ApiError::Internal(error) => error,
+    };
+    if !pressure_gate.record_error(task, error) {
+        return None;
+    }
+    let retry_after = Duration::from_millis(
+        pressure_gate
+            .snapshot()
+            .pressure_cooldown_remaining_ms
+            .max(1),
+    );
+    Some(TimeseriesMinuteProjectionDeferred {
+        retry_after: Some(retry_after),
+    })
+}
+
 fn fold_minute_projection_aggregates(
     minute_aggregates: BTreeMap<i64, BucketAggregate>,
     bucket_seconds: i64,
@@ -338,7 +360,7 @@ async fn store_timeseries_minute_projection_v2_warm(
     coverage_generation: u64,
     trigger: &'static str,
 ) -> Result<TimeseriesMinuteProjectionWarmOutcome, ApiError> {
-    store_timeseries_minute_projection_v2_warm_with_coordinator(
+    let outcome = store_timeseries_minute_projection_v2_warm_with_coordinator(
         pool,
         start,
         end,
@@ -349,7 +371,22 @@ async fn store_timeseries_minute_projection_v2_warm(
         trigger,
         &crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator(),
     )
-    .await
+    .await;
+    match outcome {
+        Ok(outcome) => Ok(outcome),
+        Err(error) => {
+            let gate = crate::db_pressure::global_db_pressure_gate();
+            if let Some(deferred) = timeseries_minute_projection_pressure_deferred(
+                gate,
+                "timeseries_minute_projection_warm",
+                &error,
+            ) {
+                Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred(deferred))
+            } else {
+                Err(error)
+            }
+        }
+    }
 }
 
 async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
@@ -363,7 +400,6 @@ async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
     trigger: &'static str,
 ) -> Result<TimeseriesMinuteProjectionWarmOutcome, ApiError> {
     let pressure_gate = crate::db_pressure::global_db_pressure_gate();
-    let observed_eligibility_generation = pressure_gate.eligibility_generation();
     let outcome = store_timeseries_minute_projection_v2_warm(
         pool,
         start,
@@ -378,6 +414,7 @@ async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
     let TimeseriesMinuteProjectionWarmOutcome::Deferred(deferred) = outcome else {
         return Ok(outcome);
     };
+    let observed_eligibility_generation = pressure_gate.eligibility_generation();
     debug!(
         route = "timeseries_projection",
         builder = "minute_projection_v2",
@@ -1947,7 +1984,29 @@ async fn flush_timeseries_minute_projection_with_coordinator_and_cancellation(
             true,
         )
         .await;
-    result
+    match result {
+        Ok(outcome) => Ok(outcome),
+        Err(error) => {
+            let gate = crate::db_pressure::global_db_pressure_gate();
+            if let Some(deferred) = timeseries_minute_projection_pressure_deferred(
+                gate,
+                "timeseries_minute_projection_flush",
+                &error,
+            ) {
+                debug!(
+                    route = "timeseries_projection",
+                    builder = "minute_projection_v2",
+                    trigger,
+                    defer_reason = "sqlite_pressure",
+                    retry_after_ms = deferred.retry_after.map(|value| value.as_millis() as u64),
+                    "minute projection flush deferred after a database pressure error"
+                );
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred))
+            } else {
+                Err(error)
+            }
+        }
+    }
 }
 
 pub(crate) fn spawn_timeseries_minute_projection_supervisor(
@@ -1957,11 +2016,11 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
     tokio::spawn(async move {
         let pressure_gate = crate::db_pressure::global_db_pressure_gate();
         loop {
-            let observed_eligibility_generation = pressure_gate.eligibility_generation();
             match prepare_timeseries_minute_projection_after_restart(state.as_ref(), &cancel).await
             {
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => break,
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred)) => {
+                    let observed_eligibility_generation = pressure_gate.eligibility_generation();
                     debug!(
                         route = "timeseries_projection",
                         builder = "minute_projection_v2",
@@ -1984,15 +2043,30 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
                 }
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled) => return,
                 Err(error) => {
+                    let pressure_deferred = timeseries_minute_projection_pressure_deferred(
+                        pressure_gate,
+                        "timeseries_minute_projection_startup",
+                        &error,
+                    );
+                    let observed_eligibility_generation = pressure_gate.eligibility_generation();
                     warn!(
                         route = "timeseries_projection",
                         builder = "minute_projection_v2",
+                        pressure_deferred = pressure_deferred.is_some(),
                         ?error,
                         "failed to invalidate minute projection during startup recovery"
                     );
-                    tokio::select! {
-                        _ = cancel.cancelled() => return,
-                        _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    if let Some(deferred) = pressure_deferred {
+                        tokio::select! {
+                            _ = cancel.cancelled() => return,
+                            _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                            _ = tokio::time::sleep(deferred.retry_after.expect("pressure deferral has a retry deadline")) => {}
+                        }
+                    } else {
+                        tokio::select! {
+                            _ = cancel.cancelled() => return,
+                            _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                        }
                     }
                 }
             }
@@ -2028,7 +2102,6 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
                 }
             }
 
-            let observed_eligibility_generation = pressure_gate.eligibility_generation();
             match flush_timeseries_minute_projection_with_coordinator_and_cancellation(
                 state.as_ref(),
                 "terminal_deadline",
@@ -2039,6 +2112,7 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
             {
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => {}
                 Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred(deferred)) => {
+                    let observed_eligibility_generation = pressure_gate.eligibility_generation();
                     deferred_eligibility_generation = Some(observed_eligibility_generation);
                     deferred_retry_after = deferred.retry_after;
                     debug!(
@@ -5064,6 +5138,37 @@ mod tests {
             pressure_gate.eligibility_generation(),
             observed_eligibility_generation,
             "releasing a denied P2 permit must not wake its own retry waiter"
+        );
+    }
+
+    #[tokio::test]
+    async fn projection_sqlite_pressure_error_enters_cooldown_with_a_retry_deadline() {
+        let pressure_gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(30));
+        let error = ApiError::Internal(anyhow!("database is locked"));
+
+        let deferred = timeseries_minute_projection_pressure_deferred(
+            &pressure_gate,
+            "timeseries_minute_projection_test",
+            &error,
+        )
+        .expect("SQLite lock errors must defer projection writes through the pressure gate");
+
+        assert!(
+            deferred
+                .retry_after
+                .is_some_and(|retry_after| retry_after >= Duration::from_secs(29)),
+            "pressure deferral must retain the gate cooldown deadline"
+        );
+        assert_eq!(pressure_gate.snapshot().pressure_events, 1);
+        let observed_eligibility_generation = pressure_gate.eligibility_generation();
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(5),
+                pressure_gate.wait_for_eligibility_change(observed_eligibility_generation),
+            )
+            .await
+            .is_err(),
+            "retry wait must observe the post-error generation instead of self-waking"
         );
     }
 }

--- a/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/timeseries.rs
@@ -40,6 +40,7 @@ const TIMESERIES_MINUTE_PROJECTION_INVALIDATION_ROW_BATCH_LIMIT: i64 = 256;
 pub(crate) enum TimeseriesMinuteProjectionFlushOutcome {
     Flushed,
     Deferred,
+    Cancelled,
 }
 
 struct TimeseriesMinuteProjectionWriteAdmission {
@@ -51,6 +52,18 @@ struct TimeseriesMinuteProjectionWriteAdmission {
 struct TimeseriesMinuteProjectionCoverageInvalidationStats {
     row_count: u64,
     transaction_count: u64,
+}
+
+enum TimeseriesMinuteProjectionCoverageInvalidationOutcome {
+    Invalidated(TimeseriesMinuteProjectionCoverageInvalidationStats),
+    Deferred,
+    Cancelled,
+}
+
+fn timeseries_minute_projection_is_cancelled(
+    cancellation: Option<&tokio_util::sync::CancellationToken>,
+) -> bool {
+    cancellation.is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
 }
 
 fn fold_minute_projection_aggregates(
@@ -235,7 +248,8 @@ async fn load_timeseries_minute_projection_v2(
     Ok(Some((aggregates, cursor)))
 }
 
-async fn store_timeseries_minute_projection_v2(
+#[cfg(test)]
+async fn store_timeseries_minute_projection_v2_for_test(
     pool: &Pool<Sqlite>,
     start: DateTime<Utc>,
     end: DateTime<Utc>,
@@ -296,6 +310,218 @@ async fn store_timeseries_minute_projection_v2(
     }
     tx.commit().await?;
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TimeseriesMinuteProjectionWarmOutcome {
+    Stored,
+    Deferred,
+}
+
+async fn store_timeseries_minute_projection_v2_warm(
+    pool: &Pool<Sqlite>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+    records: &[InvocationAggregateRecord],
+    terminal_projection_hub: &TerminalProjectionHub,
+    coverage_generation: u64,
+    trigger: &'static str,
+) -> Result<TimeseriesMinuteProjectionWarmOutcome, ApiError> {
+    store_timeseries_minute_projection_v2_warm_with_coordinator(
+        pool,
+        start,
+        end,
+        source_scope,
+        upstream_account_id,
+        records,
+        terminal_projection_hub,
+        coverage_generation,
+        trigger,
+        &crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator(),
+    )
+    .await
+}
+
+async fn store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
+    pool: &Pool<Sqlite>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+    records: &[InvocationAggregateRecord],
+    terminal_projection_hub: &TerminalProjectionHub,
+    coverage_generation: u64,
+    trigger: &'static str,
+) -> Result<TimeseriesMinuteProjectionWarmOutcome, ApiError> {
+    let pressure_gate = crate::db_pressure::global_db_pressure_gate();
+    let observed_eligibility_generation = pressure_gate.eligibility_generation();
+    let outcome = store_timeseries_minute_projection_v2_warm(
+        pool,
+        start,
+        end,
+        source_scope,
+        upstream_account_id,
+        records,
+        terminal_projection_hub,
+        coverage_generation,
+        trigger,
+    )
+    .await?;
+    if outcome != TimeseriesMinuteProjectionWarmOutcome::Deferred {
+        return Ok(outcome);
+    }
+    debug!(
+        route = "timeseries_projection",
+        builder = "minute_projection_v2",
+        trigger,
+        transaction_phase = "exact_warm",
+        observed_eligibility_generation,
+        "waiting briefly to retry a deferred exact-fallback minute projection warm write"
+    );
+    tokio::select! {
+        _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {
+            store_timeseries_minute_projection_v2_warm(
+                pool,
+                start,
+                end,
+                source_scope,
+                upstream_account_id,
+                records,
+                terminal_projection_hub,
+                coverage_generation,
+                trigger,
+            ).await
+        }
+        _ = tokio::time::sleep(Duration::from_secs(5)) => Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred),
+    }
+}
+
+pub(crate) async fn store_timeseries_minute_projection_v2_warm_with_coordinator(
+    pool: &Pool<Sqlite>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    source_scope: InvocationSourceScope,
+    upstream_account_id: Option<i64>,
+    records: &[InvocationAggregateRecord],
+    terminal_projection_hub: &TerminalProjectionHub,
+    coverage_generation: u64,
+    trigger: &'static str,
+    coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
+) -> Result<TimeseriesMinuteProjectionWarmOutcome, ApiError> {
+    let (minute_start, minute_end) = complete_minute_bounds(start, end);
+    if minute_end <= minute_start {
+        return Ok(TimeseriesMinuteProjectionWarmOutcome::Stored);
+    }
+    let mut by_minute: HashMap<i64, BucketAggregate> = HashMap::new();
+    let mut max_row_ids = HashMap::new();
+    for record in records {
+        if prompt_shared::invocation_status_is_in_flight(record.status.as_deref()) {
+            continue;
+        }
+        let Some(occurred) = parse_to_utc_datetime(&record.occurred_at) else {
+            continue;
+        };
+        let minute = occurred.timestamp().div_euclid(60) * 60;
+        if minute < minute_start || minute >= minute_end {
+            continue;
+        }
+        add_exact_record_to_timeseries_aggregate(by_minute.entry(minute).or_default(), record);
+        max_row_ids
+            .entry(minute)
+            .and_modify(|max_row_id: &mut i64| *max_row_id = (*max_row_id).max(record.id))
+            .or_insert(record.id);
+    }
+    let rows = (minute_start..minute_end)
+        .step_by(60_usize)
+        .map(|minute| {
+            (
+                TimeseriesMinuteProjectionKey {
+                    minute_start_epoch: minute,
+                    source_scope: timeseries_projection_scope(source_scope),
+                    upstream_account_key: upstream_account_id.unwrap_or(-1),
+                },
+                by_minute.remove(&minute).unwrap_or_default(),
+                max_row_ids.remove(&minute).unwrap_or(0),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for key_batch in rows.chunks(TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT) {
+        if terminal_projection_hub.timeseries_coverage_generation() != coverage_generation
+            || terminal_projection_hub
+                .timeseries_coverage_invalidation_pending()
+                .is_some()
+        {
+            debug!(
+                route = "timeseries_projection",
+                builder = "minute_projection_v2",
+                trigger,
+                transaction_phase = "exact_warm",
+                admission_outcome = "deferred",
+                defer_reason = "coverage_generation_changed",
+                coverage_generation,
+                "minute projection warm write deferred for a newer coverage generation"
+            );
+            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+        }
+        let Some(admission) = try_acquire_timeseries_minute_projection_write(
+            coordinator,
+            trigger,
+            "exact_warm",
+            records.len(),
+        )
+        .await
+        else {
+            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+        };
+        // The exact source snapshot was read before admission. Re-check while holding the
+        // shared P2 permit so an invalidation completed in that interval cannot be overwritten.
+        if terminal_projection_hub.timeseries_coverage_generation() != coverage_generation
+            || terminal_projection_hub
+                .timeseries_coverage_invalidation_pending()
+                .is_some()
+        {
+            drop(admission);
+            return Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred);
+        }
+        let transaction_started = Instant::now();
+        let mut tx = pool.begin().await?;
+        for (key, aggregate, max_row_id) in key_batch {
+            sqlx::query(
+                "INSERT INTO timeseries_minute_projection_v2 (minute_start_epoch, source_scope, upstream_account_key, aggregate_json, total_latency_samples_json, first_byte_samples_json, first_response_byte_total_samples_json, first_token_samples_json, max_row_id, coverage_state, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'ready', datetime('now')) ON CONFLICT(minute_start_epoch, source_scope, upstream_account_key) DO UPDATE SET aggregate_json = excluded.aggregate_json, total_latency_samples_json = excluded.total_latency_samples_json, first_byte_samples_json = excluded.first_byte_samples_json, first_response_byte_total_samples_json = excluded.first_response_byte_total_samples_json, first_token_samples_json = excluded.first_token_samples_json, max_row_id = excluded.max_row_id, coverage_state = 'ready', updated_at = excluded.updated_at WHERE excluded.max_row_id > timeseries_minute_projection_v2.max_row_id OR (timeseries_minute_projection_v2.coverage_state = 'warming' AND excluded.max_row_id = timeseries_minute_projection_v2.max_row_id)",
+            )
+            .bind(key.minute_start_epoch)
+            .bind(key.source_scope)
+            .bind(key.upstream_account_key)
+            .bind(serde_json::to_string(aggregate).map_err(ApiError::from)?)
+            .bind(serde_json::to_string(&aggregate.total_latency_values).map_err(ApiError::from)?)
+            .bind(serde_json::to_string(&aggregate.first_byte_ttfb_values).map_err(ApiError::from)?)
+            .bind(
+                serde_json::to_string(&aggregate.first_response_byte_total_values)
+                    .map_err(ApiError::from)?,
+            )
+            .bind(serde_json::to_string(&aggregate.first_token_values).map_err(ApiError::from)?)
+            .bind(*max_row_id)
+            .execute(tx.as_mut())
+            .await?;
+        }
+        tx.commit().await?;
+        debug!(
+            route = "timeseries_projection",
+            builder = "minute_projection_v2",
+            trigger,
+            transaction_phase = "exact_warm",
+            transaction_key_limit = TIMESERIES_MINUTE_PROJECTION_WRITE_KEY_BATCH_LIMIT,
+            transaction_key_count = key_batch.len(),
+            elapsed_ms = transaction_started.elapsed().as_millis() as u64,
+            "materialized a bounded exact-fallback minute projection slice"
+        );
+        drop(admission);
+        tokio::task::yield_now().await;
+    }
+    Ok(TimeseriesMinuteProjectionWarmOutcome::Stored)
 }
 
 pub(crate) fn add_timeseries_terminal_delta_to_aggregate(
@@ -860,6 +1086,16 @@ async fn build_exact_timeseries_topic_baseline(
     reporting_tz: Tz,
     warm_minute_projection: bool,
 ) -> Result<BTreeMap<i64, BucketAggregate>, ApiError> {
+    let warm_coverage_generation = (warm_minute_projection
+        && state
+            .terminal_projection_hub
+            .timeseries_coverage_invalidation_pending()
+            .is_none())
+    .then(|| {
+        state
+            .terminal_projection_hub
+            .timeseries_coverage_generation()
+    });
     let records = query_timeseries_topic_baseline_records(
         &state.pool,
         ExactUtcRange { start, end },
@@ -869,7 +1105,7 @@ async fn build_exact_timeseries_topic_baseline(
         upstream_account_id,
     )
     .await?;
-    if warm_minute_projection {
+    if let Some(coverage_generation) = warm_coverage_generation {
         let pool = state.pool.clone();
         let projection_records = records.clone();
         let projection_snapshot_records = projection_records
@@ -885,25 +1121,38 @@ async fn build_exact_timeseries_topic_baseline(
             upstream_account_id,
         };
         tokio::spawn(async move {
-            if let Err(error) = store_timeseries_minute_projection_v2(
+            match store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
                 &pool,
                 start,
                 end,
                 source_scope,
                 upstream_account_id,
                 &projection_records,
+                terminal_projection_hub.as_ref(),
+                coverage_generation,
+                "topic_exact_fallback",
             )
             .await
             {
-                debug!(
-                    ?error,
-                    "materialized timeseries minute projection warm write failed"
-                );
-            } else {
-                terminal_projection_hub.mark_timeseries_warm_coverage(
-                    projection_selection,
-                    &projection_snapshot_records,
-                );
+                Ok(TimeseriesMinuteProjectionWarmOutcome::Stored) => {
+                    terminal_projection_hub.mark_timeseries_warm_coverage(
+                        projection_selection,
+                        &projection_snapshot_records,
+                    );
+                }
+                Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred) => {
+                    debug!(
+                        route = "timeseries_projection",
+                        projection_store_outcome = "deferred",
+                        "materialized timeseries minute projection warm write yielded to higher-priority work"
+                    );
+                }
+                Err(error) => {
+                    debug!(
+                        ?error,
+                        "materialized timeseries minute projection warm write failed"
+                    );
+                }
             }
         });
     }
@@ -1341,9 +1590,13 @@ async fn invalidate_timeseries_minute_projection_coverage(
     coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
     trigger: &'static str,
     pending_event_count: usize,
-) -> Result<Option<TimeseriesMinuteProjectionCoverageInvalidationStats>, ApiError> {
+    cancellation: Option<&tokio_util::sync::CancellationToken>,
+) -> Result<TimeseriesMinuteProjectionCoverageInvalidationOutcome, ApiError> {
     let mut stats = TimeseriesMinuteProjectionCoverageInvalidationStats::default();
     loop {
+        if timeseries_minute_projection_is_cancelled(cancellation) {
+            return Ok(TimeseriesMinuteProjectionCoverageInvalidationOutcome::Cancelled);
+        }
         let row_ids = sqlx::query_scalar::<_, i64>(
             "SELECT rowid FROM timeseries_minute_projection_v2 WHERE coverage_state <> 'warming' ORDER BY rowid LIMIT ?1",
         )
@@ -1351,7 +1604,7 @@ async fn invalidate_timeseries_minute_projection_coverage(
         .fetch_all(&state.pool)
         .await?;
         if row_ids.is_empty() {
-            return Ok(Some(stats));
+            return Ok(TimeseriesMinuteProjectionCoverageInvalidationOutcome::Invalidated(stats));
         }
 
         let Some(admission) = try_acquire_timeseries_minute_projection_write(
@@ -1362,7 +1615,7 @@ async fn invalidate_timeseries_minute_projection_coverage(
         )
         .await
         else {
-            return Ok(None);
+            return Ok(TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred);
         };
 
         let started = Instant::now();
@@ -1413,6 +1666,24 @@ pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
     trigger: &'static str,
     coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
 ) -> Result<TimeseriesMinuteProjectionFlushOutcome, ApiError> {
+    flush_timeseries_minute_projection_with_coordinator_and_cancellation(
+        state,
+        trigger,
+        coordinator,
+        None,
+    )
+    .await
+}
+
+async fn flush_timeseries_minute_projection_with_coordinator_and_cancellation(
+    state: &AppState,
+    trigger: &'static str,
+    coordinator: &Arc<crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator>,
+    cancellation: Option<&tokio_util::sync::CancellationToken>,
+) -> Result<TimeseriesMinuteProjectionFlushOutcome, ApiError> {
+    if timeseries_minute_projection_is_cancelled(cancellation) {
+        return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
+    }
     let pending = state
         .terminal_projection_hub
         .pending_timeseries_deltas(10_000);
@@ -1439,11 +1710,17 @@ pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
                 coordinator,
                 trigger,
                 flushed_event_ids.len(),
+                cancellation,
             )
             .await?
             {
-                Some(stats) => stats,
-                None => return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred),
+                TimeseriesMinuteProjectionCoverageInvalidationOutcome::Invalidated(stats) => stats,
+                TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred => {
+                    return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+                }
+                TimeseriesMinuteProjectionCoverageInvalidationOutcome::Cancelled => {
+                    return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
+                }
             }
         } else {
             TimeseriesMinuteProjectionCoverageInvalidationStats::default()
@@ -1482,6 +1759,9 @@ pub(crate) async fn flush_timeseries_minute_projection_with_coordinator(
         let mut exact_fallback_minute_count = 0usize;
         let mut transaction_count = 0usize;
         for key_batch in work_batches {
+            if timeseries_minute_projection_is_cancelled(cancellation) {
+                return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
+            }
             let Some(admission) = try_acquire_timeseries_minute_projection_write(
                 coordinator,
                 trigger,
@@ -1605,14 +1885,38 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        if let Err(error) = prepare_timeseries_minute_projection_after_restart(state.as_ref()).await
-        {
-            warn!(
-                route = "timeseries_projection",
-                builder = "minute_projection_v2",
-                ?error,
-                "failed to invalidate minute projection during startup recovery"
-            );
+        let pressure_gate = crate::db_pressure::global_db_pressure_gate();
+        loop {
+            let observed_eligibility_generation = pressure_gate.eligibility_generation();
+            match prepare_timeseries_minute_projection_after_restart(state.as_ref()).await {
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => break,
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred) => {
+                    debug!(
+                        route = "timeseries_projection",
+                        builder = "minute_projection_v2",
+                        trigger = "startup_recovery",
+                        observed_eligibility_generation,
+                        "startup minute projection recovery yielded to higher-priority database work"
+                    );
+                    tokio::select! {
+                        _ = cancel.cancelled() => return,
+                        _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                    }
+                }
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled) => return,
+                Err(error) => {
+                    warn!(
+                        route = "timeseries_projection",
+                        builder = "minute_projection_v2",
+                        ?error,
+                        "failed to invalidate minute projection during startup recovery"
+                    );
+                    tokio::select! {
+                        _ = cancel.cancelled() => return,
+                        _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    }
+                }
+            }
         }
         state
             .terminal_projection_hub
@@ -1620,31 +1924,51 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
         let mut ticker = interval(Duration::from_secs(60));
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         ticker.tick().await;
+        let mut deferred_eligibility_generation = None;
         loop {
-            tokio::select! {
-                _ = cancel.cancelled() => return,
-                _ = ticker.tick() => {
-                    match flush_timeseries_minute_projection(state.as_ref(), "terminal_deadline").await {
-                        Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => {}
-                        Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred) => {
-                            debug!(
-                                route = "timeseries_projection",
-                                builder = "minute_projection_v2",
-                                trigger = "terminal_deadline",
-                                flush_outcome = "deferred",
-                                "minute projection flush yielded to higher-priority database work"
-                            );
-                        }
-                        Err(error) => {
-                            warn!(
-                                route = "timeseries_projection",
-                                builder = "minute_projection_v2",
-                                trigger = "terminal_deadline",
-                                ?error,
-                                "minute projection flush failed"
-                            );
-                        }
-                    }
+            if let Some(observed_eligibility_generation) = deferred_eligibility_generation.take() {
+                tokio::select! {
+                    _ = cancel.cancelled() => return,
+                    _ = ticker.tick() => {}
+                    _ = pressure_gate.wait_for_eligibility_change(observed_eligibility_generation) => {}
+                }
+            } else {
+                tokio::select! {
+                    _ = cancel.cancelled() => return,
+                    _ = ticker.tick() => {}
+                }
+            }
+
+            let observed_eligibility_generation = pressure_gate.eligibility_generation();
+            match flush_timeseries_minute_projection_with_coordinator_and_cancellation(
+                state.as_ref(),
+                "terminal_deadline",
+                &crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator(),
+                Some(&cancel),
+            )
+            .await
+            {
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed) => {}
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred) => {
+                    deferred_eligibility_generation = Some(observed_eligibility_generation);
+                    debug!(
+                        route = "timeseries_projection",
+                        builder = "minute_projection_v2",
+                        trigger = "terminal_deadline",
+                        flush_outcome = "deferred",
+                        observed_eligibility_generation,
+                        "minute projection flush yielded to higher-priority database work"
+                    );
+                }
+                Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled) => return,
+                Err(error) => {
+                    warn!(
+                        route = "timeseries_projection",
+                        builder = "minute_projection_v2",
+                        trigger = "terminal_deadline",
+                        ?error,
+                        "minute projection flush failed"
+                    );
                 }
             }
         }
@@ -1653,29 +1977,72 @@ pub(crate) fn spawn_timeseries_minute_projection_supervisor(
 
 async fn prepare_timeseries_minute_projection_after_restart(
     state: &AppState,
-) -> Result<(), ApiError> {
+) -> Result<TimeseriesMinuteProjectionFlushOutcome, ApiError> {
+    let coordinator = crate::proxy_sqlite_write_coordinator::proxy_sqlite_write_coordinator();
+    let Some(admission) = try_acquire_timeseries_minute_projection_write(
+        &coordinator,
+        "startup_recovery",
+        "startup_state_warming",
+        0,
+    )
+    .await
+    else {
+        return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+    };
     let mut tx = state.pool.begin().await?;
     sqlx::query(
         "INSERT INTO timeseries_minute_projection_v2_state (consumer, cursor_row_id, last_flush_at, last_error, updated_at) VALUES ('timeseries_minute_v2', 0, NULL, 'warming', datetime('now')) ON CONFLICT(consumer) DO UPDATE SET last_error = 'warming', updated_at = excluded.updated_at",
     )
     .execute(tx.as_mut())
     .await?;
-    sqlx::query("UPDATE timeseries_minute_projection_v2 SET coverage_state = 'warming'")
-        .execute(tx.as_mut())
-        .await?;
+    tx.commit().await?;
+    drop(admission);
+
+    let coverage = match invalidate_timeseries_minute_projection_coverage(
+        state,
+        &coordinator,
+        "startup_recovery",
+        0,
+        None,
+    )
+    .await?
+    {
+        TimeseriesMinuteProjectionCoverageInvalidationOutcome::Invalidated(stats) => stats,
+        TimeseriesMinuteProjectionCoverageInvalidationOutcome::Deferred => {
+            return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+        }
+        TimeseriesMinuteProjectionCoverageInvalidationOutcome::Cancelled => {
+            return Ok(TimeseriesMinuteProjectionFlushOutcome::Cancelled);
+        }
+    };
+
+    let Some(admission) = try_acquire_timeseries_minute_projection_write(
+        &coordinator,
+        "startup_recovery",
+        "startup_state_ready",
+        0,
+    )
+    .await
+    else {
+        return Ok(TimeseriesMinuteProjectionFlushOutcome::Deferred);
+    };
+    let mut tx = state.pool.begin().await?;
     sqlx::query(
         "UPDATE timeseries_minute_projection_v2_state SET last_error = 'ready', updated_at = datetime('now') WHERE consumer = 'timeseries_minute_v2'",
     )
     .execute(tx.as_mut())
     .await?;
     tx.commit().await?;
+    drop(admission);
     debug!(
         route = "timeseries_projection",
         builder = "minute_projection_v2",
         response_source = "startup_invalidation",
+        coverage_invalidation_row_count = coverage.row_count,
+        coverage_invalidation_transaction_count = coverage.transaction_count,
         "invalidated stale minute coverage before accepting projection reads"
     );
-    Ok(())
+    Ok(TimeseriesMinuteProjectionFlushOutcome::Flushed)
 }
 
 #[cfg(test)]
@@ -1855,7 +2222,7 @@ mod minute_projection_tests {
         second.first_token_ms = Some(101.0);
         let mut in_flight = record(19, "2026-08-01 08:00:40");
         in_flight.status = Some("running".to_string());
-        store_timeseries_minute_projection_v2(
+        store_timeseries_minute_projection_v2_for_test(
             &pool,
             start,
             end,
@@ -2105,7 +2472,7 @@ mod minute_projection_tests {
         let start = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).single().unwrap();
         let end = start + ChronoDuration::minutes(2);
 
-        store_timeseries_minute_projection_v2(
+        store_timeseries_minute_projection_v2_for_test(
             &pool,
             start,
             end,
@@ -2164,7 +2531,7 @@ mod minute_projection_tests {
         let old = record(17, "2026-08-01 08:00:12");
         let newer = record(18, "2026-08-01 08:00:30");
 
-        store_timeseries_minute_projection_v2(
+        store_timeseries_minute_projection_v2_for_test(
             &pool,
             start,
             end,
@@ -2174,7 +2541,7 @@ mod minute_projection_tests {
         )
         .await
         .expect("store newer snapshot");
-        store_timeseries_minute_projection_v2(
+        store_timeseries_minute_projection_v2_for_test(
             &pool,
             start,
             end,
@@ -2214,7 +2581,7 @@ mod minute_projection_tests {
             .expect("load invalidated projection")
             .is_none()
         );
-        store_timeseries_minute_projection_v2(
+        store_timeseries_minute_projection_v2_for_test(
             &pool,
             start,
             end,
@@ -2452,6 +2819,11 @@ pub(crate) async fn fetch_timeseries(
     }
 
     let (records, response_source) = if use_minute_projection {
+        let warm_coverage_generation = (!coverage_invalidation_pending).then(|| {
+            state
+                .terminal_projection_hub
+                .timeseries_coverage_generation()
+        });
         let records = query_invocation_aggregate_records_from_live_range(
             &state.pool,
             ExactUtcRange {
@@ -2463,46 +2835,61 @@ pub(crate) async fn fetch_timeseries(
             Some(snapshot_id),
         )
         .await?;
-        // Projection persistence is P2 work. Never make a read request wait for a SQLite
-        // writer when a first-time exact fallback already produced a valid response.
-        let projection_pool = state.pool.clone();
-        let projection_records = records.clone();
-        let projection_snapshot_records = projection_records
-            .iter()
-            .filter(|record| {
-                !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
-            })
-            .map(timeseries_projection_snapshot_record)
-            .collect::<Vec<_>>();
-        let terminal_projection_hub = state.terminal_projection_hub.clone();
-        let projection_selection = TimeseriesProjectionSelection {
-            source_scope: timeseries_projection_scope(source_scope),
-            upstream_account_id: None,
-        };
-        tokio::spawn(async move {
-            if let Err(error) = store_timeseries_minute_projection_v2(
-                &projection_pool,
-                start_dt,
-                end_dt,
-                source_scope,
-                None,
-                &projection_records,
-            )
-            .await
-            {
-                debug!(
-                    route = "timeseries_projection",
-                    projection_store_outcome = "deferred_failed",
-                    ?error,
-                    "v2 minute projection warm write failed"
-                );
-            } else {
-                terminal_projection_hub.mark_timeseries_warm_coverage(
-                    projection_selection,
-                    &projection_snapshot_records,
-                );
-            }
-        });
+        if let Some(warm_coverage_generation) = warm_coverage_generation {
+            // Projection persistence is P2 work. Never make a read request wait for a SQLite
+            // writer when a first-time exact fallback already produced a valid response.
+            let projection_pool = state.pool.clone();
+            let projection_records = records.clone();
+            let projection_snapshot_records = projection_records
+                .iter()
+                .filter(|record| {
+                    !prompt_shared::invocation_status_is_in_flight(record.status.as_deref())
+                })
+                .map(timeseries_projection_snapshot_record)
+                .collect::<Vec<_>>();
+            let terminal_projection_hub = state.terminal_projection_hub.clone();
+            let projection_selection = TimeseriesProjectionSelection {
+                source_scope: timeseries_projection_scope(source_scope),
+                upstream_account_id: None,
+            };
+            tokio::spawn(async move {
+                match store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
+                    &projection_pool,
+                    start_dt,
+                    end_dt,
+                    source_scope,
+                    None,
+                    &projection_records,
+                    terminal_projection_hub.as_ref(),
+                    warm_coverage_generation,
+                    "http_exact_fallback",
+                )
+                .await
+                {
+                    Ok(TimeseriesMinuteProjectionWarmOutcome::Stored) => {
+                        terminal_projection_hub.mark_timeseries_warm_coverage(
+                            projection_selection,
+                            &projection_snapshot_records,
+                        );
+                    }
+                    Ok(TimeseriesMinuteProjectionWarmOutcome::Deferred) => {
+                        debug!(
+                            route = "timeseries_projection",
+                            projection_store_outcome = "deferred",
+                            "v2 minute projection warm write yielded to higher-priority work"
+                        );
+                    }
+                    Err(error) => {
+                        debug!(
+                            route = "timeseries_projection",
+                            projection_store_outcome = "failed",
+                            ?error,
+                            "v2 minute projection warm write failed"
+                        );
+                    }
+                }
+            });
+        }
         (
             records,
             if coverage_invalidation_pending {
@@ -2855,11 +3242,18 @@ pub(crate) async fn fetch_timeseries_for_account(
     }
 
     let snapshot_id = resolve_invocation_snapshot_id(&state.pool, source_scope).await?;
-    if bucket_seconds < 3_600 && range_window.duration <= ChronoDuration::days(1) {
+    if bucket_seconds < 3_600
+        && range_window.duration <= ChronoDuration::days(1)
+        && state
+            .terminal_projection_hub
+            .timeseries_coverage_invalidation_pending()
+            .is_none()
+    {
         // Account projections include empty minutes, so a first exact fallback must warm
         // the complete selection instead of relying on future terminal events to fill gaps.
         let projection_pool = state.pool.clone();
         let terminal_projection_hub = state.terminal_projection_hub.clone();
+        let warm_coverage_generation = terminal_projection_hub.timeseries_coverage_generation();
         let projection_selection = TimeseriesProjectionSelection {
             source_scope: timeseries_projection_scope(source_scope),
             upstream_account_id: Some(upstream_account_id),
@@ -2886,24 +3280,38 @@ pub(crate) async fn fetch_timeseries_for_account(
                         })
                         .map(timeseries_projection_snapshot_record)
                         .collect::<Vec<_>>();
-                    store_timeseries_minute_projection_v2(
+                    store_timeseries_minute_projection_v2_warm_with_eligibility_retry(
                         &projection_pool,
                         start_dt,
                         end_dt,
                         source_scope,
                         Some(upstream_account_id),
                         &records,
+                        terminal_projection_hub.as_ref(),
+                        warm_coverage_generation,
+                        "account_exact_fallback",
                     )
                     .await
-                    .map(|()| projection_snapshot_records)
+                    .map(|outcome| (outcome, projection_snapshot_records))
                 }
                 Err(error) => Err(error),
             };
             match result {
-                Ok(projection_snapshot_records) => {
+                Ok((
+                    TimeseriesMinuteProjectionWarmOutcome::Stored,
+                    projection_snapshot_records,
+                )) => {
                     terminal_projection_hub.mark_timeseries_warm_coverage(
                         projection_selection,
                         &projection_snapshot_records,
+                    );
+                }
+                Ok((TimeseriesMinuteProjectionWarmOutcome::Deferred, _)) => {
+                    debug!(
+                        route = "timeseries_projection",
+                        upstream_account_id,
+                        projection_store_outcome = "deferred",
+                        "account v2 minute projection warm write yielded to higher-priority work"
                     );
                 }
                 Err(error) => {

--- a/src/api/slices/subscriptions.rs
+++ b/src/api/slices/subscriptions.rs
@@ -3027,6 +3027,7 @@ impl SubscriptionHub {
     pub(crate) async fn dashboard_hot_topic_health(
         &self,
         projection: DashboardRuntimeTopologyCounterSnapshot,
+        timeseries_projection_deferred: bool,
     ) -> DashboardHotTopicsHealthSnapshot {
         let recovery = {
             let guard = self.state.lock().await;
@@ -3049,7 +3050,9 @@ impl SubscriptionHub {
                     SubscriptionTopic::DashboardWorkingConversationsCurrent { .. }
                 ) && (cached.prompt_cache_pressure_deferred
                     || cached.prompt_cache_reconcile_required
-                    || !cached.prompt_cache_pending_key_hydrations.is_empty());
+                    || !cached.prompt_cache_pending_key_hydrations.is_empty())
+                    || (matches!(cached.topic, SubscriptionTopic::TimeseriesOpenWindow { .. })
+                        && timeseries_projection_deferred);
                 recovery.record(
                     &cached.topic,
                     DashboardHotTopicRecoveryState {
@@ -13658,13 +13661,48 @@ mod tests {
         hub.mark_runtime_mutation_gap_and_recover(state, 4, "cursor_gap")
             .await;
         let health = hub
-            .dashboard_hot_topic_health(DashboardRuntimeTopologyCounterSnapshot::default())
+            .dashboard_hot_topic_health(DashboardRuntimeTopologyCounterSnapshot::default(), false)
             .await;
 
         assert_eq!(health.working_conversations.state, "degraded");
         assert_eq!(health.parallel_work.state, "degraded");
         assert_eq!(health.timeseries.state, "degraded");
         assert_eq!(health.state, "degraded");
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn dashboard_hot_topic_health_defers_timeseries_while_coverage_is_warming() {
+        let state = crate::tests::test_state_with_openai_base(
+            Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let hub = state.subscription_hub.clone();
+        let topic = SubscriptionTopic::TimeseriesOpenWindow {
+            range: "1d".to_string(),
+            time_zone: SUBSCRIPTION_DEFAULT_TIME_ZONE.to_string(),
+            bucket: Some("1m".to_string()),
+            settlement_hour: None,
+            upstream_account_id: None,
+        };
+        {
+            let mut guard = hub.state.lock().await;
+            guard.topics.insert(
+                topic.cache_key().expect("hot topic key"),
+                seeded_cached_topic(topic.clone(), &[7], Utc::now()),
+            );
+        }
+        let lease = hub
+            .register_topic_subscribers(&[topic])
+            .await
+            .expect("register timeseries topic owner");
+
+        let health = hub
+            .dashboard_hot_topic_health(DashboardRuntimeTopologyCounterSnapshot::default(), true)
+            .await;
+
+        assert_eq!(health.timeseries.state, "deferred");
+        assert_eq!(health.state, "deferred");
         drop(lease);
     }
 

--- a/src/api/slices/system_routes_and_tasks.rs
+++ b/src/api/slices/system_routes_and_tasks.rs
@@ -167,10 +167,14 @@ pub(crate) async fn load_runtime_pressure_health(state: &AppState) -> SystemRunt
     let prompt_cache_pressure_deferred = prompt_cache_projection.pressure_deferred_topic_count > 0;
     let dashboard_hot_topics = state
         .subscription_hub
-        .dashboard_hot_topic_health(dashboard_projection.slice_counters)
+        .dashboard_hot_topic_health(
+            dashboard_projection.slice_counters,
+            terminal_projection.timeseries_coverage_invalidation_pending,
+        )
         .await;
     let projection_deferred = dashboard_projection.last_defer_reason.is_some()
         || terminal_projection.hard_limit_reason.is_some()
+        || terminal_projection.timeseries_coverage_invalidation_pending
         || long_term_projection.last_defer_reason.is_some();
     let cursor_growth = terminal_projection.last_persisted_row_id
         > long_term_projection.cursor_row_id

--- a/src/proxy_sqlite_write_coordinator.rs
+++ b/src/proxy_sqlite_write_coordinator.rs
@@ -114,6 +114,15 @@ pub(crate) struct ProxySqliteWriteCoordinator {
 }
 
 impl ProxySqliteWriteCoordinator {
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Arc<Self> {
+        Arc::new(Self {
+            coordinated: true,
+            state: Mutex::new(CoordinatorState::default()),
+            notify: Notify::new(),
+        })
+    }
+
     fn from_env() -> Self {
         let coordinated = !matches!(
             std::env::var(PROXY_SQLITE_WRITE_COORDINATOR_MODE_ENV),

--- a/src/terminal_projection.rs
+++ b/src/terminal_projection.rs
@@ -352,6 +352,21 @@ impl TerminalProjectionHub {
         deltas
     }
 
+    fn pending_timeseries_delta_matching_selection(
+        event: &TerminalProjectionEvent,
+        selection: TimeseriesProjectionSelection,
+    ) -> Option<(i64, &TimeseriesTerminalDelta)> {
+        let row_id = event.persisted_row_id?;
+        let delta = event.timeseries.as_ref()?;
+        (!event.timeseries_flushed
+            && !event.timeseries_warm_coverage.contains(&selection)
+            && (selection.source_scope != "proxy_only" || delta.source == SOURCE_PROXY)
+            && selection
+                .upstream_account_id
+                .is_none_or(|account_id| delta.upstream_account_id == Some(account_id)))
+        .then_some((row_id, delta))
+    }
+
     pub(crate) fn pending_timeseries_deltas_for_selection(
         &self,
         selection: TimeseriesProjectionSelection,
@@ -365,20 +380,32 @@ impl TerminalProjectionHub {
             .pending
             .iter()
             .filter_map(|event| {
-                let row_id = event.persisted_row_id?;
-                let delta = event.timeseries.as_ref()?;
-                (!event.timeseries_flushed
-                    && !event.timeseries_warm_coverage.contains(&selection)
-                    && (selection.source_scope != "proxy_only" || delta.source == SOURCE_PROXY)
-                    && selection
-                        .upstream_account_id
-                        .is_none_or(|account_id| delta.upstream_account_id == Some(account_id)))
-                .then(|| (event.id, row_id, delta.clone()))
+                Self::pending_timeseries_delta_matching_selection(event, selection)
+                    .map(|(row_id, delta)| (event.id, row_id, delta.clone()))
             })
             .collect::<Vec<_>>();
         deltas.sort_by_key(|(event_id, row_id, _)| (*row_id, *event_id));
         deltas.truncate(limit);
         deltas
+    }
+
+    pub(crate) fn has_pending_timeseries_delta_for_selection(
+        &self,
+        selection: TimeseriesProjectionSelection,
+        mut matches_delta: impl FnMut(&TimeseriesTerminalDelta) -> bool,
+    ) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.pending.iter().any(|event| {
+            let Some((_, delta)) =
+                Self::pending_timeseries_delta_matching_selection(event, selection)
+            else {
+                return false;
+            };
+            matches_delta(delta)
+        })
     }
 
     pub(crate) fn mark_timeseries_warm_coverage(
@@ -561,6 +588,7 @@ impl TerminalProjectionHub {
 mod tests {
     use super::*;
     use crate::RuntimeMutationKind;
+    use chrono::{TimeZone, Utc};
 
     fn timeseries_delta() -> TimeseriesTerminalDelta {
         TimeseriesTerminalDelta {
@@ -740,6 +768,73 @@ mod tests {
         let pending = hub.pending_timeseries_deltas_for_selection(selection, 10);
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].0, second);
+    }
+
+    #[test]
+    fn minute_projection_hot_topic_defers_same_cursor_terminal_replacement_until_warmed() {
+        let hub = TerminalProjectionHub::default();
+        let selection = TimeseriesProjectionSelection {
+            source_scope: "all",
+            upstream_account_id: None,
+        };
+        let delta = timeseries_delta();
+        let first = hub
+            .register_pending_parts_with_delta(
+                "invoke",
+                &delta.occurred_at,
+                128,
+                Some(delta.clone()),
+            )
+            .expect("first event is within the projection hard limit");
+        hub.acknowledge_persisted(Some(first), "invoke", &delta.occurred_at, 17);
+        hub.mark_timeseries_warm_coverage(
+            selection,
+            &[TimeseriesProjectionSnapshotRecord {
+                row_id: 17,
+                invoke_id: "invoke".to_string(),
+                occurred_at: delta.occurred_at.clone(),
+            }],
+        );
+
+        let start = Utc
+            .with_ymd_and_hms(2026, 7, 30, 1, 59, 0)
+            .single()
+            .unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 7, 30, 2, 1, 0).single().unwrap();
+        assert!(
+            !crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &hub,
+                crate::api::InvocationSourceScope::All,
+                None,
+                start,
+                end,
+            ),
+            "a warm selection can reuse its current minute projection"
+        );
+
+        let mut updated_delta = delta;
+        updated_delta.status = Some("failure".to_string());
+        let updated_occurred_at = updated_delta.occurred_at.clone();
+        let second = hub
+            .register_pending_parts_with_delta(
+                "invoke",
+                &updated_occurred_at,
+                128,
+                Some(updated_delta),
+            )
+            .expect("same-row terminal replacement fits in the projection journal");
+        hub.acknowledge_persisted(Some(second), "invoke", "2026-07-30 10:00:00", 17);
+
+        assert!(
+            crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &hub,
+                crate::api::InvocationSourceScope::All,
+                None,
+                start,
+                end,
+            ),
+            "an un-warmed replacement at the existing projection cursor must force exact reads"
+        );
     }
 
     #[test]

--- a/src/terminal_projection.rs
+++ b/src/terminal_projection.rs
@@ -84,7 +84,6 @@ pub(crate) struct TimeseriesProjectionSnapshotRecord {
     pub(crate) row_id: i64,
     pub(crate) invoke_id: String,
     pub(crate) occurred_at: String,
-    pub(crate) delta: TimeseriesTerminalDelta,
 }
 
 impl From<&ApiInvocation> for TimeseriesTerminalDelta {
@@ -123,27 +122,6 @@ impl TimeseriesTerminalDelta {
             + self.failure_kind.as_deref().map_or(0, str::len)
             + self.failure_class.as_deref().map_or(0, str::len)
             + std::mem::size_of::<Self>()
-    }
-
-    fn matches_projection_snapshot(&self, snapshot: &TimeseriesTerminalDelta) -> bool {
-        self.occurred_at == snapshot.occurred_at
-            && self.status == snapshot.status
-            && self.error_message == snapshot.error_message
-            && self.failure_kind == snapshot.failure_kind
-            && self.failure_class == snapshot.failure_class
-            && self.is_actionable == snapshot.is_actionable
-            && self.total_tokens == snapshot.total_tokens
-            && self.input_tokens == snapshot.input_tokens
-            && self.output_tokens == snapshot.output_tokens
-            && self.cache_input_tokens == snapshot.cache_input_tokens
-            && self.reasoning_tokens == snapshot.reasoning_tokens
-            && self.cost == snapshot.cost
-            && self.t_total_ms == snapshot.t_total_ms
-            && self.t_req_read_ms == snapshot.t_req_read_ms
-            && self.t_req_parse_ms == snapshot.t_req_parse_ms
-            && self.t_upstream_connect_ms == snapshot.t_upstream_connect_ms
-            && self.t_upstream_ttfb_ms == snapshot.t_upstream_ttfb_ms
-            && self.first_token_ms == snapshot.first_token_ms
     }
 }
 
@@ -429,11 +407,13 @@ impl TerminalProjectionHub {
             {
                 continue;
             }
+            // The source rows were read and committed by the same P2 transaction before this
+            // acknowledgement. Their durable identity is authoritative even when a read query
+            // normalizes derived fields such as `failure_class` differently from ingress.
             if records.iter().any(|record| {
                 record.row_id == row_id
                     && record.invoke_id == event.invoke_id
                     && record.occurred_at == event.occurred_at
-                    && delta.matches_projection_snapshot(&record.delta)
             }) {
                 event.timeseries_warm_coverage.insert(selection);
                 covered += 1;
@@ -736,7 +716,6 @@ mod tests {
                     row_id: 17,
                     invoke_id: "invoke".to_string(),
                     occurred_at: delta.occurred_at.clone(),
-                    delta: delta.clone(),
                 }],
             ),
             1
@@ -761,6 +740,41 @@ mod tests {
         let pending = hub.pending_timeseries_deltas_for_selection(selection, 10);
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].0, second);
+    }
+
+    #[test]
+    fn warm_coverage_uses_committed_row_identity_without_a_derived_delta() {
+        let hub = TerminalProjectionHub::default();
+        let selection = TimeseriesProjectionSelection {
+            source_scope: "all",
+            upstream_account_id: None,
+        };
+        let delta = timeseries_delta();
+        let event = hub
+            .register_pending_parts_with_delta(
+                "invoke",
+                &delta.occurred_at,
+                128,
+                Some(delta.clone()),
+            )
+            .expect("event is within the projection hard limit");
+        hub.acknowledge_persisted(Some(event), "invoke", &delta.occurred_at, 17);
+
+        assert_eq!(
+            hub.mark_timeseries_warm_coverage(
+                selection,
+                &[TimeseriesProjectionSnapshotRecord {
+                    row_id: 17,
+                    invoke_id: "invoke".to_string(),
+                    occurred_at: delta.occurred_at.clone(),
+                }],
+            ),
+            1
+        );
+        assert!(
+            hub.pending_timeseries_deltas_for_selection(selection, 10)
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/terminal_projection.rs
+++ b/src/terminal_projection.rs
@@ -483,6 +483,13 @@ impl TerminalProjectionHub {
             .then_some(state.timeseries_coverage_invalidation_generation)
     }
 
+    pub(crate) fn timeseries_coverage_generation(&self) -> u64 {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .timeseries_coverage_invalidation_generation
+    }
+
     pub(crate) fn complete_timeseries_coverage_invalidation(&self, generation: u64) {
         let mut state = self
             .state

--- a/src/terminal_projection.rs
+++ b/src/terminal_projection.rs
@@ -615,6 +615,22 @@ mod tests {
         }
     }
 
+    fn hub_with_persisted_timeseries_delta(
+        delta: TimeseriesTerminalDelta,
+    ) -> TerminalProjectionHub {
+        let hub = TerminalProjectionHub::default();
+        let event = hub
+            .register_pending_parts_with_delta(
+                "invoke",
+                &delta.occurred_at,
+                128,
+                Some(delta.clone()),
+            )
+            .expect("terminal event is within the projection hard limit");
+        hub.acknowledge_persisted(Some(event), "invoke", &delta.occurred_at, 17);
+        hub
+    }
+
     #[test]
     fn long_term_cursor_prunes_out_of_order_persisted_events() {
         let hub = TerminalProjectionHub::default();
@@ -834,6 +850,95 @@ mod tests {
                 end,
             ),
             "an un-warmed replacement at the existing projection cursor must force exact reads"
+        );
+    }
+
+    #[test]
+    fn minute_projection_pending_delta_selection_respects_scope_account_and_complete_minutes() {
+        let full_start = Utc
+            .with_ymd_and_hms(2026, 7, 30, 1, 59, 0)
+            .single()
+            .expect("valid full-minute range start");
+        let full_end = Utc
+            .with_ymd_and_hms(2026, 7, 30, 2, 1, 0)
+            .single()
+            .expect("valid full-minute range end");
+
+        let proxy_hub = hub_with_persisted_timeseries_delta(timeseries_delta());
+        assert!(
+            crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &proxy_hub,
+                crate::api::InvocationSourceScope::ProxyOnly,
+                None,
+                full_start,
+                full_end,
+            )
+        );
+        assert!(
+            !crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &proxy_hub,
+                crate::api::InvocationSourceScope::All,
+                None,
+                Utc.with_ymd_and_hms(2026, 7, 30, 2, 0, 30)
+                    .single()
+                    .expect("valid partial-start range"),
+                full_end,
+            )
+        );
+        assert!(
+            !crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &proxy_hub,
+                crate::api::InvocationSourceScope::All,
+                None,
+                full_start,
+                Utc.with_ymd_and_hms(2026, 7, 30, 2, 0, 30)
+                    .single()
+                    .expect("valid partial-end range"),
+            )
+        );
+
+        let mut account_delta = timeseries_delta();
+        account_delta.upstream_account_id = Some(42);
+        let account_hub = hub_with_persisted_timeseries_delta(account_delta);
+        assert!(
+            crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &account_hub,
+                crate::api::InvocationSourceScope::All,
+                Some(42),
+                full_start,
+                full_end,
+            )
+        );
+        assert!(
+            !crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &account_hub,
+                crate::api::InvocationSourceScope::All,
+                Some(7),
+                full_start,
+                full_end,
+            )
+        );
+
+        let mut non_proxy_delta = timeseries_delta();
+        non_proxy_delta.source = "cli".to_string();
+        let non_proxy_hub = hub_with_persisted_timeseries_delta(non_proxy_delta);
+        assert!(
+            crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &non_proxy_hub,
+                crate::api::InvocationSourceScope::All,
+                None,
+                full_start,
+                full_end,
+            )
+        );
+        assert!(
+            !crate::api::timeseries_minute_projection_has_uncovered_terminal_delta(
+                &non_proxy_hub,
+                crate::api::InvocationSourceScope::ProxyOnly,
+                None,
+                full_start,
+                full_end,
+            )
         );
     }
 

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -20590,6 +20590,14 @@ async fn minute_projection_flush_defers_while_p1_terminal_write_is_active() {
         "timeseries-projection-p1-priority",
         "2026-08-21 12:00:12",
     ));
+    insert_timeseries_invocation(
+        &state.pool,
+        &record.invoke_id,
+        &record.occurred_at,
+        "success",
+        Some(12.0),
+    )
+    .await;
     state
         .terminal_projection_hub
         .activate_timeseries_consumer(0);
@@ -20666,6 +20674,19 @@ async fn minute_projection_flush_defers_while_p1_terminal_write_is_active() {
         projection_count > 0,
         "retry should persist the minute projections"
     );
+    let aggregate_json = sqlx::query_scalar::<_, String>(
+        "SELECT aggregate_json FROM timeseries_minute_projection_v2 WHERE source_scope = 'all' AND upstream_account_key = -1 AND coverage_state = 'ready'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("load the all-scope minute aggregate after retry");
+    let aggregate: serde_json::Value =
+        serde_json::from_str(&aggregate_json).expect("valid persisted minute aggregate");
+    assert_eq!(
+        aggregate["total_count"].as_i64(),
+        Some(1),
+        "retry must persist the terminal aggregate, not only a ready projection row"
+    );
 }
 
 #[tokio::test]
@@ -20686,6 +20707,14 @@ async fn minute_projection_flush_commits_all_key_slices_before_acknowledging_del
             &format!("timeseries-projection-slice-{minute}"),
             &occurred_at,
         ));
+        insert_timeseries_invocation(
+            &state.pool,
+            &record.invoke_id,
+            &record.occurred_at,
+            "success",
+            Some(12.0),
+        )
+        .await;
         let event_id = state
             .terminal_projection_hub
             .register_pending(&record, None)
@@ -20725,4 +20754,96 @@ async fn minute_projection_flush_commits_all_key_slices_before_acknowledging_del
     .await
     .expect("count all committed minute projection keys");
     assert_eq!(projection_count, 68);
+    let aggregates = sqlx::query_scalar::<_, String>(
+        "SELECT aggregate_json FROM timeseries_minute_projection_v2 WHERE source_scope = 'all' AND upstream_account_key = -1 AND coverage_state = 'ready' ORDER BY minute_start_epoch",
+    )
+    .fetch_all(&state.pool)
+    .await
+    .expect("load all-scope persisted minute aggregates");
+    assert_eq!(aggregates.len(), 17);
+    assert!(
+        aggregates.iter().all(|aggregate_json| {
+            serde_json::from_str::<serde_json::Value>(aggregate_json)
+                .ok()
+                .and_then(|aggregate| aggregate["total_count"].as_i64())
+                == Some(1)
+        }),
+        "every committed key slice must persist its terminal aggregate contents"
+    );
+}
+
+#[tokio::test]
+async fn exact_fallback_warm_write_defers_behind_p1_terminal_work() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let start = Utc
+        .with_ymd_and_hms(2026, 8, 21, 12, 0, 0)
+        .single()
+        .expect("valid warm range start");
+    let end = start + ChronoDuration::minutes(1);
+    let coordinator =
+        crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator::new_for_test();
+    let p1_write = coordinator
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P1Terminal)
+        .await;
+    let coverage_generation = state
+        .terminal_projection_hub
+        .timeseries_coverage_generation();
+
+    let outcome = crate::api::store_timeseries_minute_projection_v2_warm_with_coordinator(
+        &state.pool,
+        start,
+        end,
+        InvocationSourceScope::All,
+        None,
+        &[],
+        state.terminal_projection_hub.as_ref(),
+        coverage_generation,
+        "stateful_exact_warm_p1_priority",
+        &coordinator,
+    )
+    .await
+    .expect("warm write should defer without a database error");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionWarmOutcome::Deferred
+    );
+    let projection_count =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM timeseries_minute_projection_v2")
+            .fetch_one(&state.pool)
+            .await
+            .expect("count warm projection rows before retry");
+    assert_eq!(
+        projection_count, 0,
+        "P1 preemption must occur before a warm transaction opens"
+    );
+
+    drop(p1_write);
+    let outcome = crate::api::store_timeseries_minute_projection_v2_warm_with_coordinator(
+        &state.pool,
+        start,
+        end,
+        InvocationSourceScope::All,
+        None,
+        &[],
+        state.terminal_projection_hub.as_ref(),
+        coverage_generation,
+        "stateful_exact_warm_p1_retry",
+        &coordinator,
+    )
+    .await
+    .expect("warm write should retry after P1 completes");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionWarmOutcome::Stored
+    );
+    let projection_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM timeseries_minute_projection_v2 WHERE coverage_state = 'ready'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count warm projection rows after retry");
+    assert_eq!(projection_count, 1);
 }

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -21038,3 +21038,119 @@ async fn startup_minute_projection_recovery_stops_before_writes_when_cancelled()
     .expect("count startup state writes");
     assert_eq!(state_row_count, 0);
 }
+
+#[tokio::test]
+async fn materialized_timeseries_uses_exact_fallback_for_same_cursor_terminal_replacement() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let now = Utc::now();
+    let occurred_at = format_naive(
+        (now - ChronoDuration::minutes(30))
+            .with_timezone(&Shanghai)
+            .naive_local(),
+    );
+    let invoke_id = "timeseries-materializer-same-cursor-replacement";
+    let persisted = persist_proxy_capture_record(
+        &state.pool,
+        Instant::now(),
+        test_proxy_capture_record(invoke_id, &occurred_at),
+    )
+    .await
+    .expect("persist initial terminal row")
+    .expect("initial terminal row should be stored");
+    assert_eq!(persisted.status.as_deref(), Some("success"));
+
+    let coordinator =
+        crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator::new_for_test();
+    let warm_start = now - ChronoDuration::minutes(62);
+    let warm_end = now + ChronoDuration::minutes(2);
+    let warm_outcome = crate::api::store_timeseries_minute_projection_v2_warm_with_coordinator(
+        &state.pool,
+        warm_start,
+        warm_end,
+        InvocationSourceScope::All,
+        None,
+        state.terminal_projection_hub.as_ref(),
+        state
+            .terminal_projection_hub
+            .timeseries_coverage_generation(),
+        "stateful_same_cursor_materializer_seed",
+        &coordinator,
+    )
+    .await
+    .expect("warm the complete materializer selection");
+    assert_eq!(
+        warm_outcome,
+        crate::api::TimeseriesMinuteProjectionWarmOutcome::Stored
+    );
+
+    let minute_start = parse_to_utc_datetime(&occurred_at)
+        .expect("parse persisted occurrence")
+        .timestamp()
+        .div_euclid(60)
+        * 60;
+    let (coverage_state, projection_cursor): (String, i64) = sqlx::query_as(
+        "SELECT coverage_state, max_row_id FROM timeseries_minute_projection_v2 WHERE minute_start_epoch = ?1 AND source_scope = 'all' AND upstream_account_key = -1",
+    )
+    .bind(minute_start)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load warm minute projection");
+    assert_eq!(coverage_state, "ready");
+    assert_eq!(projection_cursor, persisted.id);
+
+    sqlx::query(
+        "UPDATE codex_invocations SET status = 'failed', failure_kind = 'upstream_response_failed', failure_class = 'service_failure', is_actionable = 1 WHERE id = ?1",
+    )
+    .bind(persisted.id)
+    .execute(&state.pool)
+    .await
+    .expect("replace the terminal row without advancing its cursor");
+
+    let mut replacement =
+        api_invocation_from_runtime_record(&test_proxy_capture_record(invoke_id, &occurred_at));
+    replacement.status = Some("failed".to_string());
+    replacement.failure_kind = Some("upstream_response_failed".to_string());
+    replacement.failure_class = Some("service_failure".to_string());
+    replacement.is_actionable = Some(true);
+    state
+        .terminal_projection_hub
+        .activate_timeseries_consumer(0);
+    let event_id = state
+        .terminal_projection_hub
+        .register_pending(&replacement, None)
+        .expect("replacement must fit in the terminal projection journal");
+    state.terminal_projection_hub.acknowledge_persisted(
+        Some(event_id),
+        &replacement.invoke_id,
+        &replacement.occurred_at,
+        persisted.id,
+    );
+
+    let query = TimeseriesQuery {
+        range: "1h".to_string(),
+        bucket: Some("1m".to_string()),
+        settlement_hour: None,
+        time_zone: Some("UTC".to_string()),
+        upstream_account_id: None,
+    };
+    let base = crate::api::TimeseriesTopicMaterializedBase::build(state.as_ref(), &query)
+        .await
+        .expect("build materialized timeseries base");
+    let payload: serde_json::Value = serde_json::from_slice(
+        &base
+            .serialize(&[])
+            .expect("serialize exact-fallback materialized response"),
+    )
+    .expect("materialized timeseries JSON");
+    let point = payload["points"]
+        .as_array()
+        .expect("timeseries points")
+        .iter()
+        .find(|point| point["totalCount"] == 1)
+        .expect("replacement minute point");
+    assert_eq!(point["successCount"], 0);
+    assert_eq!(point["failureCount"], 1);
+}

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -20798,7 +20798,6 @@ async fn exact_fallback_warm_write_defers_behind_p1_terminal_work() {
         end,
         InvocationSourceScope::All,
         None,
-        &[],
         state.terminal_projection_hub.as_ref(),
         coverage_generation,
         "stateful_exact_warm_p1_priority",
@@ -20827,7 +20826,6 @@ async fn exact_fallback_warm_write_defers_behind_p1_terminal_work() {
         end,
         InvocationSourceScope::All,
         None,
-        &[],
         state.terminal_projection_hub.as_ref(),
         coverage_generation,
         "stateful_exact_warm_p1_retry",
@@ -20846,4 +20844,120 @@ async fn exact_fallback_warm_write_defers_behind_p1_terminal_work() {
     .await
     .expect("count warm projection rows after retry");
     assert_eq!(projection_count, 1);
+}
+
+#[tokio::test]
+async fn exact_fallback_warm_rebuilds_after_non_proxy_terminal_invalidation() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let start = Utc
+        .with_ymd_and_hms(2026, 8, 21, 12, 0, 0)
+        .single()
+        .expect("valid warm range start");
+    let end = start + ChronoDuration::minutes(1);
+    let occurred_at = format_naive(start.with_timezone(&Shanghai).naive_local());
+    sqlx::query(
+        "INSERT INTO codex_invocations (invoke_id, occurred_at, source, status, total_tokens, cost, t_upstream_ttfb_ms, raw_response) VALUES (?1, ?2, 'cli', 'running', 10, 0.01, 12.0, '{}')",
+    )
+    .bind("non-proxy-warm-race")
+    .bind(&occurred_at)
+    .execute(&state.pool)
+    .await
+    .expect("insert non-proxy running invocation");
+
+    let coordinator =
+        crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator::new_for_test();
+    let coverage_generation = state
+        .terminal_projection_hub
+        .timeseries_coverage_generation();
+    let outcome = crate::api::store_timeseries_minute_projection_v2_warm_with_coordinator(
+        &state.pool,
+        start,
+        end,
+        InvocationSourceScope::All,
+        None,
+        state.terminal_projection_hub.as_ref(),
+        coverage_generation,
+        "stateful_non_proxy_warm_seed",
+        &coordinator,
+    )
+    .await
+    .expect("seed warm projection");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionWarmOutcome::Stored
+    );
+
+    sqlx::query("UPDATE codex_invocations SET status = 'success' WHERE invoke_id = ?1")
+        .bind("non-proxy-warm-race")
+        .execute(&state.pool)
+        .await
+        .expect("terminalize non-proxy invocation");
+    let coverage_state = sqlx::query_scalar::<_, String>(
+        "SELECT coverage_state FROM timeseries_minute_projection_v2 WHERE minute_start_epoch = ?1 AND source_scope = 'all' AND upstream_account_key = -1",
+    )
+    .bind(start.timestamp())
+    .fetch_one(&state.pool)
+    .await
+    .expect("load invalidated projection coverage");
+    assert_eq!(coverage_state, "warming");
+
+    let outcome = crate::api::store_timeseries_minute_projection_v2_warm_with_coordinator(
+        &state.pool,
+        start,
+        end,
+        InvocationSourceScope::All,
+        None,
+        state.terminal_projection_hub.as_ref(),
+        coverage_generation,
+        "stateful_non_proxy_warm_rebuild",
+        &coordinator,
+    )
+    .await
+    .expect("rebuild invalidated projection from transaction-time source rows");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionWarmOutcome::Stored
+    );
+    let (coverage_state, aggregate_json): (String, String) = sqlx::query_as(
+        "SELECT coverage_state, aggregate_json FROM timeseries_minute_projection_v2 WHERE minute_start_epoch = ?1 AND source_scope = 'all' AND upstream_account_key = -1",
+    )
+    .bind(start.timestamp())
+    .fetch_one(&state.pool)
+    .await
+    .expect("load rebuilt non-proxy projection");
+    let aggregate: serde_json::Value =
+        serde_json::from_str(&aggregate_json).expect("valid rebuilt aggregate payload");
+    assert_eq!(coverage_state, "ready");
+    assert_eq!(aggregate["total_count"].as_i64(), Some(1));
+}
+
+#[tokio::test]
+async fn startup_minute_projection_recovery_stops_before_writes_when_cancelled() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+
+    let outcome = crate::api::prepare_timeseries_minute_projection_after_restart(
+        state.as_ref(),
+        &cancellation,
+    )
+    .await
+    .expect("cancelled startup recovery should not report a database error");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionFlushOutcome::Cancelled
+    );
+    let state_row_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM timeseries_minute_projection_v2_state WHERE consumer = 'timeseries_minute_v2'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count startup state writes");
+    assert_eq!(state_row_count, 0);
 }

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -20624,10 +20624,10 @@ async fn minute_projection_flush_defers_while_p1_terminal_write_is_active() {
     )
     .await
     .expect("flush should yield without a database error");
-    assert_eq!(
+    assert!(matches!(
         outcome,
-        crate::api::TimeseriesMinuteProjectionFlushOutcome::Deferred
-    );
+        crate::api::TimeseriesMinuteProjectionFlushOutcome::Deferred(_)
+    ));
     assert_eq!(
         state
             .terminal_projection_hub
@@ -20805,10 +20805,10 @@ async fn exact_fallback_warm_write_defers_behind_p1_terminal_work() {
     )
     .await
     .expect("warm write should defer without a database error");
-    assert_eq!(
+    assert!(matches!(
         outcome,
-        crate::api::TimeseriesMinuteProjectionWarmOutcome::Deferred
-    );
+        crate::api::TimeseriesMinuteProjectionWarmOutcome::Deferred(_)
+    ));
     let projection_count =
         sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM timeseries_minute_projection_v2")
             .fetch_one(&state.pool)

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -20579,3 +20579,150 @@ async fn dashboard_activity_response_duration_includes_success_without_cost() {
         750.0,
     );
 }
+
+#[tokio::test]
+async fn minute_projection_flush_defers_while_p1_terminal_write_is_active() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let record = api_invocation_from_runtime_record(&test_proxy_capture_record(
+        "timeseries-projection-p1-priority",
+        "2026-08-21 12:00:12",
+    ));
+    state
+        .terminal_projection_hub
+        .activate_timeseries_consumer(0);
+    let event_id = state
+        .terminal_projection_hub
+        .register_pending(&record, None)
+        .expect("terminal event should fit in the projection journal");
+    state.terminal_projection_hub.acknowledge_persisted(
+        Some(event_id),
+        &record.invoke_id,
+        &record.occurred_at,
+        91_001,
+    );
+
+    let coordinator =
+        crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator::new_for_test();
+    let p1_write = coordinator
+        .acquire(crate::proxy_sqlite_write_coordinator::ProxySqliteWriteClass::P1Terminal)
+        .await;
+    let outcome = crate::api::flush_timeseries_minute_projection_with_coordinator(
+        state.as_ref(),
+        "stateful_p1_priority",
+        &coordinator,
+    )
+    .await
+    .expect("flush should yield without a database error");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionFlushOutcome::Deferred
+    );
+    assert_eq!(
+        state
+            .terminal_projection_hub
+            .pending_timeseries_deltas(10)
+            .len(),
+        1,
+        "the P1 preemption path must leave the delta available for retry"
+    );
+    let projection_count =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM timeseries_minute_projection_v2")
+            .fetch_one(&state.pool)
+            .await
+            .expect("count minute projections before retry");
+    assert_eq!(
+        projection_count, 0,
+        "deferred work must not open a write transaction"
+    );
+
+    drop(p1_write);
+    let outcome = crate::api::flush_timeseries_minute_projection_with_coordinator(
+        state.as_ref(),
+        "stateful_p1_priority_retry",
+        &coordinator,
+    )
+    .await
+    .expect("flush should succeed after P1 completes");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionFlushOutcome::Flushed
+    );
+    assert!(
+        state
+            .terminal_projection_hub
+            .pending_timeseries_deltas(10)
+            .is_empty(),
+        "the retried flush should acknowledge the terminal delta"
+    );
+    let projection_count =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM timeseries_minute_projection_v2")
+            .fetch_one(&state.pool)
+            .await
+            .expect("count minute projections after retry");
+    assert!(
+        projection_count > 0,
+        "retry should persist the minute projections"
+    );
+}
+
+#[tokio::test]
+async fn minute_projection_flush_commits_all_key_slices_before_acknowledging_deltas() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    state
+        .terminal_projection_hub
+        .activate_timeseries_consumer(0);
+
+    // Each proxy terminal event with an upstream account contributes four selection keys.
+    // Seventeen events therefore cross the 64-key transaction boundary.
+    for minute in 0..17_i64 {
+        let occurred_at = format!("2026-08-21 12:{minute:02}:12");
+        let record = api_invocation_from_runtime_record(&test_proxy_capture_record(
+            &format!("timeseries-projection-slice-{minute}"),
+            &occurred_at,
+        ));
+        let event_id = state
+            .terminal_projection_hub
+            .register_pending(&record, None)
+            .expect("terminal event should fit in the projection journal");
+        state.terminal_projection_hub.acknowledge_persisted(
+            Some(event_id),
+            &record.invoke_id,
+            &record.occurred_at,
+            92_000 + minute,
+        );
+    }
+
+    let coordinator =
+        crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator::new_for_test();
+    let outcome = crate::api::flush_timeseries_minute_projection_with_coordinator(
+        state.as_ref(),
+        "stateful_key_slices",
+        &coordinator,
+    )
+    .await
+    .expect("flush should commit every bounded slice");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionFlushOutcome::Flushed
+    );
+    assert!(
+        state
+            .terminal_projection_hub
+            .pending_timeseries_deltas(100)
+            .is_empty(),
+        "deltas are acknowledged only after all committed key slices succeed"
+    );
+    let projection_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM timeseries_minute_projection_v2 WHERE coverage_state = 'ready'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count all committed minute projection keys");
+    assert_eq!(projection_count, 68);
+}

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -20935,6 +20935,83 @@ async fn exact_fallback_warm_rebuilds_after_non_proxy_terminal_invalidation() {
 }
 
 #[tokio::test]
+async fn exact_fallback_warm_acknowledges_the_transaction_snapshot_not_the_response_snapshot() {
+    let state = test_state_with_openai_base(
+        Url::parse("https://api.openai.com/").expect("valid upstream base url"),
+    )
+    .await;
+    let start = Utc
+        .with_ymd_and_hms(2026, 8, 21, 12, 0, 0)
+        .single()
+        .expect("valid warm range start");
+    let end = start + ChronoDuration::minutes(1);
+    let occurred_at = format_naive(start.with_timezone(&Shanghai).naive_local());
+    let capture = test_proxy_capture_record("warm-transaction-snapshot", &occurred_at);
+    let terminal = api_invocation_from_runtime_record(&capture);
+    state
+        .terminal_projection_hub
+        .activate_timeseries_consumer(0);
+    let event_id = state
+        .terminal_projection_hub
+        .register_pending(&terminal, None)
+        .expect("terminal event should fit in the projection journal");
+    let persisted = persist_proxy_capture_record(&state.pool, Instant::now(), capture)
+        .await
+        .expect("persist terminal row")
+        .expect("terminal row should be persisted");
+    state.terminal_projection_hub.acknowledge_persisted(
+        Some(event_id),
+        &terminal.invoke_id,
+        &terminal.occurred_at,
+        persisted.id,
+    );
+
+    let coordinator =
+        crate::proxy_sqlite_write_coordinator::ProxySqliteWriteCoordinator::new_for_test();
+    let coverage_generation = state
+        .terminal_projection_hub
+        .timeseries_coverage_generation();
+    let outcome = crate::api::store_timeseries_minute_projection_v2_warm_with_coordinator(
+        &state.pool,
+        start,
+        end,
+        InvocationSourceScope::All,
+        None,
+        state.terminal_projection_hub.as_ref(),
+        coverage_generation,
+        "stateful_warm_transaction_snapshot",
+        &coordinator,
+    )
+    .await
+    .expect("warm write should succeed");
+    assert_eq!(
+        outcome,
+        crate::api::TimeseriesMinuteProjectionWarmOutcome::Stored
+    );
+    let pending = state
+        .terminal_projection_hub
+        .pending_timeseries_deltas_for_selection(
+            crate::TimeseriesProjectionSelection {
+                source_scope: "all",
+                upstream_account_id: None,
+            },
+            10,
+        );
+    assert!(
+        pending.is_empty(),
+        "the committed transaction source row must be acknowledged so a later projection read cannot add it twice; pending={pending:#?}"
+    );
+    let cursor = sqlx::query_scalar::<_, i64>(
+        "SELECT max_row_id FROM timeseries_minute_projection_v2 WHERE minute_start_epoch = ?1 AND source_scope = 'all' AND upstream_account_key = -1",
+    )
+    .bind(start.timestamp())
+    .fetch_one(&state.pool)
+    .await
+    .expect("load committed projection cursor");
+    assert_eq!(cursor, persisted.id);
+}
+
+#[tokio::test]
 async fn startup_minute_projection_recovery_stops_before_writes_when_cancelled() {
     let state = test_state_with_openai_base(
         Url::parse("https://api.openai.com/").expect("valid upstream base url"),


### PR DESCRIPTION
## Summary
- Admit minute projection writes as P2-derived work so active or queued terminal writes preempt them.
- Commit coverage invalidation and projection-key updates in bounded slices, yielding between transactions.
- Preserve pending deltas on deferral and expose phase, priority, pressure, and transaction-slice attribution.

## Validation
- `bun run verify:rust`
- `bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite` (1303 tests)

## Delivery
- Delivery role: direct
- Spec: `docs/specs/dashboard-hot-topic-projection/SPEC.md`
- Spec Disposition: updated with P2 admission and bounded minute-projection transaction requirements.
- Solutions: -
- Project Docs: -
- Documentation sync: spec updated; no owner-facing UI or external contract changes.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->