### PR TITLE
fix(runtime): deduplicate pressure gate wakes

### DIFF
--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -1,7 +1,8 @@
 use std::{
+    collections::HashMap,
     fmt,
     sync::{
-        Arc,
+        Arc, Mutex, Weak,
         atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -9,7 +10,10 @@ use std::{
 
 use anyhow::Error;
 use once_cell::sync::Lazy;
-use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
+use tokio::{
+    sync::{Notify, OwnedSemaphorePermit, Semaphore},
+    task::Id as TaskId,
+};
 use tracing::warn;
 
 const DEFAULT_BACKGROUND_DB_SLOTS: usize = 1;
@@ -33,6 +37,7 @@ pub(crate) struct DbPressureGate {
     pressure_events: AtomicU64,
     background_skips: AtomicU64,
     eligibility: Arc<DbPressureEligibility>,
+    active_task_admissions: Arc<Mutex<HashMap<TaskId, Weak<DbBackgroundAdmission>>>>,
     #[cfg(test)]
     bypass_for_test_global: bool,
 }
@@ -61,18 +66,37 @@ impl fmt::Display for DbPressureDenyReason {
 }
 
 #[derive(Debug)]
-pub(crate) struct DbBackgroundPermit {
-    _permit: Option<OwnedSemaphorePermit>,
-    started_at: Instant,
-    eligibility: Option<Arc<DbPressureEligibility>>,
+struct DbBackgroundAdmission {
+    permit: Option<OwnedSemaphorePermit>,
+    eligibility: Arc<DbPressureEligibility>,
+    task_id: Option<TaskId>,
+    active_task_admissions: Arc<Mutex<HashMap<TaskId, Weak<DbBackgroundAdmission>>>>,
 }
 
-impl Drop for DbBackgroundPermit {
+impl Drop for DbBackgroundAdmission {
     fn drop(&mut self) {
-        self._permit.take();
-        if let Some(eligibility) = &self.eligibility {
-            eligibility.generation.fetch_add(1, Ordering::AcqRel);
-            eligibility.notify.notify_waiters();
+        self.permit.take();
+        if let Some(task_id) = self.task_id
+            && let Ok(mut admissions) = self.active_task_admissions.lock()
+        {
+            admissions.remove(&task_id);
+        }
+        self.eligibility.generation.fetch_add(1, Ordering::AcqRel);
+        self.eligibility.notify.notify_waiters();
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct DbBackgroundPermit {
+    admission: Option<Arc<DbBackgroundAdmission>>,
+    started_at: Instant,
+}
+
+impl DbBackgroundPermit {
+    fn bypassed() -> Self {
+        Self {
+            admission: None,
+            started_at: Instant::now(),
         }
     }
 }
@@ -102,6 +126,7 @@ impl DbPressureGate {
             pressure_events: AtomicU64::new(0),
             background_skips: AtomicU64::new(0),
             eligibility: Arc::new(DbPressureEligibility::default()),
+            active_task_admissions: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(test)]
             bypass_for_test_global: false,
         }
@@ -153,11 +178,11 @@ impl DbPressureGate {
     ) -> Result<DbBackgroundPermit, DbPressureDenyReason> {
         #[cfg(test)]
         if self.bypass_for_test_global {
-            return Ok(DbBackgroundPermit {
-                _permit: None,
-                started_at: Instant::now(),
-                eligibility: None,
-            });
+            return Ok(DbBackgroundPermit::bypassed());
+        }
+
+        if let Some(admission) = self.reenter_current_task() {
+            return Ok(admission);
         }
 
         let now_ms = current_epoch_ms();
@@ -177,11 +202,7 @@ impl DbPressureGate {
                 self.background_skips.fetch_add(1, Ordering::Relaxed);
                 DbPressureDenyReason::BackgroundBusy
             })?;
-        let admission = DbBackgroundPermit {
-            _permit: Some(permit),
-            started_at: Instant::now(),
-            eligibility: Some(self.eligibility.clone()),
-        };
+        let admission = self.new_admission(permit);
 
         // A pressure event can race with the pre-acquisition cooldown check. Re-check while
         // retaining the slot so a just-closed gate cannot admit another SQLite operation.
@@ -205,11 +226,11 @@ impl DbPressureGate {
     ) -> Result<DbBackgroundPermit, DbPressureDenyReason> {
         #[cfg(test)]
         if self.bypass_for_test_global {
-            return Ok(DbBackgroundPermit {
-                _permit: None,
-                started_at: Instant::now(),
-                eligibility: None,
-            });
+            return Ok(DbBackgroundPermit::bypassed());
+        }
+
+        if let Some(admission) = self.reenter_current_task() {
+            return Ok(admission);
         }
 
         let started_at = Instant::now();
@@ -224,11 +245,17 @@ impl DbPressureGate {
             }
 
             if let Ok(permit) = self.background_slots.clone().try_acquire_owned() {
-                return Ok(DbBackgroundPermit {
-                    _permit: Some(permit),
-                    started_at: Instant::now(),
-                    eligibility: Some(self.eligibility.clone()),
-                });
+                let admission = self.new_admission(permit);
+                let now_ms = current_epoch_ms();
+                let pressure_until_ms = self.pressure_until_epoch_ms.load(Ordering::Acquire);
+                if pressure_until_ms > now_ms {
+                    drop(admission);
+                    self.background_skips.fetch_add(1, Ordering::Relaxed);
+                    return Err(DbPressureDenyReason::PressureCooldown {
+                        remaining_ms: pressure_until_ms.saturating_sub(now_ms),
+                    });
+                }
+                return Ok(admission);
             }
 
             let elapsed = started_at.elapsed();
@@ -238,6 +265,38 @@ impl DbPressureGate {
             }
             let remaining = max_wait.saturating_sub(elapsed);
             tokio::time::sleep(remaining.min(BACKGROUND_BUSY_WAIT_POLL)).await;
+        }
+    }
+
+    fn reenter_current_task(&self) -> Option<DbBackgroundPermit> {
+        let task_id = tokio::task::try_id()?;
+        let admission = self
+            .active_task_admissions
+            .lock()
+            .ok()
+            .and_then(|admissions| admissions.get(&task_id).and_then(Weak::upgrade));
+        admission.map(|admission| DbBackgroundPermit {
+            admission: Some(admission),
+            started_at: Instant::now(),
+        })
+    }
+
+    fn new_admission(&self, permit: OwnedSemaphorePermit) -> DbBackgroundPermit {
+        let task_id = tokio::task::try_id();
+        let admission = Arc::new(DbBackgroundAdmission {
+            permit: Some(permit),
+            eligibility: self.eligibility.clone(),
+            task_id,
+            active_task_admissions: self.active_task_admissions.clone(),
+        });
+        if let Some(task_id) = task_id
+            && let Ok(mut admissions) = self.active_task_admissions.lock()
+        {
+            admissions.insert(task_id, Arc::downgrade(&admission));
+        }
+        DbBackgroundPermit {
+            admission: Some(admission),
+            started_at: Instant::now(),
         }
     }
 
@@ -407,6 +466,76 @@ mod tests {
 
         drop(permit);
         assert!(gate.try_begin_background("second").is_ok());
+    }
+
+    #[tokio::test]
+    async fn gate_reenters_work_held_by_the_same_task_without_releasing_the_slot() {
+        let gate = Arc::new(DbPressureGate::new(1, Duration::from_secs(1)));
+        let (nested_ready_tx, nested_ready_rx) = tokio::sync::oneshot::channel();
+        let (drop_outer_tx, drop_outer_rx) = tokio::sync::oneshot::channel();
+        let (outer_dropped_tx, outer_dropped_rx) = tokio::sync::oneshot::channel();
+        let (drop_nested_tx, drop_nested_rx) = tokio::sync::oneshot::channel();
+        let worker_gate = gate.clone();
+        let worker = tokio::spawn(async move {
+            let outer = worker_gate
+                .try_begin_background("outer")
+                .expect("outer background permit");
+            let nested = worker_gate
+                .try_begin_background("nested")
+                .expect("the current task may reuse its held background permit");
+            nested_ready_tx
+                .send(())
+                .expect("test should await nested admission");
+
+            drop_outer_rx
+                .await
+                .expect("test should request outer permit release");
+            drop(outer);
+            outer_dropped_tx
+                .send(())
+                .expect("test should await outer permit release");
+
+            drop_nested_rx
+                .await
+                .expect("test should request nested permit release");
+            drop(nested);
+        });
+        nested_ready_rx
+            .await
+            .expect("worker should acquire nested admission");
+
+        let other_gate = gate.clone();
+        let other = tokio::spawn(async move { other_gate.try_begin_background("other") });
+        assert_eq!(
+            other
+                .await
+                .expect("other task should not panic")
+                .unwrap_err(),
+            DbPressureDenyReason::BackgroundBusy
+        );
+
+        drop_outer_tx
+            .send(())
+            .expect("worker should be waiting to release outer permit");
+        outer_dropped_rx
+            .await
+            .expect("worker should release outer permit");
+        let other_gate = gate.clone();
+        let other =
+            tokio::spawn(async move { other_gate.try_begin_background("other_after_outer") });
+        assert_eq!(
+            other
+                .await
+                .expect("other task should not panic")
+                .unwrap_err(),
+            DbPressureDenyReason::BackgroundBusy
+        );
+
+        drop_nested_tx
+            .send(())
+            .expect("worker should be waiting to release nested permit");
+        worker.await.expect("worker should not panic");
+        assert!(gate.try_begin_background("after_nested").is_ok());
     }
 
     #[tokio::test]

--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -177,12 +177,25 @@ impl DbPressureGate {
                 self.background_skips.fetch_add(1, Ordering::Relaxed);
                 DbPressureDenyReason::BackgroundBusy
             })?;
-
-        Ok(DbBackgroundPermit {
+        let admission = DbBackgroundPermit {
             _permit: Some(permit),
             started_at: Instant::now(),
             eligibility: Some(self.eligibility.clone()),
-        })
+        };
+
+        // A pressure event can race with the pre-acquisition cooldown check. Re-check while
+        // retaining the slot so a just-closed gate cannot admit another SQLite operation.
+        let now_ms = current_epoch_ms();
+        let pressure_until_ms = self.pressure_until_epoch_ms.load(Ordering::Acquire);
+        if pressure_until_ms > now_ms {
+            drop(admission);
+            self.background_skips.fetch_add(1, Ordering::Relaxed);
+            return Err(DbPressureDenyReason::PressureCooldown {
+                remaining_ms: pressure_until_ms.saturating_sub(now_ms),
+            });
+        }
+
+        Ok(admission)
     }
 
     pub(crate) async fn begin_background_with_busy_wait(

--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -77,6 +77,7 @@ struct DbBackgroundAdmission {
     permit: Option<OwnedSemaphorePermit>,
     eligibility: Arc<DbPressureEligibility>,
     owner: Option<DbBackgroundAdmissionOwner>,
+    operation: &'static str,
     active_admissions: Arc<Mutex<HashMap<DbBackgroundAdmissionOwner, Weak<DbBackgroundAdmission>>>>,
 }
 
@@ -181,7 +182,7 @@ impl DbPressureGate {
 
     pub(crate) fn try_begin_background(
         &self,
-        _task: &'static str,
+        task: &'static str,
     ) -> Result<DbBackgroundPermit, DbPressureDenyReason> {
         #[cfg(test)]
         if self.bypass_for_test_global {
@@ -197,7 +198,7 @@ impl DbPressureGate {
             });
         }
 
-        if let Some(admission) = self.reenter_current_task() {
+        if let Some(admission) = self.reenter_current_task(task) {
             return Ok(admission);
         }
 
@@ -209,7 +210,7 @@ impl DbPressureGate {
                 self.background_skips.fetch_add(1, Ordering::Relaxed);
                 DbPressureDenyReason::BackgroundBusy
             })?;
-        let admission = self.new_admission(permit);
+        let admission = self.new_admission(permit, task);
 
         // A pressure event can race with the pre-acquisition cooldown check. Re-check while
         // retaining the slot so a just-closed gate cannot admit another SQLite operation.
@@ -228,7 +229,7 @@ impl DbPressureGate {
 
     pub(crate) async fn begin_background_with_busy_wait(
         &self,
-        _task: &'static str,
+        task: &'static str,
         max_wait: Duration,
     ) -> Result<DbBackgroundPermit, DbPressureDenyReason> {
         #[cfg(test)]
@@ -247,12 +248,12 @@ impl DbPressureGate {
                 });
             }
 
-            if let Some(admission) = self.reenter_current_task() {
+            if let Some(admission) = self.reenter_current_task(task) {
                 return Ok(admission);
             }
 
             if let Ok(permit) = self.background_slots.clone().try_acquire_owned() {
-                let admission = self.new_admission(permit);
+                let admission = self.new_admission(permit, task);
                 let now_ms = current_epoch_ms();
                 let pressure_until_ms = self.pressure_until_epoch_ms.load(Ordering::Acquire);
                 if pressure_until_ms > now_ms {
@@ -275,25 +276,38 @@ impl DbPressureGate {
         }
     }
 
-    fn reenter_current_task(&self) -> Option<DbBackgroundPermit> {
+    fn reenter_current_task(
+        &self,
+        requested_operation: &'static str,
+    ) -> Option<DbBackgroundPermit> {
         let owner = current_background_admission_owner()?;
         let admission = self
             .active_admissions
             .lock()
             .ok()
             .and_then(|admissions| admissions.get(&owner).and_then(Weak::upgrade));
-        admission.map(|admission| DbBackgroundPermit {
-            admission: Some(admission),
-            started_at: Instant::now(),
-        })
+        admission
+            .filter(|admission| {
+                matches!(owner, DbBackgroundAdmissionOwner::TokioTask(_))
+                    || runtime_root_reentry_is_allowed(admission.operation, requested_operation)
+            })
+            .map(|admission| DbBackgroundPermit {
+                admission: Some(admission),
+                started_at: Instant::now(),
+            })
     }
 
-    fn new_admission(&self, permit: OwnedSemaphorePermit) -> DbBackgroundPermit {
+    fn new_admission(
+        &self,
+        permit: OwnedSemaphorePermit,
+        operation: &'static str,
+    ) -> DbBackgroundPermit {
         let owner = current_background_admission_owner();
         let admission = Arc::new(DbBackgroundAdmission {
             permit: Some(permit),
             eligibility: self.eligibility.clone(),
             owner,
+            operation,
             active_admissions: self.active_admissions.clone(),
         });
         if let Some(owner) = owner
@@ -418,6 +432,17 @@ fn current_background_admission_owner() -> Option<DbBackgroundAdmissionOwner> {
         })
 }
 
+fn runtime_root_reentry_is_allowed(
+    held_operation: &'static str,
+    requested_operation: &'static str,
+) -> bool {
+    // A root `Runtime::block_on` future has no Tokio task ID. Retention's archive wake is the
+    // only supported root-future nesting: it holds an admission, then wakes startup backfill.
+    // Other root-future calls must preserve ordinary background single-flight semantics.
+    held_operation == "archive_backfill_wake"
+        && requested_operation == "startup_backfill_input_wake"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -489,17 +514,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gate_reenters_work_held_by_a_runtime_root_future() {
+    async fn gate_runtime_root_reenters_only_retention_archive_wake() {
         let gate = Arc::new(DbPressureGate::new(1, Duration::from_secs(1)));
         let outer = gate
-            .try_begin_background("outer")
+            .try_begin_background("archive_backfill_wake")
             .expect("root future outer background permit");
+        assert_eq!(
+            gate.try_begin_background("unrelated_root_work")
+                .unwrap_err(),
+            DbPressureDenyReason::BackgroundBusy,
+            "a root future must preserve ordinary single-flight behavior outside retention wake"
+        );
         let nested = gate
-            .try_begin_background("nested")
-            .expect("root future may reuse its held background permit");
+            .try_begin_background("startup_backfill_input_wake")
+            .expect("retention's root-future archive wake may reuse its held admission");
 
         let other_gate = gate.clone();
-        let other = tokio::spawn(async move { other_gate.try_begin_background("other") });
+        let other =
+            tokio::spawn(
+                async move { other_gate.try_begin_background("startup_backfill_input_wake") },
+            );
         assert_eq!(
             other
                 .await

--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -29,6 +29,7 @@ pub(crate) struct DbPressureGate {
     background_slots: Arc<Semaphore>,
     pressure_cooldown: Duration,
     pressure_until_epoch_ms: AtomicU64,
+    pressure_generation: AtomicU64,
     pressure_events: AtomicU64,
     background_skips: AtomicU64,
     eligibility: Arc<DbPressureEligibility>,
@@ -97,6 +98,7 @@ impl DbPressureGate {
             background_slots: Arc::new(Semaphore::new(background_slots.max(1))),
             pressure_cooldown,
             pressure_until_epoch_ms: AtomicU64::new(0),
+            pressure_generation: AtomicU64::new(0),
             pressure_events: AtomicU64::new(0),
             background_skips: AtomicU64::new(0),
             eligibility: Arc::new(DbPressureEligibility::default()),
@@ -239,12 +241,14 @@ impl DbPressureGate {
         let cooldown_ms = duration_ms_u64(self.pressure_cooldown);
         let until_ms = now_ms.saturating_add(cooldown_ms);
         update_atomic_max(&self.pressure_until_epoch_ms, until_ms);
+        let generation = self.pressure_generation.fetch_add(1, Ordering::AcqRel) + 1;
         let events = self.pressure_events.fetch_add(1, Ordering::Relaxed) + 1;
         self.eligibility.generation.fetch_add(1, Ordering::AcqRel);
         self.eligibility.notify.notify_waiters();
         warn!(
             task,
             reason,
+            generation,
             events,
             cooldown_ms,
             "database pressure detected; background database work will back off"
@@ -253,6 +257,10 @@ impl DbPressureGate {
 
     pub(crate) fn eligibility_generation(&self) -> u64 {
         self.eligibility.generation.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn pressure_generation(&self) -> u64 {
+        self.pressure_generation.load(Ordering::Acquire)
     }
 
     pub(crate) fn notify_background_eligibility(&self) {
@@ -358,6 +366,18 @@ mod tests {
             Some(deadline),
             "a cooldown must keep one absolute next-eligibility deadline"
         );
+    }
+
+    #[test]
+    fn pressure_generation_changes_only_when_new_pressure_is_recorded() {
+        let gate = DbPressureGate::new(1, Duration::from_secs(60));
+        let before = gate.pressure_generation();
+
+        gate.notify_background_eligibility();
+        assert_eq!(gate.pressure_generation(), before);
+
+        gate.record_pressure("test", "forced");
+        assert_eq!(gate.pressure_generation(), before + 1);
     }
 
     #[test]

--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -35,6 +35,7 @@ pub(crate) struct DbPressureGate {
     pressure_cooldown: Duration,
     pressure_until_epoch_ms: AtomicU64,
     pressure_generation: AtomicU64,
+    pressure_state_lock: Mutex<()>,
     pressure_events: AtomicU64,
     background_skips: AtomicU64,
     eligibility: Arc<DbPressureEligibility>,
@@ -131,6 +132,7 @@ impl DbPressureGate {
             pressure_cooldown,
             pressure_until_epoch_ms: AtomicU64::new(0),
             pressure_generation: AtomicU64::new(0),
+            pressure_state_lock: Mutex::new(()),
             pressure_events: AtomicU64::new(0),
             background_skips: AtomicU64::new(0),
             eligibility: Arc::new(DbPressureEligibility::default()),
@@ -178,6 +180,21 @@ impl DbPressureGate {
         let now_ms = current_epoch_ms();
         let deadline_ms = self.pressure_until_epoch_ms.load(Ordering::Acquire);
         (deadline_ms > now_ms).then_some(deadline_ms)
+    }
+
+    pub(crate) fn pressure_cooldown_snapshot(&self) -> Option<(u64, u64)> {
+        let _pressure_state = self
+            .pressure_state_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let now_ms = current_epoch_ms();
+        let deadline_ms = self.pressure_until_epoch_ms.load(Ordering::Acquire);
+        (deadline_ms > now_ms).then(|| {
+            (
+                self.pressure_generation.load(Ordering::Acquire),
+                deadline_ms,
+            )
+        })
     }
 
     pub(crate) fn try_begin_background(
@@ -330,11 +347,18 @@ impl DbPressureGate {
     }
 
     pub(crate) fn record_pressure(&self, task: &'static str, reason: &'static str) {
-        let now_ms = current_epoch_ms();
-        let cooldown_ms = duration_ms_u64(self.pressure_cooldown);
-        let until_ms = now_ms.saturating_add(cooldown_ms);
-        update_atomic_max(&self.pressure_until_epoch_ms, until_ms);
-        let generation = self.pressure_generation.fetch_add(1, Ordering::AcqRel) + 1;
+        let (generation, cooldown_ms) = {
+            let _pressure_state = self
+                .pressure_state_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let now_ms = current_epoch_ms();
+            let cooldown_ms = duration_ms_u64(self.pressure_cooldown);
+            let until_ms = now_ms.saturating_add(cooldown_ms);
+            update_atomic_max(&self.pressure_until_epoch_ms, until_ms);
+            let generation = self.pressure_generation.fetch_add(1, Ordering::AcqRel) + 1;
+            (generation, cooldown_ms)
+        };
         let events = self.pressure_events.fetch_add(1, Ordering::Relaxed) + 1;
         self.eligibility.generation.fetch_add(1, Ordering::AcqRel);
         self.eligibility.notify.notify_waiters();

--- a/src/db_pressure.rs
+++ b/src/db_pressure.rs
@@ -5,6 +5,7 @@ use std::{
         Arc, Mutex, Weak,
         atomic::{AtomicU64, Ordering},
     },
+    thread::ThreadId,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -37,7 +38,7 @@ pub(crate) struct DbPressureGate {
     pressure_events: AtomicU64,
     background_skips: AtomicU64,
     eligibility: Arc<DbPressureEligibility>,
-    active_task_admissions: Arc<Mutex<HashMap<TaskId, Weak<DbBackgroundAdmission>>>>,
+    active_admissions: Arc<Mutex<HashMap<DbBackgroundAdmissionOwner, Weak<DbBackgroundAdmission>>>>,
     #[cfg(test)]
     bypass_for_test_global: bool,
 }
@@ -65,21 +66,27 @@ impl fmt::Display for DbPressureDenyReason {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum DbBackgroundAdmissionOwner {
+    TokioTask(TaskId),
+    RuntimeRoot(ThreadId),
+}
+
 #[derive(Debug)]
 struct DbBackgroundAdmission {
     permit: Option<OwnedSemaphorePermit>,
     eligibility: Arc<DbPressureEligibility>,
-    task_id: Option<TaskId>,
-    active_task_admissions: Arc<Mutex<HashMap<TaskId, Weak<DbBackgroundAdmission>>>>,
+    owner: Option<DbBackgroundAdmissionOwner>,
+    active_admissions: Arc<Mutex<HashMap<DbBackgroundAdmissionOwner, Weak<DbBackgroundAdmission>>>>,
 }
 
 impl Drop for DbBackgroundAdmission {
     fn drop(&mut self) {
         self.permit.take();
-        if let Some(task_id) = self.task_id
-            && let Ok(mut admissions) = self.active_task_admissions.lock()
+        if let Some(owner) = self.owner
+            && let Ok(mut admissions) = self.active_admissions.lock()
         {
-            admissions.remove(&task_id);
+            admissions.remove(&owner);
         }
         self.eligibility.generation.fetch_add(1, Ordering::AcqRel);
         self.eligibility.notify.notify_waiters();
@@ -126,7 +133,7 @@ impl DbPressureGate {
             pressure_events: AtomicU64::new(0),
             background_skips: AtomicU64::new(0),
             eligibility: Arc::new(DbPressureEligibility::default()),
-            active_task_admissions: Arc::new(Mutex::new(HashMap::new())),
+            active_admissions: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(test)]
             bypass_for_test_global: false,
         }
@@ -181,10 +188,6 @@ impl DbPressureGate {
             return Ok(DbBackgroundPermit::bypassed());
         }
 
-        if let Some(admission) = self.reenter_current_task() {
-            return Ok(admission);
-        }
-
         let now_ms = current_epoch_ms();
         let pressure_until_ms = self.pressure_until_epoch_ms.load(Ordering::Acquire);
         if pressure_until_ms > now_ms {
@@ -192,6 +195,10 @@ impl DbPressureGate {
             return Err(DbPressureDenyReason::PressureCooldown {
                 remaining_ms: pressure_until_ms.saturating_sub(now_ms),
             });
+        }
+
+        if let Some(admission) = self.reenter_current_task() {
+            return Ok(admission);
         }
 
         let permit = self
@@ -229,10 +236,6 @@ impl DbPressureGate {
             return Ok(DbBackgroundPermit::bypassed());
         }
 
-        if let Some(admission) = self.reenter_current_task() {
-            return Ok(admission);
-        }
-
         let started_at = Instant::now();
         loop {
             let now_ms = current_epoch_ms();
@@ -242,6 +245,10 @@ impl DbPressureGate {
                 return Err(DbPressureDenyReason::PressureCooldown {
                     remaining_ms: pressure_until_ms.saturating_sub(now_ms),
                 });
+            }
+
+            if let Some(admission) = self.reenter_current_task() {
+                return Ok(admission);
             }
 
             if let Ok(permit) = self.background_slots.clone().try_acquire_owned() {
@@ -269,12 +276,12 @@ impl DbPressureGate {
     }
 
     fn reenter_current_task(&self) -> Option<DbBackgroundPermit> {
-        let task_id = tokio::task::try_id()?;
+        let owner = current_background_admission_owner()?;
         let admission = self
-            .active_task_admissions
+            .active_admissions
             .lock()
             .ok()
-            .and_then(|admissions| admissions.get(&task_id).and_then(Weak::upgrade));
+            .and_then(|admissions| admissions.get(&owner).and_then(Weak::upgrade));
         admission.map(|admission| DbBackgroundPermit {
             admission: Some(admission),
             started_at: Instant::now(),
@@ -282,17 +289,17 @@ impl DbPressureGate {
     }
 
     fn new_admission(&self, permit: OwnedSemaphorePermit) -> DbBackgroundPermit {
-        let task_id = tokio::task::try_id();
+        let owner = current_background_admission_owner();
         let admission = Arc::new(DbBackgroundAdmission {
             permit: Some(permit),
             eligibility: self.eligibility.clone(),
-            task_id,
-            active_task_admissions: self.active_task_admissions.clone(),
+            owner,
+            active_admissions: self.active_admissions.clone(),
         });
-        if let Some(task_id) = task_id
-            && let Ok(mut admissions) = self.active_task_admissions.lock()
+        if let Some(owner) = owner
+            && let Ok(mut admissions) = self.active_admissions.lock()
         {
-            admissions.insert(task_id, Arc::downgrade(&admission));
+            admissions.insert(owner, Arc::downgrade(&admission));
         }
         DbBackgroundPermit {
             admission: Some(admission),
@@ -398,6 +405,19 @@ fn current_epoch_ms() -> u64 {
         .min(u128::from(u64::MAX)) as u64
 }
 
+fn current_background_admission_owner() -> Option<DbBackgroundAdmissionOwner> {
+    tokio::task::try_id()
+        .map(DbBackgroundAdmissionOwner::TokioTask)
+        .or_else(|| {
+            // Tokio's root future has no task ID, but it remains on the thread driving
+            // `Runtime::block_on`. Restrict this fallback to an entered Tokio runtime so plain
+            // synchronous callers retain normal single-flight behavior.
+            tokio::runtime::Handle::try_current()
+                .ok()
+                .map(|_| DbBackgroundAdmissionOwner::RuntimeRoot(std::thread::current().id()))
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -469,6 +489,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gate_reenters_work_held_by_a_runtime_root_future() {
+        let gate = Arc::new(DbPressureGate::new(1, Duration::from_secs(1)));
+        let outer = gate
+            .try_begin_background("outer")
+            .expect("root future outer background permit");
+        let nested = gate
+            .try_begin_background("nested")
+            .expect("root future may reuse its held background permit");
+
+        let other_gate = gate.clone();
+        let other = tokio::spawn(async move { other_gate.try_begin_background("other") });
+        assert_eq!(
+            other
+                .await
+                .expect("other task should not panic")
+                .unwrap_err(),
+            DbPressureDenyReason::BackgroundBusy
+        );
+
+        drop(outer);
+        drop(nested);
+        assert!(gate.try_begin_background("after_nested").is_ok());
+    }
+
+    #[tokio::test]
     async fn gate_reenters_work_held_by_the_same_task_without_releasing_the_slot() {
         let gate = Arc::new(DbPressureGate::new(1, Duration::from_secs(1)));
         let (nested_ready_tx, nested_ready_rx) = tokio::sync::oneshot::channel();
@@ -536,6 +581,40 @@ mod tests {
             .expect("worker should be waiting to release nested permit");
         worker.await.expect("worker should not panic");
         assert!(gate.try_begin_background("after_nested").is_ok());
+    }
+
+    #[tokio::test]
+    async fn gate_reentrant_work_observes_a_later_pressure_cooldown() {
+        let gate = Arc::new(DbPressureGate::new(1, Duration::from_secs(60)));
+        let (outer_ready_tx, outer_ready_rx) = tokio::sync::oneshot::channel();
+        let (begin_nested_tx, begin_nested_rx) = tokio::sync::oneshot::channel();
+        let worker_gate = gate.clone();
+        let worker = tokio::spawn(async move {
+            let _outer = worker_gate
+                .try_begin_background("outer")
+                .expect("outer background permit");
+            outer_ready_tx
+                .send(())
+                .expect("test should await outer admission");
+            begin_nested_rx
+                .await
+                .expect("test should request nested admission");
+            worker_gate
+                .try_begin_background("nested_after_pressure")
+                .expect_err("a later pressure cooldown must deny nested SQLite work")
+        });
+
+        outer_ready_rx
+            .await
+            .expect("worker should acquire outer admission");
+        gate.record_pressure("test", "forced");
+        begin_nested_tx
+            .send(())
+            .expect("worker should be waiting to begin nested work");
+        assert!(matches!(
+            worker.await.expect("worker should not panic"),
+            DbPressureDenyReason::PressureCooldown { remaining_ms } if remaining_ms > 0
+        ));
     }
 
     #[tokio::test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -48,7 +48,7 @@ struct StartupBackfillScheduler {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PressureDeferredTask {
     pressure_generation: u64,
-    next_eligibility: Option<DateTime<Utc>>,
+    pressure_deadline: Option<DateTime<Utc>>,
     selected_for_eligibility: bool,
 }
 
@@ -133,7 +133,7 @@ impl StartupBackfillScheduler {
         &self,
         task: StartupBackfillTask,
         pressure_generation: u64,
-        due: DateTime<Utc>,
+        pressure_deadline: DateTime<Utc>,
     ) {
         // Keep the generation check and due write ordered under the pressure-defer lock. An
         // older arming pass must not overwrite the next deadline after a newer defer replaces it.
@@ -146,13 +146,20 @@ impl StartupBackfillScheduler {
                     .get(&task)
                     .filter(|entry| {
                         entry.pressure_generation == pressure_generation
-                            && entry.next_eligibility == Some(due)
+                            && entry.pressure_deadline == Some(pressure_deadline)
                     })
                     .and_then(|_| {
-                        self.next_due
-                            .lock()
-                            .ok()
-                            .map(|mut next_due| next_due.insert(task, due) != Some(due))
+                        self.next_due.lock().ok().map(|mut next_due| {
+                            let existing_due = next_due.get(&task).copied();
+                            let scheduled_due = existing_due
+                                .map(|due| due.max(pressure_deadline))
+                                .unwrap_or(pressure_deadline);
+                            if existing_due == Some(scheduled_due) {
+                                return false;
+                            }
+                            next_due.insert(task, scheduled_due);
+                            true
+                        })
                     })
             })
             .unwrap_or(false);
@@ -183,7 +190,7 @@ impl StartupBackfillScheduler {
                 .get(&task)
                 .filter(|entry| {
                     entry.pressure_generation == pressure_generation
-                        && entry.next_eligibility.is_none()
+                        && entry.pressure_deadline.is_none()
                 })
                 .and_then(|_| {
                     self.next_due.lock().ok().map(|mut next_due| {
@@ -196,7 +203,7 @@ impl StartupBackfillScheduler {
     fn defer_for_pressure(
         &self,
         task: StartupBackfillTask,
-        next_eligibility: Option<DateTime<Utc>>,
+        pressure_deadline: Option<DateTime<Utc>>,
         pressure_generation: u64,
     ) -> bool {
         let newly_registered = self
@@ -209,7 +216,7 @@ impl StartupBackfillScheduler {
                         task,
                         PressureDeferredTask {
                             pressure_generation,
-                            next_eligibility,
+                            pressure_deadline,
                             selected_for_eligibility: false,
                         },
                     );
@@ -218,11 +225,11 @@ impl StartupBackfillScheduler {
             })
             .unwrap_or(false);
         if newly_registered {
-            if let Some(next_eligibility) = next_eligibility {
+            if let Some(pressure_deadline) = pressure_deadline {
                 self.record_pressure_eligibility_deadline(
                     task,
                     pressure_generation,
-                    next_eligibility,
+                    pressure_deadline,
                 );
             } else {
                 self.clear_pressure_eligibility_deadline(task, pressure_generation);
@@ -250,16 +257,27 @@ impl StartupBackfillScheduler {
             self.wake(task);
             return None;
         };
-        let pressure_generation = gate.pressure_generation();
-        let next_eligibility = startup_backfill_pressure_eligibility_deadline(gate, reason);
+        let pressure_snapshot = gate.pressure_cooldown_snapshot();
+        let pressure_generation = pressure_snapshot
+            .map(|(generation, _)| generation)
+            .unwrap_or_else(|| gate.pressure_generation());
+        let pressure_deadline = pressure_snapshot
+            .and_then(|(_, deadline_ms)| startup_backfill_datetime_from_epoch_ms(deadline_ms));
+        let next_eligibility = match reason {
+            crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => {
+                pressure_deadline.or_else(|| {
+                    let remaining_ms = i64::try_from(remaining_ms.max(1)).unwrap_or(i64::MAX);
+                    Some(Utc::now() + ChronoDuration::milliseconds(remaining_ms))
+                })
+            }
+            crate::db_pressure::DbPressureDenyReason::BackgroundBusy => None,
+        };
         let newly_registered = self.defer_for_pressure(task, next_eligibility, pressure_generation);
         // The deny recheck and generation read cannot reserve the gate. Once the deferred entry
         // is visible, absorb a concurrently-recorded cooldown before its notification can be
         // consumed by the supervisor without this task present.
         self.arm_pressure_deferred_deadlines(gate);
-        let next_eligibility = self
-            .pressure_deferred_entry(task)
-            .and_then(|entry| entry.next_eligibility);
+        let next_eligibility = self.next_due_for(task);
         Some((reason, next_eligibility, newly_registered))
     }
 
@@ -272,6 +290,13 @@ impl StartupBackfillScheduler {
 
     fn pressure_deferred_entry(&self, task: StartupBackfillTask) -> Option<PressureDeferredTask> {
         self.pressure_deferred_tasks
+            .lock()
+            .ok()
+            .and_then(|tasks| tasks.get(&task).copied())
+    }
+
+    fn next_due_for(&self, task: StartupBackfillTask) -> Option<DateTime<Utc>> {
+        self.next_due
             .lock()
             .ok()
             .and_then(|tasks| tasks.get(&task).copied())
@@ -301,17 +326,12 @@ impl StartupBackfillScheduler {
     }
 
     fn arm_pressure_deferred_deadlines(&self, gate: &crate::db_pressure::DbPressureGate) {
-        let Some(next_eligibility) =
-            gate.pressure_cooldown_deadline_epoch_ms()
-                .and_then(|deadline_ms| {
-                    i64::try_from(deadline_ms)
-                        .ok()
-                        .and_then(DateTime::<Utc>::from_timestamp_millis)
-                })
-        else {
+        let Some((pressure_generation, deadline_ms)) = gate.pressure_cooldown_snapshot() else {
             return;
         };
-        let pressure_generation = gate.pressure_generation();
+        let Some(pressure_deadline) = startup_backfill_datetime_from_epoch_ms(deadline_ms) else {
+            return;
+        };
         let tasks = self
             .pressure_deferred_tasks
             .lock()
@@ -320,12 +340,12 @@ impl StartupBackfillScheduler {
                     .iter_mut()
                     .filter_map(|(task, entry)| {
                         let needs_deadline = entry.pressure_generation != pressure_generation
-                            || entry.next_eligibility.is_none();
+                            || entry.pressure_deadline != Some(pressure_deadline);
                         if !needs_deadline {
                             return None;
                         }
                         entry.pressure_generation = pressure_generation;
-                        entry.next_eligibility = Some(next_eligibility);
+                        entry.pressure_deadline = Some(pressure_deadline);
                         entry.selected_for_eligibility = false;
                         Some((*task, pressure_generation))
                     })
@@ -333,7 +353,7 @@ impl StartupBackfillScheduler {
             })
             .unwrap_or_default();
         for (task, pressure_generation) in tasks {
-            self.record_pressure_eligibility_deadline(task, pressure_generation, next_eligibility);
+            self.record_pressure_eligibility_deadline(task, pressure_generation, pressure_deadline);
         }
     }
 
@@ -565,12 +585,8 @@ fn startup_backfill_pressure_eligibility_deadline(
 ) -> Option<DateTime<Utc>> {
     match reason {
         crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => gate
-            .pressure_cooldown_deadline_epoch_ms()
-            .and_then(|deadline_ms| {
-                i64::try_from(deadline_ms)
-                    .ok()
-                    .and_then(DateTime::<Utc>::from_timestamp_millis)
-            })
+            .pressure_cooldown_snapshot()
+            .and_then(|(_, deadline_ms)| startup_backfill_datetime_from_epoch_ms(deadline_ms))
             .or_else(|| {
                 let remaining_ms = i64::try_from(remaining_ms.max(1)).unwrap_or(i64::MAX);
                 Some(Utc::now() + ChronoDuration::milliseconds(remaining_ms))
@@ -579,6 +595,12 @@ fn startup_backfill_pressure_eligibility_deadline(
         // while the same slot remains occupied, so busy defers have no due-ticker fallback.
         crate::db_pressure::DbPressureDenyReason::BackgroundBusy => None,
     }
+}
+
+fn startup_backfill_datetime_from_epoch_ms(deadline_ms: u64) -> Option<DateTime<Utc>> {
+    i64::try_from(deadline_ms)
+        .ok()
+        .and_then(DateTime::<Utc>::from_timestamp_millis)
 }
 
 fn register_startup_backfill_pressure_defer(
@@ -622,20 +644,18 @@ fn startup_backfill_pressure_error_defer_outcome(
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
 ) -> StartupBackfillTaskRunOutcome {
-    let retry_at = gate
-        .pressure_cooldown_deadline_epoch_ms()
-        .and_then(|deadline_ms| {
-            i64::try_from(deadline_ms)
-                .ok()
-                .and_then(DateTime::<Utc>::from_timestamp_millis)
-        })
+    let pressure_snapshot = gate.pressure_cooldown_snapshot();
+    let retry_at = pressure_snapshot
+        .and_then(|(_, deadline_ms)| startup_backfill_datetime_from_epoch_ms(deadline_ms))
         .unwrap_or_else(|| {
             Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
         });
     let newly_registered = STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(
         task,
         Some(retry_at),
-        gate.pressure_generation(),
+        pressure_snapshot
+            .map(|(generation, _)| generation)
+            .unwrap_or_else(|| gate.pressure_generation()),
     );
     STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task);
     if newly_registered {
@@ -2869,6 +2889,51 @@ mod startup_backfill_tests {
                 .expect("the deferred task should remain registered")
                 .pressure_generation,
             gate.pressure_generation()
+        );
+    }
+
+    #[test]
+    fn pressure_generation_rearm_replaces_a_stale_pressure_deadline() {
+        let scheduler = StartupBackfillScheduler::default();
+        let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+        let task = StartupBackfillTask::ReasoningEffort;
+
+        gate.record_pressure("test", "forced");
+        let (pressure_generation, deadline_ms) = gate
+            .pressure_cooldown_snapshot()
+            .expect("active pressure cooldown snapshot");
+        let pressure_deadline = startup_backfill_datetime_from_epoch_ms(deadline_ms)
+            .expect("pressure deadline must fit the scheduler clock");
+        let stale_deadline = pressure_deadline - ChronoDuration::milliseconds(1);
+
+        scheduler
+            .pressure_deferred_tasks
+            .lock()
+            .expect("scheduler state lock")
+            .insert(
+                task,
+                PressureDeferredTask {
+                    pressure_generation,
+                    pressure_deadline: Some(stale_deadline),
+                    selected_for_eligibility: false,
+                },
+            );
+        scheduler
+            .next_due
+            .lock()
+            .expect("scheduler due lock")
+            .insert(task, stale_deadline);
+
+        scheduler.arm_pressure_deferred_deadlines(&gate);
+
+        assert_eq!(scheduler.next_due_for(task), Some(pressure_deadline));
+        assert_eq!(
+            scheduler
+                .pressure_deferred_entry(task)
+                .expect("the deferred task should remain registered")
+                .pressure_deadline,
+            Some(pressure_deadline),
+            "a new generation paired with an old deadline must be repaired before it fires"
         );
     }
 

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -129,8 +129,39 @@ impl StartupBackfillScheduler {
         }
     }
 
-    fn record_pressure_eligibility_deadline(&self, task: StartupBackfillTask, due: DateTime<Utc>) {
-        self.record_next_due_unchecked(task, due);
+    fn record_pressure_eligibility_deadline(
+        &self,
+        task: StartupBackfillTask,
+        pressure_generation: u64,
+        due: DateTime<Utc>,
+    ) {
+        // Keep the generation check and due write ordered under the pressure-defer lock. An
+        // older arming pass must not overwrite the next deadline after a newer defer replaces it.
+        let recorded = self
+            .pressure_deferred_tasks
+            .lock()
+            .ok()
+            .and_then(|tasks| {
+                tasks
+                    .get(&task)
+                    .filter(|entry| {
+                        entry.pressure_generation == pressure_generation
+                            && entry.next_eligibility == Some(due)
+                    })
+                    .and_then(|_| {
+                        self.next_due.lock().ok().map(|mut next_due| {
+                            next_due.insert(task, due);
+                        })
+                    })
+            })
+            .is_some();
+        if !recorded {
+            return;
+        }
+        // A cooldown can be registered after the supervisor has already consumed the pressure
+        // event and selected its idle sleep. Wake it once so the new absolute deadline is armed.
+        self.wake_generation.fetch_add(1, Ordering::AcqRel);
+        self.notify.notify_waiters();
     }
 
     fn clear_next_due(&self, task: StartupBackfillTask) {
@@ -165,7 +196,11 @@ impl StartupBackfillScheduler {
             .unwrap_or(false);
         if newly_registered {
             if let Some(next_eligibility) = next_eligibility {
-                self.record_pressure_eligibility_deadline(task, next_eligibility);
+                self.record_pressure_eligibility_deadline(
+                    task,
+                    pressure_generation,
+                    next_eligibility,
+                );
             } else {
                 self.clear_next_due(task);
             }
@@ -269,13 +304,13 @@ impl StartupBackfillScheduler {
                         entry.pressure_generation = pressure_generation;
                         entry.next_eligibility = Some(next_eligibility);
                         entry.selected_for_eligibility = false;
-                        Some(*task)
+                        Some((*task, pressure_generation))
                     })
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
-        for task in tasks {
-            self.record_pressure_eligibility_deadline(task, next_eligibility);
+        for (task, pressure_generation) in tasks {
+            self.record_pressure_eligibility_deadline(task, pressure_generation, next_eligibility);
         }
     }
 
@@ -2696,6 +2731,11 @@ mod startup_backfill_tests {
             !scheduler.defer_for_pressure(task, Some(deadline + ChronoDuration::minutes(1)), 41),
             "the same pressure generation must preserve its first eligibility deadline"
         );
+        assert_eq!(
+            scheduler.generation(),
+            1,
+            "one pressure generation must schedule exactly one supervisor wake"
+        );
         scheduler.wake(task);
         assert!(
             scheduler.drain_woken_tasks().is_empty(),
@@ -2721,6 +2761,26 @@ mod startup_backfill_tests {
         assert_eq!(deferred.pressure_defer_count, 1);
         assert_eq!(deferred.scheduled_task_count, 0);
         assert_eq!(deferred.deferred_task_count, 1);
+    }
+
+    #[tokio::test]
+    async fn pressure_deadline_wakes_an_idle_scheduler() {
+        let scheduler = Arc::new(StartupBackfillScheduler::default());
+        let task = StartupBackfillTask::ReasoningEffort;
+        let observed_generation = scheduler.generation();
+        let waiting_scheduler = scheduler.clone();
+        let waiter = tokio::spawn(async move {
+            waiting_scheduler.wait_for_wake(observed_generation).await;
+        });
+        tokio::task::yield_now().await;
+
+        let deadline = Utc::now() + ChronoDuration::minutes(5);
+        assert!(scheduler.defer_for_pressure(task, Some(deadline), 73));
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("a new pressure deadline must wake an idle supervisor")
+            .expect("scheduler waiter should not panic");
+        assert_eq!(scheduler.next_due(), Some(deadline));
     }
 
     #[tokio::test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -1229,7 +1229,7 @@ async fn wake_startup_backfill_tasks_with_pricing_catalog_and_gate(
             }
             _ => task.name().to_string(),
         };
-        let outcome = sqlx::query(
+        let outcome = match sqlx::query(
             r#"
             INSERT INTO startup_backfill_progress (
                 task_name,
@@ -1264,7 +1264,17 @@ async fn wake_startup_backfill_tasks_with_pricing_catalog_and_gate(
                 task.name(),
                 task_name
             )
-        })?;
+        }) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                if startup_backfill_pressure_error_defer_outcome_if_recorded(*task, gate, &err)
+                    .is_some()
+                {
+                    continue;
+                }
+                return Err(err);
+            }
+        };
         woken += outcome.rows_affected();
         STARTUP_BACKFILL_SCHEDULER.wake(*task);
     }
@@ -1423,8 +1433,20 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
     pool: &Pool<Sqlite>,
     wake_reason: &'static str,
 ) -> Result<u64> {
+    wake_startup_backfill_coverage_repair_with_gate(
+        pool,
+        wake_reason,
+        crate::db_pressure::global_db_pressure_gate(),
+    )
+    .await
+}
+
+pub(crate) async fn wake_startup_backfill_coverage_repair_with_gate(
+    pool: &Pool<Sqlite>,
+    wake_reason: &'static str,
+    gate: &crate::db_pressure::DbPressureGate,
+) -> Result<u64> {
     let task = StartupBackfillTask::AccountActivityV2Coverage;
-    let gate = crate::db_pressure::global_db_pressure_gate();
     if STARTUP_BACKFILL_SCHEDULER.is_pressure_deferred(task) {
         return Ok(0);
     }
@@ -1439,7 +1461,16 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
         return Ok(0);
     }
     let task_name = task.name();
-    let progress = load_startup_backfill_progress(pool, task_name).await?;
+    let progress = match load_startup_backfill_progress(pool, task_name).await {
+        Ok(progress) => progress,
+        Err(err) => {
+            if startup_backfill_pressure_error_defer_outcome_if_recorded(task, gate, &err).is_some()
+            {
+                return Ok(0);
+            }
+            return Err(err);
+        }
+    };
     let deadline_preserved = !progress.is_due(Utc::now())
         && (progress.zero_update_streak > 0 || progress.last_status == STARTUP_BACKFILL_STATUS_OK);
     if deadline_preserved {
@@ -1454,7 +1485,7 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
         return Ok(progress.wake_generation);
     }
 
-    sqlx::query(
+    let wake_result = sqlx::query(
         r#"
         INSERT INTO startup_backfill_progress (
             task_name,
@@ -1488,9 +1519,25 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
     .bind(task_name)
     .bind(STARTUP_BACKFILL_STATUS_IDLE)
     .execute(pool)
-    .await?;
+    .await;
+    if let Err(err) = wake_result {
+        let err = anyhow::Error::from(err);
+        if startup_backfill_pressure_error_defer_outcome_if_recorded(task, gate, &err).is_some() {
+            return Ok(0);
+        }
+        return Err(err);
+    }
 
-    let progress = load_startup_backfill_progress(pool, task_name).await?;
+    let progress = match load_startup_backfill_progress(pool, task_name).await {
+        Ok(progress) => progress,
+        Err(err) => {
+            if startup_backfill_pressure_error_defer_outcome_if_recorded(task, gate, &err).is_some()
+            {
+                return Ok(0);
+            }
+            return Err(err);
+        }
+    };
     STARTUP_BACKFILL_SCHEDULER.wake(task);
     info!(
         task = task.log_label(),

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -163,10 +163,46 @@ impl StartupBackfillScheduler {
                 }
             })
             .unwrap_or(false);
-        if let Some(next_eligibility) = next_eligibility.filter(|_| newly_registered) {
-            self.record_pressure_eligibility_deadline(task, next_eligibility);
+        if newly_registered {
+            if let Some(next_eligibility) = next_eligibility {
+                self.record_pressure_eligibility_deadline(task, next_eligibility);
+            } else {
+                self.clear_next_due(task);
+            }
+            if let Ok(mut tasks) = self.woken_tasks.lock() {
+                tasks.remove(&task);
+            }
         }
         newly_registered
+    }
+
+    fn defer_for_current_gate(
+        &self,
+        task: StartupBackfillTask,
+        gate: &crate::db_pressure::DbPressureGate,
+    ) -> Option<(
+        crate::db_pressure::DbPressureDenyReason,
+        Option<DateTime<Utc>>,
+        bool,
+    )> {
+        let Some(reason) = gate.background_deny_reason() else {
+            // The only busy-slot release may have arrived before this defer could be registered.
+            // Re-enqueue once while the gate is open rather than retain a busy defer with no
+            // future eligibility event to consume.
+            self.wake(task);
+            return None;
+        };
+        let pressure_generation = gate.pressure_generation();
+        let next_eligibility = startup_backfill_pressure_eligibility_deadline(gate, reason);
+        let newly_registered = self.defer_for_pressure(task, next_eligibility, pressure_generation);
+        // The deny recheck and generation read cannot reserve the gate. Once the deferred entry
+        // is visible, absorb a concurrently-recorded cooldown before its notification can be
+        // consumed by the supervisor without this task present.
+        self.arm_pressure_deferred_deadlines(gate);
+        let next_eligibility = self
+            .pressure_deferred_entry(task)
+            .and_then(|entry| entry.next_eligibility);
+        Some((reason, next_eligibility, newly_registered))
     }
 
     fn is_pressure_deferred(&self, task: StartupBackfillTask) -> bool {
@@ -490,17 +526,9 @@ fn startup_backfill_pressure_eligibility_deadline(
 fn register_startup_backfill_pressure_defer(
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
-    reason: crate::db_pressure::DbPressureDenyReason,
 ) -> Option<DateTime<Utc>> {
-    let reason = gate.background_deny_reason().unwrap_or(reason);
-    let pressure_generation = gate.pressure_generation();
-    let next_eligibility = startup_backfill_pressure_eligibility_deadline(gate, reason);
-    let newly_registered =
-        STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, next_eligibility, pressure_generation);
-    // The deny recheck and generation read cannot reserve the gate. Once the deferred entry is
-    // visible, absorb a concurrently-recorded cooldown before its notification can be consumed
-    // by the supervisor without this task present.
-    STARTUP_BACKFILL_SCHEDULER.arm_pressure_deferred_deadlines(gate);
+    let (reason, next_eligibility, newly_registered) =
+        STARTUP_BACKFILL_SCHEDULER.defer_for_current_gate(task, gate)?;
     if newly_registered {
         info!(
             task = task.log_label(),
@@ -518,12 +546,10 @@ fn register_startup_backfill_pressure_defer(
 fn startup_backfill_pressure_defer_outcome(
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
-    reason: crate::db_pressure::DbPressureDenyReason,
 ) -> StartupBackfillTaskRunOutcome {
-    let next_due =
-        register_startup_backfill_pressure_defer(task, gate, reason).unwrap_or_else(|| {
-            Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
-        });
+    let next_due = register_startup_backfill_pressure_defer(task, gate).unwrap_or_else(|| {
+        Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
+    });
     STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task);
     StartupBackfillTaskRunOutcome {
         actionable: false,
@@ -1128,8 +1154,8 @@ async fn wake_startup_backfill_tasks_with_pricing_catalog_and_gate(
         // closure after successful admission does not retroactively interrupt the admitted work.
         let _permit = match gate.try_begin_background("startup_backfill_input_wake") {
             Ok(permit) => permit,
-            Err(reason) => {
-                register_startup_backfill_pressure_defer(*task, gate, reason);
+            Err(_) => {
+                register_startup_backfill_pressure_defer(*task, gate);
                 continue;
             }
         };
@@ -1347,8 +1373,8 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
     }
     let _permit = match gate.try_begin_background("startup_backfill_coverage_wake") {
         Ok(permit) => permit,
-        Err(reason) => {
-            register_startup_backfill_pressure_defer(task, gate, reason);
+        Err(_) => {
+            register_startup_backfill_pressure_defer(task, gate);
             return Ok(0);
         }
     };
@@ -1452,7 +1478,7 @@ where
     let pressure_defer = STARTUP_BACKFILL_SCHEDULER.pressure_deferred_entry(task);
     let _permit = match gate.try_begin_background("startup_backfill_account_activity_v2_coverage") {
         Ok(permit) => permit,
-        Err(reason) => return Ok(startup_backfill_pressure_defer_outcome(task, gate, reason)),
+        Err(_) => return Ok(startup_backfill_pressure_defer_outcome(task, gate)),
     };
     STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred_if_matches(task, pressure_defer);
 
@@ -1843,16 +1869,22 @@ async fn run_startup_backfill_task_if_due_outcome(
     let pressure_defer = STARTUP_BACKFILL_SCHEDULER.pressure_deferred_entry(task);
     let _permit = match gate.try_begin_background("startup_backfill") {
         Ok(permit) => permit,
-        Err(reason) => return Ok(startup_backfill_pressure_defer_outcome(task, gate, reason)),
+        Err(_) => return Ok(startup_backfill_pressure_defer_outcome(task, gate)),
     };
     STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred_if_matches(task, pressure_defer);
 
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
-    let progress = load_startup_backfill_progress(&state.pool, &task_name)
-        .await
-        .inspect_err(|err| {
-            record_startup_backfill_pressure_error(gate, err);
-        })?;
+    let progress = match load_startup_backfill_progress(&state.pool, &task_name).await {
+        Ok(progress) => progress,
+        Err(err) => {
+            if let Some(outcome) =
+                startup_backfill_pressure_error_defer_outcome_if_recorded(task, gate, &err)
+            {
+                return Ok(outcome);
+            }
+            return Err(err);
+        }
+    };
     let now = Utc::now();
     if !progress.is_due(now) {
         debug!(
@@ -1875,11 +1907,16 @@ async fn run_startup_backfill_task_if_due_outcome(
         });
     }
 
-    mark_startup_backfill_running(&state.pool, &task_name, progress.cursor_id)
-        .await
-        .inspect_err(|err| {
-            record_startup_backfill_pressure_error(gate, err);
-        })?;
+    if let Err(err) =
+        mark_startup_backfill_running(&state.pool, &task_name, progress.cursor_id).await
+    {
+        if let Some(outcome) =
+            startup_backfill_pressure_error_defer_outcome_if_recorded(task, gate, &err)
+        {
+            return Ok(outcome);
+        }
+        return Err(err);
+    }
 
     let started_at = Instant::now();
     let outcome = match run_startup_backfill_task(
@@ -1903,7 +1940,7 @@ async fn run_startup_backfill_task_if_due_outcome(
                 run.next_cursor_id.max(progress.cursor_id)
             };
             let next_run_after = startup_backfill_next_run_after(&run, zero_update_streak);
-            save_startup_backfill_progress(
+            if let Err(err) = save_startup_backfill_progress(
                 &state.pool,
                 &task_name,
                 StartupBackfillProgressUpdate {
@@ -1921,9 +1958,14 @@ async fn run_startup_backfill_task_if_due_outcome(
                 },
             )
             .await
-            .inspect_err(|err| {
-                record_startup_backfill_pressure_error(gate, err);
-            })?;
+            {
+                if let Some(outcome) =
+                    startup_backfill_pressure_error_defer_outcome_if_recorded(task, gate, &err)
+                {
+                    return Ok(outcome);
+                }
+                return Err(err);
+            }
             info!(
                 task = task.log_label(),
                 task_name = %task_name,
@@ -1959,6 +2001,11 @@ async fn run_startup_backfill_task_if_due_outcome(
             }
         }
         Err(err) => {
+            if let Some(outcome) =
+                startup_backfill_pressure_error_defer_outcome_if_recorded(task, gate, &err)
+            {
+                return Ok(outcome);
+            }
             let next_due = match persist_startup_backfill_task_failure(
                 state, task, &task_name, &progress, started_at, &err,
             )
@@ -1966,15 +2013,16 @@ async fn run_startup_backfill_task_if_due_outcome(
             {
                 Ok(next_due) => next_due,
                 Err(persist_err) => {
-                    if !record_startup_backfill_pressure_error(gate, &persist_err) {
-                        record_startup_backfill_pressure_error(gate, &err);
+                    if let Some(outcome) = startup_backfill_pressure_error_defer_outcome_if_recorded(
+                        task,
+                        gate,
+                        &persist_err,
+                    ) {
+                        return Ok(outcome);
                     }
                     return Err(persist_err);
                 }
             };
-            // Keep the permit until the failure state is durable and any relevant cooldown is
-            // visible. Releasing it first would let another background task enter SQLite.
-            record_startup_backfill_pressure_error(gate, &err);
             StartupBackfillTaskRunOutcome {
                 actionable: false,
                 failed: true,
@@ -2739,6 +2787,37 @@ mod startup_backfill_tests {
             vec![task],
             "a gate denial after selection must leave one recoverable eligibility wake"
         );
+    }
+
+    #[test]
+    fn background_busy_defer_clears_stale_wakes_and_requeues_after_a_prior_release() {
+        let scheduler = StartupBackfillScheduler::default();
+        let stale_task = StartupBackfillTask::ReasoningEffort;
+        let released_task = StartupBackfillTask::PoolAttemptPublicIdArchives;
+        let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+
+        scheduler.wake(stale_task);
+        assert!(scheduler.defer_for_pressure(stale_task, None, gate.pressure_generation()));
+        assert!(scheduler.drain_woken_tasks().is_empty());
+        assert_eq!(scheduler.next_due(), None);
+
+        let held = gate
+            .try_begin_background("test_busy_release_before_defer")
+            .expect("occupy the only background slot");
+        assert!(matches!(
+            gate.try_begin_background("test_busy_defer"),
+            Err(crate::db_pressure::DbPressureDenyReason::BackgroundBusy)
+        ));
+        drop(held);
+
+        assert!(
+            scheduler
+                .defer_for_current_gate(released_task, &gate)
+                .is_none(),
+            "an already-open gate must schedule the task instead of retaining a busy defer"
+        );
+        assert_eq!(scheduler.drain_woken_tasks(), vec![released_task]);
+        assert_eq!(scheduler.drain_due_tasks(Utc::now()), vec![released_task]);
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -170,6 +170,28 @@ impl StartupBackfillScheduler {
         }
     }
 
+    fn clear_pressure_eligibility_deadline(
+        &self,
+        task: StartupBackfillTask,
+        pressure_generation: u64,
+    ) {
+        // A stale busy defer must not erase a cooldown deadline installed by a newer pressure
+        // generation after this task released the scheduler state lock.
+        let _cleared = self.pressure_deferred_tasks.lock().ok().and_then(|tasks| {
+            tasks
+                .get(&task)
+                .filter(|entry| {
+                    entry.pressure_generation == pressure_generation
+                        && entry.next_eligibility.is_none()
+                })
+                .and_then(|_| {
+                    self.next_due.lock().ok().map(|mut next_due| {
+                        next_due.remove(&task);
+                    })
+                })
+        });
+    }
+
     fn defer_for_pressure(
         &self,
         task: StartupBackfillTask,
@@ -202,7 +224,7 @@ impl StartupBackfillScheduler {
                     next_eligibility,
                 );
             } else {
-                self.clear_next_due(task);
+                self.clear_pressure_eligibility_deadline(task, pressure_generation);
             }
             if let Ok(mut tasks) = self.woken_tasks.lock() {
                 tasks.remove(&task);
@@ -2761,6 +2783,24 @@ mod startup_backfill_tests {
         assert_eq!(deferred.pressure_defer_count, 1);
         assert_eq!(deferred.scheduled_task_count, 0);
         assert_eq!(deferred.deferred_task_count, 1);
+    }
+
+    #[test]
+    fn stale_busy_defer_cannot_clear_a_newer_pressure_deadline() {
+        let scheduler = StartupBackfillScheduler::default();
+        let task = StartupBackfillTask::ReasoningEffort;
+        let deadline = DateTime::<Utc>::from_timestamp_millis(1_800_000_000_750)
+            .expect("valid fixed pressure deadline");
+
+        assert!(scheduler.defer_for_pressure(task, None, 41));
+        assert!(scheduler.defer_for_pressure(task, Some(deadline), 42));
+
+        scheduler.clear_pressure_eligibility_deadline(task, 41);
+        assert_eq!(
+            scheduler.next_due(),
+            Some(deadline),
+            "a stale busy defer must not remove a newer pressure generation deadline"
+        );
     }
 
     #[tokio::test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -36,7 +36,7 @@ struct StartupBackfillScheduler {
     woken_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
     next_due: std::sync::Mutex<HashMap<StartupBackfillTask, DateTime<Utc>>>,
     deferred_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
-    pressure_deferred_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
+    pressure_deferred_tasks: std::sync::Mutex<HashMap<StartupBackfillTask, u64>>,
     failed_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
     wake_count: AtomicU64,
     due_dispatch_count: AtomicU64,
@@ -63,6 +63,9 @@ pub(crate) struct StartupBackfillHealthSnapshot {
 
 impl StartupBackfillScheduler {
     fn wake(&self, task: StartupBackfillTask) {
+        if self.is_pressure_deferred(task) {
+            return;
+        }
         if let Ok(mut tasks) = self.woken_tasks.lock() {
             tasks.insert(task);
         }
@@ -118,32 +121,63 @@ impl StartupBackfillScheduler {
         }
     }
 
-    fn mark_pressure_deferred(&self, task: StartupBackfillTask) {
+    fn defer_for_pressure(
+        &self,
+        task: StartupBackfillTask,
+        retry_at: DateTime<Utc>,
+        pressure_generation: u64,
+    ) -> bool {
+        let newly_registered = self
+            .pressure_deferred_tasks
+            .lock()
+            .map(|mut tasks| match tasks.get(&task) {
+                Some(generation) if *generation == pressure_generation => false,
+                _ => {
+                    tasks.insert(task, pressure_generation);
+                    true
+                }
+            })
+            .unwrap_or(false);
+        if newly_registered {
+            self.record_next_due(task, retry_at);
+        }
+        newly_registered
+    }
+
+    fn is_pressure_deferred(&self, task: StartupBackfillTask) -> bool {
+        self.pressure_deferred_tasks
+            .lock()
+            .map(|tasks| tasks.contains_key(&task))
+            .unwrap_or(false)
+    }
+
+    fn clear_pressure_deferred(&self, task: StartupBackfillTask) {
         if let Ok(mut tasks) = self.pressure_deferred_tasks.lock() {
-            tasks.insert(task);
+            tasks.remove(&task);
         }
     }
 
-    fn defer_for_pressure(&self, task: StartupBackfillTask, retry_at: DateTime<Utc>) {
-        self.mark_pressure_deferred(task);
-        self.record_next_due(task, retry_at);
-    }
-
-    fn take_pressure_deferred_tasks(&self) -> Vec<StartupBackfillTask> {
+    fn take_pressure_deferred_tasks_if_eligible(
+        &self,
+        gate: &crate::db_pressure::DbPressureGate,
+    ) -> Vec<StartupBackfillTask> {
+        if gate.background_deny_reason().is_some() {
+            return Vec::new();
+        }
         let tasks = self
             .pressure_deferred_tasks
             .lock()
             .map(|mut tasks| std::mem::take(&mut *tasks))
             .unwrap_or_default();
         if let Ok(mut next_due) = self.next_due.lock() {
-            for task in &tasks {
+            for task in tasks.keys() {
                 next_due.remove(task);
             }
         }
         StartupBackfillTask::ordered_tasks()
             .iter()
             .copied()
-            .filter(|task| tasks.contains(task))
+            .filter(|task| tasks.contains_key(task))
             .collect()
     }
 
@@ -361,22 +395,34 @@ fn startup_backfill_pressure_retry_at(
     }
 }
 
+fn register_startup_backfill_pressure_defer(
+    task: StartupBackfillTask,
+    gate: &crate::db_pressure::DbPressureGate,
+    reason: crate::db_pressure::DbPressureDenyReason,
+) -> DateTime<Utc> {
+    let retry_at = startup_backfill_pressure_retry_at(gate, reason);
+    let newly_registered =
+        STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, retry_at, gate.pressure_generation());
+    if newly_registered {
+        info!(
+            task = task.log_label(),
+            reason = %reason,
+            defer_kind = "pressure_gate",
+            defer_reason = %reason,
+            next_eligibility = %retry_at,
+            wake_reason = "pressure_defer",
+            "startup backfill task deferred before SQLite access because database pressure gate is closed"
+        );
+    }
+    retry_at
+}
+
 fn startup_backfill_pressure_defer_outcome(
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
     reason: crate::db_pressure::DbPressureDenyReason,
 ) -> StartupBackfillTaskRunOutcome {
-    let retry_at = startup_backfill_pressure_retry_at(gate, reason);
-    STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, retry_at);
-    info!(
-        task = task.log_label(),
-        reason = %reason,
-        defer_kind = "pressure_gate",
-        defer_reason = %reason,
-        next_eligibility = %retry_at,
-        wake_reason = "pressure_defer",
-        "startup backfill task deferred before SQLite access because database pressure gate is closed"
-    );
+    let retry_at = register_startup_backfill_pressure_defer(task, gate, reason);
     StartupBackfillTaskRunOutcome {
         actionable: false,
         failed: false,
@@ -400,15 +446,18 @@ fn startup_backfill_pressure_error_defer_outcome(
         .unwrap_or_else(|| {
             Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
         });
-    STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, retry_at);
-    info!(
-        task = task.log_label(),
-        defer_kind = "sqlite_pressure_error",
-        defer_reason = "sqlite_busy_or_locked",
-        next_eligibility = %retry_at,
-        wake_reason = "pressure_error_defer",
-        "startup backfill task deferred after a SQLite pressure error"
-    );
+    let newly_registered =
+        STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, retry_at, gate.pressure_generation());
+    if newly_registered {
+        info!(
+            task = task.log_label(),
+            defer_kind = "sqlite_pressure_error",
+            defer_reason = "sqlite_busy_or_locked",
+            next_eligibility = %retry_at,
+            wake_reason = "pressure_error_defer",
+            "startup backfill task deferred after a SQLite pressure error"
+        );
+    }
     StartupBackfillTaskRunOutcome {
         actionable: false,
         failed: false,
@@ -937,6 +986,16 @@ pub(crate) async fn wake_startup_backfill_tasks_with_pricing_catalog(
     let mut woken = 0;
     let mut proxy_cost_catalog_missing = false;
     for task in tasks {
+        let gate = crate::db_pressure::global_db_pressure_gate();
+        if let Some(reason) = gate.background_deny_reason() {
+            register_startup_backfill_pressure_defer(*task, gate, reason);
+            continue;
+        }
+        // A pressure defer is an in-memory scheduler decision. Do not turn an input event in
+        // the same cooldown into a progress write that clears its pending eligibility deadline.
+        if STARTUP_BACKFILL_SCHEDULER.is_pressure_deferred(*task) {
+            continue;
+        }
         let task_name = match task {
             StartupBackfillTask::ProxyCost => {
                 let Some(catalog) = pricing_catalog else {
@@ -986,7 +1045,7 @@ pub(crate) async fn wake_startup_backfill_tasks_with_pricing_catalog(
         woken += outcome.rows_affected();
         STARTUP_BACKFILL_SCHEDULER.wake(*task);
     }
-    if !tasks.is_empty() {
+    if woken > 0 {
         info!(
             wake_reason,
             woken,
@@ -1142,6 +1201,14 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
     wake_reason: &'static str,
 ) -> Result<u64> {
     let task = StartupBackfillTask::AccountActivityV2Coverage;
+    let gate = crate::db_pressure::global_db_pressure_gate();
+    if let Some(reason) = gate.background_deny_reason() {
+        register_startup_backfill_pressure_defer(task, gate, reason);
+        return Ok(0);
+    }
+    if STARTUP_BACKFILL_SCHEDULER.is_pressure_deferred(task) {
+        return Ok(0);
+    }
     let task_name = task.name();
     let progress = load_startup_backfill_progress(pool, task_name).await?;
     let deadline_preserved = !progress.is_due(Utc::now())
@@ -1240,6 +1307,7 @@ where
         Ok(permit) => permit,
         Err(reason) => return Ok(startup_backfill_pressure_defer_outcome(task, gate, reason)),
     };
+    STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred(task);
 
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
     let progress = match load_startup_backfill_progress(&state.pool, &task_name).await {
@@ -1627,6 +1695,7 @@ async fn run_startup_backfill_task_if_due_outcome(
         Ok(permit) => permit,
         Err(reason) => return Ok(startup_backfill_pressure_defer_outcome(task, gate, reason)),
     };
+    STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred(task);
 
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
     let progress = load_startup_backfill_progress(&state.pool, &task_name)
@@ -2265,7 +2334,7 @@ pub(crate) async fn run_pressure_eligible_startup_backfill_tasks(
     if cancel.is_cancelled() {
         return;
     }
-    let tasks = STARTUP_BACKFILL_SCHEDULER.take_pressure_deferred_tasks();
+    let tasks = STARTUP_BACKFILL_SCHEDULER.take_pressure_deferred_tasks_if_eligible(gate);
     if tasks.is_empty() {
         return;
     }
@@ -2410,13 +2479,22 @@ mod startup_backfill_tests {
     }
 
     #[test]
-    fn pressure_defer_schedules_one_deadline_and_dispatches_once() {
+    fn pressure_defer_deduplicates_the_same_generation_deadline_and_wake() {
         let scheduler = StartupBackfillScheduler::default();
         let task = StartupBackfillTask::ReasoningEffort;
         let deadline = DateTime::<Utc>::from_timestamp_millis(1_800_000_000_750)
             .expect("valid fixed pressure deadline");
 
-        scheduler.defer_for_pressure(task, deadline);
+        assert!(scheduler.defer_for_pressure(task, deadline, 41));
+        assert!(
+            !scheduler.defer_for_pressure(task, deadline + ChronoDuration::minutes(1), 41),
+            "the same pressure generation must preserve its first eligibility deadline"
+        );
+        scheduler.wake(task);
+        assert!(
+            scheduler.drain_woken_tasks().is_empty(),
+            "an input wake during the pending cooldown must not redispatch the task"
+        );
         assert!(
             scheduler
                 .drain_due_tasks(deadline - ChronoDuration::milliseconds(1))
@@ -2440,20 +2518,18 @@ mod startup_backfill_tests {
     }
 
     #[tokio::test]
-    async fn pressure_eligibility_change_dispatches_a_deferred_task_before_its_deadline() {
-        let scheduler = Arc::new(StartupBackfillScheduler::default());
+    async fn pressure_eligibility_notification_keeps_a_closed_cooldown_deferred() {
+        let scheduler = StartupBackfillScheduler::default();
         let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
             1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         ));
-        let permit = gate
-            .try_begin_background("test-holder")
-            .expect("occupy the sole background slot");
+        gate.record_pressure("test", "forced");
         let observed_eligibility = gate.eligibility_generation();
         let task = StartupBackfillTask::ReasoningEffort;
         let deadline = Utc::now() + ChronoDuration::minutes(5);
 
-        scheduler.defer_for_pressure(task, deadline);
+        assert!(scheduler.defer_for_pressure(task, deadline, gate.pressure_generation()));
         scheduler.record_task_result(task, false, true);
 
         assert!(
@@ -2461,29 +2537,20 @@ mod startup_backfill_tests {
             "the in-memory fallback deadline must not be due yet"
         );
 
-        let wake_gate = gate.clone();
-        let wake_scheduler = scheduler.clone();
-        let wake = tokio::spawn(async move {
-            wake_gate
-                .wait_for_eligibility_change(observed_eligibility)
-                .await;
-            wake_scheduler.take_pressure_deferred_tasks()
-        });
-        tokio::task::yield_now().await;
+        gate.notify_background_eligibility();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            gate.wait_for_eligibility_change(observed_eligibility),
+        )
+        .await
+        .expect("explicit eligibility notification must be observed");
         assert!(
-            !wake.is_finished(),
-            "the task must wait for an eligibility-clear event before its fallback deadline"
+            scheduler
+                .take_pressure_deferred_tasks_if_eligible(&gate)
+                .is_empty(),
+            "an eligibility notification must not consume a task while the cooldown remains closed"
         );
-
-        drop(permit);
-        assert_eq!(
-            tokio::time::timeout(Duration::from_secs(1), wake)
-                .await
-                .expect("permit release must wake the deferred task before its deadline")
-                .expect("eligibility waiter must not panic"),
-            vec![task]
-        );
-        assert_eq!(scheduler.next_due(), None);
+        assert_eq!(scheduler.next_due(), Some(deadline));
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -149,12 +149,13 @@ impl StartupBackfillScheduler {
                             && entry.next_eligibility == Some(due)
                     })
                     .and_then(|_| {
-                        self.next_due.lock().ok().map(|mut next_due| {
-                            next_due.insert(task, due);
-                        })
+                        self.next_due
+                            .lock()
+                            .ok()
+                            .map(|mut next_due| next_due.insert(task, due) != Some(due))
                     })
             })
-            .is_some();
+            .unwrap_or(false);
         if !recorded {
             return;
         }
@@ -2830,6 +2831,45 @@ mod startup_backfill_tests {
         assert_eq!(deferred.pressure_defer_count, 1);
         assert_eq!(deferred.scheduled_task_count, 0);
         assert_eq!(deferred.deferred_task_count, 1);
+    }
+
+    #[test]
+    fn pressure_generation_rearm_does_not_repeat_an_existing_deadline_wake() {
+        let scheduler = StartupBackfillScheduler::default();
+        let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+        let task = StartupBackfillTask::ReasoningEffort;
+
+        gate.record_pressure("test", "forced");
+        let deadline = gate
+            .pressure_cooldown_deadline_epoch_ms()
+            .and_then(|deadline_ms| {
+                i64::try_from(deadline_ms)
+                    .ok()
+                    .and_then(DateTime::<Utc>::from_timestamp_millis)
+            })
+            .expect("pressure cooldown has an absolute eligibility deadline");
+
+        // Model a defer that observed the newly published cooldown just before its generation
+        // incremented. Re-arming must retain the deadline under the new generation without a
+        // second scheduler notification for the same future wake.
+        assert!(scheduler.defer_for_pressure(task, Some(deadline), 0));
+        assert_eq!(scheduler.generation(), 1);
+
+        scheduler.arm_pressure_deferred_deadlines(&gate);
+
+        assert_eq!(
+            scheduler.generation(),
+            1,
+            "the same pressure deadline must not produce a duplicate supervisor wake"
+        );
+        assert_eq!(scheduler.next_due(), Some(deadline));
+        assert_eq!(
+            scheduler
+                .pressure_deferred_entry(task)
+                .expect("the deferred task should remain registered")
+                .pressure_generation,
+            gate.pressure_generation()
+        );
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -36,13 +36,19 @@ struct StartupBackfillScheduler {
     woken_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
     next_due: std::sync::Mutex<HashMap<StartupBackfillTask, DateTime<Utc>>>,
     deferred_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
-    pressure_deferred_tasks: std::sync::Mutex<HashMap<StartupBackfillTask, u64>>,
+    pressure_deferred_tasks: std::sync::Mutex<HashMap<StartupBackfillTask, PressureDeferredTask>>,
     failed_tasks: std::sync::Mutex<HashSet<StartupBackfillTask>>,
     wake_count: AtomicU64,
     due_dispatch_count: AtomicU64,
     noop_suppressed_count: AtomicU64,
     pressure_defer_count: AtomicU64,
     failure_count: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PressureDeferredTask {
+    pressure_generation: u64,
+    selected_for_eligibility: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -124,22 +130,28 @@ impl StartupBackfillScheduler {
     fn defer_for_pressure(
         &self,
         task: StartupBackfillTask,
-        retry_at: DateTime<Utc>,
+        next_eligibility: Option<DateTime<Utc>>,
         pressure_generation: u64,
     ) -> bool {
         let newly_registered = self
             .pressure_deferred_tasks
             .lock()
             .map(|mut tasks| match tasks.get(&task) {
-                Some(generation) if *generation == pressure_generation => false,
+                Some(entry) if entry.pressure_generation == pressure_generation => false,
                 _ => {
-                    tasks.insert(task, pressure_generation);
+                    tasks.insert(
+                        task,
+                        PressureDeferredTask {
+                            pressure_generation,
+                            selected_for_eligibility: false,
+                        },
+                    );
                     true
                 }
             })
             .unwrap_or(false);
-        if newly_registered {
-            self.record_next_due(task, retry_at);
+        if let Some(next_eligibility) = next_eligibility.filter(|_| newly_registered) {
+            self.record_next_due(task, next_eligibility);
         }
         newly_registered
     }
@@ -151,9 +163,34 @@ impl StartupBackfillScheduler {
             .unwrap_or(false)
     }
 
-    fn clear_pressure_deferred(&self, task: StartupBackfillTask) {
-        if let Ok(mut tasks) = self.pressure_deferred_tasks.lock() {
+    fn pressure_deferred_entry(&self, task: StartupBackfillTask) -> Option<PressureDeferredTask> {
+        self.pressure_deferred_tasks
+            .lock()
+            .ok()
+            .and_then(|tasks| tasks.get(&task).copied())
+    }
+
+    fn clear_pressure_deferred_if_matches(
+        &self,
+        task: StartupBackfillTask,
+        entry: Option<PressureDeferredTask>,
+    ) {
+        let Some(entry) = entry else {
+            return;
+        };
+        if let Ok(mut tasks) = self.pressure_deferred_tasks.lock()
+            && tasks.get(&task) == Some(&entry)
+        {
             tasks.remove(&task);
+        }
+    }
+
+    fn requeue_pressure_deferred(&self, task: StartupBackfillTask, pressure_generation: u64) {
+        if let Ok(mut tasks) = self.pressure_deferred_tasks.lock()
+            && let Some(entry) = tasks.get_mut(&task)
+            && entry.pressure_generation == pressure_generation
+        {
+            entry.selected_for_eligibility = false;
         }
     }
 
@@ -167,18 +204,29 @@ impl StartupBackfillScheduler {
         let tasks = self
             .pressure_deferred_tasks
             .lock()
-            .map(|mut tasks| std::mem::take(&mut *tasks))
+            .map(|mut tasks| {
+                StartupBackfillTask::ordered_tasks()
+                    .iter()
+                    .copied()
+                    .filter(|task| {
+                        let Some(entry) = tasks.get_mut(task) else {
+                            return false;
+                        };
+                        if entry.selected_for_eligibility {
+                            return false;
+                        }
+                        entry.selected_for_eligibility = true;
+                        true
+                    })
+                    .collect::<Vec<_>>()
+            })
             .unwrap_or_default();
         if let Ok(mut next_due) = self.next_due.lock() {
-            for task in tasks.keys() {
+            for task in &tasks {
                 next_due.remove(task);
             }
         }
-        StartupBackfillTask::ordered_tasks()
-            .iter()
-            .copied()
-            .filter(|task| tasks.contains_key(task))
-            .collect()
+        tasks
     }
 
     fn record_task_result(&self, task: StartupBackfillTask, failed: bool, deferred: bool) {
@@ -188,9 +236,6 @@ impl StartupBackfillScheduler {
                 tasks.insert(task);
             }
             if let Ok(mut tasks) = self.deferred_tasks.lock() {
-                tasks.remove(&task);
-            }
-            if let Ok(mut tasks) = self.pressure_deferred_tasks.lock() {
                 tasks.remove(&task);
             }
             return;
@@ -216,9 +261,6 @@ impl StartupBackfillScheduler {
         }
 
         if let Ok(mut tasks) = self.deferred_tasks.lock() {
-            tasks.remove(&task);
-        }
-        if let Ok(mut tasks) = self.pressure_deferred_tasks.lock() {
             tasks.remove(&task);
         }
         if let Ok(mut tasks) = self.failed_tasks.lock() {
@@ -373,10 +415,10 @@ fn record_startup_backfill_pressure_error(
     false
 }
 
-fn startup_backfill_pressure_retry_at(
+fn startup_backfill_pressure_eligibility_deadline(
     gate: &crate::db_pressure::DbPressureGate,
     reason: crate::db_pressure::DbPressureDenyReason,
-) -> DateTime<Utc> {
+) -> Option<DateTime<Utc>> {
     match reason {
         crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms } => gate
             .pressure_cooldown_deadline_epoch_ms()
@@ -385,13 +427,13 @@ fn startup_backfill_pressure_retry_at(
                     .ok()
                     .and_then(DateTime::<Utc>::from_timestamp_millis)
             })
-            .unwrap_or_else(|| {
+            .or_else(|| {
                 let remaining_ms = i64::try_from(remaining_ms.max(1)).unwrap_or(i64::MAX);
-                Utc::now() + ChronoDuration::milliseconds(remaining_ms)
+                Some(Utc::now() + ChronoDuration::milliseconds(remaining_ms))
             }),
-        crate::db_pressure::DbPressureDenyReason::BackgroundBusy => {
-            Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
-        }
+        // Permit release emits an eligibility event. A synthetic timer would redispatch a task
+        // while the same slot remains occupied, so busy defers have no due-ticker fallback.
+        crate::db_pressure::DbPressureDenyReason::BackgroundBusy => None,
     }
 }
 
@@ -399,22 +441,25 @@ fn register_startup_backfill_pressure_defer(
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
     reason: crate::db_pressure::DbPressureDenyReason,
-) -> DateTime<Utc> {
-    let retry_at = startup_backfill_pressure_retry_at(gate, reason);
-    let newly_registered =
-        STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, retry_at, gate.pressure_generation());
+) -> Option<DateTime<Utc>> {
+    let next_eligibility = startup_backfill_pressure_eligibility_deadline(gate, reason);
+    let newly_registered = STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(
+        task,
+        next_eligibility,
+        gate.pressure_generation(),
+    );
     if newly_registered {
         info!(
             task = task.log_label(),
             reason = %reason,
             defer_kind = "pressure_gate",
             defer_reason = %reason,
-            next_eligibility = %retry_at,
+            next_eligibility = ?next_eligibility,
             wake_reason = "pressure_defer",
             "startup backfill task deferred before SQLite access because database pressure gate is closed"
         );
     }
-    retry_at
+    next_eligibility
 }
 
 fn startup_backfill_pressure_defer_outcome(
@@ -422,13 +467,17 @@ fn startup_backfill_pressure_defer_outcome(
     gate: &crate::db_pressure::DbPressureGate,
     reason: crate::db_pressure::DbPressureDenyReason,
 ) -> StartupBackfillTaskRunOutcome {
-    let retry_at = register_startup_backfill_pressure_defer(task, gate, reason);
+    let next_due =
+        register_startup_backfill_pressure_defer(task, gate, reason).unwrap_or_else(|| {
+            Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
+        });
+    STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task, gate.pressure_generation());
     StartupBackfillTaskRunOutcome {
         actionable: false,
         failed: false,
         deferred: true,
         completed: true,
-        next_due: retry_at,
+        next_due,
     }
 }
 
@@ -446,8 +495,12 @@ fn startup_backfill_pressure_error_defer_outcome(
         .unwrap_or_else(|| {
             Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
         });
-    let newly_registered =
-        STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, retry_at, gate.pressure_generation());
+    let newly_registered = STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(
+        task,
+        Some(retry_at),
+        gate.pressure_generation(),
+    );
+    STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task, gate.pressure_generation());
     if newly_registered {
         info!(
             task = task.log_label(),
@@ -983,10 +1036,36 @@ pub(crate) async fn wake_startup_backfill_tasks_with_pricing_catalog(
     pricing_catalog: Option<&PricingCatalog>,
     wake_reason: &'static str,
 ) -> Result<u64> {
+    wake_startup_backfill_tasks_with_pricing_catalog_and_gate(
+        pool,
+        tasks,
+        pricing_catalog,
+        wake_reason,
+        crate::db_pressure::global_db_pressure_gate(),
+    )
+    .await
+}
+
+pub(crate) async fn wake_startup_backfill_tasks_with_gate(
+    pool: &Pool<Sqlite>,
+    tasks: &[StartupBackfillTask],
+    wake_reason: &'static str,
+    gate: &crate::db_pressure::DbPressureGate,
+) -> Result<u64> {
+    wake_startup_backfill_tasks_with_pricing_catalog_and_gate(pool, tasks, None, wake_reason, gate)
+        .await
+}
+
+async fn wake_startup_backfill_tasks_with_pricing_catalog_and_gate(
+    pool: &Pool<Sqlite>,
+    tasks: &[StartupBackfillTask],
+    pricing_catalog: Option<&PricingCatalog>,
+    wake_reason: &'static str,
+    gate: &crate::db_pressure::DbPressureGate,
+) -> Result<u64> {
     let mut woken = 0;
     let mut proxy_cost_catalog_missing = false;
     for task in tasks {
-        let gate = crate::db_pressure::global_db_pressure_gate();
         if let Some(reason) = gate.background_deny_reason() {
             register_startup_backfill_pressure_defer(*task, gate, reason);
             continue;
@@ -1303,11 +1382,12 @@ where
     // Coverage repair owns this one permit. The hourly-rollup convenience wrapper also acquires
     // the global gate, so calling it while the startup path holds a permit would always defer in
     // production. Keep admission before progress access, then call the underlying repair once.
+    let pressure_defer = STARTUP_BACKFILL_SCHEDULER.pressure_deferred_entry(task);
     let _permit = match gate.try_begin_background("startup_backfill_account_activity_v2_coverage") {
         Ok(permit) => permit,
         Err(reason) => return Ok(startup_backfill_pressure_defer_outcome(task, gate, reason)),
     };
-    STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred(task);
+    STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred_if_matches(task, pressure_defer);
 
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
     let progress = match load_startup_backfill_progress(&state.pool, &task_name).await {
@@ -1549,7 +1629,9 @@ async fn run_startup_backfill_maintenance_pass_with_gate_inner(
         }
         match run_startup_backfill_task_if_due_outcome(&state, *task, gate).await {
             Ok(outcome) => {
-                STARTUP_BACKFILL_SCHEDULER.record_next_due(*task, outcome.next_due);
+                if !outcome.deferred {
+                    STARTUP_BACKFILL_SCHEDULER.record_next_due(*task, outcome.next_due);
+                }
                 ran_actionable_task |= outcome.actionable;
                 had_failure |= outcome.failed;
                 had_deferred_task |= outcome.deferred;
@@ -1691,11 +1773,12 @@ async fn run_startup_backfill_task_if_due_outcome(
 
     // This admission is deliberately before progress lookup: a pressure defer must remain a
     // scheduler-only decision, not turn into a SQLite read, progress write, or task-run audit.
+    let pressure_defer = STARTUP_BACKFILL_SCHEDULER.pressure_deferred_entry(task);
     let _permit = match gate.try_begin_background("startup_backfill") {
         Ok(permit) => permit,
         Err(reason) => return Ok(startup_backfill_pressure_defer_outcome(task, gate, reason)),
     };
-    STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred(task);
+    STARTUP_BACKFILL_SCHEDULER.clear_pressure_deferred_if_matches(task, pressure_defer);
 
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
     let progress = load_startup_backfill_progress(&state.pool, &task_name)
@@ -2470,10 +2553,11 @@ mod startup_backfill_tests {
             .pressure_cooldown_deadline_epoch_ms()
             .expect("active pressure cooldown deadline");
 
-        let retry_at = startup_backfill_pressure_retry_at(
+        let retry_at = startup_backfill_pressure_eligibility_deadline(
             &gate,
             crate::db_pressure::DbPressureDenyReason::PressureCooldown { remaining_ms: 1 },
-        );
+        )
+        .expect("pressure cooldown has a durable eligibility deadline");
 
         assert_eq!(retry_at.timestamp_millis() as u64, expected_deadline);
     }
@@ -2485,9 +2569,9 @@ mod startup_backfill_tests {
         let deadline = DateTime::<Utc>::from_timestamp_millis(1_800_000_000_750)
             .expect("valid fixed pressure deadline");
 
-        assert!(scheduler.defer_for_pressure(task, deadline, 41));
+        assert!(scheduler.defer_for_pressure(task, Some(deadline), 41));
         assert!(
-            !scheduler.defer_for_pressure(task, deadline + ChronoDuration::minutes(1), 41),
+            !scheduler.defer_for_pressure(task, Some(deadline + ChronoDuration::minutes(1)), 41),
             "the same pressure generation must preserve its first eligibility deadline"
         );
         scheduler.wake(task);
@@ -2529,7 +2613,7 @@ mod startup_backfill_tests {
         let task = StartupBackfillTask::ReasoningEffort;
         let deadline = Utc::now() + ChronoDuration::minutes(5);
 
-        assert!(scheduler.defer_for_pressure(task, deadline, gate.pressure_generation()));
+        assert!(scheduler.defer_for_pressure(task, Some(deadline), gate.pressure_generation()));
         scheduler.record_task_result(task, false, true);
 
         assert!(
@@ -2551,6 +2635,36 @@ mod startup_backfill_tests {
             "an eligibility notification must not consume a task while the cooldown remains closed"
         );
         assert_eq!(scheduler.next_due(), Some(deadline));
+    }
+
+    #[test]
+    fn background_busy_defer_waits_only_for_a_gate_eligibility_event() {
+        let scheduler = StartupBackfillScheduler::default();
+        let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+        let task = StartupBackfillTask::ReasoningEffort;
+
+        assert!(scheduler.defer_for_pressure(task, None, gate.pressure_generation()));
+        assert_eq!(scheduler.next_due(), None);
+
+        scheduler.record_task_result(task, false, false);
+        assert_eq!(
+            scheduler.take_pressure_deferred_tasks_if_eligible(&gate),
+            vec![task],
+            "an older successful pass must not discard a wake registered while it was running"
+        );
+        assert!(
+            scheduler
+                .take_pressure_deferred_tasks_if_eligible(&gate)
+                .is_empty(),
+            "repeated eligibility notifications must not select the same pending task twice"
+        );
+
+        scheduler.requeue_pressure_deferred(task, gate.pressure_generation());
+        assert_eq!(
+            scheduler.take_pressure_deferred_tasks_if_eligible(&gate),
+            vec![task],
+            "a gate denial after selection must leave one recoverable eligibility wake"
+        );
     }
 
     #[test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -198,10 +198,9 @@ impl StartupBackfillScheduler {
         }
     }
 
-    fn requeue_pressure_deferred(&self, task: StartupBackfillTask, pressure_generation: u64) {
+    fn requeue_pressure_deferred(&self, task: StartupBackfillTask) {
         if let Ok(mut tasks) = self.pressure_deferred_tasks.lock()
             && let Some(entry) = tasks.get_mut(&task)
-            && entry.pressure_generation == pressure_generation
         {
             entry.selected_for_eligibility = false;
         }
@@ -494,12 +493,14 @@ fn register_startup_backfill_pressure_defer(
     reason: crate::db_pressure::DbPressureDenyReason,
 ) -> Option<DateTime<Utc>> {
     let reason = gate.background_deny_reason().unwrap_or(reason);
+    let pressure_generation = gate.pressure_generation();
     let next_eligibility = startup_backfill_pressure_eligibility_deadline(gate, reason);
-    let newly_registered = STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(
-        task,
-        next_eligibility,
-        gate.pressure_generation(),
-    );
+    let newly_registered =
+        STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(task, next_eligibility, pressure_generation);
+    // The deny recheck and generation read cannot reserve the gate. Once the deferred entry is
+    // visible, absorb a concurrently-recorded cooldown before its notification can be consumed
+    // by the supervisor without this task present.
+    STARTUP_BACKFILL_SCHEDULER.arm_pressure_deferred_deadlines(gate);
     if newly_registered {
         info!(
             task = task.log_label(),
@@ -523,7 +524,7 @@ fn startup_backfill_pressure_defer_outcome(
         register_startup_backfill_pressure_defer(task, gate, reason).unwrap_or_else(|| {
             Utc::now() + ChronoDuration::seconds(BACKGROUND_DB_PRESSURE_RETRY_INTERVAL_SECS as i64)
         });
-    STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task, gate.pressure_generation());
+    STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task);
     StartupBackfillTaskRunOutcome {
         actionable: false,
         failed: false,
@@ -552,7 +553,7 @@ fn startup_backfill_pressure_error_defer_outcome(
         Some(retry_at),
         gate.pressure_generation(),
     );
-    STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task, gate.pressure_generation());
+    STARTUP_BACKFILL_SCHEDULER.requeue_pressure_deferred(task);
     if newly_registered {
         info!(
             task = task.log_label(),
@@ -1118,12 +1119,20 @@ async fn wake_startup_backfill_tasks_with_pricing_catalog_and_gate(
     let mut woken = 0;
     let mut proxy_cost_catalog_missing = false;
     for task in tasks {
-        if let Some(reason) = gate.background_deny_reason() {
-            register_startup_backfill_pressure_defer(*task, gate, reason);
-            continue;
-        }
         // A pressure defer is an in-memory scheduler decision. Do not turn an input event in
         // the same cooldown into a progress write that clears its pending eligibility deadline.
+        if STARTUP_BACKFILL_SCHEDULER.is_pressure_deferred(*task) {
+            continue;
+        }
+        // Hold admission across the wake write. A deny remains entirely in memory, and a gate
+        // closure after successful admission does not retroactively interrupt the admitted work.
+        let _permit = match gate.try_begin_background("startup_backfill_input_wake") {
+            Ok(permit) => permit,
+            Err(reason) => {
+                register_startup_backfill_pressure_defer(*task, gate, reason);
+                continue;
+            }
+        };
         if STARTUP_BACKFILL_SCHEDULER.is_pressure_deferred(*task) {
             continue;
         }
@@ -1333,10 +1342,16 @@ pub(crate) async fn wake_startup_backfill_coverage_repair(
 ) -> Result<u64> {
     let task = StartupBackfillTask::AccountActivityV2Coverage;
     let gate = crate::db_pressure::global_db_pressure_gate();
-    if let Some(reason) = gate.background_deny_reason() {
-        register_startup_backfill_pressure_defer(task, gate, reason);
+    if STARTUP_BACKFILL_SCHEDULER.is_pressure_deferred(task) {
         return Ok(0);
     }
+    let _permit = match gate.try_begin_background("startup_backfill_coverage_wake") {
+        Ok(permit) => permit,
+        Err(reason) => {
+            register_startup_backfill_pressure_defer(task, gate, reason);
+            return Ok(0);
+        }
+    };
     if STARTUP_BACKFILL_SCHEDULER.is_pressure_deferred(task) {
         return Ok(0);
     }
@@ -2512,6 +2527,9 @@ pub(crate) fn spawn_startup_backfill_maintenance(
             // consumes its deferred task instead of treating that generation as the baseline.
             run_pressure_eligible_startup_backfill_tasks(state.clone(), &cancel, gate).await;
             let observed_pressure_eligibility = gate.eligibility_generation();
+            // Close the release-between-probe-and-snapshot race. A release before this pass is
+            // consumed here; a release after it changes the generation used by the waiter below.
+            run_pressure_eligible_startup_backfill_tasks(state.clone(), &cancel, gate).await;
             let next_due = STARTUP_BACKFILL_SCHEDULER.next_due();
             let mut wait_for = startup_backfill_wait_duration(next_due);
             if let Some(retry_at) = startup_prep_retry_at {
@@ -2715,7 +2733,7 @@ mod startup_backfill_tests {
             "repeated eligibility notifications must not select the same pending task twice"
         );
 
-        scheduler.requeue_pressure_deferred(task, gate.pressure_generation());
+        scheduler.requeue_pressure_deferred(task);
         assert_eq!(
             scheduler.take_pressure_deferred_tasks_if_eligible(&gate),
             vec![task],

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -48,6 +48,7 @@ struct StartupBackfillScheduler {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PressureDeferredTask {
     pressure_generation: u64,
+    next_eligibility: Option<DateTime<Utc>>,
     selected_for_eligibility: bool,
 }
 
@@ -116,9 +117,20 @@ impl StartupBackfillScheduler {
     }
 
     fn record_next_due(&self, task: StartupBackfillTask, due: DateTime<Utc>) {
+        if self.is_pressure_deferred(task) {
+            return;
+        }
+        self.record_next_due_unchecked(task, due);
+    }
+
+    fn record_next_due_unchecked(&self, task: StartupBackfillTask, due: DateTime<Utc>) {
         if let Ok(mut next_due) = self.next_due.lock() {
             next_due.insert(task, due);
         }
+    }
+
+    fn record_pressure_eligibility_deadline(&self, task: StartupBackfillTask, due: DateTime<Utc>) {
+        self.record_next_due_unchecked(task, due);
     }
 
     fn clear_next_due(&self, task: StartupBackfillTask) {
@@ -143,6 +155,7 @@ impl StartupBackfillScheduler {
                         task,
                         PressureDeferredTask {
                             pressure_generation,
+                            next_eligibility,
                             selected_for_eligibility: false,
                         },
                     );
@@ -151,7 +164,7 @@ impl StartupBackfillScheduler {
             })
             .unwrap_or(false);
         if let Some(next_eligibility) = next_eligibility.filter(|_| newly_registered) {
-            self.record_next_due(task, next_eligibility);
+            self.record_pressure_eligibility_deadline(task, next_eligibility);
         }
         newly_registered
     }
@@ -194,11 +207,49 @@ impl StartupBackfillScheduler {
         }
     }
 
+    fn arm_pressure_deferred_deadlines(&self, gate: &crate::db_pressure::DbPressureGate) {
+        let Some(next_eligibility) =
+            gate.pressure_cooldown_deadline_epoch_ms()
+                .and_then(|deadline_ms| {
+                    i64::try_from(deadline_ms)
+                        .ok()
+                        .and_then(DateTime::<Utc>::from_timestamp_millis)
+                })
+        else {
+            return;
+        };
+        let pressure_generation = gate.pressure_generation();
+        let tasks = self
+            .pressure_deferred_tasks
+            .lock()
+            .map(|mut tasks| {
+                tasks
+                    .iter_mut()
+                    .filter_map(|(task, entry)| {
+                        let needs_deadline = entry.pressure_generation != pressure_generation
+                            || entry.next_eligibility != Some(next_eligibility);
+                        if !needs_deadline {
+                            return None;
+                        }
+                        entry.pressure_generation = pressure_generation;
+                        entry.next_eligibility = Some(next_eligibility);
+                        entry.selected_for_eligibility = false;
+                        Some(*task)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for task in tasks {
+            self.record_pressure_eligibility_deadline(task, next_eligibility);
+        }
+    }
+
     fn take_pressure_deferred_tasks_if_eligible(
         &self,
         gate: &crate::db_pressure::DbPressureGate,
     ) -> Vec<StartupBackfillTask> {
         if gate.background_deny_reason().is_some() {
+            self.arm_pressure_deferred_deadlines(gate);
             return Vec::new();
         }
         let tasks = self
@@ -442,6 +493,7 @@ fn register_startup_backfill_pressure_defer(
     gate: &crate::db_pressure::DbPressureGate,
     reason: crate::db_pressure::DbPressureDenyReason,
 ) -> Option<DateTime<Utc>> {
+    let reason = gate.background_deny_reason().unwrap_or(reason);
     let next_eligibility = startup_backfill_pressure_eligibility_deadline(gate, reason);
     let newly_registered = STARTUP_BACKFILL_SCHEDULER.defer_for_pressure(
         task,
@@ -2455,6 +2507,10 @@ pub(crate) fn spawn_startup_backfill_maintenance(
 
         loop {
             let gate = crate::db_pressure::global_db_pressure_gate();
+            // Re-check before registering the next notification waiter. A permit release that
+            // raced with the previous pass has already advanced the gate generation, so this
+            // consumes its deferred task instead of treating that generation as the baseline.
+            run_pressure_eligible_startup_backfill_tasks(state.clone(), &cancel, gate).await;
             let observed_pressure_eligibility = gate.eligibility_generation();
             let next_due = STARTUP_BACKFILL_SCHEDULER.next_due();
             let mut wait_for = startup_backfill_wait_duration(next_due);
@@ -2664,6 +2720,38 @@ mod startup_backfill_tests {
             scheduler.take_pressure_deferred_tasks_if_eligible(&gate),
             vec![task],
             "a gate denial after selection must leave one recoverable eligibility wake"
+        );
+    }
+
+    #[test]
+    fn pressure_cooldown_upgrades_busy_defer_and_preserves_eligibility_deadline() {
+        let scheduler = StartupBackfillScheduler::default();
+        let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+        let task = StartupBackfillTask::ReasoningEffort;
+
+        assert!(scheduler.defer_for_pressure(task, None, gate.pressure_generation()));
+        gate.record_pressure("test", "forced");
+        assert!(
+            scheduler
+                .take_pressure_deferred_tasks_if_eligible(&gate)
+                .is_empty(),
+            "a newly closed cooldown must keep the deferred task out of SQLite"
+        );
+        let expected_deadline = gate
+            .pressure_cooldown_deadline_epoch_ms()
+            .and_then(|deadline_ms| {
+                i64::try_from(deadline_ms)
+                    .ok()
+                    .and_then(DateTime::<Utc>::from_timestamp_millis)
+            })
+            .expect("pressure cooldown has an absolute eligibility deadline");
+        assert_eq!(scheduler.next_due(), Some(expected_deadline));
+
+        scheduler.record_next_due(task, Utc::now());
+        assert_eq!(
+            scheduler.next_due(),
+            Some(expected_deadline),
+            "an older successful task result must not overwrite a pending pressure deadline"
         );
     }
 

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -319,7 +319,7 @@ impl StartupBackfillScheduler {
                     .iter_mut()
                     .filter_map(|(task, entry)| {
                         let needs_deadline = entry.pressure_generation != pressure_generation
-                            || entry.next_eligibility != Some(next_eligibility);
+                            || entry.next_eligibility.is_none();
                         if !needs_deadline {
                             return None;
                         }

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2394,6 +2394,62 @@ async fn startup_backfill_input_wake_busy_admission_avoids_sqlite() {
 }
 
 #[tokio::test]
+async fn startup_backfill_input_wake_sqlite_busy_closes_gate_and_defers() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::FailureClassification;
+    let task_name = task.name();
+    let trigger = format!(
+        r#"
+        CREATE TRIGGER startup_backfill_input_wake_busy
+        BEFORE INSERT ON startup_backfill_progress
+        WHEN NEW.task_name = '{task_name}'
+        BEGIN
+            SELECT RAISE(ABORT, 'database table is locked');
+        END
+        "#
+    );
+    sqlx::query(&trigger)
+        .execute(&state.pool)
+        .await
+        .expect("inject a SQLite lock into the input wake progress write");
+
+    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+    let task_runs_before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs before the input wake lock");
+
+    assert_eq!(
+        wake_startup_backfill_tasks_with_gate(
+            &state.pool,
+            &[task],
+            "input_wake_sqlite_busy",
+            &gate,
+        )
+        .await
+        .expect("a SQLite lock in the wake write should defer without surfacing an error"),
+        0
+    );
+    assert_eq!(gate.snapshot().pressure_events, 1);
+    assert!(
+        gate.pressure_cooldown_deadline_epoch_ms().is_some(),
+        "the lock must close the gate while the wake admission is still held"
+    );
+    let task_runs_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs after the input wake lock");
+    assert_eq!(task_runs_after, task_runs_before);
+}
+
+#[tokio::test]
 async fn pressure_eligibility_wake_rechecks_durable_backfill_deadline() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
@@ -3333,6 +3389,58 @@ async fn startup_coverage_gate_denial_skips_sqlite_progress_and_task_run_audit()
         .send(())
         .expect("holder should be waiting for release");
     holder.await.expect("holder should not panic");
+}
+
+#[tokio::test]
+async fn startup_coverage_wake_sqlite_busy_closes_gate_and_defers() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    sqlx::query(
+        r#"
+        CREATE TRIGGER startup_coverage_wake_busy
+        BEFORE INSERT ON startup_backfill_progress
+        WHEN NEW.task_name = 'account_activity_v2_coverage_repair_v1'
+        BEGIN
+            SELECT RAISE(ABORT, 'database table is locked');
+        END
+        "#,
+    )
+    .execute(&state.pool)
+    .await
+    .expect("inject a SQLite lock into the coverage wake progress write");
+
+    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+    let task_runs_before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs before the coverage wake lock");
+
+    assert_eq!(
+        crate::wake_startup_backfill_coverage_repair_with_gate(
+            &state.pool,
+            "coverage_wake_sqlite_busy",
+            &gate,
+        )
+        .await
+        .expect("a SQLite lock in the coverage wake should defer without surfacing an error"),
+        0
+    );
+    assert_eq!(gate.snapshot().pressure_events, 1);
+    assert!(
+        gate.pressure_cooldown_deadline_epoch_ms().is_some(),
+        "the lock must close the gate while the coverage wake admission is still held"
+    );
+    let task_runs_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs after the coverage wake lock");
+    assert_eq!(task_runs_after, task_runs_before);
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2,6 +2,32 @@ use super::*;
 use serde_json::json;
 use std::future::Future;
 
+async fn hold_background_gate_in_other_task(
+    gate: Arc<crate::db_pressure::DbPressureGate>,
+    operation: &'static str,
+) -> (
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (held_tx, held_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let holder = tokio::spawn(async move {
+        let _held = gate
+            .try_begin_background(operation)
+            .expect("occupy the sole background slot from another task");
+        held_tx
+            .send(())
+            .expect("test should await the competing background admission");
+        release_rx
+            .await
+            .expect("test should release the competing background admission");
+    });
+    held_rx
+        .await
+        .expect("holder should acquire the competing background slot");
+    (release_tx, holder)
+}
+
 async fn assert_startup_backfill_busy_error_closes_gate_before_next_task(
     state: &Arc<AppState>,
     task: StartupBackfillTask,
@@ -1975,13 +2001,15 @@ async fn startup_historical_rollup_backfill_persists_cursor_and_defers_under_pre
     seed_missing_historical_rollup_startup_candidates(&state.pool, 32).await;
     let task = StartupBackfillTask::HistoricalRollups;
     let task_name = startup_backfill_task_progress_key(state.as_ref(), task).await;
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(1));
-    let held = gate
-        .try_begin_background("test_historical_rollup_pressure")
-        .expect("hold startup backfill gate");
+    let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
+        1,
+        Duration::from_secs(1),
+    ));
+    let (release_tx, holder) =
+        hold_background_gate_in_other_task(gate.clone(), "test_historical_rollup_pressure").await;
 
     assert!(
-        !run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+        !run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref())
             .await
             .expect("defer historical startup backfill under pressure")
     );
@@ -1993,7 +2021,10 @@ async fn startup_historical_rollup_backfill_persists_cursor_and_defers_under_pre
         deferred.is_due(Utc::now()),
         "a pre-SQL pressure defer must leave durable progress untouched; the scheduler owns its deadline"
     );
-    drop(held);
+    release_tx
+        .send(())
+        .expect("holder should be waiting for release");
+    holder.await.expect("holder should not panic");
 
     sqlx::query("UPDATE startup_backfill_progress SET next_run_after = ?1 WHERE task_name = ?2")
         .bind(format_utc_iso(Utc::now() - ChronoDuration::seconds(1)))
@@ -2002,7 +2033,7 @@ async fn startup_historical_rollup_backfill_persists_cursor_and_defers_under_pre
         .await
         .expect("make historical startup backfill due");
     assert!(
-        !run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+        !run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref())
             .await
             .expect("run bounded historical startup backfill")
     );
@@ -2065,22 +2096,31 @@ async fn startup_backfill_not_due_check_does_not_claim_background_gate() {
     .await
     .expect("seed not-due startup progress");
 
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(1));
-    let held_permit = gate
-        .try_begin_background("upstream_account_maintenance")
-        .expect("hold local gate slot");
+    let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
+        1,
+        Duration::from_secs(1),
+    ));
+    let (release_tx, holder) =
+        hold_background_gate_in_other_task(gate.clone(), "upstream_account_maintenance").await;
 
-    run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+    run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref())
         .await
         .expect("not-due startup backfill should not require a background slot");
 
+    let probe_gate = gate.clone();
+    let probe =
+        tokio::spawn(
+            async move { probe_gate.try_begin_background("upstream_account_maintenance") },
+        );
     assert_eq!(
-        gate.try_begin_background("upstream_account_maintenance")
-            .unwrap_err(),
+        probe.await.expect("probe should not panic").unwrap_err(),
         crate::db_pressure::DbPressureDenyReason::BackgroundBusy,
         "not-due backfill should leave the already held slot untouched"
     );
-    drop(held_permit);
+    release_tx
+        .send(())
+        .expect("holder should be waiting for release");
+    holder.await.expect("holder should not panic");
 }
 
 #[tokio::test]
@@ -2171,16 +2211,22 @@ async fn startup_backfill_pressure_defer_never_accesses_sqlite() {
     )
     .await;
     let task = StartupBackfillTask::ReasoningEffort;
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(1));
-    let _held = gate
-        .try_begin_background("test_pressure")
-        .expect("hold background slot");
+    let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
+        1,
+        Duration::from_secs(1),
+    ));
+    let (release_tx, holder) =
+        hold_background_gate_in_other_task(gate.clone(), "test_pressure").await;
     state.pool.close().await;
 
-    let ran = run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+    let ran = run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref())
         .await
         .expect("closed pool proves the pressure defer does not access SQLite");
     assert!(!ran);
+    release_tx
+        .send(())
+        .expect("holder should be waiting for release");
+    holder.await.expect("holder should not panic");
 }
 
 #[tokio::test]
@@ -3195,19 +3241,25 @@ async fn startup_coverage_repair_executes_under_its_single_admitted_gate_permit(
     )
     .await;
     let task = StartupBackfillTask::AccountActivityV2Coverage;
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+    let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
+        1,
+        Duration::from_secs(60),
+    ));
     let rollup_guard = state.hourly_rollup_sync_lock.lock().await;
 
-    let run = run_startup_backfill_task_if_due_with_gate(&state, task, &gate);
+    let run = run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref());
     tokio::pin!(run);
     tokio::select! {
         result = &mut run => panic!("coverage repair must wait for the held rollup lock, got {result:?}"),
         _ = tokio::time::sleep(Duration::from_millis(20)) => {}
     }
 
+    let probe_gate = gate.clone();
+    let probe =
+        tokio::spawn(async move { probe_gate.try_begin_background("coverage_admission_probe") });
     assert!(
         matches!(
-            gate.try_begin_background("coverage_admission_probe"),
+            probe.await.expect("probe should not panic"),
             Err(crate::db_pressure::DbPressureDenyReason::BackgroundBusy)
         ),
         "the coverage repair must retain its single production-shaped gate permit while it waits"
@@ -3231,10 +3283,12 @@ async fn startup_coverage_gate_denial_skips_sqlite_progress_and_task_run_audit()
     )
     .await;
     let task = StartupBackfillTask::AccountActivityV2Coverage;
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
-    let _held = gate
-        .try_begin_background("coverage_gate_holder")
-        .expect("occupy the production-shaped gate");
+    let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
+        1,
+        Duration::from_secs(60),
+    ));
+    let (release_tx, holder) =
+        hold_background_gate_in_other_task(gate.clone(), "coverage_gate_holder").await;
     let task_runs_before: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
     )
@@ -3243,7 +3297,7 @@ async fn startup_coverage_gate_denial_skips_sqlite_progress_and_task_run_audit()
     .expect("count task runs before the denied coverage repair");
 
     assert!(
-        !run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+        !run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref())
             .await
             .expect("closed coverage gate should defer without an error")
     );
@@ -3271,10 +3325,14 @@ async fn startup_coverage_gate_denial_skips_sqlite_progress_and_task_run_audit()
 
     state.pool.close().await;
     assert!(
-        !run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+        !run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref())
             .await
             .expect("a closed pool proves denied coverage never accesses SQLite")
     );
+    release_tx
+        .send(())
+        .expect("holder should be waiting for release");
+    holder.await.expect("holder should not panic");
 }
 
 #[tokio::test]

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -33,12 +33,12 @@ async fn assert_startup_backfill_busy_error_closes_gate_before_next_task(
     task: StartupBackfillTask,
     gate: &crate::db_pressure::DbPressureGate,
 ) {
-    let err = run_startup_backfill_task_if_due_with_gate(state, task, gate)
+    let deferred = run_startup_backfill_task_if_due_with_gate(state, task, gate)
         .await
-        .expect_err("injected SQLite lock should fail the startup backfill task");
+        .expect("injected SQLite lock should defer the startup backfill task");
     assert!(
-        crate::is_sqlite_lock_error(&err),
-        "expected an actual SQLite BUSY/LOCKED error: {err:#}"
+        !deferred,
+        "a classified SQLite BUSY/LOCKED outcome must become a scheduler-only defer"
     );
     assert_eq!(
         gate.snapshot().pressure_events,

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2296,6 +2296,37 @@ async fn startup_backfill_repeated_cooldown_notifications_do_not_redispatch_or_r
 }
 
 #[tokio::test]
+async fn startup_backfill_input_wake_busy_admission_avoids_sqlite() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::PoolAttemptPublicIdLive;
+    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+    let _held = gate
+        .try_begin_background("test_input_wake_busy")
+        .expect("occupy the sole background slot");
+
+    state.pool.close().await;
+    assert_eq!(
+        wake_startup_backfill_tasks_with_gate(
+            &state.pool,
+            &[task],
+            "input_wake_busy_admission",
+            &gate,
+        )
+        .await
+        .expect("busy admission must defer without SQLite access"),
+        0
+    );
+    assert_eq!(
+        gate.snapshot().background_skips,
+        1,
+        "the input wake must be denied by the gate before its progress write"
+    );
+}
+
+#[tokio::test]
 async fn pressure_eligibility_wake_rechecks_durable_backfill_deadline() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2624,7 +2624,7 @@ async fn startup_backfill_busy_failure_persists_failed_state_and_bounded_retry()
 }
 
 #[tokio::test]
-async fn startup_backfill_busy_failure_closes_pressure_gate_before_the_next_task_reads_sqlite() {
+async fn startup_backfill_busy_failure_defers_without_an_audit_before_the_next_task_reads_sqlite() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
     )
@@ -2685,32 +2685,20 @@ async fn startup_backfill_busy_failure_closes_pressure_gate_before_the_next_task
         &gate,
     )
     .await;
-    state
-        .sqlite_batch_writer
-        .flush_now(&state.pool)
-        .await
-        .expect("flush injected busy failure task audit");
-
     let task_runs_after: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
     )
     .fetch_one(&state.pool)
     .await
     .expect("count task runs after injected busy failure");
-    let task_run_status: String = sqlx::query_scalar(
-        "SELECT status FROM system_task_runs WHERE task_kind = 'startup_backfill' ORDER BY started_at DESC LIMIT 1",
-    )
-    .fetch_one(&state.pool)
-    .await
-    .expect("load injected busy failure task audit");
-    let failed_progress = load_startup_backfill_progress(&state.pool, first_tasks[0].name())
+    let unchanged_progress = load_startup_backfill_progress(&state.pool, first_tasks[0].name())
         .await
-        .expect("load persisted busy failure progress");
+        .expect("load untouched busy-deferred progress");
     assert!(!first.ran_actionable_task);
-    assert!(first.had_failure);
-    assert_eq!(task_runs_after, task_runs_before + 1);
-    assert_eq!(task_run_status, "failed");
-    assert_eq!(failed_progress.last_status, STARTUP_BACKFILL_STATUS_FAILED);
+    assert!(!first.had_failure);
+    assert_eq!(task_runs_after, task_runs_before);
+    assert!(unchanged_progress.is_due(Utc::now()));
+    assert_eq!(gate.snapshot().pressure_events, 1);
     assert!(
         gate.pressure_cooldown_deadline_epoch_ms().is_some(),
         "the durable busy failure must close the gate before its permit is released"

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2275,9 +2275,14 @@ async fn startup_backfill_repeated_cooldown_notifications_do_not_redispatch_or_r
     state.pool.close().await;
     for _ in 0..3 {
         assert_eq!(
-            wake_startup_backfill_tasks(&state.pool, &selected_tasks, "repeated_cooldown_input")
-                .await
-                .expect("a pending pressure defer must suppress input wake SQLite work"),
+            wake_startup_backfill_tasks_with_gate(
+                &state.pool,
+                &selected_tasks,
+                "repeated_cooldown_input",
+                &gate,
+            )
+            .await
+            .expect("a pending pressure defer must suppress input wake SQLite work"),
             0
         );
         gate.notify_background_eligibility();

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2235,6 +2235,62 @@ async fn startup_backfill_pressure_defer_has_one_deadline_and_no_task_run_audit(
 }
 
 #[tokio::test]
+async fn startup_backfill_repeated_cooldown_notifications_do_not_redispatch_or_read_sqlite() {
+    let state = test_state_with_openai_base(
+        Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),
+    )
+    .await;
+    let task = StartupBackfillTask::InvocationServiceTier;
+    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
+    gate.record_pressure("test_pressure", "forced_cooldown");
+    let cancel = CancellationToken::new();
+    let selected_tasks = [task];
+    let audits_before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs before repeated cooldown notifications");
+
+    let first = run_startup_backfill_maintenance_pass_with_gate(
+        state.clone(),
+        &cancel,
+        Some(&selected_tasks),
+        &gate,
+    )
+    .await;
+    let audits_after_first: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_task_runs WHERE task_kind = 'startup_backfill'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count task runs after the first cooldown defer");
+    assert!(!first.ran_actionable_task);
+    assert!(!first.had_failure);
+    assert_eq!(audits_after_first, audits_before);
+    assert_eq!(gate.snapshot().background_skips, 1);
+
+    // A closed pool turns every repeated event path into a zero-I/O assertion. The scheduler
+    // must retain the original registration instead of reaching either the wake SQL or task read.
+    state.pool.close().await;
+    for _ in 0..3 {
+        assert_eq!(
+            wake_startup_backfill_tasks(&state.pool, &selected_tasks, "repeated_cooldown_input")
+                .await
+                .expect("a pending pressure defer must suppress input wake SQLite work"),
+            0
+        );
+        gate.notify_background_eligibility();
+        run_pressure_eligible_startup_backfill_tasks(state.clone(), &cancel, &gate).await;
+    }
+    assert_eq!(
+        gate.snapshot().background_skips,
+        1,
+        "repeated notifications in one closed cooldown must not redispatch the deferred task"
+    );
+}
+
+#[tokio::test]
 async fn pressure_eligibility_wake_rechecks_durable_backfill_deadline() {
     let state = test_state_with_openai_base(
         Url::parse("http://127.0.0.1:18081").expect("valid upstream url"),

--- a/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
+++ b/src/tests/stateful_sqlite/startup_rebuild_and_retention_basics.rs
@@ -2302,10 +2302,27 @@ async fn startup_backfill_input_wake_busy_admission_avoids_sqlite() {
     )
     .await;
     let task = StartupBackfillTask::PoolAttemptPublicIdLive;
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
-    let _held = gate
-        .try_begin_background("test_input_wake_busy")
-        .expect("occupy the sole background slot");
+    let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
+        1,
+        Duration::from_secs(60),
+    ));
+    let (held_tx, held_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let holder_gate = gate.clone();
+    let holder = tokio::spawn(async move {
+        let _held = holder_gate
+            .try_begin_background("test_input_wake_busy")
+            .expect("occupy the sole background slot from another task");
+        held_tx
+            .send(())
+            .expect("test should await the competing background admission");
+        release_rx
+            .await
+            .expect("test should release the competing background admission");
+    });
+    held_rx
+        .await
+        .expect("holder should acquire the competing background slot");
 
     state.pool.close().await;
     assert_eq!(
@@ -2313,7 +2330,7 @@ async fn startup_backfill_input_wake_busy_admission_avoids_sqlite() {
             &state.pool,
             &[task],
             "input_wake_busy_admission",
-            &gate,
+            gate.as_ref(),
         )
         .await
         .expect("busy admission must defer without SQLite access"),
@@ -2324,6 +2341,10 @@ async fn startup_backfill_input_wake_busy_admission_avoids_sqlite() {
         1,
         "the input wake must be denied by the gate before its progress write"
     );
+    release_tx
+        .send(())
+        .expect("holder should be waiting for release");
+    holder.await.expect("holder should not panic");
 }
 
 #[tokio::test]
@@ -2357,18 +2378,38 @@ async fn pressure_eligibility_wake_rechecks_durable_backfill_deadline() {
     .await
     .expect("count task runs before pressure eligibility wake");
 
-    let gate = crate::db_pressure::DbPressureGate::new(1, Duration::from_secs(60));
-    let held = gate
-        .try_begin_background("test_pressure_eligibility_busy")
-        .expect("occupy the background slot");
-    let first = run_startup_backfill_task_if_due_with_gate(&state, task, &gate)
+    let gate = Arc::new(crate::db_pressure::DbPressureGate::new(
+        1,
+        Duration::from_secs(60),
+    ));
+    let (held_tx, held_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let holder_gate = gate.clone();
+    let holder = tokio::spawn(async move {
+        let _held = holder_gate
+            .try_begin_background("test_pressure_eligibility_busy")
+            .expect("occupy the background slot from another task");
+        held_tx
+            .send(())
+            .expect("test should await the competing background admission");
+        release_rx
+            .await
+            .expect("test should release the competing background admission");
+    });
+    held_rx
+        .await
+        .expect("holder should acquire the competing background slot");
+    let first = run_startup_backfill_task_if_due_with_gate(&state, task, gate.as_ref())
         .await
         .expect("background-busy admission should be a scheduler-only defer");
     assert!(!first);
     assert_eq!(gate.snapshot().background_skips, 1);
 
     let observed_eligibility = gate.eligibility_generation();
-    drop(held);
+    release_tx
+        .send(())
+        .expect("holder should be waiting for release");
+    holder.await.expect("holder should not panic");
     tokio::time::timeout(
         Duration::from_secs(1),
         gate.wait_for_eligibility_change(observed_eligibility),


### PR DESCRIPTION
## Child Delivery

- Parent: #856
- Issue: #858
- Role: child
- Integration branch: `prd/runtime-read-model-pressure-recovery-next`
- Integration base: `75364c2a5707b7a7f26b99bf1c08ea55d48eded4`
- Final base: `main`
- Completion gate: `observed`
- Release: not independently published (`type:skip`)
- Spec: `docs/specs/runtime-read-model-pressure-recovery/SPEC.md @ 75364c2a5707b7a7f26b99bf1c08ea55d48eded4`

## Summary

- Deduplicate pressure-gate eligibility scheduling by task and pressure generation.
- Preserve durable deadlines across eligibility events and concurrent busy defers.
- Keep gate denials free of SQLite I/O and task-run audits.
- Record real SQLite BUSY/LOCKED wake failures while their admission remains held, then retain recoverable pressure defers.
- Support nested admissions only for the owning Tokio task or runtime root future, never across a new pressure cooldown.

## Validation

- Focused stateful SQLite regressions for repeated cooldown notifications, busy admission, actual BUSY/LOCKED wakes, no audit rows, and durable deadline preservation.
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Final three-way current-head review: clean.
- Shared-testbox stateful profile was attempted; its source filter omits tracked `src/forward_proxy/slices/manager_xray_types_and_tests.rs`, so remote compilation cannot start. This is an existing testbox source-packaging blocker, not a project test failure.