### PR TITLE
fix(proxy): restore live request body forwarding

### DIFF
--- a/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/bindings.rs
+++ b/src/api/slices/prompt_cache_and_timeseries/prompt_cache_conversations/bindings.rs
@@ -1597,11 +1597,14 @@ pub(crate) async fn broadcast_prompt_cache_conversation_changed(
     state: &AppState,
     prompt_cache_key: &str,
 ) {
-    let runtime_cache = state.pool_routing_runtime_cache.lock().await;
-    if let Some(runtime_cache) = runtime_cache.as_ref()
-        && let Ok(mut cache) = runtime_cache.prompt_route_cache.lock()
-    {
-        cache.invalidate_prompt_cache_key(prompt_cache_key);
+    let mut runtime_cache = state.pool_routing_runtime_cache.lock().await;
+    if let Some(runtime_cache) = runtime_cache.as_mut() {
+        runtime_cache
+            .live_request_route_dependencies
+            .mark_prompt_cache_routes_present();
+        if let Ok(mut cache) = runtime_cache.prompt_route_cache.lock() {
+            cache.invalidate_prompt_cache_key(prompt_cache_key);
+        }
         if let Ok(mut sticky_cache) = runtime_cache.sticky_route_cache.lock() {
             sticky_cache.invalidate_sticky_key(prompt_cache_key);
         }
@@ -1622,11 +1625,14 @@ pub(crate) async fn broadcast_prompt_cache_conversation_changed(
 }
 
 pub(crate) async fn invalidate_pool_routing_sticky_route_cache(state: &AppState, sticky_key: &str) {
-    let runtime_cache = state.pool_routing_runtime_cache.lock().await;
-    if let Some(runtime_cache) = runtime_cache.as_ref()
-        && let Ok(mut cache) = runtime_cache.sticky_route_cache.lock()
-    {
-        cache.invalidate_sticky_key(sticky_key);
+    let mut runtime_cache = state.pool_routing_runtime_cache.lock().await;
+    if let Some(runtime_cache) = runtime_cache.as_mut() {
+        runtime_cache
+            .live_request_route_dependencies
+            .mark_sticky_routes_present();
+        if let Ok(mut cache) = runtime_cache.sticky_route_cache.lock() {
+            cache.invalidate_sticky_key(sticky_key);
+        }
     }
 }
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -15,9 +15,46 @@ pub(crate) struct PoolRoutingRuntimeCache {
     pub(crate) timeouts: PoolRoutingTimeoutSettingsResolved,
     pub(crate) cache_hit_protection: CacheHitProtectionSettings,
     pub(crate) live_request_streaming: LiveRequestStreamingSettings,
+    /// Immutable summary of the routing inputs that can still occur after a
+    /// request's model field. It is rebuilt with the routing snapshot so the
+    /// live request path never has to query SQLite to decide its gate.
+    pub(crate) live_request_route_dependencies: LiveRequestRouteDependencyProfile,
     pub(crate) model_routing: PoolModelRoutingRuntimeCache,
     pub(crate) prompt_route_cache: Arc<std::sync::Mutex<PoolRoutingPromptRouteCache>>,
     pub(crate) sticky_route_cache: Arc<std::sync::Mutex<PoolRoutingStickyRouteCache>>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct LiveRequestRouteDependencyProfile {
+    pub(crate) sticky_routes_present: bool,
+    pub(crate) prompt_cache_routes_present: bool,
+    pub(crate) encrypted_session_owners_present: bool,
+    pub(crate) response_image_capability_gap: bool,
+    pub(crate) codex_imagegen_capability_gap: bool,
+}
+
+impl LiveRequestRouteDependencyProfile {
+    pub(crate) fn requires_full_body_commit(
+        self,
+        encrypted_session_owner_routing_enabled: bool,
+        codex_imagegen_request: bool,
+    ) -> bool {
+        (encrypted_session_owner_routing_enabled && self.encrypted_session_owners_present)
+            || self.response_image_capability_gap
+            || (codex_imagegen_request && self.codex_imagegen_capability_gap)
+    }
+
+    pub(crate) fn mark_prompt_cache_routes_present(&mut self) {
+        self.prompt_cache_routes_present = true;
+        // A conversation mutation may also create or update an encrypted
+        // session owner. Preserve routing correctness until the next snapshot
+        // rebuild establishes the exact table state.
+        self.encrypted_session_owners_present = true;
+    }
+
+    pub(crate) fn mark_sticky_routes_present(&mut self) {
+        self.sticky_routes_present = true;
+    }
 }
 
 pub(crate) const POOL_ROUTING_PROMPT_ROUTE_CACHE_CAPACITY: usize = 16_384;
@@ -2356,6 +2393,29 @@ mod pool_routing_prompt_route_cache_tests {
 
         assert!(cache.get(&key(1)).is_none());
         assert!(cache.get(&key(2)).is_some_and(|value| value.is_none()));
+    }
+
+    #[test]
+    fn live_route_dependency_profile_buffers_only_input_embedded_route_factors() {
+        let profile = LiveRequestRouteDependencyProfile {
+            sticky_routes_present: true,
+            prompt_cache_routes_present: true,
+            ..LiveRequestRouteDependencyProfile::default()
+        };
+        assert!(!profile.requires_full_body_commit(false, false));
+
+        let encrypted = LiveRequestRouteDependencyProfile {
+            encrypted_session_owners_present: true,
+            ..profile
+        };
+        assert!(encrypted.requires_full_body_commit(true, false));
+        assert!(!encrypted.requires_full_body_commit(false, false));
+
+        let image = LiveRequestRouteDependencyProfile {
+            response_image_capability_gap: true,
+            ..profile
+        };
+        assert!(image.requires_full_body_commit(false, false));
     }
 
     #[test]

--- a/src/proxy/dispatch.rs
+++ b/src/proxy/dispatch.rs
@@ -871,6 +871,23 @@ async fn prepare_capture_request_body(
         .read()
         .await
         .encrypted_session_owner_routing_enabled;
+    let codex_imagegen_request = codex_imagegen_protocol_from_headers(headers).is_some();
+    let live_route_commit_policy = live_routing_snapshot
+        .as_ref()
+        .map(|(snapshot, _)| {
+            let dependencies = snapshot.live_request_route_dependencies;
+            if dependencies
+                .requires_full_body_commit(encrypted_owner_routing_enabled, codex_imagegen_request)
+            {
+                LiveRouteCommitPolicy::FullBody
+            } else {
+                LiveRouteCommitPolicy::ModelAndBindings {
+                    sticky_routes_present: dependencies.sticky_routes_present,
+                    prompt_cache_routes_present: dependencies.prompt_cache_routes_present,
+                }
+            }
+        })
+        .unwrap_or(LiveRouteCommitPolicy::FullBody);
 
     let replayable_body = spawn_pool_replayable_request_body(
         body,
@@ -882,10 +899,13 @@ async fn prepare_capture_request_body(
         .get(header::CONTENT_ENCODING)
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
-    let mut live_pipeline = Some(spawn_live_responses_request_body_pipeline(
-        replayable_body.body,
-        downstream_content_encoding.clone(),
-    ));
+    let mut live_pipeline = Some(
+        spawn_live_responses_request_body_pipeline_with_route_commit_policy(
+            replayable_body.body,
+            downstream_content_encoding.clone(),
+            live_route_commit_policy,
+        ),
+    );
     let live_request_body_error_rx = live_pipeline
         .as_ref()
         .expect("live pipeline is present before the first attempt")
@@ -978,7 +998,7 @@ async fn prepare_capture_request_body(
                         None,
                         capture_target.endpoint(),
                         live_body_key_probe.image_intent,
-                        codex_imagegen_protocol_from_headers(headers).is_some(),
+                        codex_imagegen_request,
                         Some(live_routing_reservation_key.as_str()),
                     )
                     .await
@@ -997,7 +1017,7 @@ async fn prepare_capture_request_body(
                         None,
                         capture_target.endpoint(),
                         live_body_key_probe.image_intent,
-                        codex_imagegen_protocol_from_headers(headers).is_some(),
+                        codex_imagegen_request,
                         Some(live_routing_reservation_key.as_str()),
                     )
                     .await
@@ -1358,6 +1378,8 @@ async fn prepare_capture_request_body(
         live_oauth_rewrite_rx: Some(live_oauth_rewrite_rx),
         live_first_experiment_group,
         live_route_finalization_measurement: Some(LiveRequestStreamingMeasurement {
+            route_finalization_raw_bytes: live_body_key_probe.raw_bytes_observed,
+            route_finalization_logical_bytes: live_body_key_probe.logical_bytes_observed,
             route_finalization_ms: Some(live_route_finalization_ms),
             route_finalization_outcome: Some(route_finalization_outcome),
             route_dependency_factors: live_route_dependency_factors(
@@ -1746,11 +1768,21 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         None
     };
     if let Some(route_measurement) = live_route_finalization_measurement.as_mut() {
-        route_measurement.route_finalization_raw_bytes = Some(request_body_bytes_len);
-        route_measurement.route_finalization_logical_bytes = logical_request_body_bytes;
-        route_measurement.route_finalization_raw_ratio = Some(1.0);
-        route_measurement.route_finalization_logical_ratio =
-            logical_request_body_bytes.map(|_| 1.0);
+        let route_raw_bytes = route_measurement
+            .route_finalization_raw_bytes
+            .unwrap_or(request_body_bytes_len);
+        let route_logical_bytes = route_measurement
+            .route_finalization_logical_bytes
+            .or(logical_request_body_bytes);
+        route_measurement.route_finalization_raw_bytes = Some(route_raw_bytes);
+        route_measurement.route_finalization_logical_bytes = route_logical_bytes;
+        route_measurement.route_finalization_raw_ratio = (request_body_bytes_len != 0)
+            .then(|| route_raw_bytes as f64 / request_body_bytes_len as f64);
+        route_measurement.route_finalization_logical_ratio = route_logical_bytes
+            .zip(logical_request_body_bytes)
+            .and_then(|(route_bytes, body_bytes)| {
+                (body_bytes != 0).then(|| route_bytes as f64 / body_bytes as f64)
+            });
     }
     let live_first_eligible = persisted_live_request_streaming_decision
         .as_ref()
@@ -2952,12 +2984,13 @@ pub(crate) async fn proxy_openai_v1_capture_target(
         live_request_streaming_measurement.routing_hot_cache_cold_load =
             route_measurement.routing_hot_cache_cold_load;
         live_request_streaming_measurement.route_finalization_raw_bytes =
-            Some(request_body_bytes_len);
+            route_measurement.route_finalization_raw_bytes;
         live_request_streaming_measurement.route_finalization_logical_bytes =
-            logical_request_body_bytes;
-        live_request_streaming_measurement.route_finalization_raw_ratio = Some(1.0);
+            route_measurement.route_finalization_logical_bytes;
+        live_request_streaming_measurement.route_finalization_raw_ratio =
+            route_measurement.route_finalization_raw_ratio;
         live_request_streaming_measurement.route_finalization_logical_ratio =
-            logical_request_body_bytes.map(|_| 1.0);
+            route_measurement.route_finalization_logical_ratio;
     }
     let mut response_running_record = build_running_proxy_capture_record(
         &invoke_id,

--- a/src/proxy/live_request_body_pipeline.rs
+++ b/src/proxy/live_request_body_pipeline.rs
@@ -31,6 +31,7 @@ impl std::error::Error for LiveDecodedRequestBodyError {
 
 struct LiveDecodedRequestBodyReader<R> {
     inner: R,
+    logical_bytes_observed: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl<R> AsyncRead for LiveDecodedRequestBodyReader<R>
@@ -42,11 +43,19 @@ where
         context: &mut std::task::Context<'_>,
         buffer: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<io::Result<()>> {
+        let before = buffer.filled().len();
         match std::pin::Pin::new(&mut self.inner).poll_read(context, buffer) {
             std::task::Poll::Ready(Err(error)) => {
                 std::task::Poll::Ready(Err(live_decoded_request_body_error(error)))
             }
-            other => other,
+            std::task::Poll::Ready(Ok(())) => {
+                self.logical_bytes_observed.fetch_add(
+                    buffer.filled().len().saturating_sub(before),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                std::task::Poll::Ready(Ok(()))
+            }
+            std::task::Poll::Pending => std::task::Poll::Pending,
         }
     }
 }
@@ -68,6 +77,51 @@ pub(crate) struct LiveResponsesBodyTransformConfig {
     pub(crate) codex_imagegen_rewrite_mode: CodexImagegenRewriteMode,
     pub(crate) codex_imagegen_protocol: Option<CodexImagegenProtocol>,
     pub(crate) model_mapping_target: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum LiveRouteCommitPolicy {
+    #[default]
+    FullBody,
+    ModelAndBindings {
+        sticky_routes_present: bool,
+        prompt_cache_routes_present: bool,
+    },
+}
+
+impl LiveRouteCommitPolicy {
+    #[cfg(test)]
+    const fn model_only() -> Self {
+        Self::ModelAndBindings {
+            sticky_routes_present: false,
+            prompt_cache_routes_present: false,
+        }
+    }
+
+    fn permits_pre_eof_commit(self) -> bool {
+        !matches!(self, Self::FullBody)
+    }
+
+    fn requires_pending_route_field(self, key: &str) -> bool {
+        match self {
+            Self::FullBody => true,
+            Self::ModelAndBindings {
+                sticky_routes_present,
+                prompt_cache_routes_present,
+            } => {
+                key == "model"
+                    || ((sticky_routes_present || prompt_cache_routes_present)
+                        && matches!(
+                            key,
+                            "metadata"
+                                | "sticky_key"
+                                | "stickyKey"
+                                | "prompt_cache_key"
+                                | "promptCacheKey"
+                        ))
+            }
+        }
+    }
 }
 
 pub(crate) struct LiveResponsesRequestBodyPipeline {
@@ -100,6 +154,18 @@ pub(crate) fn spawn_live_responses_request_body_pipeline(
     raw_body: Body,
     downstream_content_encoding: Option<String>,
 ) -> LiveResponsesRequestBodyPipeline {
+    spawn_live_responses_request_body_pipeline_with_route_commit_policy(
+        raw_body,
+        downstream_content_encoding,
+        LiveRouteCommitPolicy::FullBody,
+    )
+}
+
+pub(crate) fn spawn_live_responses_request_body_pipeline_with_route_commit_policy(
+    raw_body: Body,
+    downstream_content_encoding: Option<String>,
+    route_commit_policy: LiveRouteCommitPolicy,
+) -> LiveResponsesRequestBodyPipeline {
     let (config_tx, config_rx) = oneshot::channel();
     let (probe_tx, probe_rx) = watch::channel(PoolReplayBodyStickyKeyProbeStatus::Pending);
     let (logical_tx, logical_rx) = mpsc::channel::<Result<Bytes, io::Error>>(8);
@@ -117,6 +183,7 @@ pub(crate) fn spawn_live_responses_request_body_pipeline(
         let result = run_live_responses_request_body_pipeline(
             raw_body,
             downstream_content_encoding.as_deref(),
+            route_commit_policy,
             config_rx,
             &probe_tx,
             &mut logical_tx,
@@ -200,6 +267,7 @@ pub(crate) fn live_responses_target_request_content_encoding_with_resolved(
 async fn run_live_responses_request_body_pipeline(
     raw_body: Body,
     downstream_content_encoding: Option<&str>,
+    route_commit_policy: LiveRouteCommitPolicy,
     config_rx: oneshot::Receiver<LiveResponsesBodyTransformConfig>,
     probe_tx: &watch::Sender<PoolReplayBodyStickyKeyProbeStatus>,
     logical_tx: &mut Option<mpsc::Sender<Result<Bytes, io::Error>>>,
@@ -209,12 +277,16 @@ async fn run_live_responses_request_body_pipeline(
     oauth_rewrite_tx: watch::Sender<Option<oauth_bridge::OauthResponsesRewriteSummary>>,
     resolved_encoding_tx: watch::Sender<Option<RequestBodyContentEncoding>>,
 ) -> io::Result<()> {
-    let (reader, resolved_encoding) =
+    let (reader, resolved_encoding, raw_bytes_observed) =
         live_decoded_request_reader(raw_body, downstream_content_encoding)
             .await
             .map_err(live_decoded_request_body_error)?;
     let _ = resolved_encoding_tx.send(Some(resolved_encoding));
-    let mut reader = LiveDecodedRequestBodyReader { inner: reader };
+    let logical_bytes_observed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut reader = LiveDecodedRequestBodyReader {
+        inner: reader,
+        logical_bytes_observed: logical_bytes_observed.clone(),
+    };
     let Some(first) = read_non_whitespace(&mut reader).await? else {
         let _ = probe_tx.send(PoolReplayBodyStickyKeyProbeStatus::Ready(
             PoolReplayBodyKeyProbe::default(),
@@ -253,7 +325,12 @@ async fn run_live_responses_request_body_pipeline(
                 return Err(invalid_live_json("request body has trailing content"));
             }
             if selected_writer.is_none() {
-                let probe = live_routing_probe_from_fields(&pending_fields, true);
+                let probe = live_routing_probe_from_fields(
+                    &pending_fields,
+                    true,
+                    raw_bytes_observed.as_ref(),
+                    logical_bytes_observed.as_ref(),
+                );
                 let _ = probe_tx.send(PoolReplayBodyStickyKeyProbeStatus::Ready(probe));
                 let Ok(selected_config) = config_rx
                     .take()
@@ -330,25 +407,23 @@ async fn run_live_responses_request_body_pipeline(
             return Err(invalid_live_json("request object value is missing"));
         };
 
-        // Once the required model, all enabled route metadata seen so far, and
-        // the potentially route-affecting input field are buffered, commit the
-        // route before consuming the next ordinary value. Until `input` has
-        // been observed, a later field may still introduce image capability or
-        // encrypted-content requirements, so an ordinary field must remain in
-        // the prefix buffer even when the model is already known.
-        let input_seen = pending_fields
-            .iter()
-            .any(|(pending_key, _)| pending_key == "input");
+        // The dispatcher uses the immutable snapshot to decide which root
+        // fields still affect this route. Once those fields have been parsed,
+        // begin forwarding the next field instead of buffering the input body.
         if selected_writer.is_none()
+            && route_commit_policy.permits_pre_eof_commit()
             && pending_fields
                 .iter()
                 .any(|(pending_key, _)| pending_key == "model")
-            && !is_precommit_routing_root_field(&key)
-            && input_seen
-            && !should_defer_route_commit(&key, value_start)
+            && !route_commit_policy.requires_pending_route_field(&key)
         {
             let _ = probe_tx.send(PoolReplayBodyStickyKeyProbeStatus::Ready(
-                live_routing_probe_from_fields(&pending_fields, false),
+                live_routing_probe_from_fields(
+                    &pending_fields,
+                    false,
+                    raw_bytes_observed.as_ref(),
+                    logical_bytes_observed.as_ref(),
+                ),
             ));
             let Ok(selected_config) = config_rx
                 .take()
@@ -473,14 +548,25 @@ fn start_live_encoder(
 async fn live_decoded_request_reader(
     raw_body: Body,
     content_encoding: Option<&str>,
-) -> io::Result<(BoxedPoolRequestReader, RequestBodyContentEncoding)> {
+) -> io::Result<(
+    BoxedPoolRequestReader,
+    RequestBodyContentEncoding,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+)> {
     let needs_deflate_prefix = parse_content_encodings(content_encoding)
         .iter()
         .any(|encoding| encoding == "deflate");
     let minimum_prefix_bytes = if needs_deflate_prefix { 2 } else { 1 };
-    let mut source = raw_body
-        .into_data_stream()
-        .map(|chunk| chunk.map_err(|err| io::Error::other(err.to_string())));
+    let raw_bytes_observed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let raw_bytes_observed_for_stream = raw_bytes_observed.clone();
+    let mut source = raw_body.into_data_stream().map(move |chunk| match chunk {
+        Ok(chunk) => {
+            raw_bytes_observed_for_stream
+                .fetch_add(chunk.len(), std::sync::atomic::Ordering::Relaxed);
+            Ok(chunk)
+        }
+        Err(err) => Err(io::Error::other(err.to_string())),
+    });
     let mut prefix = Vec::new();
     while prefix.len() < minimum_prefix_bytes {
         let Some(chunk) = source.next().await else {
@@ -500,12 +586,14 @@ async fn live_decoded_request_reader(
     let decoded = decode_pool_request_reader(raw_reader, encoding)
         .await
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.message))?;
-    Ok((decoded, encoding))
+    Ok((decoded, encoding, raw_bytes_observed))
 }
 
 fn live_routing_probe_from_fields(
     fields: &[(String, Vec<u8>)],
     root_object_complete: bool,
+    raw_bytes_observed: &std::sync::atomic::AtomicUsize,
+    logical_bytes_observed: &std::sync::atomic::AtomicUsize,
 ) -> PoolReplayBodyKeyProbe {
     let mut object = serde_json::Map::new();
     for (key, value) in fields {
@@ -534,30 +622,11 @@ fn live_routing_probe_from_fields(
             ImageIntent::Unknown
         },
         root_object_complete,
+        raw_bytes_observed: Some(raw_bytes_observed.load(std::sync::atomic::Ordering::Relaxed)),
+        logical_bytes_observed: Some(
+            logical_bytes_observed.load(std::sync::atomic::Ordering::Relaxed),
+        ),
     }
-}
-
-fn is_precommit_routing_root_field(key: &str) -> bool {
-    matches!(
-        key,
-        "model"
-            | "tools"
-            | "tool_choice"
-            | "metadata"
-            | "sticky_key"
-            | "stickyKey"
-            | "prompt_cache_key"
-            | "promptCacheKey"
-    )
-}
-
-fn should_defer_route_commit(_key: &str, _value_start: u8) -> bool {
-    // JSON object fields are unordered and optional. After any ordinary field
-    // there may still be a later input, tools, metadata, sticky, prompt-cache,
-    // or encrypted-content field that changes the route. Without a schema-level
-    // end marker, EOF is the only proof that the route-affecting root set is
-    // complete, so the live encoder must stay uncommitted until root EOF.
-    true
 }
 
 struct LiveRootFieldTransformer {
@@ -1383,6 +1452,81 @@ mod tests {
 
         let output = collect_body(pipeline.body).await;
         assert!(pipeline.first_upstream_body_poll_at_rx.borrow().is_some());
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output).expect("decode live forwarded JSON"),
+            serde_json::json!({"model":"gpt-5.6","input":"delayed tail"})
+        );
+    }
+
+    #[test]
+    fn route_commit_policy_waits_only_for_enabled_binding_fields() {
+        let model_only = LiveRouteCommitPolicy::model_only();
+        assert!(model_only.permits_pre_eof_commit());
+        assert!(model_only.requires_pending_route_field("model"));
+        assert!(!model_only.requires_pending_route_field("metadata"));
+        assert!(!model_only.requires_pending_route_field("input"));
+
+        let bindings = LiveRouteCommitPolicy::ModelAndBindings {
+            sticky_routes_present: true,
+            prompt_cache_routes_present: true,
+        };
+        assert!(bindings.requires_pending_route_field("metadata"));
+        assert!(bindings.requires_pending_route_field("sticky_key"));
+        assert!(bindings.requires_pending_route_field("prompt_cache_key"));
+        assert!(!bindings.requires_pending_route_field("input"));
+    }
+
+    #[tokio::test]
+    async fn model_only_route_gate_starts_upstream_body_before_downstream_eof() {
+        let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(2);
+        tx.send(Ok(Bytes::from_static(
+            br#"{"model":"gpt-5.6","input":"delayed "#,
+        )))
+        .await
+        .expect("send request prefix");
+        let mut pipeline = spawn_live_responses_request_body_pipeline_with_route_commit_policy(
+            Body::from_stream(ReceiverStream::new(rx)),
+            None,
+            LiveRouteCommitPolicy::model_only(),
+        );
+        let probe = wait_for_replay_body_sticky_key_probe(
+            &pipeline.routing_probe_rx,
+            Duration::from_secs(1),
+        )
+        .await;
+        assert_eq!(probe.model.as_deref(), Some("gpt-5.6"));
+        assert!(!probe.root_object_complete);
+        assert!(pipeline.configure(LiveResponsesBodyTransformConfig {
+            target_encoding: RequestBodyContentEncoding::Identity,
+            compression_level: RequestCompressionLevelPreset::Balanced,
+            enforce_include_usage: false,
+            oauth: None,
+            fast_mode_rewrite_mode: TagFastModeRewriteMode::KeepOriginal,
+            image_tool_rewrite_mode: ImageToolRewriteMode::KeepOriginal,
+            codex_imagegen_rewrite_mode: CodexImagegenRewriteMode::KeepOriginal,
+            codex_imagegen_protocol: None,
+            model_mapping_target: None,
+        }));
+
+        let mut upstream_body = pipeline.body.into_data_stream();
+        let prefix = timeout(Duration::from_secs(1), upstream_body.next())
+            .await
+            .expect("upstream body starts before downstream EOF")
+            .expect("upstream body stream remains open")
+            .expect("upstream body chunk");
+        assert!(
+            prefix.starts_with(b"{\"model\":\"gpt-5.6\",\"input\":"),
+            "unexpected upstream prefix: {prefix:?}"
+        );
+
+        tx.send(Ok(Bytes::from_static(b"tail\"}")))
+            .await
+            .expect("send delayed tail");
+        drop(tx);
+        let mut output = prefix.to_vec();
+        while let Some(chunk) = upstream_body.next().await {
+            output.extend_from_slice(&chunk.expect("upstream body tail"));
+        }
         assert_eq!(
             serde_json::from_slice::<Value>(&output).expect("decode live forwarded JSON"),
             serde_json::json!({"model":"gpt-5.6","input":"delayed tail"})

--- a/src/proxy/request_entry.rs
+++ b/src/proxy/request_entry.rs
@@ -1655,6 +1655,10 @@ pub(crate) struct PoolReplayBodyKeyProbe {
     pub(crate) contains_encrypted_content: bool,
     pub(crate) image_intent: ImageIntent,
     pub(crate) root_object_complete: bool,
+    /// Transport and decoded JSON bytes observed when the live routing probe
+    /// became ready. Snapshot-based probes leave these absent.
+    pub(crate) raw_bytes_observed: Option<usize>,
+    pub(crate) logical_bytes_observed: Option<usize>,
 }
 
 /// Immutable request semantics derived from the single replay snapshot.
@@ -5264,6 +5268,8 @@ pub(crate) fn spawn_pool_replayable_request_body(
                                 ),
                             image_intent: ImageIntent::Unknown,
                             root_object_complete: true,
+                            raw_bytes_observed: None,
+                            logical_bytes_observed: None,
                         },
                     ));
                 }
@@ -5352,6 +5358,8 @@ pub(crate) fn spawn_pool_replayable_request_body(
                         ),
                     image_intent: ImageIntent::Unknown,
                     root_object_complete: false,
+                    raw_bytes_observed: None,
+                    logical_bytes_observed: None,
                 };
                 if key_probe.sticky_key.is_some()
                     || key_probe.prompt_cache_key.is_some()

--- a/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
+++ b/src/tests/stateful_sqlite/live_first_and_owner_guard.rs
@@ -359,13 +359,13 @@ async fn proxy_openai_v1_chunked_codex_lite_keeps_live_first_and_audits_keep_ori
 }
 
 #[test]
-fn final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing() {
+fn live_route_gate_resolves_prompt_cache_and_sticky_before_early_delivery() {
     run_future_with_large_stack(async {
-        final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing_inner().await;
+        live_route_gate_resolves_prompt_cache_and_sticky_before_early_delivery_inner().await;
     });
 }
 
-async fn final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing_inner() {
+async fn live_route_gate_resolves_prompt_cache_and_sticky_before_early_delivery_inner() {
     let mut config = test_config();
     config.openai_proxy_request_read_timeout = Duration::from_millis(500);
     config.proxy_enforce_stream_include_usage = false;
@@ -475,15 +475,12 @@ async fn final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing_inn
         .await
     });
 
-    assert!(
-        timeout(
-            Duration::from_millis(100),
-            wait_for_pool_upstream_request_attempts(&state.pool, 1),
-        )
-        .await
-        .is_err(),
-        "the final-route gate must not start upstream before EOF"
-    );
+    timeout(
+        Duration::from_secs(1),
+        wait_for_pool_upstream_request_attempts(&state.pool, 1),
+    )
+    .await
+    .expect("the model, prompt-cache binding, and sticky route must commit before EOF");
     let _ = release_tail_tx.send(());
     body_task.await.expect("request body task should join");
     let response = request_task
@@ -525,17 +522,17 @@ async fn final_route_gate_waits_for_eof_with_prompt_cache_and_sticky_routing_inn
     })
     .await
     .expect("live treatment invocation should persist");
-    assert_eq!(transport_mode.as_deref(), Some("buffered"));
+    assert_eq!(transport_mode.as_deref(), Some("live_first"));
     assert_eq!(
         finalization_outcome.as_deref(),
-        Some("buffered_eof_final_route")
+        Some("live_first_model_ready")
     );
 
     upstream_handle.abort();
 }
 
 #[tokio::test]
-async fn final_route_gate_rejects_malformed_tail_before_upstream_delivery() {
+async fn live_route_gate_rejects_malformed_tail_after_upstream_delivery() {
     let mut config = test_config();
     config.openai_proxy_request_read_timeout = Duration::from_millis(500);
     config.proxy_enforce_stream_include_usage = false;
@@ -614,8 +611,8 @@ async fn final_route_gate_rejects_malformed_tail_before_upstream_delivery() {
 
     assert_eq!(
         count_pool_upstream_request_attempts(&state.pool).await,
-        0,
-        "malformed JSON must not start an upstream attempt before final route validation"
+        1,
+        "the model-ready request body may begin upstream delivery before a malformed tail"
     );
 
     let invocation = timeout(Duration::from_secs(1), async {
@@ -653,13 +650,13 @@ async fn final_route_gate_rejects_malformed_tail_before_upstream_delivery() {
             .expect("malformed live invocation payload"),
     )
     .expect("decode malformed live invocation payload");
-    assert_eq!(invocation_payload["ambiguousUpstreamDelivery"], false);
+    assert_eq!(invocation_payload["ambiguousUpstreamDelivery"], true);
 
     upstream_handle.abort();
 }
 
 #[tokio::test]
-async fn final_route_gate_rejects_downstream_read_error_without_upstream_delivery() {
+async fn live_route_gate_marks_downstream_read_error_after_upstream_delivery_ambiguous() {
     let mut config = test_config();
     config.openai_proxy_request_read_timeout = Duration::from_millis(500);
     config.proxy_enforce_stream_include_usage = false;
@@ -714,26 +711,23 @@ async fn final_route_gate_rejects_downstream_read_error_without_upstream_deliver
         .await
         .expect("send valid live request prefix");
 
-    assert!(
-        timeout(Duration::from_millis(100), async {
-            loop {
-                if attempts
-                    .lock()
-                    .expect("lock upstream attempts")
-                    .get("Bearer upstream-primary")
-                    .copied()
-                    .unwrap_or_default()
-                    > 0
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if attempts
+                .lock()
+                .expect("lock upstream attempts")
+                .get("Bearer upstream-primary")
+                .copied()
+                .unwrap_or_default()
+                > 0
+            {
+                break;
             }
-        })
-        .await
-        .is_err(),
-        "a downstream read failure must not reach an upstream before the final route is known"
-    );
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the model-ready request body should start upstream delivery before EOF");
     body_tx
         .send(Err(io::Error::other("downstream request body failed")))
         .await
@@ -746,7 +740,7 @@ async fn final_route_gate_rejects_downstream_read_error_without_upstream_deliver
         .expect("downstream body failure task should join");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    assert_eq!(count_pool_upstream_request_attempts(&state.pool).await, 0);
+    assert_eq!(count_pool_upstream_request_attempts(&state.pool).await, 1);
 
     let invocation_payload = timeout(Duration::from_secs(1), async {
         loop {
@@ -766,7 +760,7 @@ async fn final_route_gate_rejects_downstream_read_error_without_upstream_deliver
     .expect("downstream body failure invocation should persist");
     let invocation_payload: Value =
         serde_json::from_str(&invocation_payload).expect("decode downstream body failure payload");
-    assert_eq!(invocation_payload["ambiguousUpstreamDelivery"], false);
+    assert_eq!(invocation_payload["ambiguousUpstreamDelivery"], true);
 
     upstream_handle.abort();
 }
@@ -842,8 +836,8 @@ async fn live_first_capture_responses_failure_excludes_sticky_account_from_repla
         .expect("lock live-first sticky failure attempts");
     assert_eq!(
         attempts.get("Bearer upstream-primary").copied(),
-        Some(3),
-        "the buffered retry path preserves the existing same-account retry budget before failover"
+        Some(1),
+        "a failed live-first attempt must not replay a possibly delivered body to the sticky account"
     );
     assert!(matches!(
         attempts.get("Bearer upstream-secondary").copied(),
@@ -854,7 +848,7 @@ async fn live_first_capture_responses_failure_excludes_sticky_account_from_repla
 }
 
 #[tokio::test]
-async fn final_route_gate_cancellation_before_eof_does_not_reserve_or_deliver() {
+async fn live_route_gate_cancellation_after_commit_releases_reservation() {
     let mut config = test_config();
     config.openai_proxy_request_read_timeout = Duration::from_secs(5);
     config.proxy_enforce_stream_include_usage = false;
@@ -912,22 +906,19 @@ async fn final_route_gate_cancellation_before_eof_does_not_reserve_or_deliver() 
         .await
     });
 
+    timeout(
+        Duration::from_secs(1),
+        wait_for_pool_upstream_request_attempts(&state.pool, 1),
+    )
+    .await
+    .expect("a model-ready request should reserve and start upstream delivery before EOF");
     assert!(
-        timeout(
-            Duration::from_millis(100),
-            wait_for_pool_upstream_request_attempts(&state.pool, 1),
-        )
-        .await
-        .is_err(),
-        "an incomplete request must not reserve an account or open an upstream request"
-    );
-    assert!(
-        state
+        !state
             .pool_routing_reservations
             .lock()
             .expect("lock routing reservations")
             .is_empty(),
-        "an incomplete request must not hold a routing reservation"
+        "an active live-first request must hold a routing reservation"
     );
 
     request_task.abort();
@@ -951,7 +942,7 @@ async fn final_route_gate_cancellation_before_eof_does_not_reserve_or_deliver() 
     })
     .await
     .expect("cancelling a live-first request must release its routing reservation");
-    assert_eq!(count_pool_upstream_request_attempts(&state.pool).await, 0);
+    assert_eq!(count_pool_upstream_request_attempts(&state.pool).await, 1);
 
     upstream_handle.abort();
 }

--- a/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
+++ b/src/tests/stateful_sqlite/routing_timeout_and_overload_failover.rs
@@ -294,10 +294,10 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
     .fetch_all(&state.pool)
     .await
     .expect("load timeout final-route-gate no-alternate rows");
-    assert_eq!(attempt_rows.len(), 1);
+    assert_eq!(attempt_rows.len(), 2);
     assert_eq!(attempt_rows[0].attempt_index, 1);
     assert_eq!(attempt_rows[0].distinct_account_index, 1);
-    assert_eq!(attempt_rows[0].same_account_retry_index, 1);
+    assert_eq!(attempt_rows[0].same_account_retry_index, 0);
     assert_eq!(
         attempt_rows[0].status,
         POOL_UPSTREAM_REQUEST_ATTEMPT_STATUS_TRANSPORT_FAILURE
@@ -326,18 +326,17 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
     assert!(row.error_message.as_deref().is_some_and(|msg| {
         msg.contains("no alternate upstream route is available after timeout")
     }));
-    // The final route is buffered at EOF, so this terminal path has no
-    // provisional live-first attempt to replay.
+    // The model-ready route starts a provisional upstream attempt before EOF.
     assert_eq!(payload["poolAttemptCount"].as_i64(), Some(1));
     assert_eq!(payload["poolDistinctAccountCount"].as_i64(), Some(1));
     assert_eq!(
         payload["poolAttemptTerminalReason"].as_str(),
         Some(PROXY_FAILURE_POOL_NO_ALTERNATE_UPSTREAM_AFTER_TIMEOUT),
     );
-    assert_eq!(payload["requestBodyTransportMode"], "buffered");
+    assert_eq!(payload["requestBodyTransportMode"], "live_first");
     assert_eq!(
         payload["routeFinalizationOutcome"],
-        "buffered_eof_final_route"
+        "live_first_model_ready"
     );
     assert!(
         payload["routeFinalizationRawBytes"]
@@ -350,11 +349,16 @@ async fn capture_target_pool_route_timeout_after_final_route_gate_preserves_no_a
             .as_i64()
             .is_some_and(|bytes| bytes > 0)
     );
-    assert_eq!(payload["routeFinalizationLogicalRatio"], 1.0);
+    assert!(
+        payload["routeFinalizationLogicalRatio"]
+            .as_f64()
+            .is_some_and(|ratio| ratio > 0.0 && ratio < 1.0),
+        "the model-ready route must finalize before the complete logical JSON body"
+    );
     assert_eq!(payload["liveFirstExperimentVariant"], "treatment");
-    assert_eq!(payload["liveFirstAttemptFailed"], false);
-    assert_eq!(payload["liveFirstFallbackOrRetry"], false);
-    assert_eq!(payload["ambiguousUpstreamDelivery"], false);
+    assert_eq!(payload["liveFirstAttemptFailed"], true);
+    assert_eq!(payload["liveFirstFallbackOrRetry"], true);
+    assert_eq!(payload["ambiguousUpstreamDelivery"], true);
     assert!(payload["upstreamErrorMessage"].is_null());
 
     shared_upstream_handle.abort();

--- a/src/upstream_accounts/routing/settings_runtime.rs
+++ b/src/upstream_accounts/routing/settings_runtime.rs
@@ -906,6 +906,7 @@ pub(crate) fn build_pool_routing_runtime_cache(
         timeouts: resolve_pool_routing_timeouts_from_row(row, &state.config),
         cache_hit_protection: resolve_cache_hit_protection_settings(row),
         live_request_streaming: resolve_live_request_streaming_settings(row),
+        live_request_route_dependencies: LiveRequestRouteDependencyProfile::default(),
         model_routing: PoolModelRoutingRuntimeCache::default(),
         prompt_route_cache: Arc::new(std::sync::Mutex::new(PoolRoutingPromptRouteCache::default())),
         sticky_route_cache: Arc::new(std::sync::Mutex::new(PoolRoutingStickyRouteCache::default())),
@@ -925,6 +926,10 @@ async fn refresh_pool_routing_runtime_cache_locked(
     let row = load_pool_routing_settings_seeded(&state.pool, &state.config).await?;
     let mut cache = build_pool_routing_runtime_cache(state, &row)?;
     let mut model_routing = build_pool_model_routing_runtime_cache(&state.pool).await?;
+    if cache.live_request_streaming.enabled {
+        cache.live_request_route_dependencies =
+            load_live_request_route_dependency_profile(&state.pool, &model_routing).await?;
+    }
     #[cfg(test)]
     {
         cache.sqlite_data_version = pool_routing_sqlite_data_version(state).await?;
@@ -941,6 +946,72 @@ async fn refresh_pool_routing_runtime_cache_locked(
     cache.model_routing = model_routing;
     *runtime_cache = Some(cache.clone());
     Ok(cache)
+}
+
+async fn load_live_request_route_dependency_profile(
+    pool: &Pool<Sqlite>,
+    model_routing: &PoolModelRoutingRuntimeCache,
+) -> Result<LiveRequestRouteDependencyProfile> {
+    // This runs only while rebuilding the immutable routing snapshot. Live
+    // requests consult the resulting profile in memory and never perform this
+    // existence check on their hot path.
+    let (sticky_routes_present, prompt_cache_routes_present, encrypted_session_owners_present): (
+        i64,
+        i64,
+        i64,
+    ) = sqlx::query_as(
+        r#"
+        SELECT
+            EXISTS(SELECT 1 FROM pool_sticky_routes LIMIT 1)
+                OR EXISTS(SELECT 1 FROM pool_sticky_model_routes LIMIT 1),
+            EXISTS(SELECT 1 FROM prompt_cache_conversation_bindings LIMIT 1),
+            EXISTS(SELECT 1 FROM prompt_cache_encrypted_session_owners LIMIT 1)
+        "#,
+    )
+    .fetch_one(pool)
+    .await
+    .context("load live request route dependency profile")?;
+
+    let response_image_capability_gap = model_routing
+        .routing_candidates
+        .iter()
+        .filter_map(|candidate| model_routing.routing_account_rows_by_id.get(&candidate.id))
+        .any(|account| {
+            matches!(
+                effective_capability_support(
+                    decode_capability_support(account.response_image_tool_capability.as_deref()),
+                    decode_capability_override(
+                        account
+                            .policy_response_image_tool_capability_override
+                            .as_deref(),
+                    ),
+                ),
+                CapabilitySupport::Unsupported
+            )
+        });
+    let codex_imagegen_capability_gap = model_routing
+        .routing_candidates
+        .iter()
+        .filter_map(|candidate| model_routing.routing_account_rows_by_id.get(&candidate.id))
+        .any(|account| {
+            matches!(
+                effective_capability_support(
+                    decode_capability_support(account.codex_imagegen_capability.as_deref()),
+                    decode_capability_override(
+                        account.policy_codex_imagegen_capability_override.as_deref(),
+                    ),
+                ),
+                CapabilitySupport::Unsupported
+            )
+        });
+
+    Ok(LiveRequestRouteDependencyProfile {
+        sticky_routes_present: sticky_routes_present != 0,
+        prompt_cache_routes_present: prompt_cache_routes_present != 0,
+        encrypted_session_owners_present: encrypted_session_owners_present != 0,
+        response_image_capability_gap,
+        codex_imagegen_capability_gap,
+    })
 }
 
 pub(crate) async fn load_pool_routing_runtime_cache(


### PR DESCRIPTION
Summary: restore pre-EOF request-body forwarding after the model and active routing bindings are available. Derive route dependencies from the immutable routing cache without per-request SQLite reads. Persist actual route-finalization byte offsets for live-streaming benefit analysis.

Validation: targeted live-forwarding regression passed; dependency-policy regression passed; route-profile regression passed; cargo fmt check passed; git diff check passed.