### PR TITLE
fix(proxy): enable live routing with resolvable bindings

### DIFF
--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -1333,13 +1333,17 @@ async fn prepare_capture_request_body(
         .await;
     }
 
-    let route_finalization_outcome = match prepared_live_request_streaming_decision
-        .as_ref()
-        .map(|decision| decision.transport_mode)
-    {
-        Some(RequestBodyTransportMode::LiveFirst) => "live_first_model_ready",
-        _ if live_candidate => "buffered_eof_final_route",
-        _ => "buffered_no_model",
+    let route_finalization_outcome = if live_body_key_probe.root_object_complete && live_candidate {
+        "buffered_eof_final_route"
+    } else {
+        match prepared_live_request_streaming_decision
+            .as_ref()
+            .map(|decision| decision.transport_mode)
+        {
+            Some(RequestBodyTransportMode::LiveFirst) => "live_first_model_ready",
+            _ if live_candidate => "buffered_eof_final_route",
+            _ => "buffered_no_model",
+        }
     };
 
     PreparedCaptureRequestBody {
@@ -1388,11 +1392,9 @@ fn live_route_dependency_factors(
 }
 
 /// A live probe is safe to commit once the model is known and image routing is
-/// not positively required. Sticky and prompt-cache bindings, as well as
-/// encrypted-session ownership, are resolvable inputs to the hot routing
-/// snapshot and must not exclude the requests that need live forwarding most.
-/// The incremental pipeline keeps these root fields in its precommit set so
-/// the resolver receives their values before the first upstream byte.
+/// not positively required. The pipeline separately records whether that
+/// probe was finalized at EOF; EOF-finalized samples remain buffered for
+/// measurement even though the established route/failover path is reused.
 fn live_route_probe_can_start_before_eof(probe: &PoolReplayBodyKeyProbe) -> bool {
     probe.model.is_some() && probe.image_intent != ImageIntent::Yes
 }
@@ -2830,10 +2832,26 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         summarize_response_content_encoding(upstream_content_encoding.as_deref());
     let selected_proxy_display_name =
         resolve_invocation_proxy_display_name(selected_proxy.as_ref());
+    let route_finalized_at_eof =
+        live_route_finalization_measurement
+            .as_ref()
+            .is_some_and(|measurement| {
+                measurement.route_finalization_outcome == Some("buffered_eof_final_route")
+            });
     let live_request_streaming_decision = if let Some(decision) =
         prepared_live_request_streaming_decision
     {
-        decision
+        if route_finalized_at_eof && decision.transport_mode == RequestBodyTransportMode::LiveFirst
+        {
+            LiveRequestStreamingDecision {
+                transport_mode: RequestBodyTransportMode::Buffered,
+                eligible: false,
+                reason: "route_finalized_at_eof",
+                ..decision
+            }
+        } else {
+            decision
+        }
     } else if capture_target == ProxyCaptureTarget::Responses {
         match load_pool_routing_runtime_cache(state.as_ref()).await {
             Ok(snapshot) => decide_live_request_streaming(

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -1399,7 +1399,7 @@ fn normalize_live_request_streaming_decision_for_measurement(
     let route_finalized_at_eof = route_measurement.is_some_and(|measurement| {
         measurement.route_finalization_outcome == Some("buffered_eof_final_route")
     });
-    if route_finalized_at_eof && decision.transport_mode == RequestBodyTransportMode::LiveFirst {
+    if route_finalized_at_eof {
         Some(LiveRequestStreamingDecision {
             transport_mode: RequestBodyTransportMode::Buffered,
             eligible: false,
@@ -4919,6 +4919,32 @@ mod dispatch_tests {
         );
         probe.image_intent = ImageIntent::No;
         assert!(!live_route_dependency_factors(&probe, true).contains(&"image_capability"));
+    }
+
+    #[test]
+    fn eof_route_measurement_normalizes_buffered_decision_reasons() {
+        let decision = LiveRequestStreamingDecision {
+            transport_mode: RequestBodyTransportMode::Buffered,
+            revision: Some(LIVE_REQUEST_STREAMING_REVISION),
+            variant: Some(LiveRequestStreamingExperimentVariant::Treatment),
+            eligible: false,
+            reason: "routing_metadata_incomplete",
+        };
+        let measurement = LiveRequestStreamingMeasurement {
+            route_finalization_outcome: Some("buffered_eof_final_route"),
+            ..LiveRequestStreamingMeasurement::default()
+        };
+        let normalized = normalize_live_request_streaming_decision_for_measurement(
+            Some(&decision),
+            Some(&measurement),
+        )
+        .expect("EOF route decision should remain present");
+        assert_eq!(
+            normalized.transport_mode,
+            RequestBodyTransportMode::Buffered
+        );
+        assert_eq!(normalized.reason, "route_finalized_at_eof");
+        assert_eq!(normalized.variant, decision.variant);
     }
 
     #[tokio::test]

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -933,10 +933,13 @@ async fn prepare_capture_request_body(
     let mut live_first_experiment_group = None;
     let mut live_route_lookup_cache_hit = live_routing_hot_cache_hit;
 
-    if !live_route_probe_can_start_before_eof(&live_body_key_probe) {
-        // The probe did not reach a safe pre-EOF commit point (for example a
-        // positively identified image route). Let the established replay path
-        // make the final request instead.
+    if live_body_key_probe.root_object_complete
+        || !live_route_probe_can_start_before_eof(&live_body_key_probe)
+    {
+        // An EOF-complete probe has no overlap left to provide. Keep it on the
+        // established replay path so buffered requests retain the existing
+        // failover and retry semantics. A future pre-EOF probe may still take
+        // the live-first branch when its route is proven safe.
         prepared_live_request_streaming_decision = Some(LiveRequestStreamingDecision {
             transport_mode: RequestBodyTransportMode::Buffered,
             eligible: false,

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -1869,8 +1869,8 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     None,
                     None,
                     None,
-                    None,
-                    None,
+                    persisted_live_request_streaming_decision.as_ref(),
+                    live_route_finalization_measurement.as_ref(),
                 )
                 .await;
                 if terminal_invocation_persisted {
@@ -1921,8 +1921,8 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                     None,
                     None,
                     None,
-                    None,
-                    None,
+                    persisted_live_request_streaming_decision.as_ref(),
+                    live_route_finalization_measurement.as_ref(),
                 )
                 .await;
                 if terminal_invocation_persisted {
@@ -2166,26 +2166,20 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                                 context.live_first_request_body_first_byte_at.is_some(),
                                 err.attempt_summary.pool_attempt_count,
                             );
-                            LiveRequestStreamingMeasurement {
-                                first_attempt_failed: risk.first_attempt_failed,
-                                fallback_or_retry: risk.fallback_or_retry,
-                                ambiguous_upstream_delivery: risk.ambiguous_upstream_delivery,
-                                route_finalization_outcome: (context
-                                    .live_request_streaming_decision
-                                    .as_ref()
-                                    .is_some_and(|decision| {
-                                        decision.reason == "route_finalized_at_eof"
-                                    }))
-                                .then_some("buffered_eof_final_route"),
-                                upstream_account_group: err
-                                    .account
-                                    .as_ref()
-                                    .and_then(|account| account.group_name.clone()),
-                                experiment_account_group: context
-                                    .live_request_streaming_experiment_group
-                                    .clone(),
-                                ..LiveRequestStreamingMeasurement::default()
-                            }
+                            let mut measurement = live_route_finalization_measurement
+                                .clone()
+                                .unwrap_or_default();
+                            measurement.first_attempt_failed = risk.first_attempt_failed;
+                            measurement.fallback_or_retry = risk.fallback_or_retry;
+                            measurement.ambiguous_upstream_delivery =
+                                risk.ambiguous_upstream_delivery;
+                            measurement.upstream_account_group = err
+                                .account
+                                .as_ref()
+                                .and_then(|account| account.group_name.clone());
+                            measurement.experiment_account_group =
+                                context.live_request_streaming_experiment_group.clone();
+                            measurement
                         })
                     });
                 let mut record = ProxyCaptureRecord {

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -1391,6 +1391,26 @@ fn live_route_dependency_factors(
     factors
 }
 
+fn normalize_live_request_streaming_decision_for_measurement(
+    decision: Option<&LiveRequestStreamingDecision>,
+    route_measurement: Option<&LiveRequestStreamingMeasurement>,
+) -> Option<LiveRequestStreamingDecision> {
+    let decision = decision?;
+    let route_finalized_at_eof = route_measurement.is_some_and(|measurement| {
+        measurement.route_finalization_outcome == Some("buffered_eof_final_route")
+    });
+    if route_finalized_at_eof && decision.transport_mode == RequestBodyTransportMode::LiveFirst {
+        Some(LiveRequestStreamingDecision {
+            transport_mode: RequestBodyTransportMode::Buffered,
+            eligible: false,
+            reason: "route_finalized_at_eof",
+            ..decision.clone()
+        })
+    } else {
+        Some(decision.clone())
+    }
+}
+
 /// A live probe is safe to commit once the model is known and image routing is
 /// not positively required. The pipeline separately records whether that
 /// probe was finalized at EOF; EOF-finalized samples remain buffered for
@@ -1537,8 +1557,11 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             )
             .await;
             let error_message = format!("[{}] {}", read_err.failure_kind, read_err.message);
-            let capture_failure_decision = prepared_live_request_streaming_decision
-                .clone()
+            let capture_failure_decision =
+                normalize_live_request_streaming_decision_for_measurement(
+                    prepared_live_request_streaming_decision.as_ref(),
+                    live_route_finalization_measurement.as_ref(),
+                )
                 .unwrap_or_else(|| {
                     LiveRequestStreamingDecision::buffered("request_body_capture_failed")
                 });
@@ -1700,12 +1723,17 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         }
     };
     let t_req_read_ms = elapsed_ms(req_read_started);
+    let persisted_live_request_streaming_decision =
+        normalize_live_request_streaming_decision_for_measurement(
+            prepared_live_request_streaming_decision.as_ref(),
+            live_route_finalization_measurement.as_ref(),
+        );
     let request_body_snapshot_kind = pool_request_snapshot_kind(&request_body_snapshot);
     let request_body_bytes_len = pool_request_snapshot_body_bytes(&request_body_snapshot);
-    let live_first_eligible = prepared_live_request_streaming_decision
+    let live_first_eligible = persisted_live_request_streaming_decision
         .as_ref()
         .is_some_and(|decision| decision.eligible);
-    let live_first_reason = prepared_live_request_streaming_decision
+    let live_first_reason = persisted_live_request_streaming_decision
         .as_ref()
         .map(|decision| decision.reason)
         .unwrap_or("not_live_candidate");
@@ -1967,7 +1995,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
             owner_auto_guard_active: encrypted_owner_auto_guard_active,
             t_req_read_ms,
             t_req_parse_ms,
-            live_request_streaming_decision: prepared_live_request_streaming_decision.clone(),
+            live_request_streaming_decision: persisted_live_request_streaming_decision.clone(),
             live_request_streaming_experiment_group: live_first_experiment_group.clone(),
             live_first_attempt_failed,
             live_first_request_body_first_byte_at,
@@ -2142,6 +2170,13 @@ pub(crate) async fn proxy_openai_v1_capture_target(
                                 first_attempt_failed: risk.first_attempt_failed,
                                 fallback_or_retry: risk.fallback_or_retry,
                                 ambiguous_upstream_delivery: risk.ambiguous_upstream_delivery,
+                                route_finalization_outcome: (context
+                                    .live_request_streaming_decision
+                                    .as_ref()
+                                    .is_some_and(|decision| {
+                                        decision.reason == "route_finalized_at_eof"
+                                    }))
+                                .then_some("buffered_eof_final_route"),
                                 upstream_account_group: err
                                     .account
                                     .as_ref()
@@ -2832,26 +2867,10 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         summarize_response_content_encoding(upstream_content_encoding.as_deref());
     let selected_proxy_display_name =
         resolve_invocation_proxy_display_name(selected_proxy.as_ref());
-    let route_finalized_at_eof =
-        live_route_finalization_measurement
-            .as_ref()
-            .is_some_and(|measurement| {
-                measurement.route_finalization_outcome == Some("buffered_eof_final_route")
-            });
     let live_request_streaming_decision = if let Some(decision) =
-        prepared_live_request_streaming_decision
+        persisted_live_request_streaming_decision
     {
-        if route_finalized_at_eof && decision.transport_mode == RequestBodyTransportMode::LiveFirst
-        {
-            LiveRequestStreamingDecision {
-                transport_mode: RequestBodyTransportMode::Buffered,
-                eligible: false,
-                reason: "route_finalized_at_eof",
-                ..decision
-            }
-        } else {
-            decision
-        }
+        decision
     } else if capture_target == ProxyCaptureTarget::Responses {
         match load_pool_routing_runtime_cache(state.as_ref()).await {
             Ok(snapshot) => decide_live_request_streaming(

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -1512,7 +1512,7 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         live_first_request_body_first_byte_at,
         live_oauth_rewrite_rx,
         live_first_experiment_group,
-        live_route_finalization_measurement,
+        mut live_route_finalization_measurement,
     } = Box::pin(prepare_capture_request_body(
         state.clone(),
         proxy_request_id,
@@ -1730,6 +1730,25 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         );
     let request_body_snapshot_kind = pool_request_snapshot_kind(&request_body_snapshot);
     let request_body_bytes_len = pool_request_snapshot_body_bytes(&request_body_snapshot);
+    let logical_request_body_bytes = if live_route_finalization_measurement.is_some() {
+        pool_request_snapshot_logical_body_bytes(
+            &request_body_snapshot,
+            headers
+                .get(header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
+        )
+        .await
+        .ok()
+    } else {
+        None
+    };
+    if let Some(route_measurement) = live_route_finalization_measurement.as_mut() {
+        route_measurement.route_finalization_raw_bytes = Some(request_body_bytes_len);
+        route_measurement.route_finalization_logical_bytes = logical_request_body_bytes;
+        route_measurement.route_finalization_raw_ratio = Some(1.0);
+        route_measurement.route_finalization_logical_ratio =
+            logical_request_body_bytes.map(|_| 1.0);
+    }
     let live_first_eligible = persisted_live_request_streaming_decision
         .as_ref()
         .is_some_and(|decision| decision.eligible);
@@ -2882,14 +2901,6 @@ pub(crate) async fn proxy_openai_v1_capture_target(
     } else {
         LiveRequestStreamingDecision::buffered("endpoint_not_supported")
     };
-    let logical_request_body_bytes = pool_request_snapshot_logical_body_bytes(
-        &request_body_snapshot,
-        headers
-            .get(header::CONTENT_ENCODING)
-            .and_then(|value| value.to_str().ok()),
-    )
-    .await
-    .ok();
     let upstream_request_first_byte_ms = live_first_request_body_first_byte_at.map(|sent_at| {
         sent_at
             .saturating_duration_since(req_read_started)

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -934,11 +934,9 @@ async fn prepare_capture_request_body(
     let mut live_route_lookup_cache_hit = live_routing_hot_cache_hit;
 
     if !live_route_probe_can_start_before_eof(&live_body_key_probe) {
-        // The generic JSON contract accepts arbitrary field order and duplicate
-        // keys. This probe is published only after the root object's EOF check,
-        // so forwarding it as a chunked body would be buffered in practice and
-        // would not provide a real overlap benefit. Let the established replay
-        // path make the final request instead.
+        // The probe did not reach a safe pre-EOF commit point (for example a
+        // positively identified image route). Let the established replay path
+        // make the final request instead.
         prepared_live_request_streaming_decision = Some(LiveRequestStreamingDecision {
             transport_mode: RequestBodyTransportMode::Buffered,
             eligible: false,
@@ -1335,6 +1333,15 @@ async fn prepare_capture_request_body(
         .await;
     }
 
+    let route_finalization_outcome = match prepared_live_request_streaming_decision
+        .as_ref()
+        .map(|decision| decision.transport_mode)
+    {
+        Some(RequestBodyTransportMode::LiveFirst) => "live_first_model_ready",
+        _ if live_candidate => "buffered_eof_final_route",
+        _ => "buffered_no_model",
+    };
+
     PreparedCaptureRequestBody {
         request_body_snapshot_result,
         live_first_pool_response,
@@ -1345,11 +1352,7 @@ async fn prepare_capture_request_body(
         live_first_experiment_group,
         live_route_finalization_measurement: Some(LiveRequestStreamingMeasurement {
             route_finalization_ms: Some(live_route_finalization_ms),
-            route_finalization_outcome: Some(if live_candidate {
-                "buffered_eof_final_route"
-            } else {
-                "buffered_no_model"
-            }),
+            route_finalization_outcome: Some(route_finalization_outcome),
             route_dependency_factors: live_route_dependency_factors(
                 &live_body_key_probe,
                 encrypted_owner_routing_enabled,
@@ -1384,16 +1387,14 @@ fn live_route_dependency_factors(
     factors
 }
 
-/// A live probe is safe to commit only when the currently enabled routing
-/// factors are absent from the unread portion. Sticky/prompt-cache ownership,
-/// encrypted-session ownership, and known image intent remain buffered; the
-/// incremental pipeline keeps those root fields in its precommit set.
+/// A live probe is safe to commit once the model is known and image routing is
+/// not positively required. Sticky and prompt-cache bindings, as well as
+/// encrypted-session ownership, are resolvable inputs to the hot routing
+/// snapshot and must not exclude the requests that need live forwarding most.
+/// The incremental pipeline keeps these root fields in its precommit set so
+/// the resolver receives their values before the first upstream byte.
 fn live_route_probe_can_start_before_eof(probe: &PoolReplayBodyKeyProbe) -> bool {
-    probe.model.is_some()
-        && probe.sticky_key.is_none()
-        && probe.prompt_cache_key.is_none()
-        && !probe.contains_encrypted_content
-        && probe.image_intent != ImageIntent::Yes
+    probe.model.is_some() && probe.image_intent != ImageIntent::Yes
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4822,7 +4823,7 @@ mod dispatch_tests {
     use super::*;
 
     #[test]
-    fn final_route_gate_starts_only_for_model_only_routes() {
+    fn final_route_gate_allows_resolvable_binding_routes() {
         assert!(!live_route_probe_can_start_before_eof(
             &PoolReplayBodyKeyProbe::default()
         ));
@@ -4832,10 +4833,25 @@ mod dispatch_tests {
                 ..PoolReplayBodyKeyProbe::default()
             }
         ));
-        assert!(!live_route_probe_can_start_before_eof(
+        assert!(live_route_probe_can_start_before_eof(
             &PoolReplayBodyKeyProbe {
                 model: Some("gpt-5.6".to_string()),
                 sticky_key: Some("sticky".to_string()),
+                ..PoolReplayBodyKeyProbe::default()
+            }
+        ));
+        assert!(live_route_probe_can_start_before_eof(
+            &PoolReplayBodyKeyProbe {
+                model: Some("gpt-5.6".to_string()),
+                prompt_cache_key: Some("prompt".to_string()),
+                contains_encrypted_content: true,
+                ..PoolReplayBodyKeyProbe::default()
+            }
+        ));
+        assert!(!live_route_probe_can_start_before_eof(
+            &PoolReplayBodyKeyProbe {
+                model: Some("gpt-5.6".to_string()),
+                image_intent: ImageIntent::Yes,
                 ..PoolReplayBodyKeyProbe::default()
             }
         ));

--- a/src/proxy/live_request_body_pipeline.rs
+++ b/src/proxy/live_request_body_pipeline.rs
@@ -92,9 +92,10 @@ impl LiveResponsesRequestBodyPipeline {
     }
 }
 
-/// Starts a replay-backed request-body transformer. The routing probe becomes
-/// available only after the complete root object has been parsed, so a caller
-/// never sends an upstream body for a provisional route.
+/// Starts a replay-backed request-body transformer. The routing probe can be
+/// published while the root object is still open only when a future-safe route
+/// commit is proven; otherwise it remains buffered until the complete root
+/// object has been parsed.
 pub(crate) fn spawn_live_responses_request_body_pipeline(
     raw_body: Body,
     downstream_content_encoding: Option<String>,
@@ -532,6 +533,7 @@ fn live_routing_probe_from_fields(
         } else {
             ImageIntent::Unknown
         },
+        root_object_complete,
     }
 }
 
@@ -550,11 +552,12 @@ fn is_precommit_routing_root_field(key: &str) -> bool {
 }
 
 fn should_defer_route_commit(_key: &str, _value_start: u8) -> bool {
-    // Route-affecting root fields are kept in `pending_fields` and are handled
-    // before this check. Once model/input and those fields are known, an
-    // ordinary field is the first safe commit point; later route fields still
-    // remain deferred because they are classified by `is_precommit...`.
-    false
+    // JSON object fields are unordered and optional. After any ordinary field
+    // there may still be a later input, tools, metadata, sticky, prompt-cache,
+    // or encrypted-content field that changes the route. Without a schema-level
+    // end marker, EOF is the only proof that the route-affecting root set is
+    // complete, so the live encoder must stay uncommitted until root EOF.
+    true
 }
 
 struct LiveRootFieldTransformer {
@@ -1547,7 +1550,7 @@ mod tests {
     async fn final_route_gate_waits_for_late_routing_metadata_before_upstream_body() {
         let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(2);
         tx.send(Ok(Bytes::from_static(
-            br#"{"model":"gpt-5.6","input":"hello","#,
+            br#"{"model":"gpt-5.6","input":"hello","instructions":"stream","#,
         )))
         .await
         .expect("send request prefix");

--- a/src/proxy/live_request_body_pipeline.rs
+++ b/src/proxy/live_request_body_pipeline.rs
@@ -550,12 +550,11 @@ fn is_precommit_routing_root_field(key: &str) -> bool {
 }
 
 fn should_defer_route_commit(_key: &str, _value_start: u8) -> bool {
-    // JSON object fields are unordered and optional. After any ordinary field
-    // there may still be a later input, tools, metadata, sticky, prompt-cache,
-    // or encrypted-content field that changes the route. Without a schema-level
-    // end marker, EOF is the only proof that the route-affecting root set is
-    // complete, so the live encoder must stay uncommitted until root EOF.
-    true
+    // Route-affecting root fields are kept in `pending_fields` and are handled
+    // before this check. Once model/input and those fields are known, an
+    // ordinary field is the first safe commit point; later route fields still
+    // remain deferred because they are classified by `is_precommit...`.
+    false
 }
 
 struct LiveRootFieldTransformer {

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1654,6 +1654,7 @@ pub(crate) struct PoolReplayBodyKeyProbe {
     pub(crate) model: Option<String>,
     pub(crate) contains_encrypted_content: bool,
     pub(crate) image_intent: ImageIntent,
+    pub(crate) root_object_complete: bool,
 }
 
 /// Immutable request semantics derived from the single replay snapshot.
@@ -5262,6 +5263,7 @@ pub(crate) fn spawn_pool_replayable_request_body(
                                     &sticky_key_probe,
                                 ),
                             image_intent: ImageIntent::Unknown,
+                            root_object_complete: true,
                         },
                     ));
                 }
@@ -5349,6 +5351,7 @@ pub(crate) fn spawn_pool_replayable_request_body(
                             &sticky_key_probe,
                         ),
                     image_intent: ImageIntent::Unknown,
+                    root_object_complete: false,
                 };
                 if key_probe.sticky_key.is_some()
                     || key_probe.prompt_cache_key.is_some()

--- a/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
+++ b/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
@@ -359,7 +359,7 @@ async fn proxy_openai_v1_chunked_codex_lite_keeps_live_first_and_audits_keep_ori
 }
 
 #[tokio::test]
-async fn final_route_gate_waits_for_eof_before_upstream_with_prompt_cache_and_sticky_routing() {
+async fn final_route_gate_starts_upstream_before_eof_with_prompt_cache_and_sticky_routing() {
     let mut config = test_config();
     config.openai_proxy_request_read_timeout = Duration::from_millis(500);
     config.proxy_enforce_stream_include_usage = false;
@@ -428,7 +428,7 @@ async fn final_route_gate_waits_for_eof_before_upstream_with_prompt_cache_and_st
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, io::Error>>(16);
     let (release_tail_tx, release_tail_rx) = tokio::sync::oneshot::channel::<()>();
     let first_chunk = format!(
-        "{{\"model\":\"gpt-5\",\"promptCacheKey\":\"{prompt_cache_key}\",\"input\":\"ready\"}}\n"
+        "{{\"model\":\"gpt-5\",\"promptCacheKey\":\"{prompt_cache_key}\",\"input\":\"ready\",\"instructions\":\"stream\"}}\n"
     )
     .to_string();
     let body_task = tokio::spawn(async move {
@@ -469,15 +469,12 @@ async fn final_route_gate_waits_for_eof_before_upstream_with_prompt_cache_and_st
         .await
     });
 
-    assert!(
-        timeout(
-            Duration::from_millis(100),
-            wait_for_pool_upstream_request_attempts(&state.pool, 1),
-        )
-        .await
-        .is_err(),
-        "the final-route gate must not reserve or start an upstream attempt before EOF"
-    );
+    timeout(
+        Duration::from_secs(1),
+        wait_for_pool_upstream_request_attempts(&state.pool, 1),
+    )
+    .await
+    .expect("prompt-cache routing should start upstream before EOF");
     let _ = release_tail_tx.send(());
     body_task.await.expect("request body task should join");
     let response = request_task
@@ -517,10 +514,10 @@ async fn final_route_gate_waits_for_eof_before_upstream_with_prompt_cache_and_st
     })
     .await
     .expect("live treatment invocation should persist");
-    assert_eq!(transport_mode.as_deref(), Some("buffered"));
+    assert_eq!(transport_mode.as_deref(), Some("live_first"));
     assert_eq!(
         finalization_outcome.as_deref(),
-        Some("buffered_eof_final_route")
+        Some("live_first_model_ready")
     );
 
     upstream_handle.abort();
@@ -604,7 +601,11 @@ async fn final_route_gate_rejects_malformed_tail_before_upstream_delivery() {
             .is_some_and(|message| message.contains("request body must be valid JSON"))
     );
 
-    assert_eq!(count_pool_upstream_request_attempts(&state.pool).await, 0);
+    assert_eq!(
+        count_pool_upstream_request_attempts(&state.pool).await,
+        1,
+        "a malformed tail after live-first commit must cancel the provisional upstream attempt"
+    );
 
     let invocation = timeout(Duration::from_secs(1), async {
         loop {
@@ -642,8 +643,8 @@ async fn final_route_gate_rejects_malformed_tail_before_upstream_delivery() {
     )
     .expect("decode malformed live invocation payload");
     assert_eq!(
-        invocation_payload["ambiguousUpstreamDelivery"], false,
-        "malformed JSON must not report ambiguous delivery when EOF gating sent no body"
+        invocation_payload["ambiguousUpstreamDelivery"], true,
+        "a malformed tail after upstream body delivery must be recorded as ambiguous"
     );
 
     upstream_handle.abort();

--- a/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
+++ b/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
@@ -358,8 +358,14 @@ async fn proxy_openai_v1_chunked_codex_lite_keeps_live_first_and_audits_keep_ori
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn final_route_gate_starts_upstream_before_eof_with_prompt_cache_and_sticky_routing() {
+#[test]
+fn final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing() {
+    run_future_with_large_stack(async {
+        final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing_inner().await;
+    });
+}
+
+async fn final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing_inner() {
     let mut config = test_config();
     config.openai_proxy_request_read_timeout = Duration::from_millis(500);
     config.proxy_enforce_stream_include_usage = false;
@@ -428,7 +434,7 @@ async fn final_route_gate_starts_upstream_before_eof_with_prompt_cache_and_stick
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, io::Error>>(16);
     let (release_tail_tx, release_tail_rx) = tokio::sync::oneshot::channel::<()>();
     let first_chunk = format!(
-        "{{\"model\":\"gpt-5\",\"promptCacheKey\":\"{prompt_cache_key}\",\"input\":\"ready\",\"instructions\":\"stream\"}}\n"
+        "{{\"model\":\"gpt-5\",\"promptCacheKey\":\"{prompt_cache_key}\",\"input\":\"ready\"}}\n"
     )
     .to_string();
     let body_task = tokio::spawn(async move {
@@ -469,12 +475,15 @@ async fn final_route_gate_starts_upstream_before_eof_with_prompt_cache_and_stick
         .await
     });
 
-    timeout(
-        Duration::from_secs(1),
-        wait_for_pool_upstream_request_attempts(&state.pool, 1),
-    )
-    .await
-    .expect("prompt-cache routing should start upstream before EOF");
+    assert!(
+        timeout(
+            Duration::from_millis(100),
+            wait_for_pool_upstream_request_attempts(&state.pool, 1),
+        )
+        .await
+        .is_err(),
+        "the final-route gate must not start upstream before EOF"
+    );
     let _ = release_tail_tx.send(());
     body_task.await.expect("request body task should join");
     let response = request_task
@@ -487,9 +496,11 @@ async fn final_route_gate_starts_upstream_before_eof_with_prompt_cache_and_stick
     let response_payload: Value =
         serde_json::from_slice(&response_body).expect("decode routed capture response body");
     assert_eq!(response_payload["authorization"], "Bearer upstream-primary");
-    let attempts = attempts.lock().expect("lock route fixture attempts");
-    assert_eq!(attempts.get("Bearer upstream-primary").copied(), Some(1));
-    assert_eq!(attempts.get("Bearer upstream-secondary").copied(), None);
+    {
+        let attempts = attempts.lock().expect("lock route fixture attempts");
+        assert_eq!(attempts.get("Bearer upstream-primary").copied(), Some(1));
+        assert_eq!(attempts.get("Bearer upstream-secondary").copied(), None);
+    }
     let (transport_mode, finalization_outcome) = timeout(Duration::from_secs(1), async {
         loop {
             let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
@@ -514,10 +525,10 @@ async fn final_route_gate_starts_upstream_before_eof_with_prompt_cache_and_stick
     })
     .await
     .expect("live treatment invocation should persist");
-    assert_eq!(transport_mode.as_deref(), Some("live_first"));
+    assert_eq!(transport_mode.as_deref(), Some("buffered"));
     assert_eq!(
         finalization_outcome.as_deref(),
-        Some("live_first_model_ready")
+        Some("buffered_eof_final_route")
     );
 
     upstream_handle.abort();
@@ -603,8 +614,8 @@ async fn final_route_gate_rejects_malformed_tail_before_upstream_delivery() {
 
     assert_eq!(
         count_pool_upstream_request_attempts(&state.pool).await,
-        1,
-        "a malformed tail after live-first commit must cancel the provisional upstream attempt"
+        0,
+        "malformed JSON must not start an upstream attempt before final route validation"
     );
 
     let invocation = timeout(Duration::from_secs(1), async {
@@ -642,10 +653,7 @@ async fn final_route_gate_rejects_malformed_tail_before_upstream_delivery() {
             .expect("malformed live invocation payload"),
     )
     .expect("decode malformed live invocation payload");
-    assert_eq!(
-        invocation_payload["ambiguousUpstreamDelivery"], true,
-        "a malformed tail after upstream body delivery must be recorded as ambiguous"
-    );
+    assert_eq!(invocation_payload["ambiguousUpstreamDelivery"], false);
 
     upstream_handle.abort();
 }
@@ -948,8 +956,14 @@ async fn final_route_gate_cancellation_before_eof_does_not_reserve_or_deliver() 
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn final_route_gate_cancellation_after_eof_releases_active_reservation() {
+#[test]
+fn final_route_gate_cancellation_after_eof_releases_active_reservation() {
+    run_future_with_large_stack(async {
+        final_route_gate_cancellation_after_eof_releases_active_reservation_inner().await;
+    });
+}
+
+async fn final_route_gate_cancellation_after_eof_releases_active_reservation_inner() {
     let mut config = test_config();
     config.openai_proxy_request_read_timeout = Duration::from_secs(5);
     config.proxy_enforce_stream_include_usage = false;

--- a/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
+++ b/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
@@ -294,23 +294,18 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
     .fetch_all(&state.pool)
     .await
     .expect("load timeout final-route-gate no-alternate rows");
-    assert_eq!(attempt_rows.len(), 2);
+    assert_eq!(attempt_rows.len(), 1);
     assert_eq!(attempt_rows[0].attempt_index, 1);
-    assert_eq!(attempt_rows[1].attempt_index, 1);
     assert_eq!(attempt_rows[0].distinct_account_index, 1);
-    assert_eq!(attempt_rows[1].distinct_account_index, 1);
-    assert_eq!(attempt_rows[0].same_account_retry_index, 0);
-    assert_eq!(attempt_rows[1].same_account_retry_index, 1);
-    for row in &attempt_rows {
-        assert_eq!(
-            row.status,
-            POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE
-        );
-        assert_eq!(
-            row.failure_kind.as_deref(),
-            Some(PROXY_FAILURE_UPSTREAM_STREAM_ERROR),
-        );
-    }
+    assert_eq!(attempt_rows[0].same_account_retry_index, 1);
+    assert_eq!(
+        attempt_rows[0].status,
+        POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE
+    );
+    assert_eq!(
+        attempt_rows[0].failure_kind.as_deref(),
+        Some(PROXY_FAILURE_UPSTREAM_STREAM_ERROR),
+    );
     let row = sqlx::query_as::<_, PersistedPayloadRow>(
         r#"
         SELECT error_message, payload
@@ -331,8 +326,8 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
     assert!(row.error_message.as_deref().is_some_and(|msg| {
         msg.contains("no alternate upstream route is available after timeout")
     }));
-    // The two persisted rows are retries of the same logical attempt, so the
-    // invocation summary keeps the one-based attempt index count at one.
+    // The final route is buffered at EOF, so this terminal path has no
+    // provisional live-first attempt to replay.
     assert_eq!(payload["poolAttemptCount"].as_i64(), Some(1));
     assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(1));
     assert_eq!(
@@ -357,9 +352,9 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
     );
     assert_eq!(payload["routeFinalizationLogicalRatio"], 1.0);
     assert_eq!(payload["liveFirstExperimentVariant"], "treatment");
-    assert_eq!(payload["liveFirstAttemptFailed"], true);
-    assert_eq!(payload["liveFirstFallbackOrRetry"], true);
-    assert_eq!(payload["ambiguousUpstreamDelivery"], true);
+    assert_eq!(payload["liveFirstAttemptFailed"], false);
+    assert_eq!(payload["liveFirstFallbackOrRetry"], false);
+    assert_eq!(payload["ambiguousUpstreamDelivery"], false);
     assert!(payload["upstreamErrorMessage"].is_null());
 
     shared_upstream_handle.abort();

--- a/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
+++ b/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
@@ -344,6 +344,18 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
         payload["routeFinalizationOutcome"],
         "buffered_eof_final_route"
     );
+    assert!(
+        payload["routeFinalizationRawBytes"]
+            .as_i64()
+            .is_some_and(|bytes| bytes > 0)
+    );
+    assert_eq!(payload["routeFinalizationRawRatio"], 1.0);
+    assert!(
+        payload["routeFinalizationLogicalBytes"]
+            .as_i64()
+            .is_some_and(|bytes| bytes > 0)
+    );
+    assert_eq!(payload["routeFinalizationLogicalRatio"], 1.0);
     assert_eq!(payload["liveFirstExperimentVariant"], "treatment");
     assert_eq!(payload["liveFirstAttemptFailed"], true);
     assert_eq!(payload["liveFirstFallbackOrRetry"], true);

--- a/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
+++ b/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
@@ -339,7 +339,11 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
         payload["poolAttemptTerminalReason"].as_str(),
         Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
     );
-    assert_eq!(payload["requestBodyTransportMode"], "live_first");
+    assert_eq!(payload["requestBodyTransportMode"], "buffered");
+    assert_eq!(
+        payload["routeFinalizationOutcome"],
+        "buffered_eof_final_route"
+    );
     assert_eq!(payload["liveFirstExperimentVariant"], "treatment");
     assert_eq!(payload["liveFirstAttemptFailed"], true);
     assert_eq!(payload["liveFirstFallbackOrRetry"], true);


### PR DESCRIPTION
## Delivery role
Direct owner-facing PR.

## Summary
- Keep `/v1/responses` route selection behind complete JSON validation and final route metadata; arbitrary field order, late routing fields, duplicate keys, malformed tails, and image/encrypted routing never send a provisional body upstream.
- Preserve the existing replay/failover path for prompt-cache, sticky, encrypted-owner, and other route-bound requests without changing client semantics.
- Record EOF-finalized samples as `buffered` / `buffered_eof_final_route`, so persisted cohorts and performance views do not report buffered requests as live-first wins.

## Spec / documentation
- Spec: `docs/specs/high-frequency-runtime-data-plane/SPEC.md`
- Spec disposition: targeted repair to the existing live request body v2 contract; no new client fields or online configuration.
- Solutions: -
- Project Docs: -
- Sync results: no applicable document changes.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked final_route_gate_ -- --nocapture` (14 passed)
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `git diff --check`

## Notes
- `liveRequestStreaming.enabled` and `treatmentPercent` remain unchanged; no online configuration was changed.
- There is no route-complete marker in the downstream JSON contract. Therefore arbitrary `/v1/responses` bodies conservatively wait for EOF before route selection; the PR intentionally avoids claiming a streaming gain that the current protocol cannot prove safely.
- This is backend-only; visual evidence is not applicable.

## Visual Evidence

- Spec: docs/specs/high-frequency-runtime-data-plane/SPEC.md
  ![System Status runtime pressure degraded state on desktop](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/543ad1f959493a760670bf8518fd59f1882555b2/docs/specs/high-frequency-runtime-data-plane/assets/runtime-pressure-desktop.png?raw=1)

- Spec: docs/specs/high-frequency-runtime-data-plane/SPEC.md
  ![System Status runtime pressure accounting error state on mobile](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/543ad1f959493a760670bf8518fd59f1882555b2/docs/specs/high-frequency-runtime-data-plane/assets/runtime-pressure-mobile.png?raw=1)

- Spec: docs/specs/high-frequency-runtime-data-plane/SPEC.md
  ![Live request streaming measured cohort comparison](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/543ad1f959493a760670bf8518fd59f1882555b2/docs/specs/high-frequency-runtime-data-plane/assets/live-request-streaming-perf-measured.png?raw=1)

- Spec: docs/specs/high-frequency-runtime-data-plane/SPEC.md
  ![Live request streaming insufficient sample guard](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/543ad1f959493a760670bf8518fd59f1882555b2/docs/specs/high-frequency-runtime-data-plane/assets/live-request-streaming-perf-insufficient-samples.png?raw=1)

- Spec: docs/specs/high-frequency-runtime-data-plane/SPEC.md
  ![Pool routing live request streaming enabled without account group field](https://github.com/IvanLi-CN/codex-vibe-monitor/blob/543ad1f959493a760670bf8518fd59f1882555b2/docs/specs/high-frequency-runtime-data-plane/assets/pool-routing-live-streaming-no-account-group-dark.png?raw=1)
