### PR TITLE
docs(runtime): define durable invocation classification

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,25 @@ background refresh is unavailable. Its retention does not permit a stale or
 partial value to be represented as a fresh projection.
 _Avoid_: fabricated empty summary, implicit fresh cache
 
+**Canonical Invocation Classification**:
+The revisioned durable outcome fact for one terminal invocation: its failure
+class and actionable state. It is written once by terminal persistence or by a
+controlled compatibility materializer and is the only classification source for
+Summary, rollup and aggregate readers.
+_Avoid_: payload-derived reader classification, window-specific failure class
+
+**Classification Coverage**:
+Durable proof that a live or archived record range has current Canonical
+Invocation Classification. A reader with incomplete coverage is exact-unavailable
+rather than allowed to infer a result from raw payload bytes.
+_Avoid_: implicit legacy fallback, partial exactness
+
+**Archive Classification Overlay**:
+The durable identity-keyed Canonical Invocation Classification for a record in an
+immutable archive. It avoids rewriting archive files while making their outcome
+available to a background projector or rollup builder.
+_Avoid_: mutable archive, request-time archive repair
+
 **SQLite Pressure Defer**:
 A deliberate refusal of low-priority background database work before it acquires
 SQLite because the shared pressure gate is closed. It leaves durable progress

--- a/docs/adr/0003-durable-invocation-classification.md
+++ b/docs/adr/0003-durable-invocation-classification.md
@@ -1,0 +1,51 @@
+# ADR 0003: Durable invocation classification
+
+## Status
+
+Accepted
+
+## Context
+
+Summary Projection must remain an exact memory-only read model even when durable
+history contains large raw payloads. The existing `failure_class` field is not a
+complete compatibility contract for historical records: some legacy rows require
+payload or raw-response diagnostics to resolve their outcome. If Summary avoids
+those bytes while full statistics and rollups continue to inspect them, one
+invocation can be classified differently by the selected window or materialized
+source. Retaining every payload in the projection fixes neither memory pressure
+nor the split-brain classification.
+
+## Decision
+
+- Treat the terminal invocation classification (`failure_class`, actionable state,
+  and its classification revision) as a durable, versioned fact. A terminal
+  writer computes and commits it atomically with the terminal record.
+- Materialize legacy and immutable-archive classifications through a bounded,
+  resumable, pressure-aware background path. Immutable archives use a durable
+  identity-keyed overlay and coverage proof rather than archive rewrites.
+- Summary Projection, hourly rollups, and all aggregate readers consume only the
+  canonical classification fact. They do not re-derive outcomes from payload or
+  raw response bytes.
+- A range with incomplete canonical classification coverage is exact-unavailable;
+  it is never silently treated as success, reconstructed in an HTTP request, or
+  represented by partial totals. The background materializer may repair that
+  coverage and publish a later exact snapshot.
+
+## Considered Options
+
+- Keep raw payload diagnostics in every Summary record. Rejected because large
+  payloads reintroduce unbounded memory admission and do not unify rollups.
+- Let each reader retain its own legacy fallback. Rejected because result
+  semantics then depend on the reader and materialization state.
+- Rewrite historical archive files in place. Rejected because archive identities
+  are immutable and a durable primary-store overlay is recoverable and bounded.
+
+## Consequences
+
+- Classification changes are an expand-and-backfill migration with explicit
+  coverage state, not a read-time compatibility heuristic.
+- Rollup publication must only claim exact coverage after its source records have
+  current canonical classification, so legacy repair can safely recompute affected
+  buckets.
+- The materializer is low-priority work: it yields on pressure, cancellation and
+  its bounded transaction budget, while terminal persistence remains P1.

--- a/docs/specs/runtime-read-model-pressure-recovery/HISTORY.md
+++ b/docs/specs/runtime-read-model-pressure-recovery/HISTORY.md
@@ -1,6 +1,7 @@
 # Runtime Read-Model Pressure Recovery - History
 
 - The Initiative adopts an exact-read-model contract: Summary availability may not be obtained by returning partial, empty or request-time reconstructed data.
+- Summary compact admission revealed that legacy failure classification was still reader-derived: payload-aware full aggregation and payload-free compact projection could disagree. The durable contract now requires one revisioned canonical classification, bounded live/archive compatibility materialization and shared reader consumption; raw diagnostics remain confined to that controlled background path.
 - A bounded recent index records its first omitted live timestamp; rolling and account windows reaching that boundary fail closed while later fully retained windows continue from memory.
 - The Initiative records pressure defer as a scheduler state separate from an actual SQLite lock failure, so retry and audit behavior remain observable and bounded.
 - Pressure defer keeps durable progress untouched because admission happens before SQLite; its eligibility deadline belongs to the in-memory scheduler, while a persisted real lock failure closes the pressure gate before releasing its permit.

--- a/docs/specs/runtime-read-model-pressure-recovery/IMPLEMENTATION.md
+++ b/docs/specs/runtime-read-model-pressure-recovery/IMPLEMENTATION.md
@@ -4,29 +4,30 @@
 
 ## Current Status
 
-- Lifecycle: active Wave 1 recovery release.
-- Implementation: Summary archive hydration and pressure-gated startup backfill recovery are implemented in this release; long-term legacy migration remains a later Wave 2 boundary.
+- Lifecycle: active canonical-classification recovery initiative.
+- Implementation: existing `failure_class` compatibility writers and backfill are not yet sufficient to make every read model consume one revisioned durable classification fact. Canonical terminal materialization, immutable-archive overlay coverage and shared Summary/rollup consumer migration are the first delivery boundary.
 - Promotion policy: checkpointed; every included Ticket requires observed evidence after owner-confirmed manual deployment.
 
 ## Delivery Boundaries
 
-| Delivery slice                      | Purpose                                                                                                     | Integration order                            | Completion evidence                                                                                    |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Summary archive hydration           | Recover exact Summary Projection from durable rollup plus exact boundary records without request-time I/O.  | Wave 1                                       | child/integration CI, checkpoint release, owner-confirmed deployment, 900-second read-only observation |
-| Pressure defer and startup backfill | Keep gate defers in an in-memory scheduler deadline/event path and distinguish them from real lock failure. | Wave 1                                       | child/integration CI, checkpoint release, owner-confirmed deployment, 900-second read-only observation |
-| Long-term legacy migration          | Replace legacy full-window migration scans with cursor/seek microtransactions.                              | Wave 2, after the pressure slice is observed | child/integration CI, checkpoint release, owner-confirmed deployment, 900-second read-only observation |
+| Delivery slice                                 | Purpose                                                                                                                                                                        | Integration order                                           | Completion evidence                                                                                    |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Canonical classification and Summary admission | Materialize one revisioned terminal outcome across live/archive records, then build compact exact Summary snapshots from it without raw-payload retention or request-time I/O. | Wave 1                                                      | child/integration CI, checkpoint release, owner-confirmed deployment, 900-second read-only observation |
+| Pressure defer and startup backfill            | Keep gate defers in an in-memory scheduler deadline/event path and distinguish them from real lock failure.                                                                    | Wave 2 after the Summary baseline is restored               | child/integration CI, checkpoint release, owner-confirmed deployment, 900-second read-only observation |
+| P2 writer admission                            | Yield hourly rollup, projection flush and task finalization before P1 terminal durability under pressure.                                                                      | Wave 3, after pressure is observed                          | child/integration CI, checkpoint release, owner-confirmed deployment, 900-second read-only observation |
+| Long-term legacy migration                     | Replace legacy full-window migration scans with cursor/seek microtransactions.                                                                                                 | Wave 4, after pressure and P2 writer admission are observed | child/integration CI, checkpoint release, owner-confirmed deployment, 900-second read-only observation |
 
 ## Integration Rules
 
-- The integration branch is `prd/runtime-read-model-pressure-recovery`; child PRs target it and do not release directly.
-- Wave 1 may implement independently, but child integration is serialized at the shared frontier.
-- The long-term slice cannot start until the pressure slice reaches its `observed` completion gate.
+- The current Initiative binds its own canonical-classification integration branch; child PRs target it and do not release directly.
+- Canonical classification is the green baseline before pressure work, because all child CI profiles must exercise the same exact Summary behavior.
+- P2 writer admission cannot start until pressure reaches its `observed` completion gate; long-term migration cannot start until both reach that gate.
 - Existing timeseries writer work remains outside this Initiative. Draft #714 stays out of the integration branch and is only marked superseded after the successor long-term slice has passed its technical acceptance.
 - Checkpoints publish GitHub artifacts only. Dockrev and srv-101 deployment, restart, rollback and write operations remain owner-only.
 
 ## Verification Ownership
 
-- Summary: exact-response comparison, >legacy-cardinality archive coverage, bounded recent-index overflow boundaries for rolling/account reads, HTTP SQL/file counters, freshness and last-good behavior.
+- Canonical classification and Summary: transaction-atomic terminal materialization, bounded legacy live cursor, immutable archive overlay coverage, rollup recomputation, cross-reader exact-response comparison, >legacy-cardinality admission, bounded recent-index overflow boundaries for rolling/account reads, HTTP SQL/file counters, freshness and last-good behavior.
 - Pressure: one in-memory scheduler defer deadline per cooldown, no SQLite pre-read or no-op task-run write; Account Activity V2 coverage repair owns one admitted permit across its durable due check, underlying repair, and every post-repair progress operation; repair and retry-progress `BUSY`/`LOCKED` regressions assert one pressure event, no outer task-run audit or generic retry, and no early next-task SQLite access, while a non-lock coverage error remains audited and retried; eligibility wakes recheck durable due state; and real-lock cooldown/backoff separation happens before permit release.
 - Long-term: query-plan assertion, cursor persistence, 512-row transaction cap, pressure/cancel recovery and P1 priority.
 - Observation: `$srv-101-ops` is read-only and only starts after the owner confirms the exact released version is deployed.

--- a/docs/specs/runtime-read-model-pressure-recovery/SPEC.md
+++ b/docs/specs/runtime-read-model-pressure-recovery/SPEC.md
@@ -41,7 +41,7 @@ Summary、后台回填和长期投影共享 SQLite 的有限写入能力。Summa
 - terminal invocation classification、legacy/archive overlay 与 rollup classification coverage 的 materialization 合同。
 - 全局 SQLite pressure gate 与 startup backfill 的 defer/due/wake 合同。
 - long-term legacy interval migration 的 cursor/seek、短事务、pressure/cancel 合同。
-- 三个交付 Ticket 的 checkpointed promotion 与只读生产观察证据。
+- 四个交付 Ticket 的 checkpointed promotion 与只读生产观察证据。
 
 ### Out of scope
 

--- a/docs/specs/runtime-read-model-pressure-recovery/SPEC.md
+++ b/docs/specs/runtime-read-model-pressure-recovery/SPEC.md
@@ -2,9 +2,16 @@
 
 > 当前有效规范以本文为准；实现覆盖与当前状态见 `./IMPLEMENTATION.md`，关键演进原因见 `./HISTORY.md`。
 
+## Related ADRs
+
+- [ADR 0002: Exact Summary projection contract](../../adr/0002-exact-summary-projection-contract.md)
+- [ADR 0003: Durable invocation classification](../../adr/0003-durable-invocation-classification.md)
+
 ## 背景 / 问题陈述
 
 Summary、后台回填和长期投影共享 SQLite 的有限写入能力。Summary hydration 不能因大量 archive manifest 而放弃一个本可精确恢复的快照；压力门拒绝低优先级工作也不能演变为毫秒级重试、日志风暴或无动作审计；遗留长期 interval migration 不应反复执行全窗反关联扫描并阻塞 P1。
+
+历史 invocation 的分类还不能让 Summary、rollup 与全量统计各自从 payload 或 raw response 推导。一个 terminal record 的 failure class 必须是有 revision 的 durable fact；旧 live/archive 记录由受控 materializer 取得 classification coverage，而不是由 HTTP 或某个读取器临时兼容。
 
 这些是三个独立的运行态恢复问题，但它们必须共享同一条边界：SQLite 是耐久与恢复事实源，健康 Summary HTTP 是精确内存读模型，低优先级 maintenance 不得反向挤占代理 P1。
 
@@ -13,6 +20,7 @@ Summary、后台回填和长期投影共享 SQLite 的有限写入能力。Summa
 ### Goals
 
 - 让 Summary Projection 对所有已支持的合法选择提供精确、内存优先的 `StatsResponse`，并以 durable rollup 加精确边界记录承接大历史。
+- 将 terminal invocation classification 物化为统一、versioned durable fact，使 Summary、hourly rollup 与全量 aggregate 对同一记录给出同一成功/失败语义。
 - 将 `SQLite Pressure Defer` 与真实 `BUSY`/`LOCKED` 失败分开，使 defer 只有一次 due/event wake，不制造轮询或无动作写入。
 - 把长期 legacy migration 改为 cursor/seek 驱动的可取消微批，以保持 P1 优先级与可恢复 backlog。
 - 将 checkpoint 发布与手动部署后的只读 900 秒观察作为独立证据链，禁止自动化部署操作。
@@ -30,6 +38,7 @@ Summary、后台回填和长期投影共享 SQLite 的有限写入能力。Summa
 ### In scope
 
 - Summary archive hydration 的容量、coverage 与 exact-boundary 恢复合同。
+- terminal invocation classification、legacy/archive overlay 与 rollup classification coverage 的 materialization 合同。
 - 全局 SQLite pressure gate 与 startup backfill 的 defer/due/wake 合同。
 - long-term legacy interval migration 的 cursor/seek、短事务、pressure/cancel 合同。
 - 三个交付 Ticket 的 checkpointed promotion 与只读生产观察证据。
@@ -54,6 +63,10 @@ Summary、后台回填和长期投影共享 SQLite 的有限写入能力。Summa
 - rolling 与 calendar 请求的 admission 只覆盖其合法 public horizon 和精确边界；仅 `all` 可达的更早 rollup 容量不得阻止合法 rolling snapshot 发布，且 `all` 继续保持 exact-or-unavailable。
 - 后台 refresh 失败时保留可诊断的 last-good；它不能伪装为 fresh，也不能由 fabricated empty response 替代。首次尚无精确快照时保持现有 unavailable 语义。
 - hydration、archive 读取和 reconcile 必须有 deadline、取消点、coalescing 与受控重试，不得在请求路径执行。
+- terminal record 的 `failure_class`、actionable state 与 classification revision 是 canonical durable facts。terminal persistence 必须在同一 durable write 中 materialize 当前 revision；读取器不得把 raw payload 或 response bytes 当作另一条分类事实源。
+- legacy live rows 及 immutable archive rows 的 canonical classification 通过具有 durable cursor、identity-keyed archive overlay 和 coverage proof 的后台 materializer 取得。archive 文件不得为此被原地改写。
+- Summary、hourly rollup、all-time aggregate 与 failure aggregate 必须消费同一 canonical classification。分类 coverage 缺失或 revision 不匹配时，只能得到 diagnosed `unavailable` 或等待后台 repair；不得把该记录当作 success、重新解析 payload，或用局部 aggregate 填补。
+- canonical classification materializer 必须使用小批可恢复 transaction，按 pressure/cancel/deadline 让出 SQLite；其完成后需使受影响的 rollup/Projection coverage 可重新发布。
 
 #### Pressure Defer And Backfill
 
@@ -91,16 +104,18 @@ Summary、后台回填和长期投影共享 SQLite 的有限写入能力。Summa
 ### Core flows
 
 1. Summary 请求先校验 query，再从内存 Projection 选择精确 snapshot；它从不启动 hydrate 或打开 archive。
-2. Projection worker 在后台将 rollup 的完整 interiors 与精确 boundary/tail 组合成新的 immutable snapshot；失败保持 last-good 与明确 freshness 状态。
-3. 低优先级 backfill 遇到关闭的 pressure gate 时只注册一次内存 scheduler future-eligibility deadline；对应事件或 deadline 只重新选择候选任务，执行前仍检查 durable progress，durable progress 保持不变。Account Activity V2 coverage repair 在同一 permit 内完成这个 due 检查与 repair，避免嵌套获取 global gate。
-4. long-term migration 读取 cursor 后执行一个最多 512 行的微事务；压力、取消或时间预算耗尽时安全退出，后续从持久 cursor 继续。
-5. 每个 checkpoint 的 GitHub release 由累计 integration frontier 生成；主人部署确认后才开始相关 Ticket 的只读 900 秒观察。
+2. Terminal writer 在持久化 terminal outcome 的同一事务中保存 canonical classification。legacy/immutable archive materializer 在后台补齐 revisioned classification coverage，并重新建立受影响的 rollup coverage。
+3. Projection worker 在后台将 rollup 的完整 interiors 与精确 boundary/tail 组合成新的 immutable snapshot；它只消费 canonical classifications，失败保持 last-good 与明确 freshness 状态。
+4. 低优先级 backfill 遇到关闭的 pressure gate 时只注册一次内存 scheduler future-eligibility deadline；对应事件或 deadline 只重新选择候选任务，执行前仍检查 durable progress，durable progress 保持不变。Account Activity V2 coverage repair 在同一 permit 内完成这个 due 检查与 repair，避免嵌套获取 global gate。
+5. long-term migration 读取 cursor 后执行一个最多 512 行的微事务；压力、取消或时间预算耗尽时安全退出，后续从持久 cursor 继续。
+6. 每个 checkpoint 的 GitHub release 由累计 integration frontier 生成；主人部署确认后才开始相关 Ticket 的只读 900 秒观察。
 
 ### Edge cases / errors
 
 - 无精确 Summary snapshot 时保留既有 unavailable 错误，不伪造 200/zero response。
 - 过期或失败的 refresh 不得把不完整数据提升为 fresh；可诊断 last-good 与 freshness 必须一致。
 - account rollup 落后 global rollup、archive/live overlap、source partition 与未对齐窗口边界都必须保持 exactness。
+- 任何 legacy/archived row 的 classification revision 不足都不得由不同读取器各自推导；它阻止相应 exact coverage，直到 background materializer 完成。
 - pressure defer 与实际 lock 在 counters、日志、重试与审计中是不同状态。
 - 观察失败冻结相应 checkpoint 的后续 promotion，按 Initiative v4 recovery contract 处理，而不是自动部署或回滚。
 
@@ -119,6 +134,8 @@ None。现有 Summary、System Status、long-term HTTP 与 SSE wire shape 保持
 ## 验收标准（Acceptance Criteria）
 
 - Given 多于旧 manifest admission 上限的已验证 archive 历史，When Summary Projection hydrate，Then 合法 current/1d 与滚动窗口保持精确，且 HTTP 读取不执行 SQL 或文件访问。
+- Given 一个 legacy terminal invocation 的 payload diagnostics 与现有 `failure_class` 不一致，When canonical materializer 完成，Then terminal row、archive overlay、hourly rollup、all-time aggregate 和 Summary 对该 invocation 使用同一 revisioned classification；在 completion 前，覆盖它的 Summary range 是 diagnosed unavailable 而非 partial 或 payload-derived response。
+- Given 当前 terminal write，When durable transaction commits，Then canonical classification revision 与 terminal outcome 原子可见；后续 projection 不读取 raw payload 仍与 full aggregate 完全一致。
 - Given 低 retention 且 31 天外的高基数 rollup 超出 admission，When Summary Projection hydrate，Then 合法 30d 仍精确、可用且仅从内存读取。
 - Given global、account 与 source-partitioned rollup 覆盖不一致，When 请求边界或 account scope，Then 响应没有重复、漏项或缺失 usage/model/reasoning/cost 详情。
 - Given 49,999 个 48 小时内的 live 行和至少两个仍在合法 rolling window 内、但落后 global/account cursor 的更早 live 行，When 最近索引超过 50,000 条，Then 覆盖省略边界的 global 与 account rolling 请求返回 `unavailable`，较新的完整窗口仍从内存精确响应且不执行 SQL 或文件 I/O。
@@ -133,6 +150,7 @@ None。现有 Summary、System Status、long-term HTTP 与 SSE wire shape 保持
 ## 验收清单
 
 - [ ] Summary 的 exact-memory contract 覆盖 archive、rollup、boundary、last-good 与 HTTP zero-I/O。
+- [ ] Canonical invocation classification 覆盖 terminal writer、legacy live、immutable archive overlay、rollup coverage 与所有 aggregate consumers。
 - [ ] pressure defer、actual lock、next eligibility 与无动作审计边界明确且可测试。
 - [ ] long-term migration 的 cursor、seek、512-row transaction、pressure/cancel 合同明确且可测试。
 - [ ] 手动部署和 900 秒只读观察边界明确。


### PR DESCRIPTION
## Delivery role

`direct`

## Summary

- Defines revisioned durable invocation classification as the common fact for Summary, hourly rollups, and aggregate readers.
- Constrains legacy and immutable archive repair to a bounded background materializer with durable coverage proof.
- Records the no-deployment boundary for the successor performance initiative.

## Spec

`docs/specs/runtime-read-model-pressure-recovery/SPEC.md` (refreshed)

## Validation

- `git diff --check`
- markdown formatting hook

## Deployment

No runtime code, image publication, Dockrev, or srv-101 action.