### PR TITLE
fix(release): generate user-facing release notes

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -1009,8 +1009,18 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     )
     outputs = require_mapping(release_meta.get("outputs"), "release.yml.jobs.release-meta.outputs")
     require("target_sha" in outputs, "release.yml.jobs.release-meta.outputs.target_sha must be exported")
-    require("snapshot_source" in outputs, "release.yml.jobs.release-meta.outputs.snapshot_source must be exported")
-    require("manual_reason" in outputs, "release.yml.jobs.release-meta.outputs.manual_reason must be exported")
+    for output_name in (
+        "snapshot_source",
+        "manual_version",
+        "manual_bump",
+        "manual_reason",
+        "manual_actor",
+        "manual_triggered_at",
+    ):
+        require(
+            output_name not in outputs,
+            f"release.yml.jobs.release-meta.outputs.{output_name} must not be exported for Release body rendering",
+        )
 
     target_step = step_config(release_meta, "Resolve requested commit", "release.yml.jobs.release-meta")
     target_run = str(target_step.get("run", ""))
@@ -1160,11 +1170,39 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     require("git fetch --tags origin" in tag_run, "release.yml.jobs.release-publish tag step must fetch existing tags")
     release_step = step_config(publish, "Create GitHub Release", "release.yml.jobs.release-publish")
     release_env = require_mapping(release_step.get("env"), "release.yml.jobs.release-publish.steps['Create GitHub Release'].env")
-    require(release_env.get("SNAPSHOT_SOURCE") == "${{ needs.release-meta.outputs.snapshot_source }}", "release.yml.jobs.release-publish: release body must consume snapshot_source")
-    require(release_env.get("MANUAL_REASON") == "${{ needs.release-meta.outputs.manual_reason }}", "release.yml.jobs.release-publish: release body must consume manual_reason")
+    require(
+        set(release_env) == {"RELEASE_TAG", "RELEASE_PRERELEASE"},
+        "release.yml.jobs.release-publish: Create GitHub Release env must only carry tag and prerelease state",
+    )
     release_script = str(release_step.get("with", {}).get("script", ""))
-    require("Manual release override:" in release_script, "release.yml.jobs.release-publish: release body must include manual override audit block")
-    require("manualReason" in release_script, "release.yml.jobs.release-publish: release body must render manual reason")
+    create_release_marker = "await github.rest.repos.createRelease({"
+    require(create_release_marker in release_script, "release.yml.jobs.release-publish: createRelease call is required")
+    create_release_body = release_script.split(create_release_marker, 1)[1]
+    create_release_end = create_release_body.find("\n})")
+    require(create_release_end >= 0, "release.yml.jobs.release-publish: createRelease call must close its options object")
+    create_release_body = create_release_body[:create_release_end]
+    require(
+        "generate_release_notes: true" in create_release_body,
+        "release.yml.jobs.release-publish: createRelease must set generate_release_notes: true",
+    )
+    require(
+        not any(line.strip().startswith("body:") for line in create_release_body.splitlines()),
+        "release.yml.jobs.release-publish: createRelease must not set body",
+    )
+    for forbidden_marker in (
+        "PR:",
+        "Channel:",
+        "Bump:",
+        "Commit:",
+        "Manual release override:",
+        "manualReason",
+        "manualActor",
+        "manualTriggeredAt",
+    ):
+        require(
+            forbidden_marker not in create_release_body,
+            f"release.yml.jobs.release-publish: createRelease must not render {forbidden_marker!r}",
+        )
     comment_step = step_config(publish, "Upsert PR release version comment", "release.yml.jobs.release-publish")
     comment_env = require_mapping(comment_step.get("env"), "release.yml.jobs.release-publish.steps['Upsert PR release version comment'].env")
     require(comment_env.get("RELEASE_PR_NUMBER") == "${{ needs.release-meta.outputs.pr_number }}", "release.yml.jobs.release-publish: PR release comment must consume pr_number")

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -31,7 +31,7 @@ on:
           - stable
           - rc
       reason:
-        description: Required for manual release overrides; written to the release audit trail.
+        description: Required for manual release overrides; used for this run's validation.
         required: false
         type: string
 
@@ -82,12 +82,6 @@ jobs:
       release_tag: ${{ steps.snapshot.outputs.release_tag }}
       release_prerelease: ${{ steps.snapshot.outputs.release_prerelease }}
       tags_csv: ${{ steps.snapshot.outputs.tags_csv }}
-      snapshot_source: ${{ steps.snapshot.outputs.snapshot_source }}
-      manual_version: ${{ steps.snapshot.outputs.manual_version }}
-      manual_bump: ${{ steps.snapshot.outputs.manual_bump }}
-      manual_reason: ${{ steps.snapshot.outputs.manual_reason }}
-      manual_actor: ${{ steps.snapshot.outputs.manual_actor }}
-      manual_triggered_at: ${{ steps.snapshot.outputs.manual_triggered_at }}
       candidate_suffix: ${{ steps.candidate.outputs.candidate_suffix }}
     timeout-minutes: 20
     steps:
@@ -565,35 +559,13 @@ jobs:
       - name: Create GitHub Release
         uses: actions/github-script@v9
         env:
-          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
           RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
           RELEASE_PRERELEASE: ${{ needs.release-meta.outputs.release_prerelease }}
-          RELEASE_PR_NUMBER: ${{ needs.release-meta.outputs.pr_number }}
-          RELEASE_PR_TITLE: ${{ needs.release-meta.outputs.pr_title }}
-          RELEASE_BUMP: ${{ needs.release-meta.outputs.release_bump }}
-          RELEASE_CHANNEL: ${{ needs.release-meta.outputs.release_channel }}
-          SNAPSHOT_SOURCE: ${{ needs.release-meta.outputs.snapshot_source }}
-          MANUAL_VERSION: ${{ needs.release-meta.outputs.manual_version }}
-          MANUAL_BUMP: ${{ needs.release-meta.outputs.manual_bump }}
-          MANUAL_REASON: ${{ needs.release-meta.outputs.manual_reason }}
-          MANUAL_ACTOR: ${{ needs.release-meta.outputs.manual_actor }}
-          MANUAL_TRIGGERED_AT: ${{ needs.release-meta.outputs.manual_triggered_at }}
         with:
           script: |
             const { owner, repo } = context.repo
             const tag = process.env.RELEASE_TAG
             const prerelease = process.env.RELEASE_PRERELEASE === 'true'
-            const prNumber = process.env.RELEASE_PR_NUMBER
-            const prTitle = process.env.RELEASE_PR_TITLE
-            const bump = process.env.RELEASE_BUMP
-            const channel = process.env.RELEASE_CHANNEL
-            const targetSha = process.env.TARGET_SHA
-            const snapshotSource = process.env.SNAPSHOT_SOURCE
-            const manualVersion = process.env.MANUAL_VERSION
-            const manualBump = process.env.MANUAL_BUMP
-            const manualReason = process.env.MANUAL_REASON
-            const manualActor = process.env.MANUAL_ACTOR
-            const manualTriggeredAt = process.env.MANUAL_TRIGGERED_AT
 
             if (!tag) {
               core.setFailed('Missing RELEASE_TAG')
@@ -612,32 +584,13 @@ jobs:
               return
             }
 
-            const bodyLines = [
-              prNumber ? `PR: #${prNumber} ${prTitle || ''}`.trim() : 'PR: (unknown)',
-              `Channel: ${channel || '(unknown)'}`,
-              `Bump: ${bump || '(unknown)'}`,
-              `Commit: ${targetSha || '(unknown)'}`,
-            ]
-            if (snapshotSource === 'manual-release-override') {
-              bodyLines.push(
-                '',
-                'Manual release override:',
-                `- Source: ${snapshotSource}`,
-                `- Requested by: ${manualActor || '(unknown)'}`,
-                `- Requested at: ${manualTriggeredAt || '(unknown)'}`,
-                `- Version: ${manualVersion || '(not provided)'}`,
-                `- Bump: ${manualBump || '(not provided)'}`,
-                `- Reason: ${manualReason || '(missing)'}`,
-              )
-            }
-
             await github.rest.repos.createRelease({
               owner,
               repo,
               tag_name: tag,
               name: tag,
               prerelease,
-              body: bodyLines.join('\n'),
+              generate_release_notes: true,
             })
 
             core.notice(`Created GitHub Release for tag ${tag}`)

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -31,7 +31,7 @@ on:
           - stable
           - rc
       reason:
-        description: Required for manual release overrides; written to the release audit trail.
+        description: Required for manual release overrides; used for this run's validation.
         required: false
         type: string
 
@@ -82,12 +82,6 @@ jobs:
       release_tag: ${{ steps.snapshot.outputs.release_tag }}
       release_prerelease: ${{ steps.snapshot.outputs.release_prerelease }}
       tags_csv: ${{ steps.snapshot.outputs.tags_csv }}
-      snapshot_source: ${{ steps.snapshot.outputs.snapshot_source }}
-      manual_version: ${{ steps.snapshot.outputs.manual_version }}
-      manual_bump: ${{ steps.snapshot.outputs.manual_bump }}
-      manual_reason: ${{ steps.snapshot.outputs.manual_reason }}
-      manual_actor: ${{ steps.snapshot.outputs.manual_actor }}
-      manual_triggered_at: ${{ steps.snapshot.outputs.manual_triggered_at }}
       candidate_suffix: ${{ steps.candidate.outputs.candidate_suffix }}
     timeout-minutes: 20
     steps:
@@ -565,35 +559,13 @@ jobs:
       - name: Create GitHub Release
         uses: actions/github-script@v9
         env:
-          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
           RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
           RELEASE_PRERELEASE: ${{ needs.release-meta.outputs.release_prerelease }}
-          RELEASE_PR_NUMBER: ${{ needs.release-meta.outputs.pr_number }}
-          RELEASE_PR_TITLE: ${{ needs.release-meta.outputs.pr_title }}
-          RELEASE_BUMP: ${{ needs.release-meta.outputs.release_bump }}
-          RELEASE_CHANNEL: ${{ needs.release-meta.outputs.release_channel }}
-          SNAPSHOT_SOURCE: ${{ needs.release-meta.outputs.snapshot_source }}
-          MANUAL_VERSION: ${{ needs.release-meta.outputs.manual_version }}
-          MANUAL_BUMP: ${{ needs.release-meta.outputs.manual_bump }}
-          MANUAL_REASON: ${{ needs.release-meta.outputs.manual_reason }}
-          MANUAL_ACTOR: ${{ needs.release-meta.outputs.manual_actor }}
-          MANUAL_TRIGGERED_AT: ${{ needs.release-meta.outputs.manual_triggered_at }}
         with:
           script: |
             const { owner, repo } = context.repo
             const tag = process.env.RELEASE_TAG
             const prerelease = process.env.RELEASE_PRERELEASE === 'true'
-            const prNumber = process.env.RELEASE_PR_NUMBER
-            const prTitle = process.env.RELEASE_PR_TITLE
-            const bump = process.env.RELEASE_BUMP
-            const channel = process.env.RELEASE_CHANNEL
-            const targetSha = process.env.TARGET_SHA
-            const snapshotSource = process.env.SNAPSHOT_SOURCE
-            const manualVersion = process.env.MANUAL_VERSION
-            const manualBump = process.env.MANUAL_BUMP
-            const manualReason = process.env.MANUAL_REASON
-            const manualActor = process.env.MANUAL_ACTOR
-            const manualTriggeredAt = process.env.MANUAL_TRIGGERED_AT
 
             if (!tag) {
               core.setFailed('Missing RELEASE_TAG')
@@ -612,32 +584,13 @@ jobs:
               return
             }
 
-            const bodyLines = [
-              prNumber ? `PR: #${prNumber} ${prTitle || ''}`.trim() : 'PR: (unknown)',
-              `Channel: ${channel || '(unknown)'}`,
-              `Bump: ${bump || '(unknown)'}`,
-              `Commit: ${targetSha || '(unknown)'}`,
-            ]
-            if (snapshotSource === 'manual-release-override') {
-              bodyLines.push(
-                '',
-                'Manual release override:',
-                `- Source: ${snapshotSource}`,
-                `- Requested by: ${manualActor || '(unknown)'}`,
-                `- Requested at: ${manualTriggeredAt || '(unknown)'}`,
-                `- Version: ${manualVersion || '(not provided)'}`,
-                `- Bump: ${manualBump || '(not provided)'}`,
-                `- Reason: ${manualReason || '(missing)'}`,
-              )
-            }
-
             await github.rest.repos.createRelease({
               owner,
               repo,
               tag_name: tag,
               name: tag,
               prerelease,
-              body: bodyLines.join('\n'),
+              generate_release_notes: true,
             })
 
             core.notice(`Created GitHub Release for tag ${tag}`)

--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -1010,12 +1010,6 @@ def export_manual_override_snapshot(args: argparse.Namespace) -> int:
         triggered_at=args.triggered_at,
     )
     write_json(Path(args.output), snapshot)
-    print(
-        "manual release override snapshot: "
-        f"target_sha={target_sha} release_tag={snapshot['release_tag']} "
-        f"channel={snapshot['release_channel']} actor={snapshot['manual_actor']}",
-        file=sys.stderr,
-    )
     return 0
 
 

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -128,6 +128,51 @@ done
 
 python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$simplified_topology_repo" --profile final
 
+release_notes_repo="$tmp_dir/release-notes-repo"
+copy_repo_snapshot "$baseline_repo" "$release_notes_repo"
+python3 - <<'PY' "$release_notes_repo"
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/release.yml"
+text = path.read_text()
+needle = "              generate_release_notes: true,\n"
+if needle not in text:
+    raise SystemExit("failed to locate generated release notes option")
+path.write_text(text.replace(needle, "", 1))
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$release_notes_repo" --profile final >/dev/null 2>"$tmp_dir/release-notes.log"; then
+  echo "expected missing generated release notes option fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "createRelease must set generate_release_notes: true" "$tmp_dir/release-notes.log"
+
+release_body_repo="$tmp_dir/release-body-repo"
+copy_repo_snapshot "$baseline_repo" "$release_body_repo"
+python3 - <<'PY' "$release_body_repo"
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/release.yml"
+text = path.read_text()
+needle = "              generate_release_notes: true,\n"
+replacement = needle + "              body: 'legacy metadata',\n"
+if needle not in text:
+    raise SystemExit("failed to locate generated release notes option")
+path.write_text(text.replace(needle, replacement, 1))
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$release_body_repo" --profile final >/dev/null 2>"$tmp_dir/release-body.log"; then
+  echo "expected custom release body fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "createRelease must not set body" "$tmp_dir/release-body.log"
+
 label_concurrency_repo="$tmp_dir/label-concurrency-repo"
 copy_repo_snapshot "$baseline_repo" "$label_concurrency_repo"
 python3 - <<'PY' "$label_concurrency_repo"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ on:
           - stable
           - rc
       reason:
-        description: Required for manual release overrides; written to the release audit trail.
+        description: Required for manual release overrides; used for this run's validation.
         required: false
         type: string
 
@@ -82,12 +82,6 @@ jobs:
       release_tag: ${{ steps.snapshot.outputs.release_tag }}
       release_prerelease: ${{ steps.snapshot.outputs.release_prerelease }}
       tags_csv: ${{ steps.snapshot.outputs.tags_csv }}
-      snapshot_source: ${{ steps.snapshot.outputs.snapshot_source }}
-      manual_version: ${{ steps.snapshot.outputs.manual_version }}
-      manual_bump: ${{ steps.snapshot.outputs.manual_bump }}
-      manual_reason: ${{ steps.snapshot.outputs.manual_reason }}
-      manual_actor: ${{ steps.snapshot.outputs.manual_actor }}
-      manual_triggered_at: ${{ steps.snapshot.outputs.manual_triggered_at }}
       candidate_suffix: ${{ steps.candidate.outputs.candidate_suffix }}
     timeout-minutes: 20
     steps:
@@ -565,35 +559,13 @@ jobs:
       - name: Create GitHub Release
         uses: actions/github-script@v9
         env:
-          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
           RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
           RELEASE_PRERELEASE: ${{ needs.release-meta.outputs.release_prerelease }}
-          RELEASE_PR_NUMBER: ${{ needs.release-meta.outputs.pr_number }}
-          RELEASE_PR_TITLE: ${{ needs.release-meta.outputs.pr_title }}
-          RELEASE_BUMP: ${{ needs.release-meta.outputs.release_bump }}
-          RELEASE_CHANNEL: ${{ needs.release-meta.outputs.release_channel }}
-          SNAPSHOT_SOURCE: ${{ needs.release-meta.outputs.snapshot_source }}
-          MANUAL_VERSION: ${{ needs.release-meta.outputs.manual_version }}
-          MANUAL_BUMP: ${{ needs.release-meta.outputs.manual_bump }}
-          MANUAL_REASON: ${{ needs.release-meta.outputs.manual_reason }}
-          MANUAL_ACTOR: ${{ needs.release-meta.outputs.manual_actor }}
-          MANUAL_TRIGGERED_AT: ${{ needs.release-meta.outputs.manual_triggered_at }}
         with:
           script: |
             const { owner, repo } = context.repo
             const tag = process.env.RELEASE_TAG
             const prerelease = process.env.RELEASE_PRERELEASE === 'true'
-            const prNumber = process.env.RELEASE_PR_NUMBER
-            const prTitle = process.env.RELEASE_PR_TITLE
-            const bump = process.env.RELEASE_BUMP
-            const channel = process.env.RELEASE_CHANNEL
-            const targetSha = process.env.TARGET_SHA
-            const snapshotSource = process.env.SNAPSHOT_SOURCE
-            const manualVersion = process.env.MANUAL_VERSION
-            const manualBump = process.env.MANUAL_BUMP
-            const manualReason = process.env.MANUAL_REASON
-            const manualActor = process.env.MANUAL_ACTOR
-            const manualTriggeredAt = process.env.MANUAL_TRIGGERED_AT
 
             if (!tag) {
               core.setFailed('Missing RELEASE_TAG')
@@ -612,32 +584,13 @@ jobs:
               return
             }
 
-            const bodyLines = [
-              prNumber ? `PR: #${prNumber} ${prTitle || ''}`.trim() : 'PR: (unknown)',
-              `Channel: ${channel || '(unknown)'}`,
-              `Bump: ${bump || '(unknown)'}`,
-              `Commit: ${targetSha || '(unknown)'}`,
-            ]
-            if (snapshotSource === 'manual-release-override') {
-              bodyLines.push(
-                '',
-                'Manual release override:',
-                `- Source: ${snapshotSource}`,
-                `- Requested by: ${manualActor || '(unknown)'}`,
-                `- Requested at: ${manualTriggeredAt || '(unknown)'}`,
-                `- Version: ${manualVersion || '(not provided)'}`,
-                `- Bump: ${manualBump || '(not provided)'}`,
-                `- Reason: ${manualReason || '(missing)'}`,
-              )
-            }
-
             await github.rest.repos.createRelease({
               owner,
               repo,
               tag_name: tag,
               name: tag,
               prerelease,
-              body: bodyLines.join('\n'),
+              generate_release_notes: true,
             })
 
             core.notice(`Created GitHub Release for tag ${tag}`)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Codex Vibe Monitor Context
 
-This context freezes the invocation-observability terms that the product uses in diagnostics, badges, and companion docs. It exists to keep transport paths, request semantics, and response outcomes from drifting into overloaded labels.
+This context freezes the project-specific terms used in invocation observability and release automation. It exists to keep transport paths, request semantics, response outcomes, and publication surfaces from drifting into overloaded labels.
 
 ## Invocation Compaction
 
@@ -45,3 +45,21 @@ _Avoid_: Tooltip 明细, 原始数据
 **可用内容宽度**:
 统计卡片扣除内边距、图标及间距后，数值文本实际可占用的单行宽度；它不是固定视口或卡片断点。
 _Avoid_: 窄卡片阈值, 固定像素宽度
+
+## Release Automation
+
+**Release 正文**:
+GitHub Release 页面中面向使用者的发布说明；只包含明确的用户向 release notes，不混入流程元数据。
+_Avoid_: PR 元数据, 发布审计, CI 诊断
+
+**自动生成发布说明**:
+基于相邻发布 tag 之间变更生成的用户向 Release 正文；它是当前 Release 正文的来源。
+_Avoid_: PR 正文转抄, 流程元数据拼接
+
+**发布决策快照**:
+与主线提交绑定的不可变自动发布决策记录，保存版本意图与发布计算所需字段；手工覆盖字段只存在于本次 workflow 的临时快照，不写入该记录。
+_Avoid_: Release 正文, 手工覆盖审计, 公开变更说明
+
+**PR 发布评论**:
+附在源 PR 上的版本交付追溯记录；它独立于 GitHub Release 页面。
+_Avoid_: Release 正文, 发布说明

--- a/docs/specs/m7q2r-manual-release-override/HISTORY.md
+++ b/docs/specs/m7q2r-manual-release-override/HISTORY.md
@@ -8,3 +8,4 @@
 - 不带 `version`、`bump`、`reason` 的 `workflow_dispatch` 保留为内部 release queue/backfill 兼容路径；提供任一手动覆盖输入时才启用严格 manual override 校验。
 - `channel=rc` 沿用自动发版的 `vX.Y.Z-rc.<sha7>` tag 形态，且永不更新 `latest`。
 - 修改受控 workflow contract 时，Label Gate 必须具备同仓 current-branch self-validation 路径；否则 `main` 上的旧 checker 会把新拓扑误判为 drift。
+- Release 正文改为 GitHub 原生自动说明；手工覆盖字段继续留在 job-local 计算中，但不复制到 Release、PR 评论、Git note、artifact 或专用审计日志。

--- a/docs/specs/m7q2r-manual-release-override/IMPLEMENTATION.md
+++ b/docs/specs/m7q2r-manual-release-override/IMPLEMENTATION.md
@@ -6,7 +6,7 @@
 
 - [x] M1: `release_snapshot.py` 支持 job-local `manual-release-override` snapshot。
 - [x] M2: `release.yml` 支持手动覆盖 dispatch 输入，并保持内部 queue dispatch 的 immutable snapshot backfill 兼容。
-- [x] M3: GitHub Release body 输出手动覆盖审计字段。
+- [x] M3: GitHub Release body 使用 GitHub 自动生成说明，不输出流程元数据或手工覆盖审计字段。
 - [x] M4: release snapshot 与 quality-gates contract 回归测试覆盖新路径。
 - [x] M5: `label-gate.yml` 对同仓 quality-gates / workflow contract 变更使用当前分支 checker 自证，避免旧 base checker 永久挡住受控拓扑变更。
 
@@ -15,3 +15,4 @@
 - `bash .github/scripts/test-release-snapshot.sh`
 - `bash .github/scripts/test-quality-gates-contract.sh`
 - `python3 -m py_compile .github/scripts/release_snapshot.py .github/scripts/check_quality_gates_contract.py`
+- `git diff --check`

--- a/docs/specs/m7q2r-manual-release-override/SPEC.md
+++ b/docs/specs/m7q2r-manual-release-override/SPEC.md
@@ -10,8 +10,9 @@
 
 - 允许维护者对 `origin/main` 上的 40 位 commit SHA 发起受控手动发版。
 - 手动发版必须显式选择 `version` 或 `bump`，并提供 reason。
+- 手动覆盖的 reason、actor 与触发时间继续用于本次 workflow 的输入校验和版本计算，但不产生额外的持久化审计记录。
 - 手动发版必须复用现有多架构 build、smoke、manifest、Git tag、GitHub Release 与 PR comment 发布链路。
-- 手动覆盖信息必须可审计，至少出现在 GitHub Release body 与 workflow log 中。
+- GitHub Release 正文必须使用 GitHub 原生自动生成的用户向变更说明，不包含 PR、channel、bump、commit 或手工覆盖元数据。
 - 自动 PR label 发版路径继续只消费 immutable release snapshot，不受手动覆盖影响。
 
 ### Non-goals
@@ -23,7 +24,7 @@
 
 ## 范围（Scope）
 
-- `.github/workflows/release.yml`：增加手动覆盖输入、dispatch 分流与 Release body 审计输出。
+- `.github/workflows/release.yml`：增加手动覆盖输入、dispatch 分流与 GitHub 自动 Release notes。
 - `.github/scripts/release_snapshot.py`：增加 job-local `manual-release-override` snapshot 构造与校验。
 - `.github/scripts/test-release-snapshot.sh` 与 quality-gates contract fixtures：覆盖手动发版输入和 workflow 拓扑。
 
@@ -44,7 +45,7 @@
 
 - 只在 `workflow_dispatch` 提供手动覆盖输入时启用 manual override snapshot。
 - 不带 `version`、`bump`、`reason` 的内部 release queue dispatch 继续按 immutable snapshot backfill 行为运行。
-- Release body 中直接展示 source、actor、triggered_at、version/bump 与 reason。
+- Release body 使用默认扁平的 GitHub “What’s Changed” 说明，不转抄 PR 正文或流程元数据。
 
 ## 验收标准（Acceptance Criteria）
 
@@ -63,6 +64,12 @@
 - Given 目标 tag 已存在并指向其它 commit
   When 触发手动覆盖
   Then workflow 失败且不进入 publish jobs。
+- Given 任意自动或手动发布路径创建 GitHub Release
+  When 发布成功
+  Then Release body 由 GitHub 自动生成，且不包含 PR、Channel、Bump、Commit 或手工覆盖审计字段。
+- Given 手工覆盖输入通过 release meta 校验
+  When workflow 继续执行
+  Then reason、actor 与触发时间仅用于本次 job-local 计算，不被写入额外 Git note、artifact、Release body、PR comment 或专用审计日志。
 
 ## 参考（References）
 


### PR DESCRIPTION
## Summary

- Use GitHub-generated release notes instead of workflow metadata in Release bodies.
- Keep manual override validation and release computation job-local without a dedicated audit record.
- Add contract regressions and sync the release spec/context terminology.

## Validation

- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 -m py_compile .github/scripts/release_snapshot.py .github/scripts/check_quality_gates_contract.py`
- `git diff --check`