### PR TITLE
fix(maintenance): schedule pressure defers once

### DIFF
--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -139,6 +139,12 @@ impl DbPressureGate {
         None
     }
 
+    pub(crate) fn pressure_cooldown_deadline_epoch_ms(&self) -> Option<u64> {
+        let now_ms = current_epoch_ms();
+        let deadline_ms = self.pressure_until_epoch_ms.load(Ordering::Acquire);
+        (deadline_ms > now_ms).then_some(deadline_ms)
+    }
+
     pub(crate) fn try_begin_background(
         &self,
         _task: &'static str,
@@ -329,6 +335,29 @@ mod tests {
         ));
         assert_eq!(gate.snapshot().pressure_events, 1);
         assert_eq!(gate.snapshot().background_skips, 1);
+    }
+
+    #[test]
+    fn cooldown_deadline_stays_stable_across_denials() {
+        let gate = DbPressureGate::new(1, Duration::from_secs(60));
+        gate.record_pressure("test", "forced");
+
+        let deadline = gate
+            .pressure_cooldown_deadline_epoch_ms()
+            .expect("active pressure cooldown deadline");
+        assert!(matches!(
+            gate.try_begin_background("first"),
+            Err(DbPressureDenyReason::PressureCooldown { .. })
+        ));
+        assert!(matches!(
+            gate.try_begin_background("second"),
+            Err(DbPressureDenyReason::PressureCooldown { .. })
+        ));
+        assert_eq!(
+            gate.pressure_cooldown_deadline_epoch_ms(),
+            Some(deadline),
+            "a cooldown must keep one absolute next-eligibility deadline"
+        );
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -3,6 +3,8 @@ use super::*;
 const STARTUP_HISTORICAL_ROLLUP_BATCH_LIMIT: u64 = 16;
 const STARTUP_HISTORICAL_ROLLUP_BUDGET_SECS: u64 = 6;
 const COVERAGE_REPAIR_RETRY_DELAYS_SECS: [u64; 4] = [15, 60, 5 * 60, 15 * 60];
+const SQLITE_PRESSURE_COOLDOWN_SUSPENSION_REASON: &str = "sqlite_pressure_cooldown";
+const BACKGROUND_DB_BUSY_SUSPENSION_REASON: &str = "background_db_busy";
 
 pub(crate) fn push_backfill_sample(samples: &mut Vec<String>, sample: String) {
     if samples.len() < STARTUP_BACKFILL_LOG_SAMPLE_LIMIT {
@@ -250,6 +252,70 @@ struct StartupBackfillTaskRunOutcome {
     deferred: bool,
     completed: bool,
     next_due: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupBackfillFailureKind {
+    SqliteBusyOrLocked,
+    Operation,
+}
+
+impl StartupBackfillFailureKind {
+    fn telemetry_reason(self) -> &'static str {
+        match self {
+            Self::SqliteBusyOrLocked => "sqlite_busy_or_locked",
+            Self::Operation => "operation_error",
+        }
+    }
+}
+
+fn startup_backfill_failure_kind(err: &anyhow::Error) -> StartupBackfillFailureKind {
+    let has_busy_message = err.chain().any(|cause| {
+        cause
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("database is busy")
+    });
+    if crate::is_sqlite_lock_error(err) || has_busy_message {
+        StartupBackfillFailureKind::SqliteBusyOrLocked
+    } else {
+        StartupBackfillFailureKind::Operation
+    }
+}
+
+fn startup_backfill_pressure_retry_at(
+    gate: &crate::db_pressure::DbPressureGate,
+    reason: crate::db_pressure::DbPressureDenyReason,
+) -> DateTime<Utc> {
+    match reason {
+        crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => gate
+            .pressure_cooldown_deadline_epoch_ms()
+            .and_then(|deadline_ms| {
+                i64::try_from(deadline_ms)
+                    .ok()
+                    .and_then(DateTime::<Utc>::from_timestamp_millis)
+            })
+            .unwrap_or_else(|| {
+                let remaining_ms = i64::try_from(remaining_ms.max(1)).unwrap_or(i64::MAX);
+                Utc::now() + ChronoDuration::milliseconds(remaining_ms)
+            }),
+        crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
+            Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
+        }
+    }
+}
+
+fn startup_backfill_pressure_suspension_reason(
+    reason: crate::db_pressure::DbPressureDenyReason,
+) -> &'static str {
+    match reason {
+        crate::db_pressure::DbPressureDenyReason::PressureCooldown { .. } => {
+            SQLITE_PRESSURE_COOLDOWN_SUSPENSION_REASON
+        }
+        crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
+            BACKGROUND_DB_BUSY_SUSPENSION_REASON
+        }
+    }
 }
 
 impl StartupBackfillTask {
@@ -1136,6 +1202,21 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
     cancel: &CancellationToken,
     selected_tasks: Option<&[StartupBackfillTask]>,
 ) -> StartupBackfillMaintenancePass {
+    run_startup_backfill_maintenance_pass_with_gate(
+        state,
+        cancel,
+        selected_tasks,
+        crate::db_pressure::global_db_pressure_gate(),
+    )
+    .await
+}
+
+pub(crate) async fn run_startup_backfill_maintenance_pass_with_gate(
+    state: Arc<AppState>,
+    cancel: &CancellationToken,
+    selected_tasks: Option<&[StartupBackfillTask]>,
+    gate: &crate::db_pressure::DbPressureGate,
+) -> StartupBackfillMaintenancePass {
     let mut had_failure = false;
     let mut ran_actionable_task = false;
     let mut had_deferred_task = false;
@@ -1160,13 +1241,7 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
             STARTUP_BACKFILL_SCHEDULER.clear_next_due(*task);
             continue;
         }
-        match run_startup_backfill_task_if_due_outcome(
-            &state,
-            *task,
-            crate::db_pressure::global_db_pressure_gate(),
-        )
-        .await
-        {
+        match run_startup_backfill_task_if_due_outcome(&state, *task, gate).await {
             Ok(outcome) => {
                 STARTUP_BACKFILL_SCHEDULER.record_next_due(*task, outcome.next_due);
                 ran_actionable_task |= outcome.actionable;
@@ -1188,8 +1263,7 @@ pub(crate) async fn run_startup_backfill_maintenance_pass(
                     Utc::now()
                         + ChronoDuration::seconds(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS as i64),
                 );
-                crate::db_pressure::global_db_pressure_gate()
-                    .record_error("startup_backfill", &err);
+                gate.record_error("startup_backfill", &err);
                 warn!(task = task.log_label(), error = %err, "startup backfill supervisor pass failed");
             }
         }
@@ -1337,33 +1411,39 @@ async fn run_startup_backfill_task_if_due_outcome(
     let _permit = match gate.try_begin_background("startup_backfill") {
         Ok(permit) => permit,
         Err(reason) => {
+            let retry_at = startup_backfill_pressure_retry_at(gate, reason);
             let retry_after = match reason {
-                crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => {
-                    Utc::now() + ChronoDuration::milliseconds(remaining_ms as i64)
+                crate::db_pressure::DbPressureDenyReason::PressureCooldown { .. } => {
+                    format_utc_iso_millis(retry_at)
                 }
                 crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
-                    Utc::now()
-                        + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
+                    format_utc_iso(retry_at)
                 }
             };
-            let retry_after = format_utc_iso(retry_after);
-            save_startup_backfill_progress(
-                &state.pool,
-                &task_name,
-                StartupBackfillProgressUpdate {
-                    cursor_id: progress.cursor_id,
-                    scanned: progress.last_scanned,
-                    updated: progress.last_updated,
-                    zero_update_streak: progress.zero_update_streak,
-                    next_run_after: &retry_after,
-                    status: &progress.last_status,
-                    suspension_reason: progress.suspension_reason.as_deref(),
-                },
-            )
-            .await?;
+            let suspension_reason = startup_backfill_pressure_suspension_reason(reason);
+            let deadline_registered = progress.next_run_after.as_deref() != Some(&retry_after)
+                || progress.suspension_reason.as_deref() != Some(suspension_reason);
+            if deadline_registered {
+                save_startup_backfill_progress(
+                    &state.pool,
+                    &task_name,
+                    StartupBackfillProgressUpdate {
+                        cursor_id: progress.cursor_id,
+                        scanned: progress.last_scanned,
+                        updated: progress.last_updated,
+                        zero_update_streak: progress.zero_update_streak,
+                        next_run_after: &retry_after,
+                        status: &progress.last_status,
+                        suspension_reason: Some(suspension_reason),
+                    },
+                )
+                .await?;
+            }
             info!(
                 task = task.log_label(),
-                reason = %reason,
+                defer_kind = "pressure_gate",
+                defer_reason = %reason,
+                deadline_registered,
                 next_retry_after = %retry_after,
                 wake_reason = "pressure_defer",
                 "startup backfill task deferred because database pressure gate is closed"
@@ -1373,7 +1453,7 @@ async fn run_startup_backfill_task_if_due_outcome(
                 failed: false,
                 deferred: true,
                 completed: true,
-                next_due: parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now),
+                next_due: retry_at,
             });
         }
     };
@@ -1455,6 +1535,7 @@ async fn run_startup_backfill_task_if_due_outcome(
             }
         }
         Err(err) => {
+            let failure_kind = startup_backfill_failure_kind(&err);
             let retry_after = format_utc_iso(
                 Utc::now() + ChronoDuration::seconds(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS as i64),
             );
@@ -1478,6 +1559,8 @@ async fn run_startup_backfill_task_if_due_outcome(
                 cursor_id = progress.cursor_id,
                 elapsed_ms = started_at.elapsed().as_millis() as u64,
                 next_run_after = %retry_after,
+                failure_kind = failure_kind.telemetry_reason(),
+                retry_kind = "bounded_operation_backoff",
                 error = %err,
                 "startup backfill pass failed"
             );
@@ -2048,6 +2131,39 @@ mod startup_backfill_tests {
         assert_eq!(recovered.state, "healthy");
         assert_eq!(recovered.failure_count, 1);
         assert_eq!(recovered.failed_task_count, 0);
+    }
+
+    #[test]
+    fn pressure_defer_uses_the_gate_absolute_deadline() {
+        let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+        gate.record_pressure("test", "forced");
+        let expected_deadline = gate
+            .pressure_cooldown_deadline_epoch_ms()
+            .expect("active pressure cooldown deadline");
+
+        let retry_at = startup_backfill_pressure_retry_at(
+            &gate,
+            crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms: 1 },
+        );
+
+        assert_eq!(retry_at.timestamp_millis() as u64, expected_deadline);
+    }
+
+    #[test]
+    fn sqlite_busy_and_locked_are_actual_backfill_failures() {
+        for error in [
+            anyhow::anyhow!("database is busy"),
+            anyhow::anyhow!("database table is locked"),
+        ] {
+            assert_eq!(
+                startup_backfill_failure_kind(&error),
+                StartupBackfillFailureKind::SqliteBusyOrLocked
+            );
+        }
+        assert_eq!(
+            startup_backfill_failure_kind(&anyhow::anyhow!("source unavailable")),
+            StartupBackfillFailureKind::Operation
+        );
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -305,6 +305,18 @@ fn startup_backfill_pressure_retry_at(
     }
 }
 
+fn startup_backfill_pressure_retry_after(
+    retry_at: DateTime<Utc>,
+    reason: crate::db_pressure::DbPressureDenyReason,
+) -> String {
+    match reason {
+        crate::db_pressure::DbPressureDenyReason::PressureCooldown { .. } => {
+            format_utc_iso_millis(retry_at)
+        }
+        crate::db_pressure::DbPressureDenyReason::BackgroundBusy => format_utc_iso(retry_at),
+    }
+}
+
 fn startup_backfill_pressure_suspension_reason(
     reason: crate::db_pressure::DbPressureDenyReason,
 ) -> &'static str {
@@ -1412,14 +1424,7 @@ async fn run_startup_backfill_task_if_due_outcome(
         Ok(permit) => permit,
         Err(reason) => {
             let retry_at = startup_backfill_pressure_retry_at(gate, reason);
-            let retry_after = match reason {
-                crate::db_pressure::DbPressureDenyReason::PressureCooldown { .. } => {
-                    format_utc_iso_millis(retry_at)
-                }
-                crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
-                    format_utc_iso(retry_at)
-                }
-            };
+            let retry_after = startup_backfill_pressure_retry_after(retry_at, reason);
             let suspension_reason = startup_backfill_pressure_suspension_reason(reason);
             let deadline_registered = progress.next_run_after.as_deref() != Some(&retry_after)
                 || progress.suspension_reason.as_deref() != Some(suspension_reason);
@@ -1441,6 +1446,7 @@ async fn run_startup_backfill_task_if_due_outcome(
             }
             info!(
                 task = task.log_label(),
+                reason = %reason,
                 defer_kind = "pressure_gate",
                 defer_reason = %reason,
                 deadline_registered,
@@ -1535,46 +1541,61 @@ async fn run_startup_backfill_task_if_due_outcome(
             }
         }
         Err(err) => {
-            let failure_kind = startup_backfill_failure_kind(&err);
-            let retry_after = format_utc_iso(
-                Utc::now() + ChronoDuration::seconds(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS as i64),
-            );
-            save_startup_backfill_progress(
-                &state.pool,
-                &task_name,
-                StartupBackfillProgressUpdate {
-                    cursor_id: progress.cursor_id,
-                    scanned: 0,
-                    updated: 0,
-                    zero_update_streak: progress.zero_update_streak,
-                    next_run_after: &retry_after,
-                    status: STARTUP_BACKFILL_STATUS_FAILED,
-                    suspension_reason: None,
-                },
+            let next_due = persist_startup_backfill_task_failure(
+                state, task, &task_name, &progress, started_at, &err,
             )
             .await?;
-            warn!(
-                task = task.log_label(),
-                task_name = %task_name,
-                cursor_id = progress.cursor_id,
-                elapsed_ms = started_at.elapsed().as_millis() as u64,
-                next_run_after = %retry_after,
-                failure_kind = failure_kind.telemetry_reason(),
-                retry_kind = "bounded_operation_backoff",
-                error = %err,
-                "startup backfill pass failed"
-            );
             StartupBackfillTaskRunOutcome {
                 actionable: false,
                 failed: true,
                 deferred: false,
                 completed: true,
-                next_due: parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now),
+                next_due,
             }
         }
     };
 
     Ok(outcome)
+}
+
+pub(crate) async fn persist_startup_backfill_task_failure(
+    state: &Arc<AppState>,
+    task: StartupBackfillTask,
+    task_name: &str,
+    progress: &StartupBackfillProgress,
+    started_at: Instant,
+    err: &anyhow::Error,
+) -> Result<DateTime<Utc>> {
+    let failure_kind = startup_backfill_failure_kind(err);
+    let retry_after = format_utc_iso(
+        Utc::now() + ChronoDuration::seconds(STARTUP_BACKFILL_ACTIVE_INTERVAL_SECS as i64),
+    );
+    save_startup_backfill_progress(
+        &state.pool,
+        task_name,
+        StartupBackfillProgressUpdate {
+            cursor_id: progress.cursor_id,
+            scanned: 0,
+            updated: 0,
+            zero_update_streak: progress.zero_update_streak,
+            next_run_after: &retry_after,
+            status: STARTUP_BACKFILL_STATUS_FAILED,
+            suspension_reason: None,
+        },
+    )
+    .await?;
+    warn!(
+        task = task.log_label(),
+        task_name,
+        cursor_id = progress.cursor_id,
+        elapsed_ms = started_at.elapsed().as_millis() as u64,
+        next_run_after = %retry_after,
+        failure_kind = failure_kind.telemetry_reason(),
+        retry_kind = "bounded_operation_backoff",
+        error = %err,
+        "startup backfill pass failed"
+    );
+    Ok(parse_to_utc_datetime(&retry_after).unwrap_or_else(Utc::now))
 }
 
 fn startup_backfill_run_is_actionable(run: &StartupBackfillRunState) -> bool {
@@ -2150,6 +2171,42 @@ mod startup_backfill_tests {
     }
 
     #[test]
+    fn pressure_defer_schedules_one_deadline_and_dispatches_once() {
+        let scheduler = StartupBackfillScheduler::default();
+        let task = StartupBackfillTask::ReasoningEffort;
+        let deadline = DateTime::<Utc>::from_timestamp_millis(1_800_000_000_750)
+            .expect("valid fixed pressure deadline");
+        let retry_after = startup_backfill_pressure_retry_after(
+            deadline,
+            crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms: 750 },
+        );
+        let retry_at = parse_to_utc_datetime(&retry_after).expect("parse millisecond deadline");
+        assert_eq!(retry_at, deadline);
+
+        scheduler.record_next_due(task, retry_at);
+        assert!(
+            scheduler
+                .drain_due_tasks(deadline - ChronoDuration::milliseconds(1))
+                .is_empty()
+        );
+        let waiting = scheduler.health_snapshot();
+        assert_eq!(waiting.wake_count, 0);
+        assert_eq!(waiting.due_dispatch_count, 0);
+        assert_eq!(waiting.pressure_defer_count, 0);
+        assert_eq!(waiting.scheduled_task_count, 1);
+
+        assert_eq!(scheduler.drain_due_tasks(deadline), vec![task]);
+        scheduler.record_task_result(task, false, true);
+        assert!(scheduler.drain_due_tasks(deadline).is_empty());
+        let deferred = scheduler.health_snapshot();
+        assert_eq!(deferred.wake_count, 0);
+        assert_eq!(deferred.due_dispatch_count, 1);
+        assert_eq!(deferred.pressure_defer_count, 1);
+        assert_eq!(deferred.scheduled_task_count, 0);
+        assert_eq!(deferred.deferred_task_count, 1);
+    }
+
+    #[test]
     fn sqlite_busy_and_locked_are_actual_backfill_failures() {
         for error in [
             anyhow::anyhow!("database is busy"),
@@ -2164,6 +2221,15 @@ mod startup_backfill_tests {
             startup_backfill_failure_kind(&anyhow::anyhow!("source unavailable")),
             StartupBackfillFailureKind::Operation
         );
+
+        let scheduler = StartupBackfillScheduler::default();
+        scheduler.record_task_result(StartupBackfillTask::ReasoningEffort, true, false);
+        let health = scheduler.health_snapshot();
+        assert_eq!(health.state, "degraded");
+        assert_eq!(health.failure_count, 1);
+        assert_eq!(health.pressure_defer_count, 0);
+        assert_eq!(health.failed_task_count, 1);
+        assert_eq!(health.deferred_task_count, 0);
     }
 
     #[test]

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2086,11 +2086,11 @@ async fn startup_backfill_pressure_defer_has_one_deadline_and_no_task_run_audit(
     .await;
     let task = StartupBackfillTask::ReasoningEffort;
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
-    while Utc::now().timestamp_subsec_millis() > 400 {
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_millis(500));
+    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
     gate.record_pressure("test_pressure", "forced_cooldown");
+    let expected_deadline = gate
+        .pressure_cooldown_deadline_epoch_ms()
+        .expect("active pressure cooldown deadline");
     let before: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
     )
@@ -2115,6 +2115,12 @@ async fn startup_backfill_pressure_defer_has_one_deadline_and_no_task_run_audit(
         .clone()
         .expect("persisted pressure defer deadline");
     let first_finished_at = deferred.last_finished_at.clone();
+    assert_eq!(
+        parse_to_utc_datetime(&first_deadline)
+            .expect("parse persisted pressure deadline")
+            .timestamp_millis() as u64,
+        expected_deadline
+    );
     assert!(
         !deferred.is_due(Utc::now()),
         "the subsecond cooldown deadline must not be truncated into an immediate retry"
@@ -2151,6 +2157,61 @@ async fn startup_backfill_pressure_defer_has_one_deadline_and_no_task_run_audit(
         repeated.suspension_reason.as_deref(),
         Some("sqlite_pressure_cooldown"),
         "a gate refusal must remain distinct from a SQLite operation failure"
+    );
+}
+
+#[tokio::test]
+async fn startup_backfill_busy_failure_persists_failed_state_and_bounded_retry() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::ReasoningEffort;
+    let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
+    let suspended_until = format_utc_iso(Utc::now() + ChronoDuration::hours(1));
+    save_startup_backfill_progress(
+        &state.pool,
+        &task_name,
+        StartupBackfillProgressUpdate {
+            cursor_id: 12,
+            scanned: 4,
+            updated: 0,
+            zero_update_streak: 2,
+            next_run_after: &suspended_until,
+            status: STARTUP_BACKFILL_STATUS_IDLE,
+            suspension_reason: Some("sqlite_pressure_cooldown"),
+        },
+    )
+    .await
+    .expect("seed pressure-deferred progress");
+    let progress = load_startup_backfill_progress(&state.pool, &task_name)
+        .await
+        .expect("load seeded startup backfill progress");
+    let before_retry = Utc::now();
+    persist_startup_backfill_task_failure(
+        &state,
+        task,
+        &task_name,
+        &progress,
+        std::time::Instant::now(),
+        &anyhow::anyhow!("database table is locked"),
+    )
+    .await
+    .expect("record SQLite locked backfill failure");
+
+    let failed = load_startup_backfill_progress(&state.pool, &task_name)
+        .await
+        .expect("load failed startup backfill progress");
+    let retry_at = failed
+        .next_run_after
+        .as_deref()
+        .and_then(parse_to_utc_datetime)
+        .expect("parse bounded failure retry");
+    assert_eq!(failed.last_status, STARTUP_BACKFILL_STATUS_FAILED);
+    assert_eq!(failed.suspension_reason, None);
+    assert!(
+        retry_at >= before_retry + ChronoDuration::seconds(10),
+        "SQLite BUSY/LOCKED must use the bounded failure retry rather than a pressure defer"
     );
 }
 

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2079,6 +2079,82 @@ async fn startup_backfill_pressure_defer_persists_a_retry_deadline() {
 }
 
 #[tokio::test]
+async fn startup_backfill_pressure_defer_has_one_deadline_and_no_task_run_audit() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::ReasoningEffort;
+    let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
+    while Utc::now().timestamp_subsec_millis() > 400 {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_millis(500));
+    gate.record_pressure("test_pressure", "forced_cooldown");
+    let before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs before pressure defer");
+
+    let cancel = CancellationToken::new();
+    let selected_tasks = [task];
+    let first = run_startup_backfill_maintenance_pass_with_gate(
+        state.clone(),
+        &cancel,
+        Some(&selected_tasks),
+        &gate,
+    )
+    .await;
+    let deferred = load_startup_backfill_progress(&state.pool, &task_name)
+        .await
+        .expect("load pressure-deferred task");
+    let first_deadline = deferred
+        .next_run_after
+        .clone()
+        .expect("persisted pressure defer deadline");
+    let first_finished_at = deferred.last_finished_at.clone();
+    assert!(
+        !deferred.is_due(Utc::now()),
+        "the subsecond cooldown deadline must not be truncated into an immediate retry"
+    );
+
+    let second = run_startup_backfill_maintenance_pass_with_gate(
+        state.clone(),
+        &cancel,
+        Some(&selected_tasks),
+        &gate,
+    )
+    .await;
+    let after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs after pressure defer");
+    let repeated = load_startup_backfill_progress(&state.pool, &task_name)
+        .await
+        .expect("load repeated pressure defer");
+
+    assert!(!first.ran_actionable_task);
+    assert!(!first.had_failure);
+    assert!(!second.ran_actionable_task);
+    assert!(!second.had_failure);
+    assert_eq!(after, before, "deferred passes must not create audit rows");
+    assert_eq!(
+        repeated.next_run_after.as_deref(),
+        Some(first_deadline.as_str())
+    );
+    assert_eq!(repeated.last_finished_at, first_finished_at);
+    assert_eq!(
+        repeated.suspension_reason.as_deref(),
+        Some("sqlite_pressure_cooldown"),
+        "a gate refusal must remain distinct from a SQLite operation failure"
+    );
+}
+
+#[tokio::test]
 async fn coverage_repair_defer_persists_its_own_retry_deadline() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),


### PR DESCRIPTION
## Summary
- persist one absolute millisecond deadline for startup-backfill pressure cooldowns
- preserve deferred/no-action audit suppression and distinguish gate defers from SQLite BUSY/LOCKED failures
- add deterministic scheduler and stateful SQLite regressions

## Validation
- cargo fmt --all -- --check
- cargo test --locked pressure_defer -- --nocapture
- cargo test --locked sqlite_busy_and_locked_are_actual_backfill_failures -- --nocapture
- cargo test --locked startup_backfill_busy_failure_persists_failed_state_and_bounded_retry -- --nocapture
- cargo check --locked --all-targets --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings

Initiative child for #850. Targets prd/runtime-read-model-pressure-recovery; do not merge independently.