### PR TITLE
fix(summary): recover exact archive hydration

### DIFF
--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7002,6 +7002,7 @@ const SUMMARY_SNAPSHOT_MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 // Do not turn a locked or overloaded SQLite database into a continuous sequence of timed-out
 // full hydrations. Mutations remain coalesced as dirty while this bounded retry gate is active.
 const SUMMARY_SNAPSHOT_FAILURE_RETRY_BACKOFF: Duration = Duration::from_secs(30);
+const SUMMARY_PROJECTION_MANIFEST_ADMISSION_RETRY_BACKOFF: Duration = Duration::from_secs(5 * 60);
 // A cadence refresh begins after the 10-second floor without event debounce. Its scheduling
 // phase, hub coordination allowance, and build deadline remain strictly inside the 15-second
 // serving ceiling; mutations still use the separate debounce below.
@@ -7227,6 +7228,16 @@ impl SummaryProjectionFreshness {
     }
 }
 
+fn summary_projection_manifest_admission_retry_is_due(
+    blocked_at: Option<Instant>,
+    now: Instant,
+) -> bool {
+    blocked_at.is_none_or(|blocked_at| {
+        now.saturating_duration_since(blocked_at)
+            >= SUMMARY_PROJECTION_MANIFEST_ADMISSION_RETRY_BACKOFF
+    })
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SummaryProjection {
     records: Vec<SummaryProjectionRecord>,
@@ -7290,9 +7301,12 @@ pub(crate) struct SummaryProjection {
     // keep their freshness independent from the projection-wide timestamp.
     all_time_refreshed_at: Option<Instant>,
     // An all-history manifest set beyond admission cannot be made exact without an unbounded
-    // proof. Preserve that fail-closed result so maintenance does not retry the same query on
-    // every rolling refresh.
-    all_time_manifest_admission_blocked: bool,
+    // proof. Retry only after a long, controlled backoff so maintenance does not recreate the
+    // production pressure pattern while a recoverable all-time source is unavailable.
+    all_time_manifest_admission_blocked_at: Option<Instant>,
+    // Account discovery has a distinct admission budget. It must not suppress an exact global
+    // all-time aggregate when only the account scope cannot be proven.
+    all_time_account_manifest_admission_blocked_at: Option<Instant>,
     // Global all-time rollups and account archive fallbacks have independent durable coverage.
     // A failed account rebuild must not make a fresh global aggregate stale, and an old account
     // response must never borrow the global aggregate's freshness.
@@ -7317,10 +7331,6 @@ pub(crate) struct SummaryProjection {
     // than publishing an undercount or turning a selection-level unavailability into an HTTP
     // builder failure.
     unavailable_unmaterialized_archive_ranges: Vec<ExactUtcRange>,
-    // Boundary archive admission is independent from all-time admission. The projection keeps
-    // this state so an oversized exact-horizon manifest set does not make later refreshes repeat
-    // the same SQLite work while affected windows remain unavailable.
-    archive_boundary_manifest_admission_blocked: bool,
     // In-progress state is not the same thing as a row whose persisted status happens to be
     // `running`: the typed runtime overlay reconciles terminal replacements and retry lineage.
     // Keep that reconciled view alongside the immutable history projection.
@@ -7401,11 +7411,30 @@ impl SummaryProjection {
                 refreshed_at.elapsed() >= SUMMARY_SNAPSHOT_MIN_REFRESH_INTERVAL
             })
         };
+        let now = Instant::now();
+        let all_time_refresh_due = if self.all_time_manifest_admission_blocked_at.is_some() {
+            summary_projection_manifest_admission_retry_is_due(
+                self.all_time_manifest_admission_blocked_at,
+                now,
+            )
+        } else {
+            refresh_due(self.all_time_refreshed_at)
+        };
+        let account_refresh_due = if self.all_time_manifest_admission_blocked_at.is_some() {
+            false
+        } else if self
+            .all_time_account_manifest_admission_blocked_at
+            .is_some()
+        {
+            summary_projection_manifest_admission_retry_is_due(
+                self.all_time_account_manifest_admission_blocked_at,
+                now,
+            )
+        } else {
+            refresh_due(self.all_time_oldest_account_refreshed_at)
+        };
         refresh_due(self.freshness.rolling_at(self.refreshed_at))
-            || (has_all_time_owner
-                && !self.all_time_manifest_admission_blocked
-                && (refresh_due(self.all_time_refreshed_at)
-                    || refresh_due(self.all_time_oldest_account_refreshed_at)))
+            || (has_all_time_owner && (all_time_refresh_due || account_refresh_due))
     }
 
     fn empty_all_time_account_response(&self, upstream_account_id: Option<i64>) -> StatsResponse {
@@ -7446,11 +7475,14 @@ impl SummaryProjection {
             Some(_) => return Err(ApiError::bad_request(anyhow!("invalid upstream account"))),
             None => None,
         };
-        if self.archive_boundary_manifest_admission_blocked
-            && matches!(window, SummaryWindow::Current(_))
+        if matches!(window, SummaryWindow::All)
+            && upstream_account_id.is_some()
+            && self
+                .all_time_account_manifest_admission_blocked_at
+                .is_some()
         {
             return Err(ApiError::unavailable(anyhow!(
-                "summary projection archive manifest admission is unavailable for the requested range"
+                "summary all-time account manifest admission is unavailable"
             )));
         }
         let now = Utc::now();
@@ -9276,29 +9308,29 @@ async fn refresh_summary_snapshots_with_deadline(
         .subscription_hub
         .summary_projection()
         .await
-        .map(|projection| {
-            (
-                projection.all_time_by_account.clone(),
-                projection.all_time_refreshed_at,
-                projection.all_time_manifest_admission_blocked,
-                projection.all_time_account_refreshed_at.clone(),
-                projection.archive_account_ids_by_file.clone(),
-                projection.archive_coverage_ranges_by_file.clone(),
-                projection.freshness.global_all_time_eligible,
-                projection.freshness.account_all_time_eligible.clone(),
-                projection.all_time_terminal_coverage_complete(),
-                projection.all_time_terminal_sequence_watermark(),
-                projection
-                    .all_time_persisted_live_terminal_invoke_ids
-                    .clone(),
-                projection
-                    .all_time_account_terminal_sequence_watermarks
-                    .clone(),
-                projection
-                    .all_time_account_persisted_live_terminal_invoke_ids
-                    .clone(),
-                projection.archive_boundary_manifest_admission_blocked,
-            )
+        .map(|projection| PreviousSummaryProjectionAllTime {
+            all_time_by_account: projection.all_time_by_account.clone(),
+            all_time_refreshed_at: projection.all_time_refreshed_at,
+            all_time_manifest_admission_blocked_at: projection
+                .all_time_manifest_admission_blocked_at,
+            all_time_account_manifest_admission_blocked_at: projection
+                .all_time_account_manifest_admission_blocked_at,
+            all_time_account_refreshed_at: projection.all_time_account_refreshed_at.clone(),
+            archive_account_ids_by_file: projection.archive_account_ids_by_file.clone(),
+            archive_coverage_ranges_by_file: projection.archive_coverage_ranges_by_file.clone(),
+            global_all_time_eligible: projection.freshness.global_all_time_eligible,
+            account_all_time_eligible: projection.freshness.account_all_time_eligible.clone(),
+            all_time_terminal_coverage_complete: projection.all_time_terminal_coverage_complete(),
+            all_time_terminal_sequence_watermark: projection.all_time_terminal_sequence_watermark(),
+            all_time_persisted_live_terminal_invoke_ids: projection
+                .all_time_persisted_live_terminal_invoke_ids
+                .clone(),
+            all_time_account_terminal_sequence_watermarks: projection
+                .all_time_account_terminal_sequence_watermarks
+                .clone(),
+            all_time_account_persisted_live_terminal_invoke_ids: projection
+                .all_time_account_persisted_live_terminal_invoke_ids
+                .clone(),
         });
     let had_previous_projection = previous_all_time.is_some();
     // The runtime read model advances this watermark only after SQLite ACKs every preceding
@@ -9326,7 +9358,6 @@ async fn refresh_summary_snapshots_with_deadline(
         && !projection
             .unavailable_unmaterialized_archive_ranges
             .is_empty()
-        && !projection.archive_boundary_manifest_admission_blocked
     {
         // A background failure must never replace a complete revision with a partial one.  The
         // existing revision remains the exact last-good response until its own freshness budget
@@ -9540,6 +9571,85 @@ async fn load_summary_projection_archive_replay_coverage(
     Ok(coverage)
 }
 
+async fn summary_projection_overflowed_boundary_manifests_have_complete_rollups(
+    pool: &Pool<Sqlite>,
+    range: ExactUtcRange,
+) -> Result<bool> {
+    // The overflow path may page manifests only when durable compact state proves every source
+    // partition is already materialized. Missing bounds or replay markers require the regular
+    // exact-source path, because a bounded prefix cannot safely stand in for those archives.
+    let incomplete = sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS( \
+             SELECT 1 FROM archive_batches AS batches \
+             WHERE batches.dataset = 'codex_invocations' \
+               AND batches.status = 'completed' \
+               AND ( \
+                    batches.coverage_start_at IS NULL \
+                    OR batches.coverage_end_at IS NULL \
+                    OR (batches.coverage_end_at >= ?1 AND batches.coverage_start_at < ?2) \
+               ) \
+               AND ( \
+                    batches.coverage_start_at IS NULL \
+                    OR batches.coverage_end_at IS NULL \
+                    OR batches.historical_rollups_materialized_at IS NULL \
+                    OR NOT EXISTS( \
+                        SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                        WHERE replay.dataset = batches.dataset \
+                          AND replay.file_path = batches.file_path \
+                          AND replay.target = ?3 \
+                    ) \
+                    OR NOT EXISTS( \
+                        SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                        WHERE replay.dataset = batches.dataset \
+                          AND replay.file_path = batches.file_path \
+                          AND replay.target = ?4 \
+                    ) \
+                    OR NOT EXISTS( \
+                        SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                        WHERE replay.dataset = batches.dataset \
+                          AND replay.file_path = batches.file_path \
+                          AND replay.target = ?5 \
+                    ) \
+               ) \
+         )",
+    )
+    .bind(db_occurred_at_upper_bound(range.start))
+    .bind(crate::stats::db_occurred_at_lower_bound(range.end))
+    .bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
+    .fetch_one(pool)
+    .await
+    .context("summary projection overflowed boundary manifest coverage hydration failed")?;
+    Ok(incomplete == 0)
+}
+
+async fn load_summary_projection_boundary_manifest_page(
+    pool: &Pool<Sqlite>,
+    range: ExactUtcRange,
+    offset: usize,
+) -> Result<Vec<crate::stats::ArchiveBatchPathRow>> {
+    sqlx::query_as::<_, crate::stats::ArchiveBatchPathRow>(
+        "SELECT \
+             file_path, month_key, coverage_start_at, coverage_end_at, \
+             historical_rollups_materialized_at, NULL AS needs_overall, NULL AS needs_failures \
+         FROM archive_batches \
+         WHERE dataset = 'codex_invocations' \
+           AND status = 'completed' \
+           AND coverage_end_at >= ?1 \
+           AND coverage_start_at < ?2 \
+         ORDER BY month_key ASC, created_at ASC, id ASC \
+         LIMIT ?3 OFFSET ?4",
+    )
+    .bind(db_occurred_at_upper_bound(range.start))
+    .bind(crate::stats::db_occurred_at_lower_bound(range.end))
+    .bind(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE as i64)
+    .bind(offset as i64)
+    .fetch_all(pool)
+    .await
+    .context("summary projection boundary manifest page hydration failed")
+}
+
 async fn load_summary_projection_durable_account_ids(pool: &Pool<Sqlite>) -> Result<HashSet<i64>> {
     let pool_rows =
         sqlx::query_scalar::<_, i64>("SELECT id FROM pool_upstream_accounts WHERE id > 0 LIMIT ?1")
@@ -9634,65 +9744,58 @@ fn summary_projection_live_record_from_preview(
     ))
 }
 
+#[derive(Default)]
+struct PreviousSummaryProjectionAllTime {
+    all_time_by_account: HashMap<Option<i64>, StatsResponse>,
+    all_time_refreshed_at: Option<Instant>,
+    all_time_manifest_admission_blocked_at: Option<Instant>,
+    all_time_account_manifest_admission_blocked_at: Option<Instant>,
+    all_time_account_refreshed_at: HashMap<i64, Instant>,
+    archive_account_ids_by_file: HashMap<String, HashSet<i64>>,
+    archive_coverage_ranges_by_file: HashMap<String, ExactUtcRange>,
+    global_all_time_eligible: bool,
+    account_all_time_eligible: HashSet<i64>,
+    all_time_terminal_coverage_complete: bool,
+    all_time_terminal_sequence_watermark: u64,
+    all_time_persisted_live_terminal_invoke_ids: HashSet<String>,
+    all_time_account_terminal_sequence_watermarks: HashMap<i64, u64>,
+    all_time_account_persisted_live_terminal_invoke_ids: HashMap<i64, HashSet<String>>,
+}
+
 /// Reads every input needed by the hot path while running off-request.  The resulting projection
 /// is swapped atomically in the subscription hub only after the complete baseline is available.
 async fn build_summary_projection(
     state: &AppState,
     include_all_time: bool,
-    previous_all_time: Option<(
-        HashMap<Option<i64>, StatsResponse>,
-        Option<Instant>,
-        bool,
-        HashMap<i64, Instant>,
-        HashMap<String, HashSet<i64>>,
-        HashMap<String, ExactUtcRange>,
-        bool,
-        HashSet<i64>,
-        bool,
-        u64,
-        HashSet<String>,
-        HashMap<i64, u64>,
-        HashMap<i64, HashSet<String>>,
-        bool,
-    )>,
+    previous_all_time: Option<PreviousSummaryProjectionAllTime>,
     durable_terminal_sequence_watermark: u64,
 ) -> Result<SummaryProjection> {
     let end = Utc::now() + ChronoDuration::seconds(1);
-    let (
+    let PreviousSummaryProjectionAllTime {
         mut all_time_by_account,
-        previous_all_time_refreshed_at,
-        previous_all_time_manifest_admission_blocked,
+        all_time_refreshed_at: previous_all_time_refreshed_at,
+        all_time_manifest_admission_blocked_at: previous_all_time_manifest_admission_blocked_at,
+        all_time_account_manifest_admission_blocked_at:
+            previous_all_time_account_manifest_admission_blocked_at,
         mut all_time_account_refreshed_at,
         mut archive_account_ids_by_file,
         mut archive_coverage_ranges_by_file,
-        previous_global_all_time_eligible,
-        previous_account_all_time_eligible,
-        previous_all_time_terminal_coverage_complete,
-        previous_all_time_terminal_sequence_watermark,
-        previous_all_time_persisted_live_terminal_invoke_ids,
-        previous_all_time_account_terminal_sequence_watermarks,
-        previous_all_time_account_persisted_live_terminal_invoke_ids,
-        previous_archive_boundary_manifest_admission_blocked,
-    ) = previous_all_time.unwrap_or_else(|| {
-        (
-            HashMap::new(),
-            None,
-            false,
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            false,
-            HashSet::new(),
-            false,
-            0,
-            HashSet::new(),
-            HashMap::new(),
-            HashMap::new(),
-            false,
-        )
-    });
-    let all_time_was_fully_rebuilt = !previous_all_time_manifest_admission_blocked
-        && (include_all_time || previous_all_time_refreshed_at.is_none());
+        global_all_time_eligible: previous_global_all_time_eligible,
+        account_all_time_eligible: previous_account_all_time_eligible,
+        all_time_terminal_coverage_complete: previous_all_time_terminal_coverage_complete,
+        all_time_terminal_sequence_watermark: previous_all_time_terminal_sequence_watermark,
+        all_time_persisted_live_terminal_invoke_ids:
+            previous_all_time_persisted_live_terminal_invoke_ids,
+        all_time_account_terminal_sequence_watermarks:
+            previous_all_time_account_terminal_sequence_watermarks,
+        all_time_account_persisted_live_terminal_invoke_ids:
+            previous_all_time_account_persisted_live_terminal_invoke_ids,
+    } = previous_all_time.unwrap_or_default();
+    let all_time_was_fully_rebuilt = summary_projection_manifest_admission_retry_is_due(
+        previous_all_time_manifest_admission_blocked_at,
+        Instant::now(),
+    ) && (include_all_time
+        || previous_all_time_refreshed_at.is_none());
     // Materialized hourly rollups are the canonical historical baseline. Raw live preview rows
     // are limited to the moving exact tail; older live rows are represented by their durable
     // hourly rollups. Archive boundary rows use the wider finite range below so supported 7d/
@@ -9748,26 +9851,38 @@ async fn build_summary_projection(
         load_summary_projection_archive_replay_coverage(&state.pool, &all_time_archive_paths)
             .await?;
     let mut all_time_archive_account_ids_by_file = HashMap::<String, HashSet<i64>>::new();
-    let mut all_time_account_manifest_admission_exceeded = false;
-    match load_summary_projection_archive_manifest_accounts(&state.pool, &all_time_archive_paths)
+    let all_time_account_manifest_admission_attempted = all_time_was_fully_rebuilt
+        && summary_projection_manifest_admission_retry_is_due(
+            previous_all_time_account_manifest_admission_blocked_at,
+            Instant::now(),
+        );
+    let mut all_time_account_manifest_admission_exceeded =
+        previous_all_time_account_manifest_admission_blocked_at.is_some()
+            && !all_time_account_manifest_admission_attempted;
+    if all_time_account_manifest_admission_attempted {
+        match load_summary_projection_archive_manifest_accounts(
+            &state.pool,
+            &all_time_archive_paths,
+        )
         .await
-    {
-        Ok(accounts) => {
-            for (file_path, account_id) in accounts {
-                all_time_archive_account_ids_by_file
-                    .entry(file_path)
-                    .or_default()
-                    .insert(account_id);
-            }
-        }
-        Err(error)
-            if error.to_string().starts_with(
-                "summary projection archive account manifest exceeded bounded row budget",
-            ) =>
         {
-            all_time_account_manifest_admission_exceeded = true;
+            Ok(accounts) => {
+                for (file_path, account_id) in accounts {
+                    all_time_archive_account_ids_by_file
+                        .entry(file_path)
+                        .or_default()
+                        .insert(account_id);
+                }
+            }
+            Err(error)
+                if error.to_string().starts_with(
+                    "summary projection archive account manifest exceeded bounded row budget",
+                ) =>
+            {
+                all_time_account_manifest_admission_exceeded = true;
+            }
+            Err(error) => return Err(error),
         }
-        Err(error) => return Err(error),
     }
     let rollup_live_cursor = load_summary_projection_rollup_live_cursor(&state.pool).await?;
     let account_rollup_live_cursor =
@@ -9908,22 +10023,34 @@ async fn build_summary_projection(
     // Boundary-hour selection is record-exact, including when the range starts or ends inside
     // an archived hour. Archive rows are streamed into the bounded exact set while building;
     // HTTP never opens or probes archive files.
-    let (archives, archive_boundary_manifest_admission_blocked) =
-        if previous_archive_boundary_manifest_admission_blocked {
-            (Vec::new(), true)
-        } else {
-            let archives = crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
-                &state.pool,
-                Some((archive_start, end)),
-                SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
-            )
-            .await?;
-            if archives.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
-                (Vec::new(), true)
-            } else {
-                (archives, false)
-            }
-        };
+    let exact_horizon = ExactUtcRange {
+        start: archive_start,
+        end,
+    };
+    let boundary_archive_admission =
+        crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
+            &state.pool,
+            Some((archive_start, end)),
+            SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
+        )
+        .await?;
+    let (archives, paged_boundary_manifest_recovery) = if boundary_archive_admission.len()
+        > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES
+    {
+        if !summary_projection_overflowed_boundary_manifests_have_complete_rollups(
+            &state.pool,
+            exact_horizon,
+        )
+        .await?
+        {
+            return Err(anyhow!(
+                "summary projection overflowed boundary manifests lack complete durable rollup coverage"
+            ));
+        }
+        (Vec::new(), true)
+    } else {
+        (boundary_archive_admission, false)
+    };
     let archive_paths = archives
         .iter()
         .map(|archive| archive.file_path().to_string())
@@ -9989,15 +10116,6 @@ async fn build_summary_projection(
                 anyhow!("summary projection usage progress hydration failed: {error:?}")
             })?;
     let mut unavailable_unmaterialized_archive_ranges = Vec::<ExactUtcRange>::new();
-    if archive_boundary_manifest_admission_blocked {
-        // The manifest cardinality does not disclose which completed archive contains a boundary
-        // row. Treat the complete exact horizon as unavailable rather than folding only the
-        // retained prefix into an otherwise plausible, but incomplete, rolling response.
-        unavailable_unmaterialized_archive_ranges.push(ExactUtcRange {
-            start: archive_start,
-            end,
-        });
-    }
     // Discover accounts from archive rows before planning full-hour coverage. Pools are opened
     // and closed one at a time so a large retention horizon never keeps every inflated archive
     // resident concurrently. Immutable completed archives reuse the cached account set on later
@@ -10206,6 +10324,47 @@ async fn build_summary_projection(
             raw_fallback_ranges,
         )?;
     }
+    if paged_boundary_manifest_recovery {
+        // The admission overflow is proved fully materialized above. Page only manifest metadata
+        // while planning the finite exact buckets; the raw archives themselves are opened later
+        // one at a time after live boundary records have been admitted.
+        let mut offset = 0usize;
+        loop {
+            let page =
+                load_summary_projection_boundary_manifest_page(&state.pool, exact_horizon, offset)
+                    .await?;
+            if page.is_empty() {
+                break;
+            }
+            for archive in &page {
+                let Some(archive_range) =
+                    summary_projection_archive_overlap_range(archive, exact_horizon)
+                else {
+                    continue;
+                };
+                let raw_fallback_ranges = summary_projection_archive_exact_ranges_with_coverage(
+                    true,
+                    Some(true),
+                    Some(true),
+                    Some(true),
+                    archive_range,
+                    &exact_archive_buckets,
+                    &hourly_rollup_totals,
+                    &hourly_rollup_usage,
+                    &known_account_ids,
+                );
+                summary_projection_extend_exact_buckets_for_ranges(
+                    &mut exact_archive_buckets,
+                    raw_fallback_ranges,
+                )?;
+            }
+            let page_len = page.len();
+            offset = offset.saturating_add(page_len);
+            if page_len < SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE {
+                break;
+            }
+        }
+    }
     let exact_live_ranges = summary_projection_exact_bucket_ranges(&exact_archive_buckets)
         .into_iter()
         .filter_map(|range| {
@@ -10389,6 +10548,96 @@ async fn build_summary_projection(
         })?;
         archive_pool.close().await;
         drop(temp_cleanup);
+    }
+    if paged_boundary_manifest_recovery {
+        let mut offset = 0usize;
+        loop {
+            let page =
+                load_summary_projection_boundary_manifest_page(&state.pool, exact_horizon, offset)
+                    .await?;
+            if page.is_empty() {
+                break;
+            }
+            let page_paths = page
+                .iter()
+                .map(|archive| archive.file_path().to_string())
+                .collect::<Vec<_>>();
+            let usage_rollup_progress = load_usage_breakdown_archive_progress_by_file_path(
+                &state.pool,
+                &page_paths,
+            )
+            .await
+            .map_err(|error| {
+                anyhow!(
+                    "summary projection paged boundary usage progress hydration failed: {error:?}"
+                )
+            })?;
+            for archive in page {
+                let Some(archive_range) =
+                    summary_projection_archive_overlap_range(&archive, exact_horizon)
+                else {
+                    continue;
+                };
+                let exact_ranges = summary_projection_archive_exact_ranges_with_coverage(
+                    true,
+                    Some(true),
+                    Some(true),
+                    Some(true),
+                    archive_range,
+                    &exact_archive_buckets,
+                    &hourly_rollup_totals,
+                    &hourly_rollup_usage,
+                    &known_account_ids,
+                );
+                if exact_ranges.is_empty() {
+                    continue;
+                }
+                let Some((archive_pool, temp_cleanup)) =
+                    crate::stats::open_invocation_archive_batch_pool(
+                        &archive,
+                        "summary-projection-paged-boundary",
+                    )
+                    .await?
+                else {
+                    // Eligibility proved all targets are materialized. A missing immutable file
+                    // can therefore use the same compact baseline without degrading this exact
+                    // window; a missing proof would have taken the normal fail-closed path.
+                    continue;
+                };
+                merge_summary_projection_archive_records_with_coverage(
+                    &archive_pool,
+                    &state.pool,
+                    &persisted_live_ids,
+                    &hourly_rollup_totals,
+                    &hourly_rollup_usage,
+                    true,
+                    Some(true),
+                    Some(true),
+                    Some(true),
+                    archive_range,
+                    &exact_archive_buckets,
+                    usage_rollup_progress.get(archive.file_path()).copied(),
+                    &known_account_ids,
+                    &mut records_by_invoke_id,
+                    &mut exact_record_budget,
+                    &mut exact_record_bytes,
+                )
+                .await
+                .map_err(|error| {
+                    anyhow!(
+                        "summary projection paged boundary archive hydration failed for {}: {error:?}",
+                        archive.file_path()
+                    )
+                })?;
+                archive_pool.close().await;
+                drop(temp_cleanup);
+            }
+            let page_len = page_paths.len();
+            offset = offset.saturating_add(page_len);
+            if page_len < SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE {
+                break;
+            }
+        }
     }
     // Archive rows are merged after the first live-record pass. Apply the same bucket-wide
     // coverage decision once every exact archive/live contribution is present.
@@ -11049,9 +11298,17 @@ async fn build_summary_projection(
         } else {
             previous_all_time_refreshed_at
         },
-        all_time_manifest_admission_blocked: previous_all_time_manifest_admission_blocked
-            || all_time_archive_admission_exceeded
-            || all_time_account_manifest_admission_exceeded,
+        all_time_manifest_admission_blocked_at: if all_time_was_fully_rebuilt {
+            all_time_archive_admission_exceeded.then(Instant::now)
+        } else {
+            previous_all_time_manifest_admission_blocked_at
+        },
+        all_time_account_manifest_admission_blocked_at:
+            if all_time_account_manifest_admission_attempted {
+                all_time_account_manifest_admission_exceeded.then(Instant::now)
+            } else {
+                previous_all_time_account_manifest_admission_blocked_at
+            },
         all_time_account_refreshed_at,
         all_time_oldest_account_refreshed_at,
         all_time_account_ids_with_projection_data: account_ids_with_projection_data,
@@ -11059,7 +11316,6 @@ async fn build_summary_projection(
         archive_account_ids_by_file,
         archive_coverage_ranges_by_file: archive_actual_coverage_ranges,
         unavailable_unmaterialized_archive_ranges,
-        archive_boundary_manifest_admission_blocked,
         in_progress_by_account,
         maintenance: Some(maintenance),
         refreshed_at,
@@ -26935,6 +27191,33 @@ mod request_compression_query_tests {
         };
         assert!(!projection.needs_cadence_refresh(false));
         assert!(projection.needs_cadence_refresh(true));
+    }
+
+    #[test]
+    fn summary_manifest_admission_retries_only_after_the_controlled_backoff() {
+        let blocked_at = Instant::now();
+        assert!(!summary_projection_manifest_admission_retry_is_due(
+            Some(blocked_at),
+            blocked_at + SUMMARY_PROJECTION_MANIFEST_ADMISSION_RETRY_BACKOFF
+                - Duration::from_secs(1),
+        ));
+        assert!(summary_projection_manifest_admission_retry_is_due(
+            Some(blocked_at),
+            blocked_at + SUMMARY_PROJECTION_MANIFEST_ADMISSION_RETRY_BACKOFF,
+        ));
+    }
+
+    #[test]
+    fn summary_cadence_does_not_rebuild_all_time_during_manifest_admission_backoff() {
+        let projection = SummaryProjection {
+            refreshed_at: Some(Instant::now()),
+            all_time_manifest_admission_blocked_at: Some(Instant::now()),
+            ..SummaryProjection::default()
+        };
+        assert!(
+            !projection.needs_cadence_refresh(true),
+            "a blocked all-time admission must not turn an active owner into a retry loop"
+        );
     }
 
     #[test]

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7480,6 +7480,7 @@ impl SummaryProjection {
             && self
                 .all_time_account_manifest_admission_blocked_at
                 .is_some()
+            && !self.all_time_by_account.contains_key(&upstream_account_id)
         {
             return Err(ApiError::unavailable(anyhow!(
                 "summary all-time account manifest admission is unavailable"
@@ -8829,6 +8830,18 @@ fn summary_projection_mark_unavailable_archive_ranges(
     Ok(())
 }
 
+fn summary_projection_admit_paged_boundary_raw_archive(
+    admitted_archives: &mut usize,
+) -> Result<()> {
+    if *admitted_archives >= SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+        return Err(anyhow!(
+            "summary projection paged boundary raw archive admission exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES})"
+        ));
+    }
+    *admitted_archives += 1;
+    Ok(())
+}
+
 fn summary_projection_unavailable_bucket_ranges(buckets: BTreeSet<i64>) -> Vec<ExactUtcRange> {
     let mut ranges = Vec::<ExactUtcRange>::new();
     for bucket in buckets {
@@ -9770,7 +9783,7 @@ struct SummaryProjectionBoundaryManifestPage {
 async fn load_summary_projection_boundary_manifest_page(
     pool: &Pool<Sqlite>,
     range: Option<ExactUtcRange>,
-    after_id: i64,
+    after_id: Option<i64>,
     high_watermark_id: i64,
 ) -> Result<SummaryProjectionBoundaryManifestPage> {
     let mut query = QueryBuilder::<Sqlite>::new(
@@ -9778,13 +9791,12 @@ async fn load_summary_projection_boundary_manifest_page(
                 upstream_activity_manifest_refreshed_at \
          FROM archive_batches \
          WHERE dataset = 'codex_invocations' \
-           AND status = 'completed' \
-           AND id > ",
+           AND status = 'completed'",
     );
-    query
-        .push_bind(after_id)
-        .push(" AND id <= ")
-        .push_bind(high_watermark_id);
+    if let Some(after_id) = after_id {
+        query.push(" AND id > ").push_bind(after_id);
+    }
+    query.push(" AND id <= ").push_bind(high_watermark_id);
     if let Some(range) = range {
         query
             .push(" AND coverage_end_at >= ")
@@ -9879,7 +9891,7 @@ async fn summary_projection_paged_all_time_materialized_scope_coverage(
     let mut global_covered = true;
     let mut accounts_covered = true;
     let mut discovered_account_ids = HashSet::new();
-    let mut after_id = i64::MIN;
+    let mut after_id = None;
     loop {
         let page =
             load_summary_projection_boundary_manifest_page(pool, None, after_id, high_watermark_id)
@@ -9940,7 +9952,7 @@ async fn summary_projection_paged_all_time_materialized_scope_coverage(
         let Some(next_after_id) = page.next_after_id else {
             break;
         };
-        after_id = next_after_id;
+        after_id = Some(next_after_id);
     }
     Ok((global_covered, accounts_covered, discovered_account_ids))
 }
@@ -10633,11 +10645,12 @@ async fn build_summary_projection(
             raw_fallback_ranges,
         )?;
     }
+    let mut paged_boundary_raw_archive_admissions = 0usize;
     if let Some(high_watermark_id) = paged_boundary_manifest_high_watermark_id {
         // The admission overflow is proved fully materialized above. Page only manifest metadata
         // while planning the finite exact buckets; the raw archives themselves are opened later
         // one at a time after live boundary records have been admitted.
-        let mut after_id = i64::MIN;
+        let mut after_id = None;
         loop {
             let page = load_summary_projection_boundary_manifest_page(
                 &state.pool,
@@ -10674,11 +10687,12 @@ async fn build_summary_projection(
                 let account_ids = page_account_ids_by_file
                     .get(archive.file_path())
                     .expect("page account manifest includes every requested archive path");
-                let (account_replayed, usage_replayed) = if account_ids.is_empty()
-                    && page
-                        .account_manifest_refreshed_paths
-                        .contains(archive.file_path())
-                {
+                let account_manifest_complete = page
+                    .account_manifest_refreshed_paths
+                    .contains(archive.file_path());
+                let (account_replayed, usage_replayed) = if !account_manifest_complete {
+                    (Some(false), Some(false))
+                } else if account_ids.is_empty() {
                     (Some(true), Some(true))
                 } else {
                     (None, None)
@@ -10702,7 +10716,7 @@ async fn build_summary_projection(
             let Some(next_after_id) = page.next_after_id else {
                 break;
             };
-            after_id = next_after_id;
+            after_id = Some(next_after_id);
         }
     }
     let exact_live_ranges = summary_projection_exact_bucket_ranges(&exact_archive_buckets)
@@ -10890,7 +10904,7 @@ async fn build_summary_projection(
         drop(temp_cleanup);
     }
     if let Some(high_watermark_id) = paged_boundary_manifest_high_watermark_id {
-        let mut after_id = i64::MIN;
+        let mut after_id = None;
         loop {
             let page = load_summary_projection_boundary_manifest_page(
                 &state.pool,
@@ -10929,11 +10943,12 @@ async fn build_summary_projection(
                 let account_ids = page_account_ids_by_file
                     .get(archive.file_path())
                     .expect("page account manifest includes every requested archive path");
-                let (account_replayed, usage_replayed) = if account_ids.is_empty()
-                    && page
-                        .account_manifest_refreshed_paths
-                        .contains(archive.file_path())
-                {
+                let account_manifest_complete = page
+                    .account_manifest_refreshed_paths
+                    .contains(archive.file_path());
+                let (account_replayed, usage_replayed) = if !account_manifest_complete {
+                    (Some(false), Some(false))
+                } else if account_ids.is_empty() {
                     (Some(true), Some(true))
                 } else {
                     (None, None)
@@ -10952,6 +10967,9 @@ async fn build_summary_projection(
                 if exact_ranges.is_empty() {
                     continue;
                 }
+                summary_projection_admit_paged_boundary_raw_archive(
+                    &mut paged_boundary_raw_archive_admissions,
+                )?;
                 let Some((archive_pool, temp_cleanup)) =
                     crate::stats::open_invocation_archive_batch_pool(
                         &archive,
@@ -10999,7 +11017,7 @@ async fn build_summary_projection(
             let Some(next_after_id) = page.next_after_id else {
                 break;
             };
-            after_id = next_after_id;
+            after_id = Some(next_after_id);
         }
     }
     // Archive rows are merged after the first live-record pass. Apply the same bucket-wide
@@ -26853,6 +26871,51 @@ mod request_compression_query_tests {
     use super::*;
     use sqlx::sqlite::SqlitePoolOptions;
 
+    #[tokio::test]
+    async fn summary_projection_paged_manifests_include_minimum_legacy_id() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite pool");
+        sqlx::query(
+            "CREATE TABLE archive_batches ( \
+                 id INTEGER PRIMARY KEY, \
+                 dataset TEXT NOT NULL, \
+                 status TEXT NOT NULL, \
+                 file_path TEXT NOT NULL, \
+                 coverage_start_at TEXT, \
+                 coverage_end_at TEXT, \
+                 upstream_activity_manifest_refreshed_at TEXT \
+             )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create archive manifest table");
+        for (id, path) in [(i64::MIN, "minimum-id.sqlite.gz"), (0, "zero-id.sqlite.gz")] {
+            sqlx::query(
+                "INSERT INTO archive_batches \
+                 (id, dataset, status, file_path) \
+                 VALUES (?1, 'codex_invocations', 'completed', ?2)",
+            )
+            .bind(id)
+            .bind(path)
+            .execute(&pool)
+            .await
+            .expect("insert legacy manifest id");
+        }
+        let page = load_summary_projection_boundary_manifest_page(&pool, None, None, 0)
+            .await
+            .expect("load first keyset page without a sentinel cursor");
+        let paths = page
+            .archives
+            .iter()
+            .map(|archive| archive.file_path())
+            .collect::<HashSet<_>>();
+        assert!(paths.contains("minimum-id.sqlite.gz"));
+        assert!(paths.contains("zero-id.sqlite.gz"));
+    }
+
     #[test]
     fn summary_projection_terminal_coverage_includes_occurred_at() {
         let mut projection = SummaryProjection::default();
@@ -27004,6 +27067,21 @@ mod request_compression_query_tests {
         }));
         totals.insert((missing_account_bucket, Some(42)), StatsTotals::default());
         usage_totals.insert((missing_account_bucket, Some(42)), usage.clone());
+
+        // An account manifest without its durable refresh marker may omit another archived
+        // account. Treat it as untrusted even when the listed account happens to have rollups.
+        let stale_manifest_ranges = summary_projection_archive_exact_ranges_with_coverage(
+            true,
+            Some(true),
+            Some(false),
+            Some(false),
+            exact_range,
+            &HashSet::new(),
+            &totals,
+            &usage_totals,
+            &known_accounts,
+        );
+        assert!(!stale_manifest_ranges.is_empty());
 
         let missing_global_replay_ranges = summary_projection_archive_exact_ranges_with_coverage(
             true,
@@ -27638,6 +27716,61 @@ mod request_compression_query_tests {
         assert!(
             !projection.needs_cadence_refresh(true),
             "a blocked all-time admission must not turn an active owner into a retry loop"
+        );
+    }
+
+    #[test]
+    fn summary_all_time_account_manifest_backoff_retains_fresh_last_good() {
+        let account_id = 42;
+        let response = StatsTotals {
+            total_count: 3,
+            success_count: 3,
+            total_tokens: 91,
+            total_cost: 4.5,
+            ..StatsTotals::default()
+        }
+        .into_response();
+        let projection = SummaryProjection {
+            all_time_by_account: HashMap::from([(Some(account_id), response)]),
+            all_time_refreshed_at: Some(Instant::now()),
+            all_time_account_refreshed_at: HashMap::from([(account_id, Instant::now())]),
+            all_time_account_manifest_admission_blocked_at: Some(Instant::now()),
+            all_time_account_ids_with_projection_data: HashSet::from([account_id]),
+            refreshed_at: Some(Instant::now()),
+            freshness: SummaryProjectionFreshness {
+                global_all_time_eligible: true,
+                account_all_time_eligible: HashSet::from([account_id]),
+            },
+            ..SummaryProjection::default()
+        };
+        let response = projection
+            .response_for_query(
+                &SummaryQuery {
+                    window: Some("all".to_string()),
+                    limit: None,
+                    time_zone: Some("UTC".to_string()),
+                    upstream_account_id: Some(account_id),
+                },
+                50,
+            )
+            .expect("fresh last-good account snapshot remains memory-readable during backoff");
+        assert_eq!(response.total_count, 3);
+        assert_eq!(response.total_tokens, 91);
+    }
+
+    #[test]
+    fn summary_paged_boundary_raw_archive_admission_is_bounded() {
+        let mut admitted_archives = 0usize;
+        for _ in 0..SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+            summary_projection_admit_paged_boundary_raw_archive(&mut admitted_archives)
+                .expect("each archive within the bounded admission is accepted");
+        }
+        let error = summary_projection_admit_paged_boundary_raw_archive(&mut admitted_archives)
+            .expect_err("the next raw archive must fail closed before it is opened");
+        assert!(
+            error
+                .to_string()
+                .contains("paged boundary raw archive admission exceeded")
         );
     }
 

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -9714,24 +9714,92 @@ async fn load_summary_projection_archive_manifest_sha256(
     Ok(sha256_by_file_path)
 }
 
-fn verify_summary_projection_archive_file_sha256(
-    archive: &crate::stats::ArchiveBatchPathRow,
+fn verify_summary_projection_archive_file_path_sha256(
+    file_path: &str,
     expected_sha256: &str,
 ) -> Result<()> {
-    let actual_sha256 = crate::maintenance::sha256_hex_file(Path::new(archive.file_path()))
-        .with_context(|| {
+    let actual_sha256 =
+        crate::maintenance::sha256_hex_file(Path::new(file_path)).with_context(|| {
             format!(
                 "summary projection archive identity read failed for {}",
-                archive.file_path()
+                file_path
             )
         })?;
     if actual_sha256 != expected_sha256 {
         return Err(anyhow!(
             "summary projection archive changed during hydration for {}",
-            archive.file_path()
+            file_path
         ));
     }
     Ok(())
+}
+
+fn verify_summary_projection_archive_file_sha256(
+    archive: &crate::stats::ArchiveBatchPathRow,
+    expected_sha256: &str,
+) -> Result<()> {
+    verify_summary_projection_archive_file_path_sha256(archive.file_path(), expected_sha256)
+}
+
+fn verify_summary_projection_archive_file_paths_sha256(
+    archive_paths: &[String],
+    expected_sha256_by_file_path: &HashMap<String, String>,
+) -> Result<()> {
+    for file_path in archive_paths {
+        let expected_sha256 = expected_sha256_by_file_path.get(file_path).ok_or_else(|| {
+            anyhow!(
+                "summary projection archive manifest SHA is missing for {}",
+                file_path
+            )
+        })?;
+        verify_summary_projection_archive_file_path_sha256(file_path, expected_sha256)?;
+    }
+    Ok(())
+}
+
+async fn load_summary_projection_all_time_archive_scan_paths(
+    pool: &Pool<Sqlite>,
+) -> Result<Vec<String>> {
+    // These are precisely the completed archive paths that the two generic all-time
+    // aggregators may inflate: the global pass handles missing invocation replay, and the
+    // account pass additionally handles unmaterialized archives missing account replay.
+    let paths = sqlx::query_scalar::<_, String>(
+        "SELECT batches.file_path \
+         FROM archive_batches AS batches \
+         WHERE batches.dataset = 'codex_invocations' \
+           AND batches.status = 'completed' \
+           AND ( \
+               NOT EXISTS ( \
+                   SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                   WHERE replay.target = ?1 \
+                     AND replay.dataset = 'codex_invocations' \
+                     AND replay.file_path = batches.file_path \
+               ) \
+               OR ( \
+                   batches.historical_rollups_materialized_at IS NULL \
+                   AND NOT EXISTS ( \
+                       SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                       WHERE replay.target = ?2 \
+                         AND replay.dataset = 'codex_invocations' \
+                         AND replay.file_path = batches.file_path \
+                   ) \
+               ) \
+           ) \
+         ORDER BY batches.month_key ASC, batches.created_at ASC, batches.id ASC \
+         LIMIT ?3",
+    )
+    .bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind((SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES + 1) as i64)
+    .fetch_all(pool)
+    .await
+    .context("summary projection all-time archive scan admission failed")?;
+    if paths.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+        return Err(anyhow!(
+            "summary projection all-time archive scan cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES})"
+        ));
+    }
+    Ok(paths)
 }
 
 async fn load_summary_projection_archive_manifest_accounts(
@@ -10423,6 +10491,8 @@ async fn build_summary_projection_once(
         .iter()
         .map(|archive| archive.file_path().to_string())
         .collect::<Vec<_>>();
+    let all_time_archive_manifest_sha256 =
+        load_summary_projection_archive_manifest_sha256(pool, &all_time_archive_paths).await?;
     let all_time_archive_replay_coverage =
         load_summary_projection_archive_replay_coverage(pool, &all_time_archive_paths).await?;
     let mut all_time_archive_account_ids_by_file = HashMap::<String, HashSet<i64>>::new();
@@ -11504,6 +11574,8 @@ async fn build_summary_projection_once(
     let all_time_built_at = Instant::now();
     let mut rebuilt_all_time_account_ids = HashSet::new();
     if all_time_was_fully_rebuilt && !all_time_archive_admission_exceeded {
+        let all_time_archive_scan_paths =
+            load_summary_projection_all_time_archive_scan_paths(pool).await?;
         // All-time must use the same bounded projection inputs as rolling windows. The generic
         // stats query can open every unmaterialized archive and therefore cannot run in the
         // refresh path without defeating the rebuild deadline.
@@ -11667,6 +11739,10 @@ async fn build_summary_projection_once(
                 })?,
             );
         }
+        verify_summary_projection_archive_file_paths_sha256(
+            &all_time_archive_scan_paths,
+            &all_time_archive_manifest_sha256,
+        )?;
         let unmaterialized_archive_totals =
             crate::stats::query_unmaterialized_invocation_archive_totals_bounded_strict(
                 pool,
@@ -11677,7 +11753,13 @@ async fn build_summary_projection_once(
             )
             .await;
         match unmaterialized_archive_totals {
-            Ok(totals) => global_totals = global_totals.add(totals),
+            Ok(totals) => {
+                verify_summary_projection_archive_file_paths_sha256(
+                    &all_time_archive_scan_paths,
+                    &all_time_archive_manifest_sha256,
+                )?;
+                global_totals = global_totals.add(totals);
+            }
             Err(error)
                 if error
                     .to_string()
@@ -11751,6 +11833,10 @@ async fn build_summary_projection_once(
                 *entry = entry.add(totals);
             }
         }
+        verify_summary_projection_archive_file_paths_sha256(
+            &all_time_archive_scan_paths,
+            &all_time_archive_manifest_sha256,
+        )?;
         let account_archive_totals =
             crate::stats::query_unmaterialized_upstream_account_archive_totals_by_account(
                 pool,
@@ -11761,7 +11847,13 @@ async fn build_summary_projection_once(
             )
             .await;
         let account_archive_totals = match account_archive_totals {
-            Ok(totals) => totals,
+            Ok(totals) => {
+                verify_summary_projection_archive_file_paths_sha256(
+                    &all_time_archive_scan_paths,
+                    &all_time_archive_manifest_sha256,
+                )?;
+                totals
+            }
             Err(error)
                 if error
                     .to_string()

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -9631,18 +9631,36 @@ async fn load_summary_projection_archive_replay_coverage(
     Ok(coverage)
 }
 
+async fn summary_projection_completed_manifest_high_watermark(
+    pool: &Pool<Sqlite>,
+) -> Result<Option<i64>> {
+    sqlx::query_scalar::<_, Option<i64>>(
+        "SELECT MAX(id) FROM archive_batches \
+         WHERE dataset = 'codex_invocations' AND status = 'completed'",
+    )
+    .fetch_one(pool)
+    .await
+    .context("summary projection completed manifest high-watermark hydration failed")
+}
+
 async fn summary_projection_overflowed_boundary_manifests_have_complete_rollups(
     pool: &Pool<Sqlite>,
     range: ExactUtcRange,
-) -> Result<bool> {
+) -> Result<Option<i64>> {
     // The overflow path may page manifests only when durable compact state proves every source
     // partition is already materialized. Missing bounds or replay markers require the regular
     // exact-source path, because a bounded prefix cannot safely stand in for those archives.
+    let Some(high_watermark_id) =
+        summary_projection_completed_manifest_high_watermark(pool).await?
+    else {
+        return Ok(None);
+    };
     let incomplete = sqlx::query_scalar::<_, i64>(
         "SELECT EXISTS( \
              SELECT 1 FROM archive_batches AS batches \
              WHERE batches.dataset = 'codex_invocations' \
                AND batches.status = 'completed' \
+               AND batches.id <= ?6 \
                AND ( \
                     batches.coverage_start_at IS NULL \
                     OR batches.coverage_end_at IS NULL \
@@ -9678,10 +9696,60 @@ async fn summary_projection_overflowed_boundary_manifests_have_complete_rollups(
     .bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
     .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
     .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
+    .bind(high_watermark_id)
     .fetch_one(pool)
     .await
     .context("summary projection overflowed boundary manifest coverage hydration failed")?;
-    Ok(incomplete == 0)
+    Ok((incomplete == 0).then_some(high_watermark_id))
+}
+
+async fn summary_projection_overflowed_all_time_manifests_have_complete_rollups(
+    pool: &Pool<Sqlite>,
+) -> Result<Option<i64>> {
+    let Some(high_watermark_id) =
+        summary_projection_completed_manifest_high_watermark(pool).await?
+    else {
+        return Ok(None);
+    };
+    let incomplete = sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS( \
+             SELECT 1 FROM archive_batches AS batches \
+             WHERE batches.dataset = 'codex_invocations' \
+               AND batches.status = 'completed' \
+               AND batches.id <= ?1 \
+               AND ( \
+                    batches.coverage_start_at IS NULL \
+                    OR batches.coverage_end_at IS NULL \
+                    OR batches.historical_rollups_materialized_at IS NULL \
+                    OR NOT EXISTS( \
+                        SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                        WHERE replay.dataset = batches.dataset \
+                          AND replay.file_path = batches.file_path \
+                          AND replay.target = ?2 \
+                    ) \
+                    OR NOT EXISTS( \
+                        SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                        WHERE replay.dataset = batches.dataset \
+                          AND replay.file_path = batches.file_path \
+                          AND replay.target = ?3 \
+                    ) \
+                    OR NOT EXISTS( \
+                        SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                        WHERE replay.dataset = batches.dataset \
+                          AND replay.file_path = batches.file_path \
+                          AND replay.target = ?4 \
+                    ) \
+               ) \
+         )",
+    )
+    .bind(high_watermark_id)
+    .bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
+    .fetch_one(pool)
+    .await
+    .context("summary projection overflowed all-time manifest coverage hydration failed")?;
+    Ok((incomplete == 0).then_some(high_watermark_id))
 }
 
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -9690,38 +9758,53 @@ struct SummaryProjectionBoundaryManifestPageRow {
     file_path: String,
     coverage_start_at: Option<String>,
     coverage_end_at: Option<String>,
+    upstream_activity_manifest_refreshed_at: Option<String>,
 }
 
 struct SummaryProjectionBoundaryManifestPage {
     archives: Vec<crate::stats::ArchiveBatchPathRow>,
+    account_manifest_refreshed_paths: HashSet<String>,
     next_after_id: Option<i64>,
 }
 
 async fn load_summary_projection_boundary_manifest_page(
     pool: &Pool<Sqlite>,
-    range: ExactUtcRange,
+    range: Option<ExactUtcRange>,
     after_id: i64,
+    high_watermark_id: i64,
 ) -> Result<SummaryProjectionBoundaryManifestPage> {
-    let rows = sqlx::query_as::<_, SummaryProjectionBoundaryManifestPageRow>(
-        "SELECT \
-             id, file_path, coverage_start_at, coverage_end_at \
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT id, file_path, coverage_start_at, coverage_end_at, \
+                upstream_activity_manifest_refreshed_at \
          FROM archive_batches \
          WHERE dataset = 'codex_invocations' \
            AND status = 'completed' \
-           AND coverage_end_at >= ?1 \
-           AND coverage_start_at < ?2 \
-           AND id > ?3 \
-         ORDER BY id ASC \
-         LIMIT ?4",
-    )
-    .bind(db_occurred_at_upper_bound(range.start))
-    .bind(crate::stats::db_occurred_at_lower_bound(range.end))
-    .bind(after_id)
-    .bind(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE as i64)
-    .fetch_all(pool)
-    .await
-    .context("summary projection boundary manifest page hydration failed")?;
+           AND id > ",
+    );
+    query
+        .push_bind(after_id)
+        .push(" AND id <= ")
+        .push_bind(high_watermark_id);
+    if let Some(range) = range {
+        query
+            .push(" AND coverage_end_at >= ")
+            .push_bind(db_occurred_at_upper_bound(range.start))
+            .push(" AND coverage_start_at < ")
+            .push_bind(crate::stats::db_occurred_at_lower_bound(range.end));
+    }
+    let rows = query
+        .push(" ORDER BY id ASC LIMIT ")
+        .push_bind(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE as i64)
+        .build_query_as::<SummaryProjectionBoundaryManifestPageRow>()
+        .fetch_all(pool)
+        .await
+        .context("summary projection boundary manifest page hydration failed")?;
     let next_after_id = rows.last().map(|row| row.id);
+    let account_manifest_refreshed_paths = rows
+        .iter()
+        .filter(|row| row.upstream_activity_manifest_refreshed_at.is_some())
+        .map(|row| row.file_path.clone())
+        .collect();
     let archives = rows
         .into_iter()
         .map(|row| {
@@ -9734,8 +9817,132 @@ async fn load_summary_projection_boundary_manifest_page(
         .collect();
     Ok(SummaryProjectionBoundaryManifestPage {
         archives,
+        account_manifest_refreshed_paths,
         next_after_id,
     })
+}
+
+async fn load_summary_projection_archive_manifest_account_sets(
+    pool: &Pool<Sqlite>,
+    archive_paths: &[String],
+) -> Result<HashMap<String, HashSet<i64>>> {
+    let mut account_ids_by_file = archive_paths
+        .iter()
+        .cloned()
+        .map(|path| (path, HashSet::new()))
+        .collect::<HashMap<_, _>>();
+    for (file_path, account_id) in
+        load_summary_projection_archive_manifest_accounts(pool, archive_paths).await?
+    {
+        if let Some(account_ids) = account_ids_by_file.get_mut(&file_path) {
+            account_ids.insert(account_id);
+        }
+    }
+    Ok(account_ids_by_file)
+}
+
+fn summary_projection_all_time_manifest_scope_coverage(
+    archive: &crate::stats::ArchiveBatchPathRow,
+    replay_coverage: SummaryProjectionArchiveReplayCoverage,
+    account_manifest_complete: bool,
+    account_ids: &HashSet<i64>,
+    hourly_rollup_totals: &HashMap<(i64, Option<i64>), StatsTotals>,
+) -> Result<(bool, bool)> {
+    let Some(range) = summary_projection_archive_coverage_range(archive) else {
+        return Ok((false, false));
+    };
+    if summary_projection_exact_range_fits_bucket_budget(range).is_err() {
+        return Ok((false, false));
+    }
+    let mut global_covered = replay_coverage.overall;
+    let mut accounts_covered = replay_coverage.account_stats && account_manifest_complete;
+    let mut bucket = align_bucket_epoch(range.start.timestamp(), 3_600, 0);
+    let last_bucket = align_bucket_epoch(range.end.timestamp().saturating_sub(1), 3_600, 0);
+    while bucket <= last_bucket {
+        global_covered &= hourly_rollup_totals.contains_key(&(bucket, None));
+        accounts_covered &= account_ids
+            .iter()
+            .all(|account_id| hourly_rollup_totals.contains_key(&(bucket, Some(*account_id))));
+        if !global_covered && !accounts_covered {
+            break;
+        }
+        bucket = bucket.saturating_add(3_600);
+    }
+    Ok((global_covered, accounts_covered))
+}
+
+async fn summary_projection_paged_all_time_materialized_scope_coverage(
+    pool: &Pool<Sqlite>,
+    high_watermark_id: i64,
+    hourly_rollup_totals: &HashMap<(i64, Option<i64>), StatsTotals>,
+) -> Result<(bool, bool, HashSet<i64>)> {
+    let mut global_covered = true;
+    let mut accounts_covered = true;
+    let mut discovered_account_ids = HashSet::new();
+    let mut after_id = i64::MIN;
+    loop {
+        let page =
+            load_summary_projection_boundary_manifest_page(pool, None, after_id, high_watermark_id)
+                .await?;
+        if page.archives.is_empty() {
+            break;
+        }
+        let paths = page
+            .archives
+            .iter()
+            .map(|archive| archive.file_path().to_string())
+            .collect::<Vec<_>>();
+        let replay_coverage = load_summary_projection_archive_replay_coverage(pool, &paths).await?;
+        let account_ids_by_file =
+            match load_summary_projection_archive_manifest_account_sets(pool, &paths).await {
+                Ok(account_ids_by_file) => account_ids_by_file,
+                Err(error)
+                    if error.to_string().starts_with(
+                        "summary projection archive account manifest exceeded bounded row budget",
+                    ) =>
+                {
+                    accounts_covered = false;
+                    paths
+                        .iter()
+                        .cloned()
+                        .map(|path| (path, HashSet::new()))
+                        .collect()
+                }
+                Err(error) => return Err(error),
+            };
+        for archive in &page.archives {
+            let account_ids = account_ids_by_file
+                .get(archive.file_path())
+                .expect("page account manifest includes every requested archive path");
+            if accounts_covered {
+                discovered_account_ids.extend(account_ids.iter().copied());
+                if discovered_account_ids.len() > SUMMARY_PROJECTION_MAX_ACCOUNTS {
+                    accounts_covered = false;
+                    discovered_account_ids.clear();
+                }
+            }
+            let replay = replay_coverage
+                .get(archive.file_path())
+                .copied()
+                .unwrap_or_default();
+            let (archive_global_covered, archive_accounts_covered) =
+                summary_projection_all_time_manifest_scope_coverage(
+                    archive,
+                    replay,
+                    page.account_manifest_refreshed_paths
+                        .contains(archive.file_path()),
+                    account_ids,
+                    hourly_rollup_totals,
+                )?;
+            global_covered &= archive_global_covered;
+            accounts_covered &= archive_accounts_covered;
+        }
+        let Some(next_after_id) = page.next_after_id else {
+            break;
+        };
+        after_id = next_after_id;
+    }
+    Ok((global_covered, accounts_covered, discovered_account_ids))
 }
 
 async fn load_summary_projection_durable_account_ids(pool: &Pool<Sqlite>) -> Result<HashSet<i64>> {
@@ -9912,25 +10119,35 @@ async fn build_summary_projection(
         .await?
         .is_empty();
     // All-time aggregation needs manifest-level key proof, while rolling windows only need the
-    // bounded exact horizon below. A history that exceeds the manifest admission limit keeps
-    // `all` on its last-good/unavailable contract, but must not prevent the first rolling
-    // snapshot from becoming available.
-    let (all_time_archives, all_time_archive_admission_exceeded) =
-        if all_time_was_fully_rebuilt && has_any_completed_archive {
-            let archives = crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
+    // bounded exact horizon below. An oversized, fully materialized history is validated in
+    // fixed manifest pages against one immutable high-watermark; it never needs an unbounded
+    // path vector or a request-time source fallback.
+    let (
+        all_time_archives,
+        mut all_time_archive_admission_exceeded,
+        all_time_manifest_high_watermark_id,
+    ) = if all_time_was_fully_rebuilt && has_any_completed_archive {
+        let archives = crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
+            &state.pool,
+            None,
+            SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
+        )
+        .await?;
+        if archives.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+            match summary_projection_overflowed_all_time_manifests_have_complete_rollups(
                 &state.pool,
-                None,
-                SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
             )
-            .await?;
-            if archives.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
-                (Vec::new(), true)
-            } else {
-                (archives, false)
+            .await?
+            {
+                Some(high_watermark_id) => (Vec::new(), false, Some(high_watermark_id)),
+                None => (Vec::new(), true, None),
             }
         } else {
-            (Vec::new(), false)
-        };
+            (archives, false, None)
+        }
+    } else {
+        (Vec::new(), false, None)
+    };
     let all_time_archive_paths = all_time_archives
         .iter()
         .map(|archive| archive.file_path().to_string())
@@ -9947,7 +10164,9 @@ async fn build_summary_projection(
     let mut all_time_account_manifest_admission_exceeded =
         previous_all_time_account_manifest_admission_blocked_at.is_some()
             && !all_time_account_manifest_admission_attempted;
-    if all_time_account_manifest_admission_attempted {
+    if all_time_account_manifest_admission_attempted
+        && all_time_manifest_high_watermark_id.is_none()
+    {
         match load_summary_projection_archive_manifest_accounts(
             &state.pool,
             &all_time_archive_paths,
@@ -10122,22 +10341,23 @@ async fn build_summary_projection(
             SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
         )
         .await?;
-    let (archives, paged_boundary_manifest_recovery) = if boundary_archive_admission.len()
+    let (archives, paged_boundary_manifest_high_watermark_id) = if boundary_archive_admission.len()
         > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES
     {
-        if !summary_projection_overflowed_boundary_manifests_have_complete_rollups(
-            &state.pool,
-            exact_horizon,
-        )
-        .await?
-        {
+        let Some(high_watermark_id) =
+            summary_projection_overflowed_boundary_manifests_have_complete_rollups(
+                &state.pool,
+                exact_horizon,
+            )
+            .await?
+        else {
             return Err(anyhow!(
                 "summary projection overflowed boundary manifests lack complete durable rollup coverage"
             ));
-        }
-        (Vec::new(), true)
+        };
+        (Vec::new(), Some(high_watermark_id))
     } else {
-        (boundary_archive_admission, false)
+        (boundary_archive_admission, None)
     };
     let archive_paths = archives
         .iter()
@@ -10413,20 +10633,37 @@ async fn build_summary_projection(
             raw_fallback_ranges,
         )?;
     }
-    if paged_boundary_manifest_recovery {
+    if let Some(high_watermark_id) = paged_boundary_manifest_high_watermark_id {
         // The admission overflow is proved fully materialized above. Page only manifest metadata
         // while planning the finite exact buckets; the raw archives themselves are opened later
         // one at a time after live boundary records have been admitted.
-        let mut after_id = 0_i64;
+        let mut after_id = i64::MIN;
         loop {
             let page = load_summary_projection_boundary_manifest_page(
                 &state.pool,
-                exact_horizon,
+                Some(exact_horizon),
                 after_id,
+                high_watermark_id,
             )
             .await?;
             if page.archives.is_empty() {
                 break;
+            }
+            let page_paths = page
+                .archives
+                .iter()
+                .map(|archive| archive.file_path().to_string())
+                .collect::<Vec<_>>();
+            let page_account_ids_by_file =
+                load_summary_projection_archive_manifest_account_sets(&state.pool, &page_paths)
+                    .await?;
+            for account_ids in page_account_ids_by_file.values() {
+                known_account_ids.extend(account_ids.iter().copied());
+            }
+            if known_account_ids.len() > SUMMARY_PROJECTION_MAX_ACCOUNTS {
+                return Err(anyhow!(
+                    "summary projection paged boundary account cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ACCOUNTS})"
+                ));
             }
             for archive in &page.archives {
                 let Some(archive_range) =
@@ -10434,16 +10671,28 @@ async fn build_summary_projection(
                 else {
                     continue;
                 };
+                let account_ids = page_account_ids_by_file
+                    .get(archive.file_path())
+                    .expect("page account manifest includes every requested archive path");
+                let (account_replayed, usage_replayed) = if account_ids.is_empty()
+                    && page
+                        .account_manifest_refreshed_paths
+                        .contains(archive.file_path())
+                {
+                    (Some(true), Some(true))
+                } else {
+                    (None, None)
+                };
                 let raw_fallback_ranges = summary_projection_archive_exact_ranges_with_coverage(
                     true,
                     Some(true),
-                    Some(true),
-                    Some(true),
+                    account_replayed,
+                    usage_replayed,
                     archive_range,
                     &exact_archive_buckets,
                     &hourly_rollup_totals,
                     &hourly_rollup_usage,
-                    &known_account_ids,
+                    account_ids,
                 );
                 summary_projection_extend_exact_buckets_for_ranges(
                     &mut exact_archive_buckets,
@@ -10640,13 +10889,14 @@ async fn build_summary_projection(
         archive_pool.close().await;
         drop(temp_cleanup);
     }
-    if paged_boundary_manifest_recovery {
-        let mut after_id = 0_i64;
+    if let Some(high_watermark_id) = paged_boundary_manifest_high_watermark_id {
+        let mut after_id = i64::MIN;
         loop {
             let page = load_summary_projection_boundary_manifest_page(
                 &state.pool,
-                exact_horizon,
+                Some(exact_horizon),
                 after_id,
+                high_watermark_id,
             )
             .await?;
             if page.archives.is_empty() {
@@ -10667,22 +10917,37 @@ async fn build_summary_projection(
                     "summary projection paged boundary usage progress hydration failed: {error:?}"
                 )
             })?;
+            let page_account_ids_by_file =
+                load_summary_projection_archive_manifest_account_sets(&state.pool, &page_paths)
+                    .await?;
             for archive in page.archives {
                 let Some(archive_range) =
                     summary_projection_archive_overlap_range(&archive, exact_horizon)
                 else {
                     continue;
                 };
+                let account_ids = page_account_ids_by_file
+                    .get(archive.file_path())
+                    .expect("page account manifest includes every requested archive path");
+                let (account_replayed, usage_replayed) = if account_ids.is_empty()
+                    && page
+                        .account_manifest_refreshed_paths
+                        .contains(archive.file_path())
+                {
+                    (Some(true), Some(true))
+                } else {
+                    (None, None)
+                };
                 let exact_ranges = summary_projection_archive_exact_ranges_with_coverage(
                     true,
                     Some(true),
-                    Some(true),
-                    Some(true),
+                    account_replayed,
+                    usage_replayed,
                     archive_range,
                     &exact_archive_buckets,
                     &hourly_rollup_totals,
                     &hourly_rollup_usage,
-                    &known_account_ids,
+                    account_ids,
                 );
                 if exact_ranges.is_empty() {
                     continue;
@@ -10711,12 +10976,12 @@ async fn build_summary_projection(
                     &hourly_rollup_usage,
                     true,
                     Some(true),
-                    Some(true),
-                    Some(true),
+                    account_replayed,
+                    usage_replayed,
                     archive_range,
                     &exact_archive_buckets,
                     usage_rollup_progress.get(archive.file_path()).copied(),
-                    &known_account_ids,
+                    account_ids,
                     &mut records_by_invoke_id,
                     &mut exact_record_budget,
                     &mut exact_record_bytes,
@@ -10942,19 +11207,48 @@ async fn build_summary_projection(
                 record.account_rollup_covered = true;
             }
         }
-        let (global_rollup_coverage_proven, account_rollup_coverage_proven) =
-            summary_projection_all_time_materialized_scope_coverage(
-                &all_time_archives,
-                &all_time_archive_replay_coverage,
-                &all_time_archive_account_ids_by_file,
+        let (
+            global_rollup_coverage_proven,
+            account_rollup_coverage_proven,
+            paged_all_time_account_ids,
+        ) = if let Some(high_watermark_id) = all_time_manifest_high_watermark_id {
+            summary_projection_paged_all_time_materialized_scope_coverage(
+                &state.pool,
+                high_watermark_id,
                 &all_time_rollup_totals,
-            )?;
+            )
+            .await?
+        } else {
+            let (global_covered, account_covered) =
+                summary_projection_all_time_materialized_scope_coverage(
+                    &all_time_archives,
+                    &all_time_archive_replay_coverage,
+                    &all_time_archive_account_ids_by_file,
+                    &all_time_rollup_totals,
+                )?;
+            (global_covered, account_covered, HashSet::new())
+        };
+        account_ids.extend(paged_all_time_account_ids.iter().copied());
+        account_ids_with_projection_data.extend(paged_all_time_account_ids);
+        if account_ids.len() > SUMMARY_PROJECTION_MAX_ACCOUNTS {
+            return Err(anyhow!(
+                "summary projection all-time account cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ACCOUNTS})"
+            ));
+        }
         // A replay marker is not sufficient by itself: a deleted or never-written aggregate key
         // would make the compact all-time baseline silently lose that archive bucket. Preserve
         // an exact last-good aggregate (or its existing unavailable contract) until durable
         // coverage can again be proven off-request.
         global_all_time_source_unavailable |= !global_rollup_coverage_proven;
         account_all_time_unavailable |= !account_rollup_coverage_proven;
+        // A failed paged proof is retried on the same controlled admission cadence as a failed
+        // bounded admission. A normally admitted manifest set keeps its existing immediate
+        // repair behavior, but an overflowed history must not rescan every 10 seconds after an
+        // incomplete durable repair.
+        if all_time_manifest_high_watermark_id.is_some() {
+            all_time_archive_admission_exceeded |= !global_rollup_coverage_proven;
+            all_time_account_manifest_admission_exceeded |= !account_rollup_coverage_proven;
+        }
         // An unreadable archive without replay coverage cannot contribute to either compact
         // all-time aggregate. Preserve last-good/unavailable for `all`; range selections use
         // the bounded marker carried by this projection.
@@ -26655,7 +26949,7 @@ mod request_compression_query_tests {
         );
 
         totals.insert((missing_account_bucket, Some(42)), StatsTotals::default());
-        usage_totals.insert((missing_account_bucket, Some(42)), usage);
+        usage_totals.insert((missing_account_bucket, Some(42)), usage.clone());
         let covered_ranges = summary_projection_archive_exact_ranges(
             true,
             exact_range,
@@ -26684,6 +26978,32 @@ mod request_compression_query_tests {
             &known_accounts,
         );
         assert!(replayed_ranges.is_empty());
+
+        // Paged manifests must not let their replay marker bypass account-key verification. The
+        // compact global bucket is present here, but a manifest-proven account without both
+        // account rollup dimensions still requires the exact archive boundary source.
+        totals.remove(&(missing_account_bucket, Some(42)));
+        usage_totals.remove(&(missing_account_bucket, Some(42)));
+        let paged_missing_account_ranges = summary_projection_archive_exact_ranges_with_coverage(
+            true,
+            Some(true),
+            None,
+            None,
+            exact_range,
+            &HashSet::new(),
+            &totals,
+            &usage_totals,
+            &known_accounts,
+        );
+        assert!(paged_missing_account_ranges.iter().any(|range| {
+            range.start <= Utc.timestamp_opt(missing_account_bucket, 0).unwrap()
+                && range.end
+                    >= Utc
+                        .timestamp_opt(missing_account_bucket + 3_600, 0)
+                        .unwrap()
+        }));
+        totals.insert((missing_account_bucket, Some(42)), StatsTotals::default());
+        usage_totals.insert((missing_account_bucket, Some(42)), usage.clone());
 
         let missing_global_replay_ranges = summary_projection_archive_exact_ranges_with_coverage(
             true,

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -8458,54 +8458,65 @@ fn summary_projection_archive_coverage_range(
     (start < end).then_some(ExactUtcRange { start, end })
 }
 
-async fn summary_projection_all_time_materialized_scope_coverage(
-    pool: &Pool<Sqlite>,
+fn summary_projection_all_time_materialized_scope_coverage(
+    archives: &[crate::stats::ArchiveBatchPathRow],
+    replay_coverage: &HashMap<String, SummaryProjectionArchiveReplayCoverage>,
+    archive_account_ids_by_file: &HashMap<String, HashSet<i64>>,
+    hourly_rollup_totals: &HashMap<(i64, Option<i64>), StatsTotals>,
 ) -> Result<(bool, bool)> {
-    // Materialization and its replay markers are committed together. Check for an incomplete
-    // durable target with constant-space EXISTS probes instead of retaining every historical
-    // manifest just to re-prove an all-time rollup already stored in SQLite.
-    let (global_complete, account_complete) = sqlx::query_as::<_, (i64, i64)>(
-        "SELECT \
-           NOT EXISTS( \
-               SELECT 1 FROM archive_batches AS batches \
-               WHERE batches.dataset = 'codex_invocations' \
-                 AND batches.status = 'completed' \
-                 AND batches.historical_rollups_materialized_at IS NOT NULL \
-                 AND NOT EXISTS( \
-                     SELECT 1 FROM hourly_rollup_archive_replay AS replay \
-                     WHERE replay.dataset = batches.dataset \
-                       AND replay.file_path = batches.file_path \
-                       AND replay.target = ?1 \
-                 ) \
-           ), \
-           NOT EXISTS( \
-               SELECT 1 FROM archive_batches AS batches \
-               WHERE batches.dataset = 'codex_invocations' \
-                 AND batches.status = 'completed' \
-                 AND batches.historical_rollups_materialized_at IS NOT NULL \
-                 AND ( \
-                     NOT EXISTS( \
-                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
-                         WHERE replay.dataset = batches.dataset \
-                           AND replay.file_path = batches.file_path \
-                           AND replay.target = ?2 \
-                     ) \
-                     OR NOT EXISTS( \
-                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
-                         WHERE replay.dataset = batches.dataset \
-                           AND replay.file_path = batches.file_path \
-                           AND replay.target = ?3 \
-                     ) \
-                 ) \
-           )",
-    )
-    .bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
-    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
-    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
-    .fetch_one(pool)
-    .await
-    .context("summary projection all-time materialized coverage hydration failed")?;
-    Ok((global_complete != 0, account_complete != 0))
+    let mut global_covered = true;
+    let mut accounts_covered = true;
+
+    for archive in archives {
+        if !archive.has_materialized_historical_rollups() {
+            continue;
+        }
+        let replay = summary_projection_effective_replay_coverage(
+            archive,
+            replay_coverage
+                .get(archive.file_path())
+                .copied()
+                .unwrap_or_default(),
+        );
+        let Some(range) = summary_projection_archive_coverage_range(archive) else {
+            // Legacy manifests lack a finite durable coverage range. Their materialization flag
+            // remains the established proof for the global compact baseline. Account coverage
+            // cannot be inferred without a bounded manifest, so retain that legacy response
+            // only when its independent account replay marker exists.
+            accounts_covered &= replay.account_stats;
+            continue;
+        };
+        if summary_projection_exact_range_fits_bucket_budget(range).is_err() {
+            return Ok((false, false));
+        }
+        // A missing manifest cannot prove that the archive contains no account-scoped rows.
+        // Serving its global compact aggregate to an account request would silently omit those
+        // rows when the account rollup is absent, so preserve last-good/unavailable instead.
+        let account_ids = archive_account_ids_by_file.get(archive.file_path());
+        if account_ids.is_none() {
+            accounts_covered = false;
+        }
+        let mut bucket = align_bucket_epoch(range.start.timestamp(), 3_600, 0);
+        let last_bucket = align_bucket_epoch(range.end.timestamp().saturating_sub(1), 3_600, 0);
+        while bucket <= last_bucket {
+            // An aggregate row alone can represent an interrupted replay prefix. Its durable
+            // replay marker is the completion proof, so require both before replacing the
+            // exact archive source outside the bounded raw horizon.
+            global_covered &= replay.overall && hourly_rollup_totals.contains_key(&(bucket, None));
+            if let Some(account_ids) = account_ids.filter(|account_ids| !account_ids.is_empty()) {
+                accounts_covered &= replay.account_stats
+                    && account_ids.iter().all(|account_id| {
+                        hourly_rollup_totals.contains_key(&(bucket, Some(*account_id)))
+                    });
+            }
+            if !global_covered && !accounts_covered {
+                return Ok((false, false));
+            }
+            bucket = bucket.saturating_add(3_600);
+        }
+    }
+
+    Ok((global_covered, accounts_covered))
 }
 
 async fn load_summary_projection_archive_coverage_range(
@@ -9668,6 +9679,55 @@ async fn build_summary_projection(
         )
         .await?
         .is_empty();
+    // All-time aggregation needs manifest-level key proof, while rolling windows only need the
+    // bounded exact horizon below. A history that exceeds the manifest admission limit keeps
+    // `all` on its last-good/unavailable contract, but must not prevent the first rolling
+    // snapshot from becoming available.
+    let (all_time_archives, all_time_archive_admission_exceeded) =
+        if all_time_was_fully_rebuilt && has_any_completed_archive {
+            let archives = crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
+                &state.pool,
+                None,
+                SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
+            )
+            .await?;
+            if archives.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+                (Vec::new(), true)
+            } else {
+                (archives, false)
+            }
+        } else {
+            (Vec::new(), false)
+        };
+    let all_time_archive_paths = all_time_archives
+        .iter()
+        .map(|archive| archive.file_path().to_string())
+        .collect::<Vec<_>>();
+    let all_time_archive_replay_coverage =
+        load_summary_projection_archive_replay_coverage(&state.pool, &all_time_archive_paths)
+            .await?;
+    let mut all_time_archive_account_ids_by_file = HashMap::<String, HashSet<i64>>::new();
+    let mut all_time_account_manifest_admission_exceeded = false;
+    match load_summary_projection_archive_manifest_accounts(&state.pool, &all_time_archive_paths)
+        .await
+    {
+        Ok(accounts) => {
+            for (file_path, account_id) in accounts {
+                all_time_archive_account_ids_by_file
+                    .entry(file_path)
+                    .or_default()
+                    .insert(account_id);
+            }
+        }
+        Err(error)
+            if error.to_string().starts_with(
+                "summary projection archive account manifest exceeded bounded row budget",
+            ) =>
+        {
+            all_time_account_manifest_admission_exceeded = true;
+        }
+        Err(error) => return Err(error),
+    }
     let rollup_live_cursor = load_summary_projection_rollup_live_cursor(&state.pool).await?;
     let account_rollup_live_cursor =
         load_summary_projection_account_rollup_live_cursor(&state.pool).await?;
@@ -9781,6 +9841,11 @@ async fn build_summary_projection(
         .filter_map(|record| record.row.upstream_account_id)
         .filter(|account_id| *account_id > 0)
         .collect::<HashSet<_>>();
+    known_account_ids.extend(
+        all_time_archive_account_ids_by_file
+            .values()
+            .flat_map(|account_ids| account_ids.iter().copied()),
+    );
     known_account_ids.extend(load_summary_projection_durable_account_ids(&state.pool).await?);
     known_account_ids.extend(
         hourly_rollup_totals
@@ -10287,7 +10352,8 @@ async fn build_summary_projection(
             record.usage_account_rollup_covered = false;
         }
     }
-    let mut global_all_time_source_unavailable = all_time_global_exact_source_unavailable;
+    let mut global_all_time_source_unavailable =
+        all_time_global_exact_source_unavailable || all_time_archive_admission_exceeded;
     // Runtime is an authoritative typed overlay until the terminal writer persists it.  Replace
     // only matching live keys; a new in-flight record is inserted exactly once.
     for runtime_record in state.proxy_runtime_invocations.snapshot() {
@@ -10436,7 +10502,9 @@ async fn build_summary_projection(
             .filter(|account_id| *account_id > 0),
     );
     let mut batched_all_time_by_account = HashMap::<i64, StatsTotals>::new();
-    let mut account_all_time_unavailable = all_time_account_exact_source_unavailable;
+    let mut account_all_time_unavailable = all_time_account_exact_source_unavailable
+        || all_time_archive_admission_exceeded
+        || all_time_account_manifest_admission_exceeded;
     // Rolling-only rebuilds preserve the already-owned all-time map unchanged. Avoid a second
     // high-cardinality clone on that path; a previous copy is needed only when an all-time
     // rebuild may have to restore an exact last-good aggregate after a source failure.
@@ -10444,7 +10512,7 @@ async fn build_summary_projection(
         all_time_was_fully_rebuilt.then(|| all_time_by_account.clone());
     let all_time_built_at = Instant::now();
     let mut rebuilt_all_time_account_ids = HashSet::new();
-    if all_time_was_fully_rebuilt {
+    if all_time_was_fully_rebuilt && !all_time_archive_admission_exceeded {
         // All-time must use the same bounded projection inputs as rolling windows. The generic
         // stats query can open every unmaterialized archive and therefore cannot run in the
         // refresh path without defeating the rebuild deadline.
@@ -10473,10 +10541,16 @@ async fn build_summary_projection(
             }
         }
         let (global_rollup_coverage_proven, account_rollup_coverage_proven) =
-            summary_projection_all_time_materialized_scope_coverage(&state.pool).await?;
-        // A materialization record plus all required durable replay targets is the compact
-        // coverage proof for history outside the finite exact horizon. Missing targets retain
-        // exact last-good/unavailable behavior without blocking a rolling snapshot.
+            summary_projection_all_time_materialized_scope_coverage(
+                &all_time_archives,
+                &all_time_archive_replay_coverage,
+                &all_time_archive_account_ids_by_file,
+                &all_time_rollup_totals,
+            )?;
+        // A replay marker is not sufficient by itself: a deleted or never-written aggregate key
+        // would make the compact all-time baseline silently lose that archive bucket. Preserve
+        // an exact last-good aggregate (or its existing unavailable contract) until durable
+        // coverage can again be proven off-request.
         global_all_time_source_unavailable |= !global_rollup_coverage_proven;
         account_all_time_unavailable |= !account_rollup_coverage_proven;
         // An unreadable archive without replay coverage cannot contribute to either compact

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -9724,37 +9724,77 @@ fn summary_projection_archive_file_is_readable(file_path: &str) -> bool {
     io::copy(&mut decoder, &mut io::sink()).is_ok()
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SummaryProjectionArchiveFileIdentity {
+    Verified,
+    Unavailable,
+}
+
 fn verify_summary_projection_archive_file_path_sha256(
     file_path: &str,
     expected_sha256: &str,
-) -> Result<()> {
+) -> Result<SummaryProjectionArchiveFileIdentity> {
     let actual_sha256 = match crate::maintenance::sha256_hex_file(Path::new(file_path)) {
         Ok(actual_sha256) => actual_sha256,
         // An unreadable archive contributes no raw data. Preserve the existing exact fallback:
         // materialized rollups remain usable, while an unmaterialized source is marked
         // unavailable by the strict archive readers below.
-        Err(_) => return Ok(()),
+        Err(_) => return Ok(SummaryProjectionArchiveFileIdentity::Unavailable),
     };
     if actual_sha256 != expected_sha256 {
         if !summary_projection_archive_file_is_readable(file_path) {
-            return Ok(());
+            return Ok(SummaryProjectionArchiveFileIdentity::Unavailable);
         }
         return Err(anyhow!(
             "summary projection archive changed during hydration for {}",
             file_path
         ));
     }
-    Ok(())
+    Ok(SummaryProjectionArchiveFileIdentity::Verified)
 }
 
 fn verify_summary_projection_archive_file_sha256(
     archive: &crate::stats::ArchiveBatchPathRow,
     expected_sha256: &str,
-) -> Result<()> {
+) -> Result<SummaryProjectionArchiveFileIdentity> {
     verify_summary_projection_archive_file_path_sha256(archive.file_path(), expected_sha256)
 }
 
+fn require_summary_projection_archive_file_sha256(
+    archive: &crate::stats::ArchiveBatchPathRow,
+    expected_sha256: &str,
+) -> Result<()> {
+    match verify_summary_projection_archive_file_sha256(archive, expected_sha256)? {
+        SummaryProjectionArchiveFileIdentity::Verified => Ok(()),
+        SummaryProjectionArchiveFileIdentity::Unavailable => Err(anyhow!(
+            "summary projection archive became unavailable during hydration for {}",
+            archive.file_path()
+        )),
+    }
+}
+
 fn verify_summary_projection_archive_file_paths_sha256(
+    archive_paths: &[String],
+    expected_sha256_by_file_path: &HashMap<String, String>,
+) -> Result<Vec<String>> {
+    let mut verified_paths = Vec::with_capacity(archive_paths.len());
+    for file_path in archive_paths {
+        let expected_sha256 = expected_sha256_by_file_path.get(file_path).ok_or_else(|| {
+            anyhow!(
+                "summary projection archive manifest SHA is missing for {}",
+                file_path
+            )
+        })?;
+        if verify_summary_projection_archive_file_path_sha256(file_path, expected_sha256)?
+            == SummaryProjectionArchiveFileIdentity::Verified
+        {
+            verified_paths.push(file_path.clone());
+        }
+    }
+    Ok(verified_paths)
+}
+
+fn require_summary_projection_archive_file_paths_sha256(
     archive_paths: &[String],
     expected_sha256_by_file_path: &HashMap<String, String>,
 ) -> Result<()> {
@@ -9765,7 +9805,15 @@ fn verify_summary_projection_archive_file_paths_sha256(
                 file_path
             )
         })?;
-        verify_summary_projection_archive_file_path_sha256(file_path, expected_sha256)?;
+        match verify_summary_projection_archive_file_path_sha256(file_path, expected_sha256)? {
+            SummaryProjectionArchiveFileIdentity::Verified => {}
+            SummaryProjectionArchiveFileIdentity::Unavailable => {
+                return Err(anyhow!(
+                    "summary projection archive became unavailable during hydration for {}",
+                    file_path
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -10775,6 +10823,9 @@ async fn build_summary_projection_once(
                 anyhow!("summary projection usage progress hydration failed: {error:?}")
             })?;
     let mut unavailable_unmaterialized_archive_buckets = BTreeSet::<i64>::new();
+    // Rolling boundary ranges may need raw records even when an all-time compact rollup is
+    // complete. Keep that narrower unavailability separate from all-time source proof.
+    let mut all_time_source_unavailable_from_archive_ranges = false;
     // Discover accounts from archive rows before planning full-hour coverage. Pools are opened
     // and closed one at a time so a large retention horizon never keeps every inflated archive
     // resident concurrently. Immutable completed archives reuse the cached account set on later
@@ -10860,13 +10911,14 @@ async fn build_summary_projection_once(
                 // global total could conceal missing account or usage/model detail.
                 continue;
             }
+            all_time_source_unavailable_from_archive_ranges = true;
             summary_projection_mark_unavailable_archive_ranges(
                 &mut unavailable_unmaterialized_archive_buckets,
                 [archive_range],
             )?;
             continue;
         };
-        verify_summary_projection_archive_file_sha256(archive, manifest_sha256)?;
+        require_summary_projection_archive_file_sha256(archive, manifest_sha256)?;
         if !summary_projection_archive_has_coverage_bounds(archive)
             && let Some(actual_range) = load_summary_projection_archive_coverage_range(
                 &archive_pool,
@@ -10903,7 +10955,7 @@ async fn build_summary_projection_once(
             ));
         }
         archive_account_ids_by_file.insert(archive.file_path().to_string(), account_ids);
-        verify_summary_projection_archive_file_sha256(archive, manifest_sha256)?;
+        require_summary_projection_archive_file_sha256(archive, manifest_sha256)?;
         archive_pool.close().await;
         drop(temp_cleanup);
     }
@@ -11230,18 +11282,25 @@ async fn build_summary_projection_once(
                     archive.file_path()
                 )
             })?;
-        if Path::new(archive.file_path()).exists() {
-            verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+        if Path::new(archive.file_path()).exists()
+            && verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?
+                == SummaryProjectionArchiveFileIdentity::Unavailable
+        {
+            if !replay_coverage.supports_unavailable_archive() {
+                all_time_source_unavailable_from_archive_ranges = true;
+            }
+            summary_projection_mark_unavailable_archive_ranges(
+                &mut unavailable_unmaterialized_archive_buckets,
+                exact_ranges,
+            )?;
+            continue;
         }
         let Some((archive_pool, temp_cleanup)) =
             crate::stats::open_invocation_archive_batch_pool(&archive, "summary-projection")
                 .await?
         else {
-            if replay_coverage.supports_unavailable_archive() {
-                // A complete replay marker is coupled to the same manifest SHA captured for
-                // this build. Its durable hourly baseline remains exact when the optional raw
-                // file is unreadable, so retain that source instead of degrading a full hour.
-                continue;
+            if !replay_coverage.supports_unavailable_archive() {
+                all_time_source_unavailable_from_archive_ranges = true;
             }
             // Complete replay can replace a full compact hour, but it cannot reconstruct this
             // request-visible partial hour or its usage/model detail. The raw archive is an
@@ -11253,7 +11312,7 @@ async fn build_summary_projection_once(
             )?;
             continue;
         };
-        verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+        require_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
         merge_summary_projection_archive_records_with_coverage(
             &archive_pool,
             pool,
@@ -11279,7 +11338,7 @@ async fn build_summary_projection_once(
                 archive.file_path()
             )
         })?;
-        verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+        require_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
         archive_pool.close().await;
         drop(temp_cleanup);
     }
@@ -11360,8 +11419,15 @@ async fn build_summary_projection_once(
                                 archive.file_path()
                             )
                         })?;
-                if Path::new(archive.file_path()).exists() {
-                    verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+                if Path::new(archive.file_path()).exists()
+                    && verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?
+                        == SummaryProjectionArchiveFileIdentity::Unavailable
+                {
+                    summary_projection_mark_unavailable_archive_ranges(
+                        &mut unavailable_unmaterialized_archive_buckets,
+                        exact_ranges,
+                    )?;
+                    continue;
                 }
                 let Some((archive_pool, temp_cleanup)) =
                     crate::stats::open_invocation_archive_batch_pool(
@@ -11379,7 +11445,7 @@ async fn build_summary_projection_once(
                     )?;
                     continue;
                 };
-                verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+                require_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
                 merge_summary_projection_archive_records_with_coverage(
                     &archive_pool,
                     pool,
@@ -11405,7 +11471,7 @@ async fn build_summary_projection_once(
                         archive.file_path()
                     )
                 })?;
-                verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+                require_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
                 archive_pool.close().await;
                 drop(temp_cleanup);
             }
@@ -11432,8 +11498,9 @@ async fn build_summary_projection_once(
             record.usage_account_rollup_covered = false;
         }
     }
-    let mut global_all_time_source_unavailable =
-        all_time_global_exact_source_unavailable || all_time_archive_admission_exceeded;
+    let mut global_all_time_source_unavailable = all_time_global_exact_source_unavailable
+        || all_time_archive_admission_exceeded
+        || all_time_source_unavailable_from_archive_ranges;
     // Runtime is an authoritative typed overlay until the terminal writer persists it.  Replace
     // only matching live keys; a new in-flight record is inserted exactly once.
     for runtime_record in state.proxy_runtime_invocations.snapshot() {
@@ -11584,7 +11651,8 @@ async fn build_summary_projection_once(
     let mut batched_all_time_by_account = HashMap::<i64, StatsTotals>::new();
     let mut account_all_time_unavailable = all_time_account_exact_source_unavailable
         || all_time_archive_admission_exceeded
-        || all_time_account_manifest_admission_exceeded;
+        || all_time_account_manifest_admission_exceeded
+        || all_time_source_unavailable_from_archive_ranges;
     // Rolling-only rebuilds preserve the already-owned all-time map unchanged. Avoid a second
     // high-cardinality clone on that path; a previous copy is needed only when an all-time
     // rebuild may have to restore an exact last-good aggregate after a source failure.
@@ -11663,11 +11731,6 @@ async fn build_summary_projection_once(
             all_time_archive_admission_exceeded |= !global_rollup_coverage_proven;
             all_time_account_manifest_admission_exceeded |= !account_rollup_coverage_proven;
         }
-        // An unreadable archive without replay coverage cannot contribute to either compact
-        // all-time aggregate. Preserve last-good/unavailable for `all`; range selections use
-        // the bounded marker carried by this projection.
-        global_all_time_source_unavailable |=
-            !unavailable_unmaterialized_archive_buckets.is_empty();
         // With no completed archives, the canonical live rows are authoritative even when a
         // stale hourly rollup exists. Once archives are present, the rollup is the historical
         // prefix and only rows beyond the shared live cursor are an exact live tail.
@@ -11743,7 +11806,6 @@ async fn build_summary_projection_once(
                 account_all_time_unavailable = true;
             }
         }
-        account_all_time_unavailable |= !unavailable_unmaterialized_archive_buckets.is_empty();
         if has_any_completed_archive && rollup_live_cursor > 0 {
             global_totals = global_totals.add(
                 crate::stats::query_live_invocation_totals_after_id(
@@ -11758,10 +11820,11 @@ async fn build_summary_projection_once(
                 })?,
             );
         }
-        verify_summary_projection_archive_file_paths_sha256(
-            &all_time_archive_scan_paths,
-            &all_time_archive_manifest_sha256,
-        )?;
+        let global_archive_scan_verified_paths =
+            verify_summary_projection_archive_file_paths_sha256(
+                &all_time_archive_scan_paths,
+                &all_time_archive_manifest_sha256,
+            )?;
         let unmaterialized_archive_totals =
             crate::stats::query_unmaterialized_invocation_archive_totals_bounded_strict(
                 pool,
@@ -11773,8 +11836,8 @@ async fn build_summary_projection_once(
             .await;
         match unmaterialized_archive_totals {
             Ok(totals) => {
-                verify_summary_projection_archive_file_paths_sha256(
-                    &all_time_archive_scan_paths,
+                require_summary_projection_archive_file_paths_sha256(
+                    &global_archive_scan_verified_paths,
                     &all_time_archive_manifest_sha256,
                 )?;
                 global_totals = global_totals.add(totals);
@@ -11852,10 +11915,11 @@ async fn build_summary_projection_once(
                 *entry = entry.add(totals);
             }
         }
-        verify_summary_projection_archive_file_paths_sha256(
-            &all_time_archive_scan_paths,
-            &all_time_archive_manifest_sha256,
-        )?;
+        let account_archive_scan_verified_paths =
+            verify_summary_projection_archive_file_paths_sha256(
+                &all_time_archive_scan_paths,
+                &all_time_archive_manifest_sha256,
+            )?;
         let account_archive_totals =
             crate::stats::query_unmaterialized_upstream_account_archive_totals_by_account(
                 pool,
@@ -11867,8 +11931,8 @@ async fn build_summary_projection_once(
             .await;
         let account_archive_totals = match account_archive_totals {
             Ok(totals) => {
-                verify_summary_projection_archive_file_paths_sha256(
-                    &all_time_archive_scan_paths,
+                require_summary_projection_archive_file_paths_sha256(
+                    &account_archive_scan_verified_paths,
                     &all_time_archive_manifest_sha256,
                 )?;
                 totals

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7289,6 +7289,10 @@ pub(crate) struct SummaryProjection {
     // Regular rolling refreshes may reuse all-time responses when no all-time owner is active;
     // keep their freshness independent from the projection-wide timestamp.
     all_time_refreshed_at: Option<Instant>,
+    // An all-history manifest set beyond admission cannot be made exact without an unbounded
+    // proof. Preserve that fail-closed result so maintenance does not retry the same query on
+    // every rolling refresh.
+    all_time_manifest_admission_blocked: bool,
     // Global all-time rollups and account archive fallbacks have independent durable coverage.
     // A failed account rebuild must not make a fresh global aggregate stale, and an old account
     // response must never borrow the global aggregate's freshness.
@@ -7313,6 +7317,10 @@ pub(crate) struct SummaryProjection {
     // than publishing an undercount or turning a selection-level unavailability into an HTTP
     // builder failure.
     unavailable_unmaterialized_archive_ranges: Vec<ExactUtcRange>,
+    // Boundary archive admission is independent from all-time admission. The projection keeps
+    // this state so an oversized exact-horizon manifest set does not make later refreshes repeat
+    // the same SQLite work while affected windows remain unavailable.
+    archive_boundary_manifest_admission_blocked: bool,
     // In-progress state is not the same thing as a row whose persisted status happens to be
     // `running`: the typed runtime overlay reconciles terminal replacements and retry lineage.
     // Keep that reconciled view alongside the immutable history projection.
@@ -7395,6 +7403,7 @@ impl SummaryProjection {
         };
         refresh_due(self.freshness.rolling_at(self.refreshed_at))
             || (has_all_time_owner
+                && !self.all_time_manifest_admission_blocked
                 && (refresh_due(self.all_time_refreshed_at)
                     || refresh_due(self.all_time_oldest_account_refreshed_at)))
     }
@@ -7437,6 +7446,13 @@ impl SummaryProjection {
             Some(_) => return Err(ApiError::bad_request(anyhow!("invalid upstream account"))),
             None => None,
         };
+        if self.archive_boundary_manifest_admission_blocked
+            && matches!(window, SummaryWindow::Current(_))
+        {
+            return Err(ApiError::unavailable(anyhow!(
+                "summary projection archive manifest admission is unavailable for the requested range"
+            )));
+        }
         let now = Utc::now();
         let range = summary_window_range(&window, reporting_tz, now)?;
         if let Some((start, end)) = range
@@ -9228,7 +9244,7 @@ async fn refresh_summary_snapshots(state: &AppState) -> Result<()> {
     refresh_summary_snapshots_with_mode(state, include_all_time).await
 }
 
-async fn refresh_summary_snapshots_with_mode(
+pub(crate) async fn refresh_summary_snapshots_with_mode(
     state: &AppState,
     include_all_time: bool,
 ) -> Result<()> {
@@ -9264,6 +9280,7 @@ async fn refresh_summary_snapshots_with_deadline(
             (
                 projection.all_time_by_account.clone(),
                 projection.all_time_refreshed_at,
+                projection.all_time_manifest_admission_blocked,
                 projection.all_time_account_refreshed_at.clone(),
                 projection.archive_account_ids_by_file.clone(),
                 projection.archive_coverage_ranges_by_file.clone(),
@@ -9280,6 +9297,7 @@ async fn refresh_summary_snapshots_with_deadline(
                 projection
                     .all_time_account_persisted_live_terminal_invoke_ids
                     .clone(),
+                projection.archive_boundary_manifest_admission_blocked,
             )
         });
     let had_previous_projection = previous_all_time.is_some();
@@ -9308,6 +9326,7 @@ async fn refresh_summary_snapshots_with_deadline(
         && !projection
             .unavailable_unmaterialized_archive_ranges
             .is_empty()
+        && !projection.archive_boundary_manifest_admission_blocked
     {
         // A background failure must never replace a complete revision with a partial one.  The
         // existing revision remains the exact last-good response until its own freshness budget
@@ -9623,6 +9642,7 @@ async fn build_summary_projection(
     previous_all_time: Option<(
         HashMap<Option<i64>, StatsResponse>,
         Option<Instant>,
+        bool,
         HashMap<i64, Instant>,
         HashMap<String, HashSet<i64>>,
         HashMap<String, ExactUtcRange>,
@@ -9633,6 +9653,7 @@ async fn build_summary_projection(
         HashSet<String>,
         HashMap<i64, u64>,
         HashMap<i64, HashSet<String>>,
+        bool,
     )>,
     durable_terminal_sequence_watermark: u64,
 ) -> Result<SummaryProjection> {
@@ -9640,6 +9661,7 @@ async fn build_summary_projection(
     let (
         mut all_time_by_account,
         previous_all_time_refreshed_at,
+        previous_all_time_manifest_admission_blocked,
         mut all_time_account_refreshed_at,
         mut archive_account_ids_by_file,
         mut archive_coverage_ranges_by_file,
@@ -9650,8 +9672,27 @@ async fn build_summary_projection(
         previous_all_time_persisted_live_terminal_invoke_ids,
         previous_all_time_account_terminal_sequence_watermarks,
         previous_all_time_account_persisted_live_terminal_invoke_ids,
-    ) = previous_all_time.unwrap_or_default();
-    let all_time_was_fully_rebuilt = include_all_time || previous_all_time_refreshed_at.is_none();
+        previous_archive_boundary_manifest_admission_blocked,
+    ) = previous_all_time.unwrap_or_else(|| {
+        (
+            HashMap::new(),
+            None,
+            false,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            HashSet::new(),
+            false,
+            0,
+            HashSet::new(),
+            HashMap::new(),
+            HashMap::new(),
+            false,
+        )
+    });
+    let all_time_was_fully_rebuilt = !previous_all_time_manifest_admission_blocked
+        && (include_all_time || previous_all_time_refreshed_at.is_none());
     // Materialized hourly rollups are the canonical historical baseline. Raw live preview rows
     // are limited to the moving exact tail; older live rows are represented by their durable
     // hourly rollups. Archive boundary rows use the wider finite range below so supported 7d/
@@ -9668,9 +9709,9 @@ async fn build_summary_projection(
         load_summary_projection_rollup_totals_in_range(&state.pool, Some(rollup_range)).await?;
     let hourly_rollup_usage =
         load_summary_projection_rollup_usage_in_range(&state.pool, Some(rollup_range)).await?;
-    // All-time aggregation must distinguish "no archives exist" from "archives are older than
-    // the bounded exact horizon". The latter still has durable rollup history even though those
-    // archive files are intentionally not opened during this refresh.
+    // Rolling aggregation must still distinguish an archive-backed retention database from a
+    // live-only one. This bounded existence probe is independent of the expensive all-history
+    // manifest admission below.
     let has_any_completed_archive =
         !crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
             &state.pool,
@@ -9867,21 +9908,26 @@ async fn build_summary_projection(
     // Boundary-hour selection is record-exact, including when the range starts or ends inside
     // an archived hour. Archive rows are streamed into the bounded exact set while building;
     // HTTP never opens or probes archive files.
-    let archives = crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
-        &state.pool,
-        Some((archive_start, end)),
-        SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
-    )
-    .await?;
+    let (archives, archive_boundary_manifest_admission_blocked) =
+        if previous_archive_boundary_manifest_admission_blocked {
+            (Vec::new(), true)
+        } else {
+            let archives = crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
+                &state.pool,
+                Some((archive_start, end)),
+                SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
+            )
+            .await?;
+            if archives.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+                (Vec::new(), true)
+            } else {
+                (archives, false)
+            }
+        };
     let archive_paths = archives
         .iter()
         .map(|archive| archive.file_path().to_string())
         .collect::<Vec<_>>();
-    if archive_paths.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
-        return Err(anyhow!(
-            "summary projection archive batch cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES})"
-        ));
-    }
     let archive_path_set = archive_paths.iter().cloned().collect::<HashSet<_>>();
     archive_account_ids_by_file.retain(|path, _| archive_path_set.contains(path));
     archive_coverage_ranges_by_file.retain(|path, _| archive_path_set.contains(path));
@@ -9943,6 +9989,15 @@ async fn build_summary_projection(
                 anyhow!("summary projection usage progress hydration failed: {error:?}")
             })?;
     let mut unavailable_unmaterialized_archive_ranges = Vec::<ExactUtcRange>::new();
+    if archive_boundary_manifest_admission_blocked {
+        // The manifest cardinality does not disclose which completed archive contains a boundary
+        // row. Treat the complete exact horizon as unavailable rather than folding only the
+        // retained prefix into an otherwise plausible, but incomplete, rolling response.
+        unavailable_unmaterialized_archive_ranges.push(ExactUtcRange {
+            start: archive_start,
+            end,
+        });
+    }
     // Discover accounts from archive rows before planning full-hour coverage. Pools are opened
     // and closed one at a time so a large retention horizon never keeps every inflated archive
     // resident concurrently. Immutable completed archives reuse the cached account set on later
@@ -10994,6 +11049,9 @@ async fn build_summary_projection(
         } else {
             previous_all_time_refreshed_at
         },
+        all_time_manifest_admission_blocked: previous_all_time_manifest_admission_blocked
+            || all_time_archive_admission_exceeded
+            || all_time_account_manifest_admission_exceeded,
         all_time_account_refreshed_at,
         all_time_oldest_account_refreshed_at,
         all_time_account_ids_with_projection_data: account_ids_with_projection_data,
@@ -11001,6 +11059,7 @@ async fn build_summary_projection(
         archive_account_ids_by_file,
         archive_coverage_ranges_by_file: archive_actual_coverage_ranges,
         unavailable_unmaterialized_archive_ranges,
+        archive_boundary_manifest_admission_blocked,
         in_progress_by_account,
         maintenance: Some(maintenance),
         refreshed_at,

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7014,10 +7014,9 @@ const SUMMARY_PROJECTION_MAX_EXACT_RECORDS: usize = 50_000;
 // rows.  A refresh which cannot represent the durable cardinality fails closed and keeps the
 // previous projection, rather than publishing a partial aggregate.
 const SUMMARY_PROJECTION_MAX_ACCOUNTS: usize = 50_000;
-// Archive manifests remain a bounded background input, but share the established exact-record
-// admission rather than rejecting a durable rollup solely because it spans more than 4,096
-// archive batches. Path-based SQLite reads are chunked below to stay well under bind limits.
-const SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES: usize = SUMMARY_PROJECTION_MAX_EXACT_RECORDS;
+// Exact archive-boundary hydration remains bounded independently from the compact all-time
+// rollup baseline. Path-based SQLite reads are chunked below to stay well under bind limits.
+const SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES: usize = 4_096;
 const SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE: usize = 512;
 // Exact replacement is intentionally exceptional. Keeping this separately bounded prevents a
 // wide retention horizon with a compact-coverage gap from turning a background rebuild into an
@@ -8459,63 +8458,54 @@ fn summary_projection_archive_coverage_range(
     (start < end).then_some(ExactUtcRange { start, end })
 }
 
-fn summary_projection_all_time_materialized_scope_coverage(
-    archives: &[crate::stats::ArchiveBatchPathRow],
-    replay_coverage: &HashMap<String, SummaryProjectionArchiveReplayCoverage>,
-    archive_account_ids_by_file: &HashMap<String, HashSet<i64>>,
-    hourly_rollup_totals: &HashMap<(i64, Option<i64>), StatsTotals>,
+async fn summary_projection_all_time_materialized_scope_coverage(
+    pool: &Pool<Sqlite>,
 ) -> Result<(bool, bool)> {
-    let mut global_covered = true;
-    let mut accounts_covered = true;
-
-    for archive in archives {
-        if !archive.has_materialized_historical_rollups() {
-            continue;
-        }
-        let replay = summary_projection_effective_replay_coverage(
-            archive,
-            replay_coverage
-                .get(archive.file_path())
-                .copied()
-                .unwrap_or_default(),
-        );
-        let Some(range) = summary_projection_archive_coverage_range(archive) else {
-            // Legacy manifests lack a finite durable coverage range. Their materialization flag
-            // remains the established proof for the global compact baseline. Account coverage
-            // cannot be inferred without a bounded manifest, so retain that legacy response
-            // only when its independent account replay marker exists.
-            accounts_covered &= replay.account_stats;
-            continue;
-        };
-        summary_projection_exact_range_fits_bucket_budget(range)?;
-        // A missing manifest cannot prove that the archive contains no account-scoped rows.
-        // Serving its global compact aggregate to an account request would silently omit those
-        // rows when the account rollup is absent, so preserve last-good/unavailable instead.
-        let account_ids = archive_account_ids_by_file.get(archive.file_path());
-        if account_ids.is_none() {
-            accounts_covered = false;
-        }
-        let mut bucket = align_bucket_epoch(range.start.timestamp(), 3_600, 0);
-        let last_bucket = align_bucket_epoch(range.end.timestamp().saturating_sub(1), 3_600, 0);
-        while bucket <= last_bucket {
-            // An aggregate row alone can represent an interrupted replay prefix. Its durable
-            // replay marker is the completion proof, so require both before replacing the
-            // exact archive source outside the bounded raw horizon.
-            global_covered &= replay.overall && hourly_rollup_totals.contains_key(&(bucket, None));
-            if let Some(account_ids) = account_ids.filter(|account_ids| !account_ids.is_empty()) {
-                accounts_covered &= replay.account_stats
-                    && account_ids.iter().all(|account_id| {
-                        hourly_rollup_totals.contains_key(&(bucket, Some(*account_id)))
-                    });
-            }
-            if !global_covered && !accounts_covered {
-                return Ok((false, false));
-            }
-            bucket = bucket.saturating_add(3_600);
-        }
-    }
-
-    Ok((global_covered, accounts_covered))
+    // Materialization and its replay markers are committed together. Check for an incomplete
+    // durable target with constant-space EXISTS probes instead of retaining every historical
+    // manifest just to re-prove an all-time rollup already stored in SQLite.
+    let (global_complete, account_complete) = sqlx::query_as::<_, (i64, i64)>(
+        "SELECT \
+           NOT EXISTS( \
+               SELECT 1 FROM archive_batches AS batches \
+               WHERE batches.dataset = 'codex_invocations' \
+                 AND batches.status = 'completed' \
+                 AND batches.historical_rollups_materialized_at IS NOT NULL \
+                 AND NOT EXISTS( \
+                     SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                     WHERE replay.dataset = batches.dataset \
+                       AND replay.file_path = batches.file_path \
+                       AND replay.target = ?1 \
+                 ) \
+           ), \
+           NOT EXISTS( \
+               SELECT 1 FROM archive_batches AS batches \
+               WHERE batches.dataset = 'codex_invocations' \
+                 AND batches.status = 'completed' \
+                 AND batches.historical_rollups_materialized_at IS NOT NULL \
+                 AND ( \
+                     NOT EXISTS( \
+                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                         WHERE replay.dataset = batches.dataset \
+                           AND replay.file_path = batches.file_path \
+                           AND replay.target = ?2 \
+                     ) \
+                     OR NOT EXISTS( \
+                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                         WHERE replay.dataset = batches.dataset \
+                           AND replay.file_path = batches.file_path \
+                           AND replay.target = ?3 \
+                     ) \
+                 ) \
+           )",
+    )
+    .bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+    .bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
+    .fetch_one(pool)
+    .await
+    .context("summary projection all-time materialized coverage hydration failed")?;
+    Ok((global_complete != 0, account_complete != 0))
 }
 
 async fn load_summary_projection_archive_coverage_range(
@@ -9452,18 +9442,21 @@ async fn load_summary_projection_archive_manifest_accounts(
             }
         }
         query.push(")");
-        accounts.extend(
-            query
-                .build_query_as::<(String, i64)>()
-                .fetch_all(pool)
-                .await
-                .context("summary projection archive account manifest hydration failed")?,
-        );
-        if accounts.len() > SUMMARY_PROJECTION_MAX_EXACT_RECORDS {
+        let remaining = SUMMARY_PROJECTION_MAX_EXACT_RECORDS.saturating_sub(accounts.len());
+        query
+            .push(" LIMIT ")
+            .push_bind((remaining.saturating_add(1)) as i64);
+        let rows = query
+            .build_query_as::<(String, i64)>()
+            .fetch_all(pool)
+            .await
+            .context("summary projection archive account manifest hydration failed")?;
+        if rows.len() > remaining {
             return Err(anyhow!(
                 "summary projection archive account manifest exceeded bounded row budget ({SUMMARY_PROJECTION_MAX_EXACT_RECORDS})"
             ));
         }
+        accounts.extend(rows);
     }
     Ok(accounts)
 }
@@ -9675,41 +9668,6 @@ async fn build_summary_projection(
         )
         .await?
         .is_empty();
-    // All-time aggregates consume compact rollups outside the finite exact horizon. Keep only
-    // their bounded manifest metadata in this build, then prove the actual per-scope rollup keys
-    // before serving the aggregate. Raw archive files remain limited to the finite range below.
-    let all_time_archives = if all_time_was_fully_rebuilt && has_any_completed_archive {
-        crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
-            &state.pool,
-            None,
-            SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
-        )
-        .await?
-    } else {
-        Vec::new()
-    };
-    if all_time_archives.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
-        return Err(anyhow!(
-            "summary projection all-time archive batch cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES})"
-        ));
-    }
-    let all_time_archive_paths = all_time_archives
-        .iter()
-        .map(|archive| archive.file_path().to_string())
-        .collect::<Vec<_>>();
-    let all_time_archive_replay_coverage =
-        load_summary_projection_archive_replay_coverage(&state.pool, &all_time_archive_paths)
-            .await?;
-    let mut all_time_archive_account_ids_by_file = HashMap::<String, HashSet<i64>>::new();
-    for (file_path, account_id) in
-        load_summary_projection_archive_manifest_accounts(&state.pool, &all_time_archive_paths)
-            .await?
-    {
-        all_time_archive_account_ids_by_file
-            .entry(file_path)
-            .or_default()
-            .insert(account_id);
-    }
     let rollup_live_cursor = load_summary_projection_rollup_live_cursor(&state.pool).await?;
     let account_rollup_live_cursor =
         load_summary_projection_account_rollup_live_cursor(&state.pool).await?;
@@ -9823,11 +9781,6 @@ async fn build_summary_projection(
         .filter_map(|record| record.row.upstream_account_id)
         .filter(|account_id| *account_id > 0)
         .collect::<HashSet<_>>();
-    known_account_ids.extend(
-        all_time_archive_account_ids_by_file
-            .values()
-            .flat_map(|account_ids| account_ids.iter().copied()),
-    );
     known_account_ids.extend(load_summary_projection_durable_account_ids(&state.pool).await?);
     known_account_ids.extend(
         hourly_rollup_totals
@@ -10520,16 +10473,10 @@ async fn build_summary_projection(
             }
         }
         let (global_rollup_coverage_proven, account_rollup_coverage_proven) =
-            summary_projection_all_time_materialized_scope_coverage(
-                &all_time_archives,
-                &all_time_archive_replay_coverage,
-                &all_time_archive_account_ids_by_file,
-                &all_time_rollup_totals,
-            )?;
-        // A replay marker is not sufficient by itself: a deleted or never-written aggregate key
-        // would make the compact all-time baseline silently lose that archive bucket. Preserve
-        // an exact last-good aggregate (or its existing unavailable contract) until durable
-        // coverage can again be proven off-request.
+            summary_projection_all_time_materialized_scope_coverage(&state.pool).await?;
+        // A materialization record plus all required durable replay targets is the compact
+        // coverage proof for history outside the finite exact horizon. Missing targets retain
+        // exact last-good/unavailable behavior without blocking a rolling snapshot.
         global_all_time_source_unavailable |= !global_rollup_coverage_proven;
         account_all_time_unavailable |= !account_rollup_coverage_proven;
         // An unreadable archive without replay coverage cannot contribute to either compact
@@ -26519,122 +26466,6 @@ mod request_compression_query_tests {
         hydrate_summary_snapshots(state.as_ref())
             .await
             .expect("hydrate summary projection fixture");
-    }
-
-    #[tokio::test]
-    async fn summary_projection_hydrates_more_than_legacy_archive_manifest_limit_from_rollups() {
-        let state = crate::tests::test_state_with_openai_base(
-            url::Url::parse("http://127.0.0.1:9").expect("valid test URL"),
-        )
-        .await;
-        let archive_start = Utc
-            .timestamp_opt(
-                align_bucket_epoch(
-                    (Utc::now() - ChronoDuration::days(1_000)).timestamp(),
-                    3_600,
-                    0,
-                ),
-                0,
-            )
-            .single()
-            .expect("align archive fixture to a full hour");
-        let archive_end = archive_start + ChronoDuration::hours(1);
-        let bucket = align_bucket_epoch(archive_start.timestamp(), 3_600, 0);
-
-        sqlx::query(
-            "INSERT INTO invocation_rollup_hourly \
-             (bucket_start_epoch, source, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
-             VALUES (?1, 'proxy', 1, 1, 0, 17, 1.25, 0)",
-        )
-        .bind(bucket)
-        .execute(&state.pool)
-        .await
-        .expect("insert durable summary rollup");
-        sqlx::query(
-            "INSERT INTO upstream_account_stats_hourly \
-             (bucket_start_epoch, source, upstream_account_id, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
-             VALUES (?1, 'proxy', 42, 1, 1, 0, 17, 1.25, 0)",
-        )
-        .bind(bucket)
-        .execute(&state.pool)
-        .await
-        .expect("insert durable account summary rollup");
-        sqlx::query(
-            "WITH RECURSIVE manifests(ordinal) AS ( \
-                SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal <= 4096 \
-             ) \
-             INSERT INTO archive_batches \
-             (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
-              historical_rollups_materialized_at, created_at) \
-             SELECT 'codex_invocations', '2026-01', \
-                    '/tmp/summary-manifest-admission-' || ordinal || '.sqlite.gz', \
-                    'summary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now') \
-             FROM manifests",
-        )
-        .bind(db_occurred_at_lower_bound(archive_start))
-        .bind(db_occurred_at_upper_bound(archive_end))
-        .execute(&state.pool)
-        .await
-        .expect("insert archive manifests beyond the legacy limit");
-        sqlx::query(
-            "INSERT INTO archive_batch_upstream_activity (archive_batch_id, account_id, last_activity_at) \
-             SELECT id, 42, ?1 FROM archive_batches \
-             WHERE file_path GLOB '/tmp/summary-manifest-admission-*.sqlite.gz'",
-        )
-        .bind(db_occurred_at_lower_bound(archive_end))
-        .execute(&state.pool)
-        .await
-        .expect("record archive account manifests");
-        for target in [
-            HOURLY_ROLLUP_TARGET_INVOCATIONS,
-            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
-            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN,
-        ] {
-            sqlx::query(
-                "INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, archive_sha256) \
-                 SELECT ?1, dataset, file_path, sha256 FROM archive_batches \
-                 WHERE file_path GLOB '/tmp/summary-manifest-admission-*.sqlite.gz'",
-            )
-            .bind(target)
-            .execute(&state.pool)
-            .await
-            .expect("record complete rollup replay coverage");
-        }
-
-        hydrate_summary_snapshots(state.as_ref())
-            .await
-            .expect("hydrate exact summary projection beyond the legacy manifest limit");
-        state.pool.close().await;
-
-        let Json(response) = fetch_summary(
-            State(state.clone()),
-            Query(SummaryQuery {
-                window: Some("all".to_string()),
-                limit: None,
-                time_zone: Some("UTC".to_string()),
-                upstream_account_id: None,
-            }),
-        )
-        .await
-        .expect("serve the hydrated all-time response without SQLite");
-        assert_eq!(response.total_count, 1);
-        assert_eq!(response.total_tokens, 17);
-        assert_eq!(response.total_cost, 1.25);
-
-        let Json(account_response) = fetch_summary(
-            State(state),
-            Query(SummaryQuery {
-                window: Some("all".to_string()),
-                limit: None,
-                time_zone: Some("UTC".to_string()),
-                upstream_account_id: Some(42),
-            }),
-        )
-        .await
-        .expect("serve the hydrated account response without SQLite");
-        assert_eq!(account_response.total_count, 1);
-        assert_eq!(account_response.total_tokens, 17);
-        assert_eq!(account_response.total_cost, 1.25);
     }
 
     #[tokio::test]

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::anyhow;
 use chrono::{TimeZone, Timelike};
 use chrono_tz::TZ_VARIANTS;
+use flate2::read::GzDecoder;
 use futures_util::TryStreamExt;
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -20,6 +21,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
+use std::{fs, io};
 use tracing::debug;
 
 #[cfg(test)]
@@ -9714,18 +9716,29 @@ async fn load_summary_projection_archive_manifest_sha256(
     Ok(sha256_by_file_path)
 }
 
+fn summary_projection_archive_file_is_readable(file_path: &str) -> bool {
+    let Ok(file) = fs::File::open(file_path) else {
+        return false;
+    };
+    let mut decoder = GzDecoder::new(file);
+    io::copy(&mut decoder, &mut io::sink()).is_ok()
+}
+
 fn verify_summary_projection_archive_file_path_sha256(
     file_path: &str,
     expected_sha256: &str,
 ) -> Result<()> {
-    let actual_sha256 =
-        crate::maintenance::sha256_hex_file(Path::new(file_path)).with_context(|| {
-            format!(
-                "summary projection archive identity read failed for {}",
-                file_path
-            )
-        })?;
+    let actual_sha256 = match crate::maintenance::sha256_hex_file(Path::new(file_path)) {
+        Ok(actual_sha256) => actual_sha256,
+        // An unreadable archive contributes no raw data. Preserve the existing exact fallback:
+        // materialized rollups remain usable, while an unmaterialized source is marked
+        // unavailable by the strict archive readers below.
+        Err(_) => return Ok(()),
+    };
     if actual_sha256 != expected_sha256 {
+        if !summary_projection_archive_file_is_readable(file_path) {
+            return Ok(());
+        }
         return Err(anyhow!(
             "summary projection archive changed during hydration for {}",
             file_path
@@ -11224,6 +11237,12 @@ async fn build_summary_projection_once(
             crate::stats::open_invocation_archive_batch_pool(&archive, "summary-projection")
                 .await?
         else {
+            if replay_coverage.supports_unavailable_archive() {
+                // A complete replay marker is coupled to the same manifest SHA captured for
+                // this build. Its durable hourly baseline remains exact when the optional raw
+                // file is unreadable, so retain that source instead of degrading a full hour.
+                continue;
+            }
             // Complete replay can replace a full compact hour, but it cannot reconstruct this
             // request-visible partial hour or its usage/model detail. The raw archive is an
             // exact source for every range in `exact_ranges`; without it, retain unavailable

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7014,7 +7014,11 @@ const SUMMARY_PROJECTION_MAX_EXACT_RECORDS: usize = 50_000;
 // rows.  A refresh which cannot represent the durable cardinality fails closed and keeps the
 // previous projection, rather than publishing a partial aggregate.
 const SUMMARY_PROJECTION_MAX_ACCOUNTS: usize = 50_000;
-const SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES: usize = 4_096;
+// Archive manifests remain a bounded background input, but share the established exact-record
+// admission rather than rejecting a durable rollup solely because it spans more than 4,096
+// archive batches. Path-based SQLite reads are chunked below to stay well under bind limits.
+const SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES: usize = SUMMARY_PROJECTION_MAX_EXACT_RECORDS;
+const SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE: usize = 512;
 // Exact replacement is intentionally exceptional. Keeping this separately bounded prevents a
 // wide retention horizon with a compact-coverage gap from turning a background rebuild into an
 // uninterruptible hour-by-hour allocation and CPU sweep.
@@ -9389,30 +9393,35 @@ async fn load_summary_projection_archive_row_counts(
     if archive_paths.is_empty() {
         return Ok(HashMap::new());
     }
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT file_path, row_count FROM archive_batches \
-         WHERE dataset = 'codex_invocations' AND status = 'completed' AND file_path IN (",
-    );
+
+    let mut counts = HashMap::new();
+    for archive_paths in archive_paths.chunks(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE)
     {
-        let mut separated = query.separated(", ");
-        for path in archive_paths {
-            separated.push_bind(path);
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "SELECT file_path, row_count FROM archive_batches \
+             WHERE dataset = 'codex_invocations' AND status = 'completed' AND file_path IN (",
+        );
+        {
+            let mut separated = query.separated(", ");
+            for path in archive_paths {
+                separated.push_bind(path);
+            }
+        }
+        query.push(")");
+        counts.extend(
+            query
+                .build_query_as::<(String, i64)>()
+                .fetch_all(pool)
+                .await
+                .context("summary projection archive row-count hydration failed")?,
+        );
+        if counts.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+            return Err(anyhow!(
+                "summary projection archive batch cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES})"
+            ));
         }
     }
-    query
-        .push(") LIMIT ")
-        .push_bind((SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES + 1) as i64);
-    let rows = query
-        .build_query_as::<(String, i64)>()
-        .fetch_all(pool)
-        .await
-        .context("summary projection archive row-count hydration failed")?;
-    if rows.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
-        return Err(anyhow!(
-            "summary projection archive batch cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES})"
-        ));
-    }
-    Ok(rows.into_iter().collect())
+    Ok(counts)
 }
 
 async fn load_summary_projection_archive_manifest_accounts(
@@ -9422,36 +9431,41 @@ async fn load_summary_projection_archive_manifest_accounts(
     if archive_paths.is_empty() {
         return Ok(Vec::new());
     }
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT batches.file_path, activity.account_id \
-         FROM archive_batches AS batches \
-         JOIN archive_batch_upstream_activity AS activity \
-           ON activity.archive_batch_id = batches.id \
-         WHERE batches.dataset = 'codex_invocations' \
-           AND batches.status = 'completed' \
-           AND activity.account_id > 0 \
-           AND batches.file_path IN (",
-    );
+
+    let mut accounts = Vec::new();
+    for archive_paths in archive_paths.chunks(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE)
     {
-        let mut separated = query.separated(", ");
-        for path in archive_paths {
-            separated.push_bind(path);
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "SELECT batches.file_path, activity.account_id \
+             FROM archive_batches AS batches \
+             JOIN archive_batch_upstream_activity AS activity \
+               ON activity.archive_batch_id = batches.id \
+             WHERE batches.dataset = 'codex_invocations' \
+               AND batches.status = 'completed' \
+               AND activity.account_id > 0 \
+               AND batches.file_path IN (",
+        );
+        {
+            let mut separated = query.separated(", ");
+            for path in archive_paths {
+                separated.push_bind(path);
+            }
+        }
+        query.push(")");
+        accounts.extend(
+            query
+                .build_query_as::<(String, i64)>()
+                .fetch_all(pool)
+                .await
+                .context("summary projection archive account manifest hydration failed")?,
+        );
+        if accounts.len() > SUMMARY_PROJECTION_MAX_EXACT_RECORDS {
+            return Err(anyhow!(
+                "summary projection archive account manifest exceeded bounded row budget ({SUMMARY_PROJECTION_MAX_EXACT_RECORDS})"
+            ));
         }
     }
-    query
-        .push(") LIMIT ")
-        .push_bind((SUMMARY_PROJECTION_MAX_EXACT_RECORDS + 1) as i64);
-    let rows = query
-        .build_query_as::<(String, i64)>()
-        .fetch_all(pool)
-        .await
-        .context("summary projection archive account manifest hydration failed")?;
-    if rows.len() > SUMMARY_PROJECTION_MAX_EXACT_RECORDS {
-        return Err(anyhow!(
-            "summary projection archive account manifest exceeded bounded row budget ({SUMMARY_PROJECTION_MAX_EXACT_RECORDS})"
-        ));
-    }
-    Ok(rows)
+    Ok(accounts)
 }
 
 async fn load_summary_projection_archive_replay_coverage(
@@ -9461,40 +9475,43 @@ async fn load_summary_projection_archive_replay_coverage(
     if archive_paths.is_empty() {
         return Ok(HashMap::new());
     }
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT file_path, target FROM hourly_rollup_archive_replay \
-         WHERE dataset = 'codex_invocations' AND target IN (",
-    );
-    query
-        .push_bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
-        .push(", ")
-        .push_bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
-        .push(", ")
-        .push_bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
-        .push(") AND file_path IN (");
-    {
-        let mut separated = query.separated(", ");
-        for path in archive_paths {
-            separated.push_bind(path);
-        }
-    }
-    query.push(")");
-    let rows = query
-        .build_query_as::<(String, String)>()
-        .fetch_all(pool)
-        .await
-        .context("summary projection archive replay coverage hydration failed")?;
     let mut coverage = HashMap::<String, SummaryProjectionArchiveReplayCoverage>::new();
-    for (file_path, target) in rows {
-        let entry = coverage.entry(file_path).or_default();
-        if target == HOURLY_ROLLUP_TARGET_INVOCATIONS {
-            entry.overall = true;
+    for archive_paths in archive_paths.chunks(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE)
+    {
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "SELECT file_path, target FROM hourly_rollup_archive_replay \
+             WHERE dataset = 'codex_invocations' AND target IN (",
+        );
+        query
+            .push_bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
+            .push(", ")
+            .push_bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
+            .push(", ")
+            .push_bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
+            .push(") AND file_path IN (");
+        {
+            let mut separated = query.separated(", ");
+            for path in archive_paths {
+                separated.push_bind(path);
+            }
         }
-        if target == HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY {
-            entry.account_stats = true;
-        }
-        if target == HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN {
-            entry.usage_breakdown = true;
+        query.push(")");
+        let rows = query
+            .build_query_as::<(String, String)>()
+            .fetch_all(pool)
+            .await
+            .context("summary projection archive replay coverage hydration failed")?;
+        for (file_path, target) in rows {
+            let entry = coverage.entry(file_path).or_default();
+            if target == HOURLY_ROLLUP_TARGET_INVOCATIONS {
+                entry.overall = true;
+            }
+            if target == HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY {
+                entry.account_stats = true;
+            }
+            if target == HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN {
+                entry.usage_breakdown = true;
+            }
         }
     }
     Ok(coverage)
@@ -16041,26 +16058,30 @@ async fn load_hourly_rollup_archive_progress_by_file_path(
         return Ok(HashMap::new());
     }
 
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT file_path, cursor_id FROM hourly_rollup_archive_progress WHERE dataset = ",
-    );
-    query.push_bind(dataset).push(" AND file_path IN (");
-    {
-        let mut separated = query.separated(", ");
-        for file_path in file_paths {
-            separated.push_bind(file_path);
+    let mut progress = HashMap::new();
+    for file_paths in file_paths.chunks(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE) {
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "SELECT file_path, cursor_id FROM hourly_rollup_archive_progress WHERE dataset = ",
+        );
+        query.push_bind(dataset).push(" AND file_path IN (");
+        {
+            let mut separated = query.separated(", ");
+            for file_path in file_paths {
+                separated.push_bind(file_path);
+            }
         }
-    }
-    query.push(")");
+        query.push(")");
 
-    let rows = query
-        .build_query_as::<HourlyRollupArchiveProgressRow>()
-        .fetch_all(pool)
-        .await?;
-    Ok(rows
-        .into_iter()
-        .map(|row| (row.file_path, row.cursor_id.max(0)))
-        .collect())
+        progress.extend(
+            query
+                .build_query_as::<HourlyRollupArchiveProgressRow>()
+                .fetch_all(pool)
+                .await?
+                .into_iter()
+                .map(|row| (row.file_path, row.cursor_id.max(0))),
+        );
+    }
+    Ok(progress)
 }
 
 async fn load_usage_breakdown_archive_progress_by_file_path(
@@ -26498,6 +26519,122 @@ mod request_compression_query_tests {
         hydrate_summary_snapshots(state.as_ref())
             .await
             .expect("hydrate summary projection fixture");
+    }
+
+    #[tokio::test]
+    async fn summary_projection_hydrates_more_than_legacy_archive_manifest_limit_from_rollups() {
+        let state = crate::tests::test_state_with_openai_base(
+            url::Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let archive_start = Utc
+            .timestamp_opt(
+                align_bucket_epoch(
+                    (Utc::now() - ChronoDuration::days(1_000)).timestamp(),
+                    3_600,
+                    0,
+                ),
+                0,
+            )
+            .single()
+            .expect("align archive fixture to a full hour");
+        let archive_end = archive_start + ChronoDuration::hours(1);
+        let bucket = align_bucket_epoch(archive_start.timestamp(), 3_600, 0);
+
+        sqlx::query(
+            "INSERT INTO invocation_rollup_hourly \
+             (bucket_start_epoch, source, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
+             VALUES (?1, 'proxy', 1, 1, 0, 17, 1.25, 0)",
+        )
+        .bind(bucket)
+        .execute(&state.pool)
+        .await
+        .expect("insert durable summary rollup");
+        sqlx::query(
+            "INSERT INTO upstream_account_stats_hourly \
+             (bucket_start_epoch, source, upstream_account_id, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
+             VALUES (?1, 'proxy', 42, 1, 1, 0, 17, 1.25, 0)",
+        )
+        .bind(bucket)
+        .execute(&state.pool)
+        .await
+        .expect("insert durable account summary rollup");
+        sqlx::query(
+            "WITH RECURSIVE manifests(ordinal) AS ( \
+                SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal <= 4096 \
+             ) \
+             INSERT INTO archive_batches \
+             (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
+              historical_rollups_materialized_at, created_at) \
+             SELECT 'codex_invocations', '2026-01', \
+                    '/tmp/summary-manifest-admission-' || ordinal || '.sqlite.gz', \
+                    'summary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now') \
+             FROM manifests",
+        )
+        .bind(db_occurred_at_lower_bound(archive_start))
+        .bind(db_occurred_at_upper_bound(archive_end))
+        .execute(&state.pool)
+        .await
+        .expect("insert archive manifests beyond the legacy limit");
+        sqlx::query(
+            "INSERT INTO archive_batch_upstream_activity (archive_batch_id, account_id, last_activity_at) \
+             SELECT id, 42, ?1 FROM archive_batches \
+             WHERE file_path GLOB '/tmp/summary-manifest-admission-*.sqlite.gz'",
+        )
+        .bind(db_occurred_at_lower_bound(archive_end))
+        .execute(&state.pool)
+        .await
+        .expect("record archive account manifests");
+        for target in [
+            HOURLY_ROLLUP_TARGET_INVOCATIONS,
+            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN,
+        ] {
+            sqlx::query(
+                "INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, archive_sha256) \
+                 SELECT ?1, dataset, file_path, sha256 FROM archive_batches \
+                 WHERE file_path GLOB '/tmp/summary-manifest-admission-*.sqlite.gz'",
+            )
+            .bind(target)
+            .execute(&state.pool)
+            .await
+            .expect("record complete rollup replay coverage");
+        }
+
+        hydrate_summary_snapshots(state.as_ref())
+            .await
+            .expect("hydrate exact summary projection beyond the legacy manifest limit");
+        state.pool.close().await;
+
+        let Json(response) = fetch_summary(
+            State(state.clone()),
+            Query(SummaryQuery {
+                window: Some("all".to_string()),
+                limit: None,
+                time_zone: Some("UTC".to_string()),
+                upstream_account_id: None,
+            }),
+        )
+        .await
+        .expect("serve the hydrated all-time response without SQLite");
+        assert_eq!(response.total_count, 1);
+        assert_eq!(response.total_tokens, 17);
+        assert_eq!(response.total_cost, 1.25);
+
+        let Json(account_response) = fetch_summary(
+            State(state),
+            Query(SummaryQuery {
+                window: Some("all".to_string()),
+                limit: None,
+                time_zone: Some("UTC".to_string()),
+                upstream_account_id: Some(42),
+            }),
+        )
+        .await
+        .expect("serve the hydrated account response without SQLite");
+        assert_eq!(account_response.total_count, 1);
+        assert_eq!(account_response.total_tokens, 17);
+        assert_eq!(account_response.total_cost, 1.25);
     }
 
     #[tokio::test]

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -11,8 +11,13 @@ use chrono_tz::TZ_VARIANTS;
 use futures_util::TryStreamExt;
 use serde::Serialize;
 use serde_json::{Value, json};
-use sqlx::{FromRow, SqliteConnection};
+use sqlx::{
+    FromRow, SqliteConnection,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode},
+};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::Path;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tracing::debug;
@@ -63,7 +68,6 @@ pub(crate) const INVOCATION_LIVE_PHASE_REQUESTING: &str = "requesting";
 pub(crate) const INVOCATION_LIVE_PHASE_RESPONDING: &str = "responding";
 const INVOCATION_ANCHOR_TTL: Duration = Duration::from_secs(30 * 60);
 const INVOCATION_ANCHOR_CACHE_LIMIT: usize = 32;
-const SUMMARY_PROJECTION_STABLE_SQLITE_VERSION_ATTEMPTS: usize = 3;
 
 #[derive(Clone)]
 struct InvocationAnchorSnapshot {
@@ -8294,11 +8298,14 @@ async fn summary_projection_live_history_within_aggregate_budget(
     }
 }
 
-async fn count_summary_projection_rollup_rows(
-    pool: &Pool<Sqlite>,
+async fn count_summary_projection_rollup_rows<'e, E>(
+    executor: E,
     table_name: &'static str,
     range: Option<(i64, i64)>,
-) -> Result<usize> {
+) -> Result<usize>
+where
+    E: sqlx::Executor<'e, Database = Sqlite>,
+{
     let mut query = QueryBuilder::<Sqlite>::new("SELECT COUNT(*) FROM ");
     // Callers pass only the two fixed rollup table names in this module. Keeping the table name
     // out of user-controlled SQL preserves the background-only hydration boundary.
@@ -8312,7 +8319,7 @@ async fn count_summary_projection_rollup_rows(
     }
     let count = query
         .build_query_scalar::<i64>()
-        .fetch_one(pool)
+        .fetch_one(executor)
         .await
         .with_context(|| format!("summary projection {table_name} row count failed"))?;
     let count = usize::try_from(count).context("summary projection rollup row count overflow")?;
@@ -8456,12 +8463,16 @@ async fn load_summary_projection_rollup_usage_in_range(
     pool: &Pool<Sqlite>,
     range: Option<(i64, i64)>,
 ) -> Result<HashMap<(i64, Option<i64>), UsageBreakdownResponse>> {
-    count_summary_projection_rollup_rows(pool, "upstream_account_usage_breakdown_hourly", range)
-        .await?;
-    let mut tx = pool.begin().await?;
+    let mut connection = pool.acquire().await?;
+    count_summary_projection_rollup_rows(
+        &mut *connection,
+        "upstream_account_usage_breakdown_hourly",
+        range,
+    )
+    .await?;
     let (start_epoch, end_epoch) = range.unwrap_or((i64::MIN, i64::MAX));
     let rows = query_upstream_account_usage_breakdown_hourly_rollup_range_bounded_tx(
-        tx.as_mut(),
+        &mut connection,
         start_epoch,
         end_epoch,
         InvocationSourceScope::All,
@@ -8470,7 +8481,6 @@ async fn load_summary_projection_rollup_usage_in_range(
     )
     .await
     .map_err(|error| anyhow!("summary projection usage rollup hydration failed: {error:?}"))?;
-    tx.commit().await?;
 
     let mut accumulators = HashMap::<(i64, Option<i64>), UsageBreakdownAccumulator>::new();
     let mut rollup_bytes = 0usize;
@@ -8993,22 +9003,19 @@ fn summary_projection_mark_account_exact_replacement_buckets(
     archive_has_materialized_rollups: bool,
     exact_range: ExactUtcRange,
     exact_account_total_rollup_buckets: &mut HashSet<i64>,
-    exact_account_usage_rollup_buckets: &mut HashSet<i64>,
 ) -> Result<()> {
     if !archive_has_materialized_rollups {
         return Ok(());
     }
     // A stale account manifest makes the account compact aggregate unverifiable even when the
     // global replay is complete. The paged raw fallback owns this whole bucket for account
-    // totals and usage, while the global compact aggregates remain available.
+    // totals, while the independently replay-proven account usage rollup remains canonical.
     summary_projection_exact_range_fits_bucket_budget(exact_range)?;
     let mut bucket = align_bucket_epoch(exact_range.start.timestamp(), 3_600, 0);
     let last_bucket = align_bucket_epoch(exact_range.end.timestamp().saturating_sub(1), 3_600, 0);
     while bucket <= last_bucket {
         exact_account_total_rollup_buckets.insert(bucket);
-        exact_account_usage_rollup_buckets.insert(bucket);
         summary_projection_ensure_exact_bucket_budget(exact_account_total_rollup_buckets)?;
-        summary_projection_ensure_exact_bucket_budget(exact_account_usage_rollup_buckets)?;
         bucket = bucket.saturating_add(3_600);
     }
     Ok(())
@@ -9561,14 +9568,12 @@ async fn refresh_summary_snapshots_with_deadline(
 }
 
 async fn load_summary_projection_rollup_live_cursor(pool: &Pool<Sqlite>) -> Result<i64> {
-    let mut tx = pool.begin().await?;
-    let cursor = load_invocation_summary_rollup_live_cursor_tx(tx.as_mut())
+    let mut connection = pool.acquire().await?;
+    load_invocation_summary_rollup_live_cursor_tx(&mut connection)
         .await
         .map_err(|error| {
             anyhow!("summary projection live rollup cursor hydration failed: {error:?}")
-        })?;
-    tx.commit().await?;
-    Ok(cursor)
+        })
 }
 
 async fn load_summary_projection_account_rollup_live_cursor(
@@ -9659,6 +9664,74 @@ async fn load_summary_projection_archive_row_counts(
         }
     }
     Ok(counts)
+}
+
+async fn load_summary_projection_archive_manifest_sha256(
+    pool: &Pool<Sqlite>,
+    archive_paths: &[String],
+) -> Result<HashMap<String, String>> {
+    if archive_paths.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let expected_count = archive_paths.iter().collect::<HashSet<_>>().len();
+    let mut sha256_by_file_path = HashMap::with_capacity(expected_count);
+    for archive_paths in archive_paths.chunks(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE)
+    {
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "SELECT file_path, sha256 FROM archive_batches WHERE dataset = 'codex_invocations' \
+             AND status = 'completed' AND file_path IN (",
+        );
+        {
+            let mut separated = query.separated(", ");
+            for path in archive_paths {
+                separated.push_bind(path);
+            }
+        }
+        query.push(")");
+        for (file_path, sha256) in query
+            .build_query_as::<(String, String)>()
+            .fetch_all(pool)
+            .await
+            .context("summary projection archive manifest SHA hydration failed")?
+        {
+            if sha256.trim().is_empty()
+                || sha256_by_file_path
+                    .insert(file_path.clone(), sha256)
+                    .is_some()
+            {
+                return Err(anyhow!(
+                    "summary projection archive manifest SHA is missing or ambiguous for {file_path}"
+                ));
+            }
+        }
+    }
+    if sha256_by_file_path.len() != expected_count {
+        return Err(anyhow!(
+            "summary projection archive manifest SHA hydration omitted snapshot rows"
+        ));
+    }
+    Ok(sha256_by_file_path)
+}
+
+fn verify_summary_projection_archive_file_sha256(
+    archive: &crate::stats::ArchiveBatchPathRow,
+    expected_sha256: &str,
+) -> Result<()> {
+    let actual_sha256 = crate::maintenance::sha256_hex_file(Path::new(archive.file_path()))
+        .with_context(|| {
+            format!(
+                "summary projection archive identity read failed for {}",
+                archive.file_path()
+            )
+        })?;
+    if actual_sha256 != expected_sha256 {
+        return Err(anyhow!(
+            "summary projection archive changed during hydration for {}",
+            archive.file_path()
+        ));
+    }
+    Ok(())
 }
 
 async fn load_summary_projection_archive_manifest_accounts(
@@ -10201,42 +10274,68 @@ async fn build_summary_projection(
     previous_all_time: Option<PreviousSummaryProjectionAllTime>,
     durable_terminal_sequence_watermark: u64,
 ) -> Result<SummaryProjection> {
-    // The pool performs each query on its own connection, so a stable archive id alone cannot
-    // prevent a retention commit from replacing a manifest and its compact rollups between two
-    // projection reads. Keep one observer connection for the whole build and retry only a small,
-    // fixed number of times whenever another connection commits any SQLite change.
-    for _ in 0..SUMMARY_PROJECTION_STABLE_SQLITE_VERSION_ATTEMPTS {
-        let mut observer = state
-            .pool
-            .acquire()
-            .await
-            .context("summary projection stable SQLite observer acquisition failed")?;
-        let version_before = sqlx::query_scalar::<_, i64>("PRAGMA data_version")
-            .fetch_one(&mut *observer)
-            .await
-            .context("summary projection stable SQLite version hydration failed")?;
-        let projection = build_summary_projection_once(
+    #[cfg(test)]
+    if state.config.database_path == std::path::Path::new(":memory:") {
+        // Stateful unit fixtures use a private shared-memory URI while their AppConfig retains
+        // `:memory:`. A second URI would point at a blank database, so exercise the regular
+        // bounded builder directly in those fixtures.
+        return build_summary_projection_once(
             state,
+            &state.pool,
             include_all_time,
-            previous_all_time.clone(),
+            previous_all_time,
             durable_terminal_sequence_watermark,
         )
-        .await?;
-        let version_after = sqlx::query_scalar::<_, i64>("PRAGMA data_version")
-            .fetch_one(&mut *observer)
-            .await
-            .context("summary projection stable SQLite version revalidation failed")?;
-        if version_before == version_after {
-            return Ok(projection);
-        }
+        .await;
     }
-    Err(anyhow!(
-        "summary projection SQLite source changed during bounded hydration retries"
-    ))
+
+    // Hydration issues hundreds of bounded queries. Keep them on one read transaction so a
+    // retention commit cannot mix an old rollup with a replacement manifest. WAL readers do not
+    // block terminal writers, unlike a global `data_version` retry which treats any new request
+    // as a source invalidation and can leave the first snapshot unavailable under normal load.
+    let snapshot_options = SqliteConnectOptions::from_str(&state.config.database_url())
+        .context("summary projection snapshot connection options failed")?
+        .create_if_missing(false)
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(DEFAULT_SQLITE_BUSY_TIMEOUT_SECS));
+    let snapshot_pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(snapshot_options)
+        .await
+        .context("summary projection snapshot connection failed")?;
+    let mut connection = snapshot_pool
+        .acquire()
+        .await
+        .context("summary projection snapshot acquisition failed")?;
+    sqlx::query("BEGIN")
+        .execute(&mut *connection)
+        .await
+        .context("summary projection snapshot begin failed")?;
+    drop(connection);
+
+    let build = build_summary_projection_once(
+        state,
+        &snapshot_pool,
+        include_all_time,
+        previous_all_time,
+        durable_terminal_sequence_watermark,
+    )
+    .await;
+    let rollback = sqlx::query("ROLLBACK")
+        .execute(&snapshot_pool)
+        .await
+        .context("summary projection snapshot rollback failed");
+    snapshot_pool.close().await;
+
+    match (build, rollback) {
+        (Ok(projection), Ok(_)) => Ok(projection),
+        (Ok(_), Err(error)) | (Err(error), Ok(_)) | (Err(error), Err(_)) => Err(error),
+    }
 }
 
 async fn build_summary_projection_once(
     state: &AppState,
+    pool: &Pool<Sqlite>,
     include_all_time: bool,
     previous_all_time: Option<PreviousSummaryProjectionAllTime>,
     durable_terminal_sequence_watermark: u64,
@@ -10280,22 +10379,18 @@ async fn build_summary_projection_once(
         align_bucket_epoch(end.timestamp(), 3_600, 0) + 3_600,
     );
     let (hourly_rollup_totals, hourly_rollup_non_success_tokens) =
-        load_summary_projection_rollup_totals_in_range(&state.pool, Some(rollup_range)).await?;
+        load_summary_projection_rollup_totals_in_range(pool, Some(rollup_range)).await?;
     let hourly_rollup_usage =
-        load_summary_projection_rollup_usage_in_range(&state.pool, Some(rollup_range)).await?;
+        load_summary_projection_rollup_usage_in_range(pool, Some(rollup_range)).await?;
     #[cfg(test)]
-    pause_summary_projection_test_interleave(&state.pool).await?;
+    pause_summary_projection_test_interleave(pool).await?;
     // Rolling aggregation must still distinguish an archive-backed retention database from a
     // live-only one. This bounded existence probe is independent of the expensive all-history
     // manifest admission below.
     let has_any_completed_archive =
-        !crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
-            &state.pool,
-            None,
-            1,
-        )
-        .await?
-        .is_empty();
+        !crate::stats::load_completed_invocation_archive_paths_in_range_bounded(pool, None, 1)
+            .await?
+            .is_empty();
     // All-time aggregation needs manifest-level key proof, while rolling windows only need the
     // bounded exact horizon below. An oversized, fully materialized history is validated in
     // fixed manifest pages against one immutable high-watermark; it never needs an unbounded
@@ -10306,16 +10401,14 @@ async fn build_summary_projection_once(
         all_time_manifest_high_watermark_id,
     ) = if all_time_was_fully_rebuilt && has_any_completed_archive {
         let archives = crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
-            &state.pool,
+            pool,
             None,
             SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
         )
         .await?;
         if archives.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
-            match summary_projection_overflowed_all_time_manifests_have_complete_rollups(
-                &state.pool,
-            )
-            .await?
+            match summary_projection_overflowed_all_time_manifests_have_complete_rollups(pool)
+                .await?
             {
                 Some(high_watermark_id) => (Vec::new(), false, Some(high_watermark_id)),
                 None => (Vec::new(), true, None),
@@ -10331,8 +10424,7 @@ async fn build_summary_projection_once(
         .map(|archive| archive.file_path().to_string())
         .collect::<Vec<_>>();
     let all_time_archive_replay_coverage =
-        load_summary_projection_archive_replay_coverage(&state.pool, &all_time_archive_paths)
-            .await?;
+        load_summary_projection_archive_replay_coverage(pool, &all_time_archive_paths).await?;
     let mut all_time_archive_account_ids_by_file = HashMap::<String, HashSet<i64>>::new();
     let all_time_account_manifest_admission_attempted = all_time_was_fully_rebuilt
         && summary_projection_manifest_admission_retry_is_due(
@@ -10345,11 +10437,7 @@ async fn build_summary_projection_once(
     if all_time_account_manifest_admission_attempted
         && all_time_manifest_high_watermark_id.is_none()
     {
-        match load_summary_projection_archive_manifest_accounts(
-            &state.pool,
-            &all_time_archive_paths,
-        )
-        .await
+        match load_summary_projection_archive_manifest_accounts(pool, &all_time_archive_paths).await
         {
             Ok(accounts) => {
                 for (file_path, account_id) in accounts {
@@ -10369,11 +10457,11 @@ async fn build_summary_projection_once(
             Err(error) => return Err(error),
         }
     }
-    let rollup_live_cursor = load_summary_projection_rollup_live_cursor(&state.pool).await?;
+    let rollup_live_cursor = load_summary_projection_rollup_live_cursor(pool).await?;
     let account_rollup_live_cursor =
-        load_summary_projection_account_rollup_live_cursor(&state.pool).await?;
+        load_summary_projection_account_rollup_live_cursor(pool).await?;
     let rows = query_summary_projection_live_rows_with_budget(
-        &state.pool,
+        pool,
         InvocationSourceScope::All,
         ExactUtcRange {
             start: live_start,
@@ -10430,7 +10518,7 @@ async fn build_summary_projection_once(
         ));
     }
     let mut recent_rows = query_summary_projection_live_rows_with_budget(
-        &state.pool,
+        pool,
         InvocationSourceScope::All,
         ExactUtcRange {
             start: Utc
@@ -10487,7 +10575,7 @@ async fn build_summary_projection_once(
             .values()
             .flat_map(|account_ids| account_ids.iter().copied()),
     );
-    known_account_ids.extend(load_summary_projection_durable_account_ids(&state.pool).await?);
+    known_account_ids.extend(load_summary_projection_durable_account_ids(pool).await?);
     known_account_ids.extend(
         hourly_rollup_totals
             .keys()
@@ -10514,7 +10602,7 @@ async fn build_summary_projection_once(
     };
     let boundary_archive_admission =
         crate::stats::load_completed_invocation_archive_paths_in_range_bounded(
-            &state.pool,
+            pool,
             Some((archive_start, end)),
             SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES,
         )
@@ -10524,7 +10612,7 @@ async fn build_summary_projection_once(
     {
         let Some(high_watermark_id) =
             summary_projection_overflowed_boundary_manifests_have_complete_rollups(
-                &state.pool,
+                pool,
                 exact_horizon,
             )
             .await?
@@ -10554,9 +10642,11 @@ async fn build_summary_projection_once(
         ));
     }
     let archive_row_counts =
-        load_summary_projection_archive_row_counts(&state.pool, &archive_paths).await?;
+        load_summary_projection_archive_row_counts(pool, &archive_paths).await?;
+    let archive_manifest_sha256 =
+        load_summary_projection_archive_manifest_sha256(pool, &archive_paths).await?;
     let archive_replay_coverage =
-        load_summary_projection_archive_replay_coverage(&state.pool, &archive_paths).await?;
+        load_summary_projection_archive_replay_coverage(pool, &archive_paths).await?;
     // All-time has no finite request boundary. A materialized archive outside the bounded exact
     // horizon whose replay marker is absent cannot be reconstructed without an unbounded file
     // scan, so preserve an exact last-good all-time response (or its existing unavailable
@@ -10572,7 +10662,7 @@ async fn build_summary_projection_once(
     }) {
         Vec::new()
     } else {
-        load_summary_projection_archive_manifest_accounts(&state.pool, &archive_paths).await?
+        load_summary_projection_archive_manifest_accounts(pool, &archive_paths).await?
     };
     for (file_path, account_id) in manifest_accounts {
         if !archive_path_set.contains(&file_path) {
@@ -10596,7 +10686,7 @@ async fn build_summary_projection_once(
         known_account_ids.extend(account_ids.iter().copied());
     }
     let usage_rollup_progress =
-        load_usage_breakdown_archive_progress_by_file_path(&state.pool, &archive_paths)
+        load_usage_breakdown_archive_progress_by_file_path(pool, &archive_paths)
             .await
             .map_err(|error| {
                 anyhow!("summary projection usage progress hydration failed: {error:?}")
@@ -10667,6 +10757,17 @@ async fn build_summary_projection_once(
                 "summary projection cannot prove account coverage for a large materialized archive without complete replay coverage"
             ));
         }
+        let manifest_sha256 = archive_manifest_sha256
+            .get(archive.file_path())
+            .ok_or_else(|| {
+                anyhow!(
+                    "summary projection archive manifest SHA is missing for {}",
+                    archive.file_path()
+                )
+            })?;
+        if Path::new(archive.file_path()).exists() {
+            verify_summary_projection_archive_file_sha256(archive, manifest_sha256)?;
+        }
         let Some((archive_pool, temp_cleanup)) =
             crate::stats::open_invocation_archive_batch_pool(archive, "summary-projection").await?
         else {
@@ -10682,6 +10783,7 @@ async fn build_summary_projection_once(
             )?;
             continue;
         };
+        verify_summary_projection_archive_file_sha256(archive, manifest_sha256)?;
         if !summary_projection_archive_has_coverage_bounds(archive)
             && let Some(actual_range) = load_summary_projection_archive_coverage_range(
                 &archive_pool,
@@ -10718,6 +10820,7 @@ async fn build_summary_projection_once(
             ));
         }
         archive_account_ids_by_file.insert(archive.file_path().to_string(), account_ids);
+        verify_summary_projection_archive_file_sha256(archive, manifest_sha256)?;
         archive_pool.close().await;
         drop(temp_cleanup);
     }
@@ -10819,7 +10922,7 @@ async fn build_summary_projection_once(
         let mut after_id = None;
         loop {
             let page = load_summary_projection_boundary_manifest_page(
-                &state.pool,
+                pool,
                 Some(exact_horizon),
                 after_id,
                 high_watermark_id,
@@ -10834,8 +10937,7 @@ async fn build_summary_projection_once(
                 .map(|archive| archive.file_path().to_string())
                 .collect::<Vec<_>>();
             let page_account_ids_by_file =
-                load_summary_projection_archive_manifest_account_sets(&state.pool, &page_paths)
-                    .await?;
+                load_summary_projection_archive_manifest_account_sets(pool, &page_paths).await?;
             for account_ids in page_account_ids_by_file.values() {
                 known_account_ids.extend(account_ids.iter().copied());
             }
@@ -10861,7 +10963,6 @@ async fn build_summary_projection_once(
                         true,
                         archive_range,
                         &mut exact_account_total_rollup_buckets,
-                        &mut exact_account_usage_rollup_buckets,
                     )?;
                 }
                 let (account_replayed, usage_replayed) = if !account_manifest_complete {
@@ -10925,7 +11026,7 @@ async fn build_summary_projection_once(
             .saturating_sub(records_by_invoke_id.len())
             .saturating_add(1);
         let exact_live_rows = query_summary_projection_live_rows_with_budget(
-            &state.pool,
+            pool,
             InvocationSourceScope::All,
             range,
             None,
@@ -11038,6 +11139,17 @@ async fn build_summary_projection_once(
                 "summary projection exact archive boundary exceeds bounded row budget ({SUMMARY_PROJECTION_MAX_EXACT_RECORDS})"
             ));
         }
+        let manifest_sha256 = archive_manifest_sha256
+            .get(archive.file_path())
+            .ok_or_else(|| {
+                anyhow!(
+                    "summary projection archive manifest SHA is missing for {}",
+                    archive.file_path()
+                )
+            })?;
+        if Path::new(archive.file_path()).exists() {
+            verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+        }
         let Some((archive_pool, temp_cleanup)) =
             crate::stats::open_invocation_archive_batch_pool(&archive, "summary-projection")
                 .await?
@@ -11052,9 +11164,10 @@ async fn build_summary_projection_once(
             )?;
             continue;
         };
+        verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
         merge_summary_projection_archive_records_with_coverage(
             &archive_pool,
-            &state.pool,
+            pool,
             &persisted_live_ids,
             &hourly_rollup_totals,
             &hourly_rollup_usage,
@@ -11077,6 +11190,7 @@ async fn build_summary_projection_once(
                 archive.file_path()
             )
         })?;
+        verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
         archive_pool.close().await;
         drop(temp_cleanup);
     }
@@ -11084,7 +11198,7 @@ async fn build_summary_projection_once(
         let mut after_id = None;
         loop {
             let page = load_summary_projection_boundary_manifest_page(
-                &state.pool,
+                pool,
                 Some(exact_horizon),
                 after_id,
                 high_watermark_id,
@@ -11098,8 +11212,10 @@ async fn build_summary_projection_once(
                 .iter()
                 .map(|archive| archive.file_path().to_string())
                 .collect::<Vec<_>>();
+            let page_manifest_sha256 =
+                load_summary_projection_archive_manifest_sha256(pool, &page_paths).await?;
             let usage_rollup_progress = load_usage_breakdown_archive_progress_by_file_path(
-                &state.pool,
+                pool,
                 &page_paths,
             )
             .await
@@ -11109,8 +11225,7 @@ async fn build_summary_projection_once(
                 )
             })?;
             let page_account_ids_by_file =
-                load_summary_projection_archive_manifest_account_sets(&state.pool, &page_paths)
-                    .await?;
+                load_summary_projection_archive_manifest_account_sets(pool, &page_paths).await?;
             for archive in page.archives {
                 let Some(archive_range) =
                     summary_projection_archive_overlap_range(&archive, exact_horizon)
@@ -11147,6 +11262,18 @@ async fn build_summary_projection_once(
                 summary_projection_admit_paged_boundary_raw_archive(
                     &mut paged_boundary_raw_archive_admissions,
                 )?;
+                let manifest_sha256 =
+                    page_manifest_sha256
+                        .get(archive.file_path())
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "summary projection paged archive manifest SHA is missing for {}",
+                                archive.file_path()
+                            )
+                        })?;
+                if Path::new(archive.file_path()).exists() {
+                    verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
+                }
                 let Some((archive_pool, temp_cleanup)) =
                     crate::stats::open_invocation_archive_batch_pool(
                         &archive,
@@ -11163,9 +11290,10 @@ async fn build_summary_projection_once(
                     )?;
                     continue;
                 };
+                verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
                 merge_summary_projection_archive_records_with_coverage(
                     &archive_pool,
-                    &state.pool,
+                    pool,
                     &persisted_live_ids,
                     &hourly_rollup_totals,
                     &hourly_rollup_usage,
@@ -11188,6 +11316,7 @@ async fn build_summary_projection_once(
                         archive.file_path()
                     )
                 })?;
+                verify_summary_projection_archive_file_sha256(&archive, manifest_sha256)?;
                 archive_pool.close().await;
                 drop(temp_cleanup);
             }
@@ -11301,7 +11430,7 @@ async fn build_summary_projection_once(
             .filter(|account_id| *account_id > 0)
             .collect::<HashSet<_>>(),
     );
-    account_ids.extend(load_summary_projection_durable_account_ids(&state.pool).await?);
+    account_ids.extend(load_summary_projection_durable_account_ids(pool).await?);
     if account_ids.len() > SUMMARY_PROJECTION_MAX_ACCOUNTS {
         return Err(anyhow!(
             "summary projection account cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ACCOUNTS})"
@@ -11378,8 +11507,7 @@ async fn build_summary_projection_once(
         // All-time must use the same bounded projection inputs as rolling windows. The generic
         // stats query can open every unmaterialized archive and therefore cannot run in the
         // refresh path without defeating the rebuild deadline.
-        let (all_time_rollup_totals, _) =
-            load_summary_projection_rollup_totals(&state.pool).await?;
+        let (all_time_rollup_totals, _) = load_summary_projection_rollup_totals(pool).await?;
         // The finite exact tail deliberately does not retain every historical live row. When a
         // retained boundary replacement row is older than that tail, the complete all-time map
         // is the durable proof that it is already included. Refresh its per-scope flags before
@@ -11408,7 +11536,7 @@ async fn build_summary_projection_once(
             paged_all_time_account_ids,
         ) = if let Some(high_watermark_id) = all_time_manifest_high_watermark_id {
             summary_projection_paged_all_time_materialized_scope_coverage(
-                &state.pool,
+                pool,
                 high_watermark_id,
                 &all_time_rollup_totals,
             )
@@ -11453,7 +11581,7 @@ async fn build_summary_projection_once(
         // stale hourly rollup exists. Once archives are present, the rollup is the historical
         // prefix and only rows beyond the shared live cursor are an exact live tail.
         let live_history_admission = if !has_any_completed_archive {
-            summary_projection_live_history_within_aggregate_budget(&state.pool).await?
+            summary_projection_live_history_within_aggregate_budget(pool).await?
         } else {
             None
         };
@@ -11471,7 +11599,7 @@ async fn build_summary_projection_once(
             if let Some(admission) = live_history_admission.as_ref() {
                 StatsTotals::from(
                     crate::stats::query_stats_row_through_id(
-                        &state.pool,
+                        pool,
                         InvocationSourceScope::All,
                         admission.upper_bound_id,
                     )
@@ -11500,7 +11628,7 @@ async fn build_summary_projection_once(
             }
         } else {
             crate::stats::load_live_invocation_ids_after_id_bounded_snapshot(
-                &state.pool,
+                pool,
                 InvocationSourceScope::All,
                 rollup_live_cursor,
                 SUMMARY_PROJECTION_MAX_EXACT_RECORDS,
@@ -11528,7 +11656,7 @@ async fn build_summary_projection_once(
         if has_any_completed_archive && rollup_live_cursor > 0 {
             global_totals = global_totals.add(
                 crate::stats::query_live_invocation_totals_after_id(
-                    &state.pool,
+                    pool,
                     InvocationSourceScope::All,
                     rollup_live_cursor,
                     live_tail.upper_bound_id,
@@ -11541,7 +11669,7 @@ async fn build_summary_projection_once(
         }
         let unmaterialized_archive_totals =
             crate::stats::query_unmaterialized_invocation_archive_totals_bounded_strict(
-                &state.pool,
+                pool,
                 InvocationSourceScope::All,
                 None,
                 Some(live_tail_ids),
@@ -11593,17 +11721,13 @@ async fn build_summary_projection_once(
 
         let account_totals = if !has_any_completed_archive {
             if let Some(admission) = live_history_admission.as_ref() {
-                load_summary_projection_live_account_totals(&state.pool, admission.upper_bound_id)
-                    .await?
+                load_summary_projection_live_account_totals(pool, admission.upper_bound_id).await?
             } else {
                 HashMap::new()
             }
         } else {
-            load_summary_projection_account_rollup_totals(
-                &state.pool,
-                &exact_account_total_rollup_buckets,
-            )
-            .await?
+            load_summary_projection_account_rollup_totals(pool, &exact_account_total_rollup_buckets)
+                .await?
         };
         for (account_id, totals) in account_totals {
             batched_all_time_by_account.insert(account_id, totals);
@@ -11613,13 +11737,11 @@ async fn build_summary_projection_once(
         // fenced above. A lagging account cursor must not turn one background refresh into an
         // unbounded table scan or absorb writes that arrived after this projection revision.
         if has_any_completed_archive {
-            let account_live_tail = admit_summary_projection_live_tail_account_ids(
-                &state.pool,
-                account_rollup_live_cursor,
-            )
-            .await?;
+            let account_live_tail =
+                admit_summary_projection_live_tail_account_ids(pool, account_rollup_live_cursor)
+                    .await?;
             for (account_id, totals) in load_summary_projection_live_tail_account_totals(
-                &state.pool,
+                pool,
                 account_rollup_live_cursor,
                 account_live_tail.map(|tail| tail.upper_bound_id),
             )
@@ -11631,7 +11753,7 @@ async fn build_summary_projection_once(
         }
         let account_archive_totals =
             crate::stats::query_unmaterialized_upstream_account_archive_totals_by_account(
-                &state.pool,
+                pool,
                 HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
                 InvocationSourceScope::All,
                 None,
@@ -16281,9 +16403,9 @@ async fn query_summary_projection_live_rows_with_budget(
     telemetry: UpstreamAccountActivityPreviewReadTelemetry,
 ) -> Result<Vec<UpstreamAccountInvocationPreviewRow>, anyhow::Error> {
     let text_columns = load_summary_projection_live_text_columns(pool).await?;
-    let mut tx = pool.begin().await?;
+    let mut connection = pool.acquire().await?;
     let max_id = ensure_summary_projection_live_text_budget(
-        &mut *tx,
+        &mut *connection,
         &text_columns,
         source_scope,
         range,
@@ -16293,7 +16415,7 @@ async fn query_summary_projection_live_rows_with_budget(
     )
     .await?;
     let mut rows = query_live_upstream_account_activity_preview_rows_with_limit_executor(
-        &mut *tx,
+        &mut *connection,
         source_scope,
         range,
         upstream_account_id,
@@ -16304,10 +16426,9 @@ async fn query_summary_projection_live_rows_with_budget(
     )
     .await
     .map_err(|error| anyhow!("summary projection live preview fetch failed: {error:?}"))?;
-    restore_summary_projection_persisted_statuses(&mut tx, &mut rows)
+    restore_summary_projection_persisted_statuses(&mut connection, &mut rows)
         .await
         .context("summary projection live status hydration failed")?;
-    tx.commit().await?;
     Ok(rows)
 }
 

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -17,6 +17,9 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tracing::debug;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
 pub(crate) const INVOCATION_PROXY_DISPLAY_SQL: &str = "NULLIF(TRIM(CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.proxyDisplayName') AS TEXT) END), '')";
 pub(crate) const INVOCATION_ENDPOINT_SQL: &str =
     "CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.endpoint') AS TEXT) END";
@@ -60,6 +63,7 @@ pub(crate) const INVOCATION_LIVE_PHASE_REQUESTING: &str = "requesting";
 pub(crate) const INVOCATION_LIVE_PHASE_RESPONDING: &str = "responding";
 const INVOCATION_ANCHOR_TTL: Duration = Duration::from_secs(30 * 60);
 const INVOCATION_ANCHOR_CACHE_LIMIT: usize = 32;
+const SUMMARY_PROJECTION_STABLE_SQLITE_VERSION_ATTEMPTS: usize = 3;
 
 #[derive(Clone)]
 struct InvocationAnchorSnapshot {
@@ -72,6 +76,90 @@ struct InvocationAnchorSnapshot {
 static INVOCATION_ANCHOR_SNAPSHOTS: once_cell::sync::Lazy<
     StdMutex<HashMap<String, InvocationAnchorSnapshot>>,
 > = once_cell::sync::Lazy::new(|| StdMutex::new(HashMap::new()));
+
+#[cfg(test)]
+const SUMMARY_PROJECTION_TEST_INTERLEAVE_TABLE: &str = "summary_projection_test_interleave_gate";
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct SummaryProjectionTestInterleave {
+    writer_ready: Arc<tokio::sync::Notify>,
+    resume_build: Arc<tokio::sync::Notify>,
+    paused: Arc<AtomicBool>,
+    build_attempts: Arc<AtomicUsize>,
+}
+
+#[cfg(test)]
+static SUMMARY_PROJECTION_TEST_INTERLEAVE: once_cell::sync::Lazy<
+    StdMutex<Option<SummaryProjectionTestInterleave>>,
+> = once_cell::sync::Lazy::new(|| StdMutex::new(None));
+
+#[cfg(test)]
+impl SummaryProjectionTestInterleave {
+    pub(crate) async fn wait_for_writer(&self) {
+        self.writer_ready.notified().await;
+    }
+
+    pub(crate) fn resume_build(&self) {
+        self.resume_build.notify_one();
+    }
+
+    pub(crate) fn build_attempts(&self) -> usize {
+        self.build_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn install_summary_projection_test_interleave() -> SummaryProjectionTestInterleave {
+    let interleave = SummaryProjectionTestInterleave {
+        writer_ready: Arc::new(tokio::sync::Notify::new()),
+        resume_build: Arc::new(tokio::sync::Notify::new()),
+        paused: Arc::new(AtomicBool::new(false)),
+        build_attempts: Arc::new(AtomicUsize::new(0)),
+    };
+    let mut installed = SUMMARY_PROJECTION_TEST_INTERLEAVE
+        .lock()
+        .expect("summary projection test interleave lock");
+    assert!(
+        installed.is_none(),
+        "summary projection test interleave is already installed"
+    );
+    *installed = Some(interleave.clone());
+    interleave
+}
+
+#[cfg(test)]
+pub(crate) fn clear_summary_projection_test_interleave() {
+    *SUMMARY_PROJECTION_TEST_INTERLEAVE
+        .lock()
+        .expect("summary projection test interleave lock") = None;
+}
+
+#[cfg(test)]
+async fn pause_summary_projection_test_interleave(pool: &Pool<Sqlite>) -> Result<()> {
+    let table_present = sqlx::query_scalar::<_, i64>(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+    )
+    .bind(SUMMARY_PROJECTION_TEST_INTERLEAVE_TABLE)
+    .fetch_one(pool)
+    .await?;
+    if table_present == 0 {
+        return Ok(());
+    }
+    let interleave = SUMMARY_PROJECTION_TEST_INTERLEAVE
+        .lock()
+        .expect("summary projection test interleave lock")
+        .clone();
+    let Some(interleave) = interleave else {
+        return Ok(());
+    };
+    interleave.build_attempts.fetch_add(1, Ordering::SeqCst);
+    if !interleave.paused.swap(true, Ordering::SeqCst) {
+        interleave.writer_ready.notify_one();
+        interleave.resume_build.notified().await;
+    }
+    Ok(())
+}
 
 fn store_invocation_anchor_snapshot(
     snapshot_id: i64,
@@ -8901,6 +8989,31 @@ fn summary_projection_mark_exact_replacement_buckets(
     Ok(())
 }
 
+fn summary_projection_mark_account_exact_replacement_buckets(
+    archive_has_materialized_rollups: bool,
+    exact_range: ExactUtcRange,
+    exact_account_total_rollup_buckets: &mut HashSet<i64>,
+    exact_account_usage_rollup_buckets: &mut HashSet<i64>,
+) -> Result<()> {
+    if !archive_has_materialized_rollups {
+        return Ok(());
+    }
+    // A stale account manifest makes the account compact aggregate unverifiable even when the
+    // global replay is complete. The paged raw fallback owns this whole bucket for account
+    // totals and usage, while the global compact aggregates remain available.
+    summary_projection_exact_range_fits_bucket_budget(exact_range)?;
+    let mut bucket = align_bucket_epoch(exact_range.start.timestamp(), 3_600, 0);
+    let last_bucket = align_bucket_epoch(exact_range.end.timestamp().saturating_sub(1), 3_600, 0);
+    while bucket <= last_bucket {
+        exact_account_total_rollup_buckets.insert(bucket);
+        exact_account_usage_rollup_buckets.insert(bucket);
+        summary_projection_ensure_exact_bucket_budget(exact_account_total_rollup_buckets)?;
+        summary_projection_ensure_exact_bucket_budget(exact_account_usage_rollup_buckets)?;
+        bucket = bucket.saturating_add(3_600);
+    }
+    Ok(())
+}
+
 async fn merge_summary_projection_archive_records(
     pool: &Pool<Sqlite>,
     persisted_live_ids: &HashSet<String>,
@@ -9606,8 +9719,13 @@ async fn load_summary_projection_archive_replay_coverage(
     for archive_paths in archive_paths.chunks(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE)
     {
         let mut query = QueryBuilder::<Sqlite>::new(
-            "SELECT file_path, target FROM hourly_rollup_archive_replay \
-             WHERE dataset = 'codex_invocations' AND target IN (",
+            "SELECT replay.file_path, replay.target FROM hourly_rollup_archive_replay AS replay \
+             INNER JOIN archive_batches AS batches \
+               ON batches.dataset = replay.dataset \
+              AND batches.file_path = replay.file_path \
+              AND batches.status = 'completed' \
+              AND batches.sha256 = replay.archive_sha256 \
+             WHERE replay.dataset = 'codex_invocations' AND replay.target IN (",
         );
         query
             .push_bind(HOURLY_ROLLUP_TARGET_INVOCATIONS)
@@ -9615,7 +9733,7 @@ async fn load_summary_projection_archive_replay_coverage(
             .push_bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY)
             .push(", ")
             .push_bind(HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN)
-            .push(") AND file_path IN (");
+            .push(") AND replay.file_path IN (");
         {
             let mut separated = query.separated(", ");
             for path in archive_paths {
@@ -9687,18 +9805,21 @@ async fn summary_projection_overflowed_boundary_manifests_have_complete_rollups(
                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
                         WHERE replay.dataset = batches.dataset \
                           AND replay.file_path = batches.file_path \
+                          AND replay.archive_sha256 = batches.sha256 \
                           AND replay.target = ?3 \
                     ) \
                     OR NOT EXISTS( \
                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
                         WHERE replay.dataset = batches.dataset \
                           AND replay.file_path = batches.file_path \
+                          AND replay.archive_sha256 = batches.sha256 \
                           AND replay.target = ?4 \
                     ) \
                     OR NOT EXISTS( \
                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
                         WHERE replay.dataset = batches.dataset \
                           AND replay.file_path = batches.file_path \
+                          AND replay.archive_sha256 = batches.sha256 \
                           AND replay.target = ?5 \
                     ) \
                ) \
@@ -9738,18 +9859,21 @@ async fn summary_projection_overflowed_all_time_manifests_have_complete_rollups(
                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
                         WHERE replay.dataset = batches.dataset \
                           AND replay.file_path = batches.file_path \
+                          AND replay.archive_sha256 = batches.sha256 \
                           AND replay.target = ?2 \
                     ) \
                     OR NOT EXISTS( \
                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
                         WHERE replay.dataset = batches.dataset \
                           AND replay.file_path = batches.file_path \
+                          AND replay.archive_sha256 = batches.sha256 \
                           AND replay.target = ?3 \
                     ) \
                     OR NOT EXISTS( \
                         SELECT 1 FROM hourly_rollup_archive_replay AS replay \
                         WHERE replay.dataset = batches.dataset \
                           AND replay.file_path = batches.file_path \
+                          AND replay.archive_sha256 = batches.sha256 \
                           AND replay.target = ?4 \
                     ) \
                ) \
@@ -10051,7 +10175,7 @@ fn summary_projection_live_record_from_preview(
     ))
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct PreviousSummaryProjectionAllTime {
     all_time_by_account: HashMap<Option<i64>, StatsResponse>,
     all_time_refreshed_at: Option<Instant>,
@@ -10072,6 +10196,46 @@ struct PreviousSummaryProjectionAllTime {
 /// Reads every input needed by the hot path while running off-request.  The resulting projection
 /// is swapped atomically in the subscription hub only after the complete baseline is available.
 async fn build_summary_projection(
+    state: &AppState,
+    include_all_time: bool,
+    previous_all_time: Option<PreviousSummaryProjectionAllTime>,
+    durable_terminal_sequence_watermark: u64,
+) -> Result<SummaryProjection> {
+    // The pool performs each query on its own connection, so a stable archive id alone cannot
+    // prevent a retention commit from replacing a manifest and its compact rollups between two
+    // projection reads. Keep one observer connection for the whole build and retry only a small,
+    // fixed number of times whenever another connection commits any SQLite change.
+    for _ in 0..SUMMARY_PROJECTION_STABLE_SQLITE_VERSION_ATTEMPTS {
+        let mut observer = state
+            .pool
+            .acquire()
+            .await
+            .context("summary projection stable SQLite observer acquisition failed")?;
+        let version_before = sqlx::query_scalar::<_, i64>("PRAGMA data_version")
+            .fetch_one(&mut *observer)
+            .await
+            .context("summary projection stable SQLite version hydration failed")?;
+        let projection = build_summary_projection_once(
+            state,
+            include_all_time,
+            previous_all_time.clone(),
+            durable_terminal_sequence_watermark,
+        )
+        .await?;
+        let version_after = sqlx::query_scalar::<_, i64>("PRAGMA data_version")
+            .fetch_one(&mut *observer)
+            .await
+            .context("summary projection stable SQLite version revalidation failed")?;
+        if version_before == version_after {
+            return Ok(projection);
+        }
+    }
+    Err(anyhow!(
+        "summary projection SQLite source changed during bounded hydration retries"
+    ))
+}
+
+async fn build_summary_projection_once(
     state: &AppState,
     include_all_time: bool,
     previous_all_time: Option<PreviousSummaryProjectionAllTime>,
@@ -10119,6 +10283,8 @@ async fn build_summary_projection(
         load_summary_projection_rollup_totals_in_range(&state.pool, Some(rollup_range)).await?;
     let hourly_rollup_usage =
         load_summary_projection_rollup_usage_in_range(&state.pool, Some(rollup_range)).await?;
+    #[cfg(test)]
+    pause_summary_projection_test_interleave(&state.pool).await?;
     // Rolling aggregation must still distinguish an archive-backed retention database from a
     // live-only one. This bounded existence probe is independent of the expensive all-history
     // manifest admission below.
@@ -10690,8 +10856,19 @@ async fn build_summary_projection(
                 let account_manifest_complete = page
                     .account_manifest_refreshed_paths
                     .contains(archive.file_path());
+                if !account_manifest_complete {
+                    summary_projection_mark_account_exact_replacement_buckets(
+                        true,
+                        archive_range,
+                        &mut exact_account_total_rollup_buckets,
+                        &mut exact_account_usage_rollup_buckets,
+                    )?;
+                }
                 let (account_replayed, usage_replayed) = if !account_manifest_complete {
-                    (Some(false), Some(false))
+                    // The page admission proof already establishes the global usage replay
+                    // target. A stale account manifest only invalidates account-scoped usage,
+                    // which is handled by the exact account bucket set above.
+                    (Some(false), Some(true))
                 } else if account_ids.is_empty() {
                     (Some(true), Some(true))
                 } else {
@@ -10947,7 +11124,7 @@ async fn build_summary_projection(
                     .account_manifest_refreshed_paths
                     .contains(archive.file_path());
                 let (account_replayed, usage_replayed) = if !account_manifest_complete {
-                    (Some(false), Some(false))
+                    (Some(false), Some(true))
                 } else if account_ids.is_empty() {
                     (Some(true), Some(true))
                 } else {
@@ -26914,6 +27091,98 @@ mod request_compression_query_tests {
             .collect::<HashSet<_>>();
         assert!(paths.contains("minimum-id.sqlite.gz"));
         assert!(paths.contains("zero-id.sqlite.gz"));
+    }
+
+    #[tokio::test]
+    async fn summary_projection_replay_coverage_requires_current_manifest_sha() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite pool");
+        sqlx::query(
+            "CREATE TABLE archive_batches ( \
+                 id INTEGER PRIMARY KEY, \
+                 dataset TEXT NOT NULL, \
+                 status TEXT NOT NULL, \
+                 file_path TEXT NOT NULL, \
+                 sha256 TEXT NOT NULL \
+             )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create archive manifest table");
+        sqlx::query(
+            "CREATE TABLE hourly_rollup_archive_replay ( \
+                 target TEXT NOT NULL, \
+                 dataset TEXT NOT NULL, \
+                 file_path TEXT NOT NULL, \
+                 archive_sha256 TEXT NOT NULL \
+             )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create archive replay table");
+        sqlx::query(
+            "INSERT INTO archive_batches \
+             (id, dataset, status, file_path, sha256) \
+             VALUES (1, 'codex_invocations', 'completed', 'replacement.sqlite.gz', 'new-sha')",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert replacement archive manifest");
+        for target in [
+            HOURLY_ROLLUP_TARGET_INVOCATIONS,
+            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+            HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN,
+        ] {
+            sqlx::query(
+                "INSERT INTO hourly_rollup_archive_replay \
+                 (target, dataset, file_path, archive_sha256) \
+                 VALUES (?1, 'codex_invocations', 'replacement.sqlite.gz', 'old-sha')",
+            )
+            .bind(target)
+            .execute(&pool)
+            .await
+            .expect("insert stale replay marker");
+        }
+
+        let stale_coverage = load_summary_projection_archive_replay_coverage(
+            &pool,
+            &["replacement.sqlite.gz".to_string()],
+        )
+        .await
+        .expect("read stale replay coverage");
+        assert!(
+            !stale_coverage
+                .get("replacement.sqlite.gz")
+                .copied()
+                .unwrap_or_default()
+                .supports_unavailable_archive(),
+            "a replacement manifest must not inherit old replay proof"
+        );
+
+        sqlx::query(
+            "UPDATE hourly_rollup_archive_replay SET archive_sha256 = 'new-sha' \
+             WHERE dataset = 'codex_invocations' AND file_path = 'replacement.sqlite.gz'",
+        )
+        .execute(&pool)
+        .await
+        .expect("refresh replay markers for replacement manifest");
+        let current_coverage = load_summary_projection_archive_replay_coverage(
+            &pool,
+            &["replacement.sqlite.gz".to_string()],
+        )
+        .await
+        .expect("read current replay coverage");
+        assert!(
+            current_coverage
+                .get("replacement.sqlite.gz")
+                .copied()
+                .unwrap_or_default()
+                .supports_unavailable_archive(),
+            "current replay proof must cover every compact response dimension"
+        );
     }
 
     #[test]

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -7487,12 +7487,21 @@ impl SummaryProjection {
         }
         let now = Utc::now();
         let range = summary_window_range(&window, reporting_tz, now)?;
-        if let Some((start, end)) = range
-            && self
+        let unavailable_archive_range_affects_query = match range {
+            Some((start, end)) => self
                 .unavailable_unmaterialized_archive_ranges
                 .iter()
-                .any(|unavailable| unavailable.start < end && start < unavailable.end)
-        {
+                .any(|unavailable| unavailable.start < end && start < unavailable.end),
+            // `current` is a bounded recent-record selection, rather than a timestamp range.
+            // Once a protected archive boundary cannot be reconstructed, its position in that
+            // selection is unknown without request-time I/O. Fail closed instead of returning a
+            // shorter in-memory list that silently omits the archive record.
+            None => {
+                matches!(window, SummaryWindow::Current(_))
+                    && !self.unavailable_unmaterialized_archive_ranges.is_empty()
+            }
+        };
+        if unavailable_archive_range_affects_query {
             return Err(ApiError::unavailable(anyhow!(
                 "summary projection archive source is unavailable for the requested range"
             )));
@@ -10511,11 +10520,10 @@ async fn build_summary_projection(
             crate::stats::open_invocation_archive_batch_pool(&archive, "summary-projection")
                 .await?
         else {
-            if replay_coverage.supports_unavailable_archive() {
-                // Preserve the read-only historical fallback only when durable state proves
-                // every response dimension. A global-only replay marker is not enough.
-                continue;
-            }
+            // Complete replay can replace a full compact hour, but it cannot reconstruct this
+            // request-visible partial hour or its usage/model detail. The raw archive is an
+            // exact source for every range in `exact_ranges`; without it, retain unavailable
+            // rather than allowing the memory-only reducer to omit that contribution.
             if !unavailable_unmaterialized_archive_ranges.contains(&archive_range) {
                 unavailable_unmaterialized_archive_ranges.push(archive_range);
             }
@@ -10599,9 +10607,12 @@ async fn build_summary_projection(
                     )
                     .await?
                 else {
-                    // Eligibility proved all targets are materialized. A missing immutable file
-                    // can therefore use the same compact baseline without degrading this exact
-                    // window; a missing proof would have taken the normal fail-closed path.
+                    // The page is durable enough to use compact rollups for full hours, but the
+                    // planned exact ranges still need raw partial-hour records. Mark the range
+                    // unavailable so HTTP cannot publish an undercount from the compact source.
+                    if !unavailable_unmaterialized_archive_ranges.contains(&archive_range) {
+                        unavailable_unmaterialized_archive_ranges.push(archive_range);
+                    }
                     continue;
                 };
                 merge_summary_projection_archive_records_with_coverage(
@@ -28256,7 +28267,7 @@ mod request_compression_query_tests {
         );
         state.pool.close().await;
 
-        for window in ["1d", "all"] {
+        for window in ["current", "1d", "all"] {
             let response = fetch_summary(
                 State(state.clone()),
                 Query(SummaryQuery {

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -25,7 +25,7 @@ use std::{fs, io};
 use tracing::debug;
 
 #[cfg(test)]
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub(crate) const INVOCATION_PROXY_DISPLAY_SQL: &str = "NULLIF(TRIM(CASE WHEN json_valid(payload) THEN CAST(json_extract(payload, '$.proxyDisplayName') AS TEXT) END), '')";
 pub(crate) const INVOCATION_ENDPOINT_SQL: &str =
@@ -87,12 +87,21 @@ static INVOCATION_ANCHOR_SNAPSHOTS: once_cell::sync::Lazy<
 const SUMMARY_PROJECTION_TEST_INTERLEAVE_TABLE: &str = "summary_projection_test_interleave_gate";
 
 #[cfg(test)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum SummaryProjectionTestInterleaveStage {
+    AfterRollupLoad,
+    AfterAllTimeArchiveDiscovery,
+    BeforeAllTimeArchiveScan,
+}
+
+#[cfg(test)]
 #[derive(Clone)]
 pub(crate) struct SummaryProjectionTestInterleave {
     writer_ready: Arc<tokio::sync::Notify>,
     resume_build: Arc<tokio::sync::Notify>,
-    paused: Arc<AtomicBool>,
     build_attempts: Arc<AtomicUsize>,
+    stages: Arc<[SummaryProjectionTestInterleaveStage]>,
+    next_stage_index: Arc<AtomicUsize>,
 }
 
 #[cfg(test)]
@@ -117,11 +126,32 @@ impl SummaryProjectionTestInterleave {
 
 #[cfg(test)]
 pub(crate) fn install_summary_projection_test_interleave() -> SummaryProjectionTestInterleave {
+    install_summary_projection_test_interleave_at(
+        SummaryProjectionTestInterleaveStage::AfterRollupLoad,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn install_summary_projection_test_interleave_at(
+    stage: SummaryProjectionTestInterleaveStage,
+) -> SummaryProjectionTestInterleave {
+    install_summary_projection_test_interleave_for_stages(&[stage])
+}
+
+#[cfg(test)]
+pub(crate) fn install_summary_projection_test_interleave_for_stages(
+    stages: &[SummaryProjectionTestInterleaveStage],
+) -> SummaryProjectionTestInterleave {
+    assert!(
+        !stages.is_empty(),
+        "summary projection test interleave needs at least one stage"
+    );
     let interleave = SummaryProjectionTestInterleave {
         writer_ready: Arc::new(tokio::sync::Notify::new()),
         resume_build: Arc::new(tokio::sync::Notify::new()),
-        paused: Arc::new(AtomicBool::new(false)),
         build_attempts: Arc::new(AtomicUsize::new(0)),
+        stages: stages.into(),
+        next_stage_index: Arc::new(AtomicUsize::new(0)),
     };
     let mut installed = SUMMARY_PROJECTION_TEST_INTERLEAVE
         .lock()
@@ -142,7 +172,10 @@ pub(crate) fn clear_summary_projection_test_interleave() {
 }
 
 #[cfg(test)]
-async fn pause_summary_projection_test_interleave(pool: &Pool<Sqlite>) -> Result<()> {
+async fn pause_summary_projection_test_interleave(
+    pool: &Pool<Sqlite>,
+    stage: SummaryProjectionTestInterleaveStage,
+) -> Result<()> {
     let table_present = sqlx::query_scalar::<_, i64>(
         "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
     )
@@ -159,11 +192,14 @@ async fn pause_summary_projection_test_interleave(pool: &Pool<Sqlite>) -> Result
     let Some(interleave) = interleave else {
         return Ok(());
     };
-    interleave.build_attempts.fetch_add(1, Ordering::SeqCst);
-    if !interleave.paused.swap(true, Ordering::SeqCst) {
-        interleave.writer_ready.notify_one();
-        interleave.resume_build.notified().await;
+    let next_stage_index = interleave.next_stage_index.load(Ordering::SeqCst);
+    if interleave.stages.get(next_stage_index) != Some(&stage) {
+        return Ok(());
     }
+    interleave.next_stage_index.fetch_add(1, Ordering::SeqCst);
+    interleave.build_attempts.fetch_add(1, Ordering::SeqCst);
+    interleave.writer_ready.notify_one();
+    interleave.resume_build.notified().await;
     Ok(())
 }
 
@@ -9818,18 +9854,37 @@ fn require_summary_projection_archive_file_paths_sha256(
     Ok(())
 }
 
+struct SummaryProjectionAllTimeArchiveScanPaths {
+    global: Vec<String>,
+    account: Vec<String>,
+    global_unmaterialized_count: usize,
+}
+
 async fn load_summary_projection_all_time_archive_scan_paths(
     pool: &Pool<Sqlite>,
-) -> Result<Vec<String>> {
+) -> Result<SummaryProjectionAllTimeArchiveScanPaths> {
     // These are precisely the completed archive paths that the two generic all-time
     // aggregators may inflate: the global pass handles missing invocation replay, and the
     // account pass additionally handles unmaterialized archives missing account replay.
-    let paths = sqlx::query_scalar::<_, String>(
-        "SELECT batches.file_path \
+    let rows = sqlx::query_as::<_, (String, i64, i64, i64)>(
+        "SELECT batches.file_path, \
+                NOT EXISTS ( \
+                    SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                    WHERE replay.target = ?1 \
+                      AND replay.dataset = 'codex_invocations' \
+                      AND replay.file_path = batches.file_path \
+                ) AS needs_global_archive_scan, \
+                (batches.historical_rollups_materialized_at IS NULL AND NOT EXISTS ( \
+                    SELECT 1 FROM hourly_rollup_archive_replay AS replay \
+                    WHERE replay.target = ?2 \
+                      AND replay.dataset = 'codex_invocations' \
+                      AND replay.file_path = batches.file_path \
+                )) AS needs_account_archive_scan, \
+                batches.historical_rollups_materialized_at IS NULL AS is_unmaterialized \
          FROM archive_batches AS batches \
          WHERE batches.dataset = 'codex_invocations' \
-           AND batches.status = 'completed' \
-           AND ( \
+         AND batches.status = 'completed' \
+         AND ( \
                NOT EXISTS ( \
                    SELECT 1 FROM hourly_rollup_archive_replay AS replay \
                    WHERE replay.target = ?1 \
@@ -9855,12 +9910,32 @@ async fn load_summary_projection_all_time_archive_scan_paths(
     .fetch_all(pool)
     .await
     .context("summary projection all-time archive scan admission failed")?;
-    if paths.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+    if rows.len() > SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
         return Err(anyhow!(
             "summary projection all-time archive scan cardinality exceeded bounded budget ({SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES})"
         ));
     }
-    Ok(paths)
+    let mut global = Vec::new();
+    let mut account = Vec::new();
+    let mut global_unmaterialized_count = 0usize;
+    for (file_path, needs_global_archive_scan, needs_account_archive_scan, is_unmaterialized) in
+        rows
+    {
+        if needs_global_archive_scan != 0 {
+            if is_unmaterialized != 0 {
+                global_unmaterialized_count += 1;
+            }
+            global.push(file_path.clone());
+        }
+        if needs_account_archive_scan != 0 {
+            account.push(file_path);
+        }
+    }
+    Ok(SummaryProjectionAllTimeArchiveScanPaths {
+        global,
+        account,
+        global_unmaterialized_count,
+    })
 }
 
 async fn load_summary_projection_archive_manifest_accounts(
@@ -10512,7 +10587,11 @@ async fn build_summary_projection_once(
     let hourly_rollup_usage =
         load_summary_projection_rollup_usage_in_range(pool, Some(rollup_range)).await?;
     #[cfg(test)]
-    pause_summary_projection_test_interleave(pool).await?;
+    pause_summary_projection_test_interleave(
+        pool,
+        SummaryProjectionTestInterleaveStage::AfterRollupLoad,
+    )
+    .await?;
     // Rolling aggregation must still distinguish an archive-backed retention database from a
     // live-only one. This bounded existence probe is independent of the expensive all-history
     // manifest admission below.
@@ -11820,39 +11899,62 @@ async fn build_summary_projection_once(
                 })?,
             );
         }
+        #[cfg(test)]
+        pause_summary_projection_test_interleave(
+            pool,
+            SummaryProjectionTestInterleaveStage::AfterAllTimeArchiveDiscovery,
+        )
+        .await?;
         let global_archive_scan_verified_paths =
             verify_summary_projection_archive_file_paths_sha256(
-                &all_time_archive_scan_paths,
+                &all_time_archive_scan_paths.global,
                 &all_time_archive_manifest_sha256,
             )?;
-        let unmaterialized_archive_totals =
-            crate::stats::query_unmaterialized_invocation_archive_totals_bounded_strict(
-                pool,
-                InvocationSourceScope::All,
-                None,
-                Some(live_tail_ids),
-                SUMMARY_PROJECTION_MAX_EXACT_RECORDS,
-            )
-            .await;
-        match unmaterialized_archive_totals {
-            Ok(totals) => {
-                require_summary_projection_archive_file_paths_sha256(
-                    &global_archive_scan_verified_paths,
-                    &all_time_archive_manifest_sha256,
-                )?;
-                global_totals = global_totals.add(totals);
-            }
-            Err(error)
-                if error
-                    .to_string()
-                    .starts_with("summary archive is unavailable:") =>
-            {
+        #[cfg(test)]
+        pause_summary_projection_test_interleave(
+            pool,
+            SummaryProjectionTestInterleaveStage::BeforeAllTimeArchiveScan,
+        )
+        .await?;
+        if global_archive_scan_verified_paths.len() != all_time_archive_scan_paths.global.len() {
+            // The generic global aggregate chooses its own archive paths inside `stats`. Do not
+            // let a source which was unavailable at preflight become readable and enter that
+            // scan under a different manifest revision. When every candidate is already
+            // materialized, the compact global rollup is its exact all-time source and no raw
+            // reconciliation is necessary; otherwise retain the last-good global aggregate.
+            if all_time_archive_scan_paths.global_unmaterialized_count != 0 {
                 global_all_time_source_unavailable = true;
             }
-            Err(error) => {
-                return Err(anyhow!(
-                    "summary projection global archive hydration failed: {error:?}"
-                ));
+        } else {
+            let unmaterialized_archive_totals =
+                crate::stats::query_unmaterialized_invocation_archive_totals_bounded_strict(
+                    pool,
+                    InvocationSourceScope::All,
+                    None,
+                    Some(live_tail_ids),
+                    SUMMARY_PROJECTION_MAX_EXACT_RECORDS,
+                )
+                .await;
+            match unmaterialized_archive_totals {
+                Ok(totals) => {
+                    require_summary_projection_archive_file_paths_sha256(
+                        &all_time_archive_scan_paths.global,
+                        &all_time_archive_manifest_sha256,
+                    )?;
+                    global_totals = global_totals.add(totals);
+                }
+                Err(error)
+                    if error
+                        .to_string()
+                        .starts_with("summary archive is unavailable:") =>
+                {
+                    global_all_time_source_unavailable = true;
+                }
+                Err(error) => {
+                    return Err(anyhow!(
+                        "summary projection global archive hydration failed: {error:?}"
+                    ));
+                }
             }
         }
         // Any materialized compact gap, including a missing rollup key with complete replay
@@ -11917,52 +12019,47 @@ async fn build_summary_projection_once(
         }
         let account_archive_scan_verified_paths =
             verify_summary_projection_archive_file_paths_sha256(
-                &all_time_archive_scan_paths,
+                &all_time_archive_scan_paths.account,
                 &all_time_archive_manifest_sha256,
             )?;
-        let account_archive_totals =
-            crate::stats::query_unmaterialized_upstream_account_archive_totals_by_account(
-                pool,
-                HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
-                InvocationSourceScope::All,
-                None,
-                Some(live_tail_ids),
-            )
-            .await;
-        let account_archive_totals = match account_archive_totals {
-            Ok(totals) => {
-                require_summary_projection_archive_file_paths_sha256(
-                    &account_archive_scan_verified_paths,
-                    &all_time_archive_manifest_sha256,
-                )?;
-                totals
-            }
-            Err(error)
-                if error
-                    .to_string()
-                    .starts_with("summary account archive is unavailable:") =>
-            {
-                // Global rollups remain a valid read-only fallback for this refresh, but an
-                // account response would be an undercount without the missing archive. Restore
-                // the exact last-good account map so a fresh prior response remains serviceable
-                // within its own freshness budget instead of publishing a partial aggregate.
-                account_all_time_unavailable = true;
-                all_time_by_account.retain(|account_id, _| account_id.is_none());
-                for (account_id, response) in previous_all_time_by_account
-                    .as_ref()
-                    .into_iter()
-                    .flat_map(HashMap::iter)
-                {
-                    if account_id.is_some() {
-                        all_time_by_account.insert(*account_id, response.clone());
-                    }
+        let account_archive_totals = if account_archive_scan_verified_paths.len()
+            != all_time_archive_scan_paths.account.len()
+        {
+            account_all_time_unavailable = true;
+            HashMap::new()
+        } else {
+            let account_archive_totals =
+                crate::stats::query_unmaterialized_upstream_account_archive_totals_by_account(
+                    pool,
+                    HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+                    InvocationSourceScope::All,
+                    None,
+                    Some(live_tail_ids),
+                )
+                .await;
+            match account_archive_totals {
+                Ok(totals) => {
+                    require_summary_projection_archive_file_paths_sha256(
+                        &all_time_archive_scan_paths.account,
+                        &all_time_archive_manifest_sha256,
+                    )?;
+                    totals
                 }
-                HashMap::new()
-            }
-            Err(error) => {
-                return Err(anyhow!(
-                    "summary projection account archive hydration failed: {error:?}"
-                ));
+                Err(error)
+                    if error
+                        .to_string()
+                        .starts_with("summary account archive is unavailable:") =>
+                {
+                    // Global rollups remain a valid read-only fallback for this refresh, but an
+                    // account response would be an undercount without the missing archive.
+                    account_all_time_unavailable = true;
+                    HashMap::new()
+                }
+                Err(error) => {
+                    return Err(anyhow!(
+                        "summary projection account archive hydration failed: {error:?}"
+                    ));
+                }
             }
         };
         for (account_id, totals) in account_archive_totals {

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -12,7 +12,7 @@ use futures_util::TryStreamExt;
 use serde::Serialize;
 use serde_json::{Value, json};
 use sqlx::{FromRow, SqliteConnection};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tracing::debug;
@@ -8796,6 +8796,57 @@ fn summary_projection_extend_exact_buckets_for_ranges(
     Ok(())
 }
 
+fn summary_projection_mark_unavailable_archive_ranges(
+    buckets: &mut BTreeSet<i64>,
+    ranges: impl IntoIterator<Item = ExactUtcRange>,
+) -> Result<()> {
+    for range in ranges {
+        if range.start >= range.end {
+            continue;
+        }
+        let first_bucket = align_bucket_epoch(range.start.timestamp(), 3_600, 0);
+        let last_bucket = align_bucket_epoch(range.end.timestamp().saturating_sub(1), 3_600, 0);
+        let bucket_count = last_bucket
+            .saturating_sub(first_bucket)
+            .saturating_div(3_600)
+            .saturating_add(1) as usize;
+        if bucket_count > SUMMARY_PROJECTION_MAX_EXACT_BUCKETS {
+            return Err(anyhow!(
+                "summary projection unavailable archive range budget ({SUMMARY_PROJECTION_MAX_EXACT_BUCKETS}) exceeded"
+            ));
+        }
+        let mut bucket = first_bucket;
+        while bucket <= last_bucket {
+            if !buckets.contains(&bucket) && buckets.len() >= SUMMARY_PROJECTION_MAX_EXACT_BUCKETS {
+                return Err(anyhow!(
+                    "summary projection unavailable archive range budget ({SUMMARY_PROJECTION_MAX_EXACT_BUCKETS}) exceeded"
+                ));
+            }
+            buckets.insert(bucket);
+            bucket = bucket.saturating_add(3_600);
+        }
+    }
+    Ok(())
+}
+
+fn summary_projection_unavailable_bucket_ranges(buckets: BTreeSet<i64>) -> Vec<ExactUtcRange> {
+    let mut ranges = Vec::<ExactUtcRange>::new();
+    for bucket in buckets {
+        let Some(start) = Utc.timestamp_opt(bucket, 0).single() else {
+            continue;
+        };
+        let end = start + ChronoDuration::hours(1);
+        if let Some(previous) = ranges.last_mut()
+            && previous.end >= start
+        {
+            previous.end = previous.end.max(end);
+        } else {
+            ranges.push(ExactUtcRange { start, end });
+        }
+    }
+    ranges
+}
+
 fn summary_projection_mark_exact_replacement_buckets(
     archive_has_materialized_rollups: bool,
     replay_coverage: SummaryProjectionArchiveReplayCoverage,
@@ -9633,30 +9684,58 @@ async fn summary_projection_overflowed_boundary_manifests_have_complete_rollups(
     Ok(incomplete == 0)
 }
 
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct SummaryProjectionBoundaryManifestPageRow {
+    id: i64,
+    file_path: String,
+    coverage_start_at: Option<String>,
+    coverage_end_at: Option<String>,
+}
+
+struct SummaryProjectionBoundaryManifestPage {
+    archives: Vec<crate::stats::ArchiveBatchPathRow>,
+    next_after_id: Option<i64>,
+}
+
 async fn load_summary_projection_boundary_manifest_page(
     pool: &Pool<Sqlite>,
     range: ExactUtcRange,
-    offset: usize,
-) -> Result<Vec<crate::stats::ArchiveBatchPathRow>> {
-    sqlx::query_as::<_, crate::stats::ArchiveBatchPathRow>(
+    after_id: i64,
+) -> Result<SummaryProjectionBoundaryManifestPage> {
+    let rows = sqlx::query_as::<_, SummaryProjectionBoundaryManifestPageRow>(
         "SELECT \
-             file_path, month_key, coverage_start_at, coverage_end_at, \
-             historical_rollups_materialized_at, NULL AS needs_overall, NULL AS needs_failures \
+             id, file_path, coverage_start_at, coverage_end_at \
          FROM archive_batches \
          WHERE dataset = 'codex_invocations' \
            AND status = 'completed' \
            AND coverage_end_at >= ?1 \
            AND coverage_start_at < ?2 \
-         ORDER BY month_key ASC, created_at ASC, id ASC \
-         LIMIT ?3 OFFSET ?4",
+           AND id > ?3 \
+         ORDER BY id ASC \
+         LIMIT ?4",
     )
     .bind(db_occurred_at_upper_bound(range.start))
     .bind(crate::stats::db_occurred_at_lower_bound(range.end))
+    .bind(after_id)
     .bind(SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE as i64)
-    .bind(offset as i64)
     .fetch_all(pool)
     .await
-    .context("summary projection boundary manifest page hydration failed")
+    .context("summary projection boundary manifest page hydration failed")?;
+    let next_after_id = rows.last().map(|row| row.id);
+    let archives = rows
+        .into_iter()
+        .map(|row| {
+            crate::stats::ArchiveBatchPathRow::with_coverage(
+                row.file_path,
+                row.coverage_start_at,
+                row.coverage_end_at,
+            )
+        })
+        .collect();
+    Ok(SummaryProjectionBoundaryManifestPage {
+        archives,
+        next_after_id,
+    })
 }
 
 async fn load_summary_projection_durable_account_ids(pool: &Pool<Sqlite>) -> Result<HashSet<i64>> {
@@ -10124,7 +10203,7 @@ async fn build_summary_projection(
             .map_err(|error| {
                 anyhow!("summary projection usage progress hydration failed: {error:?}")
             })?;
-    let mut unavailable_unmaterialized_archive_ranges = Vec::<ExactUtcRange>::new();
+    let mut unavailable_unmaterialized_archive_buckets = BTreeSet::<i64>::new();
     // Discover accounts from archive rows before planning full-hour coverage. Pools are opened
     // and closed one at a time so a large retention horizon never keeps every inflated archive
     // resident concurrently. Immutable completed archives reuse the cached account set on later
@@ -10199,9 +10278,10 @@ async fn build_summary_projection(
                 // global total could conceal missing account or usage/model detail.
                 continue;
             }
-            if !unavailable_unmaterialized_archive_ranges.contains(&archive_range) {
-                unavailable_unmaterialized_archive_ranges.push(archive_range);
-            }
+            summary_projection_mark_unavailable_archive_ranges(
+                &mut unavailable_unmaterialized_archive_buckets,
+                [archive_range],
+            )?;
             continue;
         };
         if !summary_projection_archive_has_coverage_bounds(archive)
@@ -10337,15 +10417,18 @@ async fn build_summary_projection(
         // The admission overflow is proved fully materialized above. Page only manifest metadata
         // while planning the finite exact buckets; the raw archives themselves are opened later
         // one at a time after live boundary records have been admitted.
-        let mut offset = 0usize;
+        let mut after_id = 0_i64;
         loop {
-            let page =
-                load_summary_projection_boundary_manifest_page(&state.pool, exact_horizon, offset)
-                    .await?;
-            if page.is_empty() {
+            let page = load_summary_projection_boundary_manifest_page(
+                &state.pool,
+                exact_horizon,
+                after_id,
+            )
+            .await?;
+            if page.archives.is_empty() {
                 break;
             }
-            for archive in &page {
+            for archive in &page.archives {
                 let Some(archive_range) =
                     summary_projection_archive_overlap_range(archive, exact_horizon)
                 else {
@@ -10367,11 +10450,10 @@ async fn build_summary_projection(
                     raw_fallback_ranges,
                 )?;
             }
-            let page_len = page.len();
-            offset = offset.saturating_add(page_len);
-            if page_len < SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE {
+            let Some(next_after_id) = page.next_after_id else {
                 break;
-            }
+            };
+            after_id = next_after_id;
         }
     }
     let exact_live_ranges = summary_projection_exact_bucket_ranges(&exact_archive_buckets)
@@ -10524,9 +10606,10 @@ async fn build_summary_projection(
             // request-visible partial hour or its usage/model detail. The raw archive is an
             // exact source for every range in `exact_ranges`; without it, retain unavailable
             // rather than allowing the memory-only reducer to omit that contribution.
-            if !unavailable_unmaterialized_archive_ranges.contains(&archive_range) {
-                unavailable_unmaterialized_archive_ranges.push(archive_range);
-            }
+            summary_projection_mark_unavailable_archive_ranges(
+                &mut unavailable_unmaterialized_archive_buckets,
+                exact_ranges,
+            )?;
             continue;
         };
         merge_summary_projection_archive_records_with_coverage(
@@ -10558,15 +10641,19 @@ async fn build_summary_projection(
         drop(temp_cleanup);
     }
     if paged_boundary_manifest_recovery {
-        let mut offset = 0usize;
+        let mut after_id = 0_i64;
         loop {
-            let page =
-                load_summary_projection_boundary_manifest_page(&state.pool, exact_horizon, offset)
-                    .await?;
-            if page.is_empty() {
+            let page = load_summary_projection_boundary_manifest_page(
+                &state.pool,
+                exact_horizon,
+                after_id,
+            )
+            .await?;
+            if page.archives.is_empty() {
                 break;
             }
             let page_paths = page
+                .archives
                 .iter()
                 .map(|archive| archive.file_path().to_string())
                 .collect::<Vec<_>>();
@@ -10580,7 +10667,7 @@ async fn build_summary_projection(
                     "summary projection paged boundary usage progress hydration failed: {error:?}"
                 )
             })?;
-            for archive in page {
+            for archive in page.archives {
                 let Some(archive_range) =
                     summary_projection_archive_overlap_range(&archive, exact_horizon)
                 else {
@@ -10610,9 +10697,10 @@ async fn build_summary_projection(
                     // The page is durable enough to use compact rollups for full hours, but the
                     // planned exact ranges still need raw partial-hour records. Mark the range
                     // unavailable so HTTP cannot publish an undercount from the compact source.
-                    if !unavailable_unmaterialized_archive_ranges.contains(&archive_range) {
-                        unavailable_unmaterialized_archive_ranges.push(archive_range);
-                    }
+                    summary_projection_mark_unavailable_archive_ranges(
+                        &mut unavailable_unmaterialized_archive_buckets,
+                        exact_ranges,
+                    )?;
                     continue;
                 };
                 merge_summary_projection_archive_records_with_coverage(
@@ -10643,11 +10731,10 @@ async fn build_summary_projection(
                 archive_pool.close().await;
                 drop(temp_cleanup);
             }
-            let page_len = page_paths.len();
-            offset = offset.saturating_add(page_len);
-            if page_len < SUMMARY_PROJECTION_ARCHIVE_MANIFEST_QUERY_CHUNK_SIZE {
+            let Some(next_after_id) = page.next_after_id else {
                 break;
-            }
+            };
+            after_id = next_after_id;
         }
     }
     // Archive rows are merged after the first live-record pass. Apply the same bucket-wide
@@ -10871,7 +10958,8 @@ async fn build_summary_projection(
         // An unreadable archive without replay coverage cannot contribute to either compact
         // all-time aggregate. Preserve last-good/unavailable for `all`; range selections use
         // the bounded marker carried by this projection.
-        global_all_time_source_unavailable |= !unavailable_unmaterialized_archive_ranges.is_empty();
+        global_all_time_source_unavailable |=
+            !unavailable_unmaterialized_archive_buckets.is_empty();
         // With no completed archives, the canonical live rows are authoritative even when a
         // stale hourly rollup exists. Once archives are present, the rollup is the historical
         // prefix and only rows beyond the shared live cursor are an exact live tail.
@@ -10947,7 +11035,7 @@ async fn build_summary_projection(
                 account_all_time_unavailable = true;
             }
         }
-        account_all_time_unavailable |= !unavailable_unmaterialized_archive_ranges.is_empty();
+        account_all_time_unavailable |= !unavailable_unmaterialized_archive_buckets.is_empty();
         if has_any_completed_archive && rollup_live_cursor > 0 {
             global_totals = global_totals.add(
                 crate::stats::query_live_invocation_totals_after_id(
@@ -11282,6 +11370,8 @@ async fn build_summary_projection(
             previous_all_time_account_persisted_live_terminal_invoke_ids,
         )
     };
+    let unavailable_unmaterialized_archive_ranges =
+        summary_projection_unavailable_bucket_ranges(unavailable_unmaterialized_archive_buckets);
     let projection = SummaryProjection {
         records,
         persisted_live_terminal_invoke_ids,
@@ -27228,6 +27318,58 @@ mod request_compression_query_tests {
         assert!(
             !projection.needs_cadence_refresh(true),
             "a blocked all-time admission must not turn an active owner into a retry loop"
+        );
+    }
+
+    #[test]
+    fn summary_unavailable_archive_ranges_compact_many_boundary_fragments() {
+        let start = Utc
+            .timestamp_opt(align_bucket_epoch(1_700_000_000, 3_600, 0), 0)
+            .single()
+            .expect("valid fixed test timestamp");
+        let mut buckets = BTreeSet::new();
+        for fragment in 0..50_001_i64 {
+            let fragment_start = start + ChronoDuration::milliseconds(fragment);
+            summary_projection_mark_unavailable_archive_ranges(
+                &mut buckets,
+                [ExactUtcRange {
+                    start: fragment_start,
+                    end: fragment_start + ChronoDuration::milliseconds(1),
+                }],
+            )
+            .expect("many fragments in one boundary bucket remain bounded");
+        }
+        assert_eq!(buckets.len(), 1);
+        let ranges = summary_projection_unavailable_bucket_ranges(buckets);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].end - ranges[0].start, ChronoDuration::hours(1));
+
+        let mut distinct_buckets = BTreeSet::new();
+        for offset in 0..SUMMARY_PROJECTION_MAX_EXACT_BUCKETS {
+            let bucket_start = start + ChronoDuration::hours(offset as i64);
+            summary_projection_mark_unavailable_archive_ranges(
+                &mut distinct_buckets,
+                [ExactUtcRange {
+                    start: bucket_start,
+                    end: bucket_start + ChronoDuration::hours(1),
+                }],
+            )
+            .expect("the configured unavailable-bucket budget is accepted exactly");
+        }
+        let next_bucket =
+            start + ChronoDuration::hours(SUMMARY_PROJECTION_MAX_EXACT_BUCKETS as i64);
+        let error = summary_projection_mark_unavailable_archive_ranges(
+            &mut distinct_buckets,
+            [ExactUtcRange {
+                start: next_bucket,
+                end: next_bucket + ChronoDuration::hours(1),
+            }],
+        )
+        .expect_err("a distinct bucket beyond the unavailable-range budget must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("unavailable archive range budget")
         );
     }
 

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -2632,8 +2632,10 @@ async fn all_time_summary_preserves_archived_history_when_rollup_failures_are_st
     config.invocation_max_days = 7;
     let state = test_state_from_config(config, true).await;
 
+    // Keep this beyond the rolling exact horizon (retention plus the 31-day grace window) so
+    // only the all-time generic archive aggregation can observe the replacement.
     let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
-        - ChronoDuration::days(10))
+        - ChronoDuration::days(45))
     .and_hms_opt(8, 0, 0)
     .expect("valid archived local hour");
     let archived_success_at = format_naive(

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22164,6 +22164,20 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
     hydrate_summary_snapshots(state.as_ref())
         .await
         .expect("hydrate rolling summary projection beyond manifest admission");
+
+    // The admission result is retained as a fail-closed all-time state. A normal rolling refresh
+    // must not enumerate the same historical manifest set again just because `all` has no exact
+    // snapshot yet.
+    sqlx::query(
+        "DELETE FROM archive_batches \
+         WHERE file_path GLOB '/tmp/summary-manifest-admission-*.sqlite.gz'",
+    )
+    .execute(&state.pool)
+    .await
+    .expect("remove the admitted manifest fixture before rolling-only refresh");
+    refresh_summary_snapshots_with_mode(state.as_ref(), false)
+        .await
+        .expect("rolling refresh retains the controlled all-time admission state");
     state.pool.close().await;
 
     for (window, upstream_account_id) in [("current", None), ("1d", None), ("1d", Some(42))] {
@@ -22196,6 +22210,63 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
         .await,
         Err(ApiError::Unavailable(_))
     ));
+}
+
+#[tokio::test]
+async fn summary_projection_fails_closed_when_archive_boundary_manifest_admission_exceeds_budget() {
+    let state =
+        test_state_with_openai_base(Url::parse("http://127.0.0.1:9").expect("valid test URL"))
+            .await;
+    let archive_start = Utc
+        .timestamp_opt(
+            crate::stats::align_bucket_epoch(
+                (Utc::now() - ChronoDuration::days(2)).timestamp(),
+                3_600,
+                0,
+            ),
+            0,
+        )
+        .single()
+        .expect("align archive fixture to a full hour within the exact horizon");
+    let archive_end = archive_start + ChronoDuration::hours(1);
+    sqlx::query(
+        "WITH RECURSIVE manifests(ordinal) AS ( \
+            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal <= 4096 \
+         ) \
+         INSERT INTO archive_batches \
+         (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
+          historical_rollups_materialized_at, created_at) \
+         SELECT 'codex_invocations', '2026-01', \
+                '/tmp/summary-boundary-manifest-admission-' || ordinal || '.sqlite.gz', \
+                'summary-boundary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now') \
+         FROM manifests",
+    )
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_start))
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_end))
+    .execute(&state.pool)
+    .await
+    .expect("insert exact-horizon manifests beyond bounded admission");
+
+    hydrate_summary_snapshots(state.as_ref())
+        .await
+        .expect("publish a controlled rolling snapshot instead of failing hydration");
+    state.pool.close().await;
+
+    for window in ["current", "1d"] {
+        assert!(matches!(
+            fetch_summary(
+                State(state.clone()),
+                Query(SummaryQuery {
+                    window: Some(window.to_string()),
+                    limit: None,
+                    time_zone: Some("UTC".to_string()),
+                    upstream_account_id: None,
+                }),
+            )
+            .await,
+            Err(ApiError::Unavailable(_))
+        ));
+    }
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -5,6 +5,8 @@ use std::sync::LazyLock;
 
 static TIMESERIES_MINUTE_PROJECTION_WRITE_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
+static SUMMARY_PROJECTION_ARCHIVE_IDENTITY_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 async fn insert_parallel_work_prompt_cache_rollup_hourly_row(
     pool: &SqlitePool,
@@ -22236,6 +22238,7 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
 
 #[tokio::test]
 async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
+    let _identity_guard = SUMMARY_PROJECTION_ARCHIVE_IDENTITY_TEST_LOCK.lock().await;
     let temp_dir = make_temp_test_dir("summary-paged-boundary-snapshot");
     let database_path = temp_dir.join("summary-projection.db");
     fs::File::create(&database_path).expect("create summary projection database");
@@ -22584,6 +22587,170 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
             }
         }
     }
+    cleanup_temp_test_dir(&temp_dir);
+}
+
+#[tokio::test]
+async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
+    let _identity_guard = SUMMARY_PROJECTION_ARCHIVE_IDENTITY_TEST_LOCK.lock().await;
+    let temp_dir = make_temp_test_dir("summary-all-time-archive-identity");
+    let database_path = temp_dir.join("summary-projection.db");
+    fs::File::create(&database_path).expect("create summary projection database");
+    let pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect(&test_sqlite_url_for_path(&database_path))
+        .await
+        .expect("open summary projection database");
+    let mut config = test_config();
+    config.database_path = database_path;
+    config.archive_dir = temp_dir.join("archives");
+    config.proxy_raw_dir = temp_dir.join("proxy-raw");
+    config.invocation_max_days = 7;
+    config.openai_upstream_base_url = Url::parse("http://127.0.0.1:9").expect("valid test URL");
+    fs::create_dir_all(&config.archive_dir).expect("create summary projection archive directory");
+    fs::create_dir_all(&config.proxy_raw_dir).expect("create summary projection raw directory");
+    let state = test_state_from_existing_pool(pool, config, true).await;
+    sqlx::query_scalar::<_, String>("PRAGMA journal_mode = WAL")
+        .fetch_one(&state.pool)
+        .await
+        .expect("enable WAL for concurrent all-time snapshot writer coverage");
+
+    let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
+        - ChronoDuration::days(10))
+    .and_hms_opt(6, 0, 0)
+    .expect("valid archived local hour");
+    let archived_at = format_naive(
+        archived_hour_local
+            .checked_add_signed(ChronoDuration::minutes(5))
+            .expect("archived invocation time"),
+    );
+    let archive_path = seed_invocation_archive_batch(
+        &state.pool,
+        &state.config,
+        "summary-all-time-archive-identity",
+        &[(
+            80_001,
+            "summary-all-time-archive-identity",
+            archived_at.as_str(),
+            SOURCE_PROXY,
+            "success",
+            10,
+            0.10,
+            Some(100.0),
+        )],
+    )
+    .await;
+
+    let replacement_archive_db_path = state
+        .config
+        .archive_dir
+        .join("summary-all-time-archive-identity-replacement.sqlite");
+    inflate_gzip_sqlite_file(&archive_path, &replacement_archive_db_path)
+        .expect("inflate replacement all-time archive");
+    let replacement_archive_pool =
+        SqlitePool::connect(&test_sqlite_url_for_path(&replacement_archive_db_path))
+            .await
+            .expect("open replacement all-time archive");
+    sqlx::query(
+        "INSERT INTO codex_invocations \
+         (id, invoke_id, occurred_at, source, status, total_tokens, cost, detail_level, payload, raw_response, created_at) \
+         VALUES (80002, 'summary-all-time-archive-identity-replacement', ?1, 'proxy', 'success', 99, 9.9, 'full', '{}', '{}', ?1)",
+    )
+    .bind(&archived_at)
+    .execute(&replacement_archive_pool)
+    .await
+    .expect("seed replacement all-time archive row");
+    replacement_archive_pool.close().await;
+    let replacement_archive_path = state
+        .config
+        .archive_dir
+        .join("summary-all-time-archive-identity-replacement.sqlite.gz");
+    deflate_sqlite_file_to_gzip(&replacement_archive_db_path, &replacement_archive_path)
+        .expect("compress replacement all-time archive");
+    let replacement_archive_sha256 =
+        sha256_hex_file(&replacement_archive_path).expect("hash replacement all-time archive");
+    fs::remove_file(&replacement_archive_db_path)
+        .expect("remove replacement all-time archive source");
+
+    hydrate_summary_snapshots(state.as_ref())
+        .await
+        .expect("publish initial exact all-time archive snapshot");
+    sqlx::query("CREATE TABLE summary_projection_test_interleave_gate (id INTEGER PRIMARY KEY)")
+        .execute(&state.pool)
+        .await
+        .expect("create all-time summary interleave gate");
+    let interleave = install_summary_projection_test_interleave();
+    let replacement_path = archive_path.to_string_lossy().to_string();
+    let replacement_pool = state.pool.clone();
+    let replacement_interleave = interleave.clone();
+    let replacement_archive_path_for_writer = replacement_archive_path.clone();
+    let archive_path_for_writer = archive_path.clone();
+    let replacement = tokio::spawn(async move {
+        replacement_interleave.wait_for_writer().await;
+        fs::rename(
+            &replacement_archive_path_for_writer,
+            &archive_path_for_writer,
+        )
+        .expect("atomically publish replacement all-time archive");
+        let mut tx = replacement_pool
+            .begin()
+            .await
+            .expect("begin all-time archive replacement");
+        sqlx::query(
+            "UPDATE archive_batches SET sha256 = ?1 \
+             WHERE dataset = 'codex_invocations' AND file_path = ?2",
+        )
+        .bind(&replacement_archive_sha256)
+        .bind(&replacement_path)
+        .execute(tx.as_mut())
+        .await
+        .expect("replace all-time archive manifest SHA");
+        sqlx::query(
+            "INSERT INTO codex_invocations \
+             (invoke_id, occurred_at, source, status, total_tokens, cost, detail_level, payload, raw_response) \
+             VALUES ('summary-all-time-archive-identity-terminal', ?1, 'proxy', 'success', 7, 0.07, 'full', '{}', '')",
+        )
+        .bind(&archived_at)
+        .execute(tx.as_mut())
+        .await
+        .expect("write terminal beside all-time archive replacement");
+        let commit = tokio::time::timeout(Duration::from_secs(2), tx.commit()).await;
+        replacement_interleave.resume_build();
+        commit
+            .expect("all-time archive replacement must not block the snapshot reader")
+            .expect("commit all-time archive replacement");
+    });
+    let hydration = hydrate_summary_snapshots(state.as_ref()).await;
+    replacement.await.expect("run all-time archive replacement");
+    clear_summary_projection_test_interleave();
+    let hydration_error = hydration.expect_err("reject the mixed all-time archive snapshot");
+    assert!(
+        hydration_error
+            .to_string()
+            .contains("summary projection archive changed during hydration"),
+        "unexpected all-time hydration failure: {hydration_error:?}"
+    );
+    assert_eq!(
+        interleave.build_attempts(),
+        1,
+        "the all-time archive mismatch must fail closed without retrying"
+    );
+    state.pool.close().await;
+
+    let Json(summary) = fetch_summary(
+        State(state.clone()),
+        Query(SummaryQuery {
+            window: Some("all".to_string()),
+            limit: None,
+            time_zone: Some("UTC".to_string()),
+            upstream_account_id: None,
+        }),
+    )
+    .await
+    .expect("serve the prior all-time snapshot without SQLite");
+    assert_eq!(summary.total_count, 1);
+    assert_eq!(summary.total_tokens, 10);
+    assert_f64_close(summary.total_cost, 0.10);
     cleanup_temp_test_dir(&temp_dir);
 }
 

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22345,7 +22345,7 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
     .expect("seed compact global usage rollup for paged manifests");
     sqlx::query(
         "WITH RECURSIVE manifests(ordinal) AS ( \
-            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal < 4096 \
+            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal < 50000 \
          ) \
          INSERT INTO archive_batches \
          (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -268,8 +268,11 @@ async fn insert_hourly_rollup_archive_replay_marker(
 ) {
     sqlx::query(
         r#"
-        INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, replayed_at)
-        VALUES (?1, ?2, ?3, datetime('now'))
+        INSERT INTO hourly_rollup_archive_replay
+            (target, dataset, file_path, archive_sha256, replayed_at)
+        SELECT ?1, ?2, batches.file_path, batches.sha256, datetime('now')
+        FROM archive_batches AS batches
+        WHERE batches.dataset = ?2 AND batches.file_path = ?3
         "#,
     )
     .bind(target)
@@ -22236,13 +22239,18 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
     let mut config = test_config();
     config.openai_upstream_base_url = Url::parse("http://127.0.0.1:9").expect("valid test URL");
     let state = test_state_from_config(config, true).await;
-    let archived_at_utc = Utc
+    let archived_bucket_start = Utc
         .timestamp_opt(
-            (Utc::now() - ChronoDuration::hours(23) - ChronoDuration::minutes(58)).timestamp(),
+            crate::stats::align_bucket_epoch(
+                (Utc::now() - ChronoDuration::hours(6)).timestamp(),
+                3_600,
+                0,
+            ),
             0,
         )
         .single()
-        .expect("align boundary fixture to a whole second");
+        .expect("align boundary fixture to a full hour");
+    let archived_at_utc = archived_bucket_start + ChronoDuration::minutes(5);
     let archived_at = format_naive(archived_at_utc.with_timezone(&Shanghai).naive_local());
     let archive_path = seed_invocation_archive_batch_with_details(
         &state.pool,
@@ -22273,14 +22281,32 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
          SET coverage_start_at = ?1, coverage_end_at = ?2, historical_rollups_materialized_at = datetime('now') \
          WHERE dataset = 'codex_invocations' AND file_path = ?3",
     )
-    .bind(crate::stats::db_occurred_at_lower_bound(archived_at_utc))
+    .bind(crate::stats::db_occurred_at_lower_bound(archived_bucket_start))
     .bind(crate::db_occurred_at_upper_bound(
-        archived_at_utc + ChronoDuration::minutes(1),
+        archived_bucket_start + ChronoDuration::hours(1),
     ))
     .bind(archive_path.to_string_lossy().to_string())
     .execute(&state.pool)
     .await
     .expect("mark the readable partial-hour archive materialized");
+    let archive_batch_id: i64 = sqlx::query_scalar(
+        "SELECT id FROM archive_batches WHERE dataset = 'codex_invocations' AND file_path = ?1",
+    )
+    .bind(archive_path.to_string_lossy().to_string())
+    .fetch_one(&state.pool)
+    .await
+    .expect("load readable boundary archive manifest id");
+    // Keep the account manifest deliberately unrefreshed. The paged fallback must replace the
+    // existing account compact bucket with this raw record rather than adding both sources.
+    sqlx::query(
+        "INSERT INTO archive_batch_upstream_activity (archive_batch_id, account_id, last_activity_at) \
+         VALUES (?1, 42, ?2)",
+    )
+    .bind(archive_batch_id)
+    .bind(crate::stats::db_occurred_at_lower_bound(archived_at_utc))
+    .execute(&state.pool)
+    .await
+    .expect("seed unrefreshed account manifest for the readable boundary archive");
     let mut tx = state.pool.begin().await.expect("begin boundary rollup tx");
     upsert_invocation_hourly_rollups_tx(
         tx.as_mut(),
@@ -22395,9 +22421,50 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
         .expect("record complete durable replay coverage");
     }
 
-    hydrate_summary_snapshots(state.as_ref())
+    sqlx::query("CREATE TABLE summary_projection_test_interleave_gate (id INTEGER PRIMARY KEY)")
+        .execute(&state.pool)
         .await
-        .expect("page durable boundary manifests instead of failing hydration");
+        .expect("create summary projection interleave gate");
+    let interleave = install_summary_projection_test_interleave();
+    let replacement_path = "/tmp/summary-boundary-manifest-admission-1.sqlite.gz".to_string();
+    let replacement_pool = state.pool.clone();
+    let replacement_interleave = interleave.clone();
+    let replacement = tokio::spawn(async move {
+        replacement_interleave.wait_for_writer().await;
+        let mut tx = replacement_pool
+            .begin()
+            .await
+            .expect("begin legacy manifest replacement");
+        sqlx::query(
+            "UPDATE archive_batches SET sha256 = 'summary-boundary-manifest-admission-1-replacement' \
+             WHERE dataset = 'codex_invocations' AND file_path = ?1",
+        )
+        .bind(&replacement_path)
+        .execute(tx.as_mut())
+        .await
+        .expect("replace legacy manifest SHA");
+        sqlx::query(
+            "UPDATE hourly_rollup_archive_replay \
+             SET archive_sha256 = 'summary-boundary-manifest-admission-1-replacement' \
+             WHERE dataset = 'codex_invocations' AND file_path = ?1",
+        )
+        .bind(&replacement_path)
+        .execute(tx.as_mut())
+        .await
+        .expect("refresh replacement replay markers");
+        tx.commit()
+            .await
+            .expect("commit legacy manifest replacement");
+        replacement_interleave.resume_build();
+    });
+    let hydration = hydrate_summary_snapshots(state.as_ref()).await;
+    replacement.await.expect("run legacy manifest replacement");
+    clear_summary_projection_test_interleave();
+    hydration.expect("retry after legacy manifest replacement before publishing hydration");
+    assert!(
+        interleave.build_attempts() >= 2,
+        "the replacement commit must invalidate the first projection build"
+    );
     state.pool.close().await;
 
     for window in ["current", "1d"] {
@@ -22429,9 +22496,10 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
                         model.model == "gpt-5" && model.reasoning_effort.as_deref() == Some("high")
                     })
                     .expect("paged boundary model/reasoning detail");
-                assert_f64_close(
-                    model.costs.expect("paged boundary model costs").unknown,
-                    0.20,
+                let model_cost = model.costs.expect("paged boundary model costs").unknown;
+                assert!(
+                    (model_cost - 0.20).abs() < 1e-6,
+                    "{window} {upstream_account_id:?}: expected model cost 0.20, got {model_cost}",
                 );
             }
         }

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22081,3 +22081,109 @@ async fn materialized_timeseries_uses_exact_fallback_for_same_cursor_terminal_re
     assert_eq!(point["successCount"], 0);
     assert_eq!(point["failureCount"], 1);
 }
+
+#[tokio::test]
+async fn summary_projection_hydrates_rollups_beyond_archive_manifest_admission() {
+    let state =
+        test_state_with_openai_base(Url::parse("http://127.0.0.1:9").expect("valid test URL"))
+            .await;
+    let archive_start = Utc
+        .timestamp_opt(
+            crate::stats::align_bucket_epoch(
+                (Utc::now() - ChronoDuration::days(1_000)).timestamp(),
+                3_600,
+                0,
+            ),
+            0,
+        )
+        .single()
+        .expect("align archive fixture to a full hour");
+    let archive_end = archive_start + ChronoDuration::hours(1);
+    let bucket = crate::stats::align_bucket_epoch(archive_start.timestamp(), 3_600, 0);
+
+    sqlx::query(
+        "INSERT INTO invocation_rollup_hourly \
+         (bucket_start_epoch, source, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
+         VALUES (?1, 'proxy', 1, 1, 0, 17, 1.25, 0)",
+    )
+    .bind(bucket)
+    .execute(&state.pool)
+    .await
+    .expect("insert durable summary rollup");
+    sqlx::query(
+        "INSERT INTO upstream_account_stats_hourly \
+         (bucket_start_epoch, source, upstream_account_id, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
+         VALUES (?1, 'proxy', 42, 1, 1, 0, 17, 1.25, 0)",
+    )
+    .bind(bucket)
+    .execute(&state.pool)
+    .await
+    .expect("insert durable account summary rollup");
+    sqlx::query(
+        "WITH RECURSIVE manifests(ordinal) AS ( \
+            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal <= 50000 \
+         ) \
+         INSERT INTO archive_batches \
+         (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
+          historical_rollups_materialized_at, created_at) \
+         SELECT 'codex_invocations', '2026-01', \
+                '/tmp/summary-manifest-admission-' || ordinal || '.sqlite.gz', \
+                'summary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now') \
+         FROM manifests",
+    )
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_start))
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_end))
+    .execute(&state.pool)
+    .await
+    .expect("insert archive manifests beyond the exact-record admission");
+    for target in [
+        HOURLY_ROLLUP_TARGET_INVOCATIONS,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN,
+    ] {
+        sqlx::query(
+            "INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, archive_sha256) \
+             SELECT ?1, dataset, file_path, sha256 FROM archive_batches \
+             WHERE file_path GLOB '/tmp/summary-manifest-admission-*.sqlite.gz'",
+        )
+        .bind(target)
+        .execute(&state.pool)
+        .await
+        .expect("record complete rollup replay coverage");
+    }
+
+    hydrate_summary_snapshots(state.as_ref())
+        .await
+        .expect("hydrate exact summary projection beyond manifest admission");
+    state.pool.close().await;
+
+    let Json(response) = fetch_summary(
+        State(state.clone()),
+        Query(SummaryQuery {
+            window: Some("all".to_string()),
+            limit: None,
+            time_zone: Some("UTC".to_string()),
+            upstream_account_id: None,
+        }),
+    )
+    .await
+    .expect("serve the hydrated all-time response without SQLite");
+    assert_eq!(response.total_count, 1);
+    assert_eq!(response.total_tokens, 17);
+    assert_eq!(response.total_cost, 1.25);
+
+    let Json(account_response) = fetch_summary(
+        State(state),
+        Query(SummaryQuery {
+            window: Some("all".to_string()),
+            limit: None,
+            time_zone: Some("UTC".to_string()),
+            upstream_account_id: Some(42),
+        }),
+    )
+    .await
+    .expect("serve the hydrated account response without SQLite");
+    assert_eq!(account_response.total_count, 1);
+    assert_eq!(account_response.total_tokens, 17);
+    assert_eq!(account_response.total_cost, 1.25);
+}

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -4208,6 +4208,151 @@ async fn all_time_summary_fallback_keeps_unmaterialized_rows_when_materialized_s
 }
 
 #[tokio::test]
+async fn summary_projection_rejects_clipped_rolling_boundary_for_unreadable_replayed_archive() {
+    let mut config = test_config();
+    config.openai_upstream_base_url =
+        Url::parse("https://api.openai.com/").expect("valid upstream base url");
+    config.invocation_max_days = 7;
+    let state = test_state_from_config(config, true).await;
+
+    let boundary = Utc::now() - ChronoDuration::days(7);
+    let before_boundary = format_naive(
+        (boundary - ChronoDuration::minutes(20))
+            .with_timezone(&Shanghai)
+            .naive_local(),
+    );
+    let after_boundary = format_naive(
+        (boundary + ChronoDuration::minutes(20))
+            .with_timezone(&Shanghai)
+            .naive_local(),
+    );
+    let original_path = seed_invocation_archive_batch(
+        &state.pool,
+        &state.config,
+        "summary-clipped-boundary-unreadable",
+        &[
+            (
+                1_i64,
+                "summary-clipped-boundary-before",
+                before_boundary.as_str(),
+                SOURCE_PROXY,
+                "success",
+                10_i64,
+                0.10_f64,
+                Some(100.0),
+            ),
+            (
+                2_i64,
+                "summary-clipped-boundary-after",
+                after_boundary.as_str(),
+                SOURCE_PROXY,
+                "success",
+                20_i64,
+                0.20_f64,
+                Some(120.0),
+            ),
+        ],
+    )
+    .await;
+    let archive_path = state
+        .config
+        .archive_dir
+        .join("summary-clipped-boundary-unreadable.sqlite.gz");
+    let _ = fs::remove_file(&archive_path);
+    fs::rename(&original_path, &archive_path)
+        .expect("move clipped-boundary archive to a unique path");
+    sqlx::query(
+        "UPDATE archive_batches \
+         SET file_path = ?1, historical_rollups_materialized_at = datetime('now'), \
+             coverage_start_at = ?3, coverage_end_at = ?4 \
+         WHERE dataset = 'codex_invocations' AND file_path = ?2",
+    )
+    .bind(archive_path.to_string_lossy().to_string())
+    .bind(original_path.to_string_lossy().to_string())
+    .bind(&before_boundary)
+    .bind(&after_boundary)
+    .execute(&state.pool)
+    .await
+    .expect("mark clipped-boundary archive as materialized");
+
+    let mut materialized_buckets = std::collections::HashSet::new();
+    for (occurred_at, total_tokens, total_cost) in [
+        (before_boundary.as_str(), 10_i64, 0.10_f64),
+        (after_boundary.as_str(), 20_i64, 0.20_f64),
+    ] {
+        let bucket_start_epoch = invocation_bucket_start_epoch(occurred_at)
+            .expect("clipped-boundary hour should have a durable bucket");
+        sqlx::query(
+            "INSERT INTO invocation_rollup_hourly \
+             (bucket_start_epoch, source, total_count, success_count, failure_count, total_tokens, total_cost) \
+             VALUES (?1, ?2, 1, 1, 0, ?3, ?4) \
+             ON CONFLICT(bucket_start_epoch, source) DO UPDATE SET \
+                 total_count = total_count + excluded.total_count, \
+                 success_count = success_count + excluded.success_count, \
+                 total_tokens = total_tokens + excluded.total_tokens, \
+                 total_cost = total_cost + excluded.total_cost",
+        )
+        .bind(bucket_start_epoch)
+        .bind(SOURCE_PROXY)
+        .bind(total_tokens)
+        .bind(total_cost)
+        .execute(&state.pool)
+        .await
+        .expect("seed full-hour durable rollup");
+        if materialized_buckets.insert(bucket_start_epoch) {
+            insert_materialized_rollup_bucket_marker(
+                &state.pool,
+                HOURLY_ROLLUP_TARGET_INVOCATIONS,
+                bucket_start_epoch,
+                SOURCE_PROXY,
+            )
+            .await;
+        }
+    }
+    mark_summary_archive_replay_complete(&state.pool, &archive_path).await;
+    fs::write(&archive_path, b"not-a-gzip-archive")
+        .expect("corrupt clipped-boundary archive after durable replay");
+
+    let Json(all_time) = fetch_summary_from_memory_snapshot(
+        State(state.clone()),
+        Query(SummaryQuery {
+            window: Some("all".to_string()),
+            limit: None,
+            time_zone: Some("UTC".to_string()),
+            upstream_account_id: None,
+        }),
+    )
+    .await
+    .expect("all-time durable rollup remains exact");
+    assert_eq!(all_time.total_count, 2);
+    assert_eq!(all_time.total_tokens, 30);
+
+    let refresh_error = hydrate_summary_snapshots(state.as_ref())
+        .await
+        .expect_err("a clipped rolling boundary requires the unreadable raw archive");
+    assert!(
+        refresh_error
+            .to_string()
+            .contains("summary projection archive source is unavailable"),
+        "the refresh must fail closed instead of publishing a clipped full-hour rollup: {refresh_error:#}"
+    );
+    let rolling = fetch_summary(
+        State(state),
+        Query(SummaryQuery {
+            window: Some("7d".to_string()),
+            limit: None,
+            time_zone: Some("UTC".to_string()),
+            upstream_account_id: None,
+        }),
+    )
+    .await;
+    assert!(
+        matches!(rolling, Err(ApiError::Unavailable(_))),
+        "a clipped rolling boundary must not use the over-inclusive full-hour rollup: {rolling:?}"
+    );
+}
+
+#[tokio::test]
 async fn all_time_summary_skips_double_count_for_readable_materialized_archive_when_same_bucket_sibling_is_unreadable()
  {
     let mut config = test_config();

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -2632,10 +2632,8 @@ async fn all_time_summary_preserves_archived_history_when_rollup_failures_are_st
     config.invocation_max_days = 7;
     let state = test_state_from_config(config, true).await;
 
-    // Keep this beyond the rolling exact horizon (retention plus the 31-day grace window) so
-    // only the all-time generic archive aggregation can observe the replacement.
     let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
-        - ChronoDuration::days(45))
+        - ChronoDuration::days(10))
     .and_hms_opt(8, 0, 0)
     .expect("valid archived local hour");
     let archived_success_at = format_naive(
@@ -2896,8 +2894,10 @@ async fn all_time_summary_includes_unmaterialized_archived_history_without_inlin
     config.invocation_max_days = 7;
     let state = test_state_from_config(config, true).await;
 
+    // Keep this beyond the rolling exact horizon (retention plus the 31-day grace window) so
+    // only the all-time generic archive aggregation can observe the replacement.
     let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
-        - ChronoDuration::days(10))
+        - ChronoDuration::days(45))
     .and_hms_opt(6, 0, 0)
     .expect("valid archived local hour");
     let archived_success_at = format_naive(

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -2894,10 +2894,8 @@ async fn all_time_summary_includes_unmaterialized_archived_history_without_inlin
     config.invocation_max_days = 7;
     let state = test_state_from_config(config, true).await;
 
-    // Keep this beyond the rolling exact horizon (retention plus the 31-day grace window) so
-    // only the all-time generic archive aggregation can observe the replacement.
     let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
-        - ChronoDuration::days(45))
+        - ChronoDuration::days(10))
     .and_hms_opt(6, 0, 0)
     .expect("valid archived local hour");
     let archived_success_at = format_naive(
@@ -22617,8 +22615,10 @@ async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
         .await
         .expect("enable WAL for concurrent all-time snapshot writer coverage");
 
+    // Keep this beyond the rolling exact horizon (retention plus the 31-day grace window) so
+    // only the all-time generic archive aggregation can observe the replacement.
     let archived_hour_local = (Utc::now().with_timezone(&Shanghai).date_naive()
-        - ChronoDuration::days(10))
+        - ChronoDuration::days(45))
     .and_hms_opt(6, 0, 0)
     .expect("valid archived local hour");
     let archived_at = format_naive(

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22083,7 +22083,7 @@ async fn materialized_timeseries_uses_exact_fallback_for_same_cursor_terminal_re
 }
 
 #[tokio::test]
-async fn summary_projection_hydrates_rollups_beyond_archive_manifest_admission() {
+async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_admission() {
     let state =
         test_state_with_openai_base(Url::parse("http://127.0.0.1:9").expect("valid test URL"))
             .await;
@@ -22151,39 +22151,129 @@ async fn summary_projection_hydrates_rollups_beyond_archive_manifest_admission()
         .await
         .expect("record complete rollup replay coverage");
     }
+    sqlx::query(
+        "INSERT INTO codex_invocations \
+         (invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response, detail_level) \
+         VALUES ('summary-manifest-admission-live', datetime('now'), 'proxy', 'success', 23, 2.5, \
+                 '{\"upstreamAccountId\":42}', '', 'full')",
+    )
+    .execute(&state.pool)
+    .await
+    .expect("insert exact live-tail row");
 
     hydrate_summary_snapshots(state.as_ref())
         .await
-        .expect("hydrate exact summary projection beyond manifest admission");
+        .expect("hydrate rolling summary projection beyond manifest admission");
     state.pool.close().await;
 
-    let Json(response) = fetch_summary(
+    for (window, upstream_account_id) in [("current", None), ("1d", None), ("1d", Some(42))] {
+        let Json(response) = fetch_summary(
+            State(state.clone()),
+            Query(SummaryQuery {
+                window: Some(window.to_string()),
+                limit: None,
+                time_zone: Some("UTC".to_string()),
+                upstream_account_id,
+            }),
+        )
+        .await
+        .expect("serve the hydrated rolling response without SQLite");
+        assert_eq!(response.total_count, 1, "window {window}");
+        assert_eq!(response.total_tokens, 23, "window {window}");
+        assert_eq!(response.total_cost, 2.5, "window {window}");
+    }
+
+    assert!(matches!(
+        fetch_summary(
+            State(state),
+            Query(SummaryQuery {
+                window: Some("all".to_string()),
+                limit: None,
+                time_zone: Some("UTC".to_string()),
+                upstream_account_id: None,
+            }),
+        )
+        .await,
+        Err(ApiError::Unavailable(_))
+    ));
+}
+
+#[tokio::test]
+async fn summary_projection_keeps_all_unavailable_when_materialized_rollup_key_is_missing() {
+    let state =
+        test_state_with_openai_base(Url::parse("http://127.0.0.1:9").expect("valid test URL"))
+            .await;
+    let archive_start = Utc
+        .timestamp_opt(
+            crate::stats::align_bucket_epoch(
+                (Utc::now() - ChronoDuration::days(1_000)).timestamp(),
+                3_600,
+                0,
+            ),
+            0,
+        )
+        .single()
+        .expect("align archive fixture to a full hour");
+    let archive_end = archive_start + ChronoDuration::hours(1);
+    let file_path = "/tmp/summary-missing-rollup-key.sqlite.gz";
+    sqlx::query(
+        "INSERT INTO archive_batches \
+         (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
+          historical_rollups_materialized_at, created_at) \
+         VALUES ('codex_invocations', '2026-01', ?1, 'summary-missing-rollup-key', 1, 'completed', \
+                 ?2, ?3, datetime('now'), datetime('now'))",
+    )
+    .bind(file_path)
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_start))
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_end))
+    .execute(&state.pool)
+    .await
+    .expect("insert materialized archive manifest");
+    for target in [
+        HOURLY_ROLLUP_TARGET_INVOCATIONS,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN,
+    ] {
+        sqlx::query(
+            "INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, archive_sha256) \
+             VALUES (?1, 'codex_invocations', ?2, 'summary-missing-rollup-key')",
+        )
+        .bind(target)
+        .bind(file_path)
+        .execute(&state.pool)
+        .await
+        .expect("record materialized replay marker");
+    }
+
+    hydrate_summary_snapshots(state.as_ref())
+        .await
+        .expect("hydrate rolling projection with an incomplete all-time rollup");
+    state.pool.close().await;
+
+    let Json(rolling) = fetch_summary(
         State(state.clone()),
         Query(SummaryQuery {
-            window: Some("all".to_string()),
+            window: Some("1d".to_string()),
             limit: None,
             time_zone: Some("UTC".to_string()),
             upstream_account_id: None,
         }),
     )
     .await
-    .expect("serve the hydrated all-time response without SQLite");
-    assert_eq!(response.total_count, 1);
-    assert_eq!(response.total_tokens, 17);
-    assert_eq!(response.total_cost, 1.25);
+    .expect("serve the exact rolling zero response without SQLite");
+    assert_eq!(rolling.total_count, 0);
 
-    let Json(account_response) = fetch_summary(
-        State(state),
-        Query(SummaryQuery {
-            window: Some("all".to_string()),
-            limit: None,
-            time_zone: Some("UTC".to_string()),
-            upstream_account_id: Some(42),
-        }),
-    )
-    .await
-    .expect("serve the hydrated account response without SQLite");
-    assert_eq!(account_response.total_count, 1);
-    assert_eq!(account_response.total_tokens, 17);
-    assert_eq!(account_response.total_cost, 1.25);
+    assert!(matches!(
+        fetch_summary(
+            State(state),
+            Query(SummaryQuery {
+                window: Some("all".to_string()),
+                limit: None,
+                time_zone: Some("UTC".to_string()),
+                upstream_account_id: None,
+            }),
+        )
+        .await,
+        Err(ApiError::Unavailable(_))
+    ));
 }

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22104,7 +22104,7 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
     sqlx::query(
         "INSERT INTO invocation_rollup_hourly \
          (bucket_start_epoch, source, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
-         VALUES (?1, 'proxy', 1, 1, 0, 17, 1.25, 0)",
+         VALUES (?1, 'proxy', 50001, 50001, 0, 850017, 62501.25, 0)",
     )
     .bind(bucket)
     .execute(&state.pool)
@@ -22113,7 +22113,7 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
     sqlx::query(
         "INSERT INTO upstream_account_stats_hourly \
          (bucket_start_epoch, source, upstream_account_id, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
-         VALUES (?1, 'proxy', 42, 1, 1, 0, 17, 1.25, 0)",
+         VALUES (?1, 'proxy', 42, 50001, 50001, 0, 850017, 62501.25, 0)",
     )
     .bind(bucket)
     .execute(&state.pool)
@@ -22125,10 +22125,10 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
          ) \
          INSERT INTO archive_batches \
          (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
-          historical_rollups_materialized_at, created_at) \
+          historical_rollups_materialized_at, upstream_activity_manifest_refreshed_at, created_at) \
          SELECT 'codex_invocations', '2026-01', \
                 '/tmp/summary-manifest-admission-' || ordinal || '.sqlite.gz', \
-                'summary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now') \
+                'summary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now'), datetime('now') \
          FROM manifests",
     )
     .bind(crate::stats::db_occurred_at_lower_bound(archive_start))
@@ -22151,7 +22151,7 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
         .await
         .expect("record complete rollup replay coverage");
     }
-    sqlx::query(
+    let live_id = sqlx::query(
         "INSERT INTO codex_invocations \
          (invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response, detail_level) \
          VALUES ('summary-manifest-admission-live', datetime('now'), 'proxy', 'success', 23, 2.5, \
@@ -22159,15 +22159,31 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
     )
     .execute(&state.pool)
     .await
-    .expect("insert exact live-tail row");
+    .expect("insert exact live-tail row")
+    .last_insert_rowid();
+    for dataset in [
+        HOURLY_ROLLUP_DATASET_INVOCATIONS,
+        "invocation_account_activity_v2_repair_live_cursor",
+    ] {
+        sqlx::query(
+            "INSERT INTO hourly_rollup_live_progress (dataset, cursor_id, updated_at) \
+             VALUES (?1, ?2, datetime('now')) \
+             ON CONFLICT(dataset) DO UPDATE SET \
+                 cursor_id = excluded.cursor_id, updated_at = excluded.updated_at",
+        )
+        .bind(dataset)
+        .bind(live_id)
+        .execute(&state.pool)
+        .await
+        .expect("mark the compact live cursor as caught up");
+    }
 
     hydrate_summary_snapshots(state.as_ref())
         .await
         .expect("hydrate rolling summary projection beyond manifest admission");
 
-    // The admission result is retained as a fail-closed all-time state. A normal rolling refresh
-    // must not enumerate the same historical manifest set again just because `all` has no exact
-    // snapshot yet.
+    // A rolling-only refresh must retain the fully hydrated all-time snapshot without reopening
+    // its large manifest set.
     sqlx::query(
         "DELETE FROM archive_batches \
          WHERE file_path GLOB '/tmp/summary-manifest-admission-*.sqlite.gz'",
@@ -22177,7 +22193,7 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
     .expect("remove the admitted manifest fixture before rolling-only refresh");
     refresh_summary_snapshots_with_mode(state.as_ref(), false)
         .await
-        .expect("rolling refresh retains the controlled all-time admission state");
+        .expect("rolling refresh retains the exact all-time snapshot");
     state.pool.close().await;
 
     for (window, upstream_account_id) in [("current", None), ("1d", None), ("1d", Some(42))] {
@@ -22197,19 +22213,22 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
         assert_eq!(response.total_cost, 2.5, "window {window}");
     }
 
-    assert!(matches!(
-        fetch_summary(
-            State(state),
+    for upstream_account_id in [None, Some(42)] {
+        let Json(response) = fetch_summary(
+            State(state.clone()),
             Query(SummaryQuery {
                 window: Some("all".to_string()),
                 limit: None,
                 time_zone: Some("UTC".to_string()),
-                upstream_account_id: None,
+                upstream_account_id,
             }),
         )
-        .await,
-        Err(ApiError::Unavailable(_))
-    ));
+        .await
+        .expect("serve the exact all-time snapshot without SQLite");
+        assert_eq!(response.total_count, 50_002);
+        assert_eq!(response.total_tokens, 850_040);
+        assert_eq!(response.total_cost, 62_503.75);
+    }
 }
 
 #[tokio::test]
@@ -22345,14 +22364,14 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
     .expect("seed compact global usage rollup for paged manifests");
     sqlx::query(
         "WITH RECURSIVE manifests(ordinal) AS ( \
-            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal < 50000 \
+            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal < 4097 \
          ) \
          INSERT INTO archive_batches \
          (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
-          historical_rollups_materialized_at, created_at) \
+          historical_rollups_materialized_at, upstream_activity_manifest_refreshed_at, created_at) \
          SELECT 'codex_invocations', '2026-01', \
                 '/tmp/summary-boundary-manifest-admission-' || ordinal || '.sqlite.gz', \
-                'summary-boundary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now') \
+                'summary-boundary-manifest-admission-' || ordinal, 1, 'completed', ?1, ?2, datetime('now'), datetime('now'), datetime('now') \
          FROM manifests",
     )
     .bind(crate::stats::db_occurred_at_lower_bound(archive_start))

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22236,9 +22236,26 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
 
 #[tokio::test]
 async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
+    let temp_dir = make_temp_test_dir("summary-paged-boundary-snapshot");
+    let database_path = temp_dir.join("summary-projection.db");
+    fs::File::create(&database_path).expect("create summary projection database");
+    let pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect(&test_sqlite_url_for_path(&database_path))
+        .await
+        .expect("open summary projection database");
     let mut config = test_config();
+    config.database_path = database_path;
+    config.archive_dir = temp_dir.join("archives");
+    config.proxy_raw_dir = temp_dir.join("proxy-raw");
+    fs::create_dir_all(&config.archive_dir).expect("create summary projection archive directory");
+    fs::create_dir_all(&config.proxy_raw_dir).expect("create summary projection raw directory");
     config.openai_upstream_base_url = Url::parse("http://127.0.0.1:9").expect("valid test URL");
-    let state = test_state_from_config(config, true).await;
+    let state = test_state_from_existing_pool(pool, config, true).await;
+    sqlx::query_scalar::<_, String>("PRAGMA journal_mode = WAL")
+        .fetch_one(&state.pool)
+        .await
+        .expect("enable WAL for concurrent snapshot writer coverage");
     let archived_bucket_start = Utc
         .timestamp_opt(
             crate::stats::align_bucket_epoch(
@@ -22312,7 +22329,7 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
         tx.as_mut(),
         &[InvocationHourlySourceRecord {
             id: 70_001,
-            occurred_at: archived_at,
+            occurred_at: archived_at.clone(),
             source: SOURCE_PROXY.to_string(),
             status: Some("success".to_string()),
             detail_level: DETAIL_LEVEL_FULL.to_string(),
@@ -22353,6 +22370,39 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
     .expect("seed complete compact rollups for the readable boundary archive");
     tx.commit().await.expect("commit boundary rollup tx");
     mark_summary_archive_replay_complete(&state.pool, &archive_path).await;
+
+    // Prepare a valid replacement archive that would add a second exact-boundary row if it
+    // were combined with the snapshot's old durable rollup and manifest state.
+    let replacement_archive_db_path = state
+        .config
+        .archive_dir
+        .join("summary-paged-boundary-replacement.sqlite");
+    inflate_gzip_sqlite_file(&archive_path, &replacement_archive_db_path)
+        .expect("inflate replacement archive source");
+    let replacement_archive_pool =
+        SqlitePool::connect(&test_sqlite_url_for_path(&replacement_archive_db_path))
+            .await
+            .expect("open replacement archive source");
+    sqlx::query(
+        "INSERT INTO codex_invocations \
+         (id, invoke_id, occurred_at, source, status, total_tokens, cost, detail_level, payload, raw_response, created_at) \
+         VALUES (70002, 'summary-paged-boundary-replacement', ?1, 'proxy', 'success', 99, 9.9, 'full', \
+                 '{\"upstreamAccountId\":42,\"responseModel\":\"gpt-5\",\"reasoningEffort\":\"high\"}', '{}', ?1)",
+    )
+    .bind(&archived_at)
+    .execute(&replacement_archive_pool)
+    .await
+    .expect("seed replacement archive row");
+    replacement_archive_pool.close().await;
+    let replacement_archive_path = state
+        .config
+        .archive_dir
+        .join("summary-paged-boundary-replacement.sqlite.gz");
+    deflate_sqlite_file_to_gzip(&replacement_archive_db_path, &replacement_archive_path)
+        .expect("compress replacement archive");
+    let replacement_archive_sha256 =
+        sha256_hex_file(&replacement_archive_path).expect("hash replacement archive");
+    fs::remove_file(&replacement_archive_db_path).expect("remove replacement archive source");
 
     // These fully materialized older manifests force paging without needing raw records for a
     // legal current/1d selection. Their compact aggregate belongs outside the exact boundary.
@@ -22421,49 +22471,79 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
         .expect("record complete durable replay coverage");
     }
 
+    hydrate_summary_snapshots(state.as_ref())
+        .await
+        .expect("publish initial exact paged-boundary snapshot");
+
     sqlx::query("CREATE TABLE summary_projection_test_interleave_gate (id INTEGER PRIMARY KEY)")
         .execute(&state.pool)
         .await
         .expect("create summary projection interleave gate");
     let interleave = install_summary_projection_test_interleave();
-    let replacement_path = "/tmp/summary-boundary-manifest-admission-1.sqlite.gz".to_string();
+    let replacement_path = archive_path.to_string_lossy().to_string();
+    let concurrent_terminal_at = archived_at.clone();
     let replacement_pool = state.pool.clone();
     let replacement_interleave = interleave.clone();
+    let replacement_archive_path_for_writer = replacement_archive_path.clone();
+    let archive_path_for_writer = archive_path.clone();
     let replacement = tokio::spawn(async move {
         replacement_interleave.wait_for_writer().await;
+        fs::rename(
+            &replacement_archive_path_for_writer,
+            &archive_path_for_writer,
+        )
+        .expect("atomically publish replacement archive file");
         let mut tx = replacement_pool
             .begin()
             .await
             .expect("begin legacy manifest replacement");
         sqlx::query(
-            "UPDATE archive_batches SET sha256 = 'summary-boundary-manifest-admission-1-replacement' \
-             WHERE dataset = 'codex_invocations' AND file_path = ?1",
+            "UPDATE archive_batches SET sha256 = ?1 \
+             WHERE dataset = 'codex_invocations' AND file_path = ?2",
         )
+        .bind(&replacement_archive_sha256)
         .bind(&replacement_path)
         .execute(tx.as_mut())
         .await
-        .expect("replace legacy manifest SHA");
+        .expect("replace readable manifest SHA");
         sqlx::query(
-            "UPDATE hourly_rollup_archive_replay \
-             SET archive_sha256 = 'summary-boundary-manifest-admission-1-replacement' \
-             WHERE dataset = 'codex_invocations' AND file_path = ?1",
+            "UPDATE hourly_rollup_archive_replay SET archive_sha256 = ?1 \
+             WHERE dataset = 'codex_invocations' AND file_path = ?2",
         )
+        .bind(&replacement_archive_sha256)
         .bind(&replacement_path)
         .execute(tx.as_mut())
         .await
         .expect("refresh replacement replay markers");
-        tx.commit()
-            .await
-            .expect("commit legacy manifest replacement");
+        sqlx::query(
+            "INSERT INTO codex_invocations \
+             (invoke_id, occurred_at, source, status, total_tokens, cost, detail_level, payload, raw_response) \
+             VALUES ('summary-paged-boundary-concurrent-terminal', ?1, 'proxy', 'success', 7, 0.07, 'full', '{\"upstreamAccountId\":42}', '')",
+        )
+        .bind(&concurrent_terminal_at)
+        .execute(tx.as_mut())
+        .await
+        .expect("commit terminal write after snapshot establishment");
+        let commit = tokio::time::timeout(Duration::from_secs(2), tx.commit()).await;
         replacement_interleave.resume_build();
+        commit
+            .expect("legacy manifest replacement must not block the snapshot reader")
+            .expect("commit legacy manifest replacement");
     });
-    let hydration = hydrate_summary_snapshots(state.as_ref()).await;
+    let hydration = refresh_summary_snapshots_with_mode(state.as_ref(), false).await;
     replacement.await.expect("run legacy manifest replacement");
     clear_summary_projection_test_interleave();
-    hydration.expect("retry after legacy manifest replacement before publishing hydration");
+    let hydration_error = hydration.expect_err("reject the mixed archive and SQLite snapshot");
     assert!(
-        interleave.build_attempts() >= 2,
-        "the replacement commit must invalidate the first projection build"
+        hydration_error
+            .to_string()
+            .contains("summary projection archive changed during hydration"),
+        "unexpected hydration failure: {hydration_error:?}"
+    );
+    assert_eq!(
+        interleave.build_attempts(),
+        1,
+        "the archive mismatch must fail closed without retrying under normal terminal writes"
     );
     state.pool.close().await;
 
@@ -22504,6 +22584,7 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
             }
         }
     }
+    cleanup_temp_test_dir(&temp_dir);
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22214,24 +22214,138 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
 
 #[tokio::test]
 async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
-    let state =
-        test_state_with_openai_base(Url::parse("http://127.0.0.1:9").expect("valid test URL"))
-            .await;
+    let mut config = test_config();
+    config.openai_upstream_base_url = Url::parse("http://127.0.0.1:9").expect("valid test URL");
+    let state = test_state_from_config(config, true).await;
+    let archived_at_utc = Utc
+        .timestamp_opt(
+            (Utc::now() - ChronoDuration::hours(23) - ChronoDuration::minutes(58)).timestamp(),
+            0,
+        )
+        .single()
+        .expect("align boundary fixture to a whole second");
+    let archived_at = format_naive(archived_at_utc.with_timezone(&Shanghai).naive_local());
+    let archive_path = seed_invocation_archive_batch_with_details(
+        &state.pool,
+        &state.config,
+        "summary-paged-boundary-manifest",
+        &[SeedInvocationArchiveBatchRow {
+            id: 70_001,
+            invoke_id: "summary-paged-boundary-manifest",
+            occurred_at: archived_at.as_str(),
+            source: SOURCE_PROXY,
+            status: "success",
+            total_tokens: 20,
+            cost: 0.20,
+            ttfb_ms: Some(120.0),
+            payload: Some(
+                r#"{"upstreamAccountId":42,"responseModel":"gpt-5","reasoningEffort":"high"}"#,
+            ),
+            detail_level: DETAIL_LEVEL_FULL,
+            error_message: None,
+            failure_kind: None,
+            failure_class: Some("none"),
+            is_actionable: Some(0),
+        }],
+    )
+    .await;
+    sqlx::query(
+        "UPDATE archive_batches \
+         SET coverage_start_at = ?1, coverage_end_at = ?2, historical_rollups_materialized_at = datetime('now') \
+         WHERE dataset = 'codex_invocations' AND file_path = ?3",
+    )
+    .bind(crate::stats::db_occurred_at_lower_bound(archived_at_utc))
+    .bind(crate::db_occurred_at_upper_bound(
+        archived_at_utc + ChronoDuration::minutes(1),
+    ))
+    .bind(archive_path.to_string_lossy().to_string())
+    .execute(&state.pool)
+    .await
+    .expect("mark the readable partial-hour archive materialized");
+    let mut tx = state.pool.begin().await.expect("begin boundary rollup tx");
+    upsert_invocation_hourly_rollups_tx(
+        tx.as_mut(),
+        &[InvocationHourlySourceRecord {
+            id: 70_001,
+            occurred_at: archived_at,
+            source: SOURCE_PROXY.to_string(),
+            status: Some("success".to_string()),
+            detail_level: DETAIL_LEVEL_FULL.to_string(),
+            model: None,
+            input_tokens: None,
+            output_tokens: Some(20),
+            cache_input_tokens: None,
+            reasoning_tokens: None,
+            total_tokens: Some(20),
+            cost: Some(0.20),
+            upstream_account_id: Some(42),
+            cost_input: None,
+            cost_cache_write: None,
+            cost_cache_read: None,
+            cost_output: None,
+            cost_reasoning: None,
+            error_message: None,
+            failure_kind: None,
+            failure_class: Some("none".to_string()),
+            is_actionable: Some(0),
+            payload: Some(
+                r#"{"upstreamAccountId":42,"responseModel":"gpt-5","reasoningEffort":"high"}"#
+                    .to_string(),
+            ),
+            t_total_ms: None,
+            t_req_read_ms: None,
+            t_req_parse_ms: None,
+            t_upstream_connect_ms: None,
+            t_upstream_ttfb_ms: Some(120.0),
+            first_token_ms: None,
+            t_upstream_stream_ms: None,
+            t_resp_parse_ms: None,
+            t_persist_ms: None,
+        }],
+        &INVOCATION_HOURLY_ROLLUP_TARGETS,
+    )
+    .await
+    .expect("seed complete compact rollups for the readable boundary archive");
+    tx.commit().await.expect("commit boundary rollup tx");
+    mark_summary_archive_replay_complete(&state.pool, &archive_path).await;
+
+    // These fully materialized older manifests force paging without needing raw records for a
+    // legal current/1d selection. Their compact aggregate belongs outside the exact boundary.
     let archive_start = Utc
         .timestamp_opt(
             crate::stats::align_bucket_epoch(
-                (Utc::now() - ChronoDuration::days(2)).timestamp(),
+                (Utc::now() - ChronoDuration::days(100)).timestamp(),
                 3_600,
                 0,
             ),
             0,
         )
         .single()
-        .expect("align archive fixture to a full hour within the exact horizon");
+        .expect("align compact manifest fixture to a full hour");
     let archive_end = archive_start + ChronoDuration::hours(1);
+    let compact_bucket = archive_start.timestamp();
+    sqlx::query(
+        "INSERT INTO invocation_rollup_hourly \
+         (bucket_start_epoch, source, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
+         VALUES (?1, 'proxy', 4096, 4096, 0, 40960, 409.6, 0)",
+    )
+    .bind(compact_bucket)
+    .execute(&state.pool)
+    .await
+    .expect("seed compact global rollup for paged manifests");
+    sqlx::query(
+        "INSERT INTO upstream_account_usage_breakdown_hourly \
+         (bucket_start_epoch, source, upstream_account_key, normalized_model, normalized_reasoning_effort, \
+          request_count, output_tokens, cost_output, has_cost) \
+         VALUES (?1, 'proxy', '-1', 'gpt-5', 'high', 4096, 40960, 409.6, 1)",
+    )
+    .bind(compact_bucket)
+    .execute(&state.pool)
+    .await
+    .expect("seed compact global usage rollup for paged manifests");
     sqlx::query(
         "WITH RECURSIVE manifests(ordinal) AS ( \
-            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal <= 4096 \
+            SELECT 1 UNION ALL SELECT ordinal + 1 FROM manifests WHERE ordinal < 4096 \
          ) \
          INSERT INTO archive_batches \
          (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
@@ -22261,36 +22375,47 @@ async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
         .await
         .expect("record complete durable replay coverage");
     }
-    sqlx::query(
-        "INSERT INTO codex_invocations \
-         (invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response, detail_level) \
-         VALUES ('summary-boundary-manifest-live', datetime('now'), 'proxy', 'success', 23, 2.5, \
-                 '{\"upstreamAccountId\":42,\"responseModel\":\"gpt-5\",\"reasoningEffort\":\"high\"}', '', 'full')",
-    )
-    .execute(&state.pool)
-    .await
-    .expect("insert exact live-tail row");
 
     hydrate_summary_snapshots(state.as_ref())
         .await
         .expect("page durable boundary manifests instead of failing hydration");
     state.pool.close().await;
 
-    for (window, upstream_account_id) in [("current", None), ("1d", None), ("1d", Some(42))] {
-        let Json(response) = fetch_summary(
-            State(state.clone()),
-            Query(SummaryQuery {
-                window: Some(window.to_string()),
-                limit: None,
-                time_zone: Some("UTC".to_string()),
-                upstream_account_id,
-            }),
-        )
-        .await
-        .expect("serve the exact paged-boundary response without SQLite");
-        assert_eq!(response.total_count, 1, "window {window}");
-        assert_eq!(response.total_tokens, 23, "window {window}");
-        assert_eq!(response.total_cost, 2.5, "window {window}");
+    for window in ["current", "1d"] {
+        for upstream_account_id in [None, Some(42)] {
+            let Json(response) = fetch_summary(
+                State(state.clone()),
+                Query(SummaryQuery {
+                    window: Some(window.to_string()),
+                    limit: None,
+                    time_zone: Some("UTC".to_string()),
+                    upstream_account_id,
+                }),
+            )
+            .await
+            .expect("serve the exact paged-boundary response without SQLite");
+            assert_eq!(response.total_count, 1, "{window} {upstream_account_id:?}");
+            assert_eq!(
+                response.total_tokens, 20,
+                "{window} {upstream_account_id:?}"
+            );
+            assert_f64_close(response.total_cost, 0.20);
+            if window == "1d" {
+                let model = response
+                    .usage_breakdown
+                    .expect("paged boundary usage breakdown")
+                    .models
+                    .into_iter()
+                    .find(|model| {
+                        model.model == "gpt-5" && model.reasoning_effort.as_deref() == Some("high")
+                    })
+                    .expect("paged boundary model/reasoning detail");
+                assert_f64_close(
+                    model.costs.expect("paged boundary model costs").unknown,
+                    0.20,
+                );
+            }
+        }
     }
 }
 

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22787,6 +22787,12 @@ async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
         )],
     )
     .await;
+    insert_hourly_rollup_archive_replay_marker(
+        &state.pool,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+        &archive_path,
+    )
+    .await;
 
     let replacement_archive_db_path = state
         .config
@@ -22826,13 +22832,20 @@ async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
         .execute(&state.pool)
         .await
         .expect("create all-time summary interleave gate");
-    let interleave = install_summary_projection_test_interleave();
+    let interleave = install_summary_projection_test_interleave_for_stages(&[
+        SummaryProjectionTestInterleaveStage::AfterAllTimeArchiveDiscovery,
+        SummaryProjectionTestInterleaveStage::BeforeAllTimeArchiveScan,
+    ]);
     let replacement_path = archive_path.to_string_lossy().to_string();
     let replacement_pool = state.pool.clone();
     let replacement_interleave = interleave.clone();
     let replacement_archive_path_for_writer = replacement_archive_path.clone();
     let archive_path_for_writer = archive_path.clone();
     let replacement = tokio::spawn(async move {
+        replacement_interleave.wait_for_writer().await;
+        fs::write(&archive_path_for_writer, b"not-a-gzip-archive")
+            .expect("make all-time archive unavailable after discovery");
+        replacement_interleave.resume_build();
         replacement_interleave.wait_for_writer().await;
         fs::rename(
             &replacement_archive_path_for_writer,
@@ -22870,17 +22883,11 @@ async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
     let hydration = hydrate_summary_snapshots(state.as_ref()).await;
     replacement.await.expect("run all-time archive replacement");
     clear_summary_projection_test_interleave();
-    let hydration_error = hydration.expect_err("reject the mixed all-time archive snapshot");
-    assert!(
-        hydration_error
-            .to_string()
-            .contains("summary projection archive changed during hydration"),
-        "unexpected all-time hydration failure: {hydration_error:?}"
-    );
+    hydration.expect("retain the prior all-time aggregate without scanning a replaced archive");
     assert_eq!(
         interleave.build_attempts(),
-        1,
-        "the all-time archive mismatch must fail closed without retrying"
+        2,
+        "the all-time identity regression must drive both preflight transitions exactly once"
     );
     state.pool.close().await;
 

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -22213,7 +22213,7 @@ async fn summary_projection_hydrates_rolling_windows_beyond_archive_manifest_adm
 }
 
 #[tokio::test]
-async fn summary_projection_fails_closed_when_archive_boundary_manifest_admission_exceeds_budget() {
+async fn summary_projection_pages_exact_boundary_manifests_beyond_admission() {
     let state =
         test_state_with_openai_base(Url::parse("http://127.0.0.1:9").expect("valid test URL"))
             .await;
@@ -22246,27 +22246,163 @@ async fn summary_projection_fails_closed_when_archive_boundary_manifest_admissio
     .execute(&state.pool)
     .await
     .expect("insert exact-horizon manifests beyond bounded admission");
+    for target in [
+        HOURLY_ROLLUP_TARGET_INVOCATIONS,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN,
+    ] {
+        sqlx::query(
+            "INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, archive_sha256) \
+             SELECT ?1, dataset, file_path, sha256 FROM archive_batches \
+             WHERE file_path GLOB '/tmp/summary-boundary-manifest-admission-*.sqlite.gz'",
+        )
+        .bind(target)
+        .execute(&state.pool)
+        .await
+        .expect("record complete durable replay coverage");
+    }
+    sqlx::query(
+        "INSERT INTO codex_invocations \
+         (invoke_id, occurred_at, source, status, total_tokens, cost, payload, raw_response, detail_level) \
+         VALUES ('summary-boundary-manifest-live', datetime('now'), 'proxy', 'success', 23, 2.5, \
+                 '{\"upstreamAccountId\":42,\"responseModel\":\"gpt-5\",\"reasoningEffort\":\"high\"}', '', 'full')",
+    )
+    .execute(&state.pool)
+    .await
+    .expect("insert exact live-tail row");
 
     hydrate_summary_snapshots(state.as_ref())
         .await
-        .expect("publish a controlled rolling snapshot instead of failing hydration");
+        .expect("page durable boundary manifests instead of failing hydration");
     state.pool.close().await;
 
-    for window in ["current", "1d"] {
-        assert!(matches!(
-            fetch_summary(
-                State(state.clone()),
-                Query(SummaryQuery {
-                    window: Some(window.to_string()),
-                    limit: None,
-                    time_zone: Some("UTC".to_string()),
-                    upstream_account_id: None,
-                }),
-            )
-            .await,
-            Err(ApiError::Unavailable(_))
-        ));
+    for (window, upstream_account_id) in [("current", None), ("1d", None), ("1d", Some(42))] {
+        let Json(response) = fetch_summary(
+            State(state.clone()),
+            Query(SummaryQuery {
+                window: Some(window.to_string()),
+                limit: None,
+                time_zone: Some("UTC".to_string()),
+                upstream_account_id,
+            }),
+        )
+        .await
+        .expect("serve the exact paged-boundary response without SQLite");
+        assert_eq!(response.total_count, 1, "window {window}");
+        assert_eq!(response.total_tokens, 23, "window {window}");
+        assert_eq!(response.total_cost, 2.5, "window {window}");
     }
+}
+
+#[tokio::test]
+async fn summary_projection_keeps_global_all_exact_when_account_manifest_admission_exceeds_budget()
+{
+    let state =
+        test_state_with_openai_base(Url::parse("http://127.0.0.1:9").expect("valid test URL"))
+            .await;
+    let archive_start = Utc
+        .timestamp_opt(
+            crate::stats::align_bucket_epoch(
+                (Utc::now() - ChronoDuration::days(1_000)).timestamp(),
+                3_600,
+                0,
+            ),
+            0,
+        )
+        .single()
+        .expect("align archive fixture to a full hour");
+    let archive_end = archive_start + ChronoDuration::hours(1);
+    let bucket = crate::stats::align_bucket_epoch(archive_start.timestamp(), 3_600, 0);
+    let file_path = "/tmp/summary-account-manifest-admission.sqlite.gz";
+    sqlx::query(
+        "INSERT INTO invocation_rollup_hourly \
+         (bucket_start_epoch, source, total_count, success_count, failure_count, total_tokens, total_cost, non_success_cost) \
+         VALUES (?1, 'proxy', 1, 1, 0, 17, 1.25, 0)",
+    )
+    .bind(bucket)
+    .execute(&state.pool)
+    .await
+    .expect("insert durable global rollup");
+    sqlx::query(
+        "INSERT INTO archive_batches \
+         (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
+          historical_rollups_materialized_at, created_at) \
+         VALUES ('codex_invocations', '2026-01', ?1, 'summary-account-manifest-admission', 1, 'completed', \
+                 ?2, ?3, datetime('now'), datetime('now'))",
+    )
+    .bind(file_path)
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_start))
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_end))
+    .execute(&state.pool)
+    .await
+    .expect("insert materialized archive manifest");
+    let archive_batch_id: i64 = sqlx::query_scalar(
+        "SELECT id FROM archive_batches WHERE dataset = 'codex_invocations' AND file_path = ?1",
+    )
+    .bind(file_path)
+    .fetch_one(&state.pool)
+    .await
+    .expect("load archive manifest id");
+    sqlx::query(
+        "WITH RECURSIVE accounts(account_id) AS ( \
+            SELECT 1 UNION ALL SELECT account_id + 1 FROM accounts WHERE account_id <= 50000 \
+         ) \
+         INSERT INTO archive_batch_upstream_activity (archive_batch_id, account_id, last_activity_at) \
+         SELECT ?1, account_id, ?2 FROM accounts",
+    )
+    .bind(archive_batch_id)
+    .bind(crate::stats::db_occurred_at_lower_bound(archive_start))
+    .execute(&state.pool)
+    .await
+    .expect("insert account activity beyond bounded admission");
+    for target in [
+        HOURLY_ROLLUP_TARGET_INVOCATIONS,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_STATS_HOURLY,
+        HOURLY_ROLLUP_TARGET_UPSTREAM_ACCOUNT_USAGE_BREAKDOWN,
+    ] {
+        sqlx::query(
+            "INSERT INTO hourly_rollup_archive_replay (target, dataset, file_path, archive_sha256) \
+             VALUES (?1, 'codex_invocations', ?2, 'summary-account-manifest-admission')",
+        )
+        .bind(target)
+        .bind(file_path)
+        .execute(&state.pool)
+        .await
+        .expect("record durable replay coverage");
+    }
+
+    hydrate_summary_snapshots(state.as_ref())
+        .await
+        .expect("hydrate exact global all-time response despite account admission overflow");
+    state.pool.close().await;
+
+    let Json(global) = fetch_summary(
+        State(state.clone()),
+        Query(SummaryQuery {
+            window: Some("all".to_string()),
+            limit: None,
+            time_zone: Some("UTC".to_string()),
+            upstream_account_id: None,
+        }),
+    )
+    .await
+    .expect("serve exact global all-time response without SQLite");
+    assert_eq!(global.total_count, 1);
+    assert_eq!(global.total_tokens, 17);
+    assert_eq!(global.total_cost, 1.25);
+    assert!(matches!(
+        fetch_summary(
+            State(state),
+            Query(SummaryQuery {
+                window: Some("all".to_string()),
+                limit: None,
+                time_zone: Some("UTC".to_string()),
+                upstream_account_id: Some(42),
+            }),
+        )
+        .await,
+        Err(ApiError::Unavailable(_))
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Role

Initiative child PR for Issue #849, Wave 1 of #848.

## Integration

Base: `prd/runtime-read-model-pressure-recovery`

## Summary

- Hydrate exact summary snapshots from bounded durable rollups, verified archive boundaries, and live-tail records.
- Bind archive reads to manifest SHA identity inside a dedicated consistent SQLite snapshot.
- Prevent rolling maintenance from re-admitting an all-time archive scan after an admission failure.

## Validation

- Targeted summary projection regressions
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

## Risk and Boundaries

- Archive and stateful SQLite profile coverage requires the shared testbox; its image is missing `cargo-nextest` before project tests begin.
- No deployment, runtime operation, schema migration, or request-path I/O fallback.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->