### PR TITLE
fix(ci): normalize backend test image name

### DIFF
--- a/.github/scripts/test-backend-test-contract.sh
+++ b/.github/scripts/test-backend-test-contract.sh
@@ -5,6 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 dockerfile="$repo_root/Dockerfile"
 runner="$repo_root/.github/scripts/run-backend-tests.sh"
 compose_file="$repo_root/compose.backend-test.yml"
+ci_main_workflow="$repo_root/.github/workflows/ci-main.yml"
 
 grep -q '^FROM rust:1.96.0-bookworm AS backend-test$' "$dockerfile"
 grep -q '^  backend-test:$' "$compose_file"
@@ -13,6 +14,26 @@ grep -q 'CARGO_NEXTEST_VERSION=0.9.138' "$dockerfile"
 grep -q 'CARGO_NEXTEST_SHA256_AMD64=3793bf0c27607b196f502c39b2108f571de89fcda7586ae6beefa11ee177b216' "$dockerfile"
 grep -q 'install -m 0755 /tmp/cargo-nextest /usr/local/cargo/bin/cargo-nextest' "$dockerfile"
 grep -q 'ENTRYPOINT \["bash", ".github/scripts/run-backend-tests.sh"\]' "$dockerfile"
+
+if ! grep -Fq 'id: backend-test-image-name' "$ci_main_workflow"; then
+  echo 'expected CI Main to normalize the backend-test GHCR image name' >&2
+  exit 1
+fi
+
+if ! grep -Fq 'image_name=${GITHUB_REPOSITORY,,}' "$ci_main_workflow"; then
+  echo 'expected CI Main backend-test image name to use Bash lowercase normalization' >&2
+  exit 1
+fi
+
+if ! grep -Fq 'tags: ${{ env.REGISTRY }}/${{ steps.backend-test-image-name.outputs.image_name }}:backend-test-${{ github.sha }}' "$ci_main_workflow"; then
+  echo 'expected CI Main backend-test image tag to use the normalized image name' >&2
+  exit 1
+fi
+
+if grep -Fq 'tags: ${{ env.REGISTRY }}/${{ github.repository }}:backend-test-${{ github.sha }}' "$ci_main_workflow"; then
+  echo 'CI Main must not publish the backend-test image with an unnormalized repository name' >&2
+  exit 1
+fi
 
 set +e
 missing_nextest_output="$(PATH=/usr/bin:/bin bash "$runner" --profile stateful-sqlite 2>&1)"

--- a/.github/scripts/test-backend-test-contract.sh
+++ b/.github/scripts/test-backend-test-contract.sh
@@ -6,6 +6,7 @@ dockerfile="$repo_root/Dockerfile"
 runner="$repo_root/.github/scripts/run-backend-tests.sh"
 compose_file="$repo_root/compose.backend-test.yml"
 ci_main_workflow="$repo_root/.github/workflows/ci-main.yml"
+release_workflow="$repo_root/.github/workflows/release.yml"
 
 grep -q '^FROM rust:1.96.0-bookworm AS backend-test$' "$dockerfile"
 grep -q '^  backend-test:$' "$compose_file"
@@ -34,6 +35,21 @@ if grep -Fq 'tags: ${{ env.REGISTRY }}/${{ github.repository }}:backend-test-${{
   echo 'CI Main must not publish the backend-test image with an unnormalized repository name' >&2
   exit 1
 fi
+
+if ! grep -Fq 'image="${REGISTRY}/${GITHUB_REPOSITORY,,}:backend-test-${TARGET_SHA}"' "$release_workflow"; then
+  echo 'expected manual release digest lookup to use the normalized backend-test image name' >&2
+  exit 1
+fi
+
+if grep -Fq 'image="${REGISTRY}/${GITHUB_REPOSITORY}:backend-test-${TARGET_SHA}"' "$release_workflow"; then
+  echo 'manual release digest lookup must not use an unnormalized repository name' >&2
+  exit 1
+fi
+
+github_repository_fixture='IvanLi-CN/Codex-Vibe-Monitor'
+target_sha_fixture='deadbeef'
+manual_image="ghcr.io/$(printf '%s' "$github_repository_fixture" | tr '[:upper:]' '[:lower:]'):backend-test-${target_sha_fixture}"
+[[ "$manual_image" == 'ghcr.io/ivanli-cn/codex-vibe-monitor:backend-test-deadbeef' ]]
 
 set +e
 missing_nextest_output="$(PATH=/usr/bin:/bin bash "$runner" --profile stateful-sqlite 2>&1)"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -580,6 +580,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize backend-test image name
+        id: backend-test-image-name
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "image_name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
       - name: Build and publish immutable backend-test image (linux/amd64)
         id: build-backend-test-image
         uses: docker/build-push-action@v7
@@ -589,7 +596,7 @@ jobs:
           target: backend-test
           platforms: linux/amd64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:backend-test-${{ github.sha }}
+          tags: ${{ env.REGISTRY }}/${{ steps.backend-test-image-name.outputs.image_name }}:backend-test-${{ github.sha }}
 
   release-snapshot:
     name: Release Snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
           TARGET_SHA: ${{ steps.requested-target.outputs.target_sha }}
         run: |
           set -euo pipefail
-          image="${REGISTRY}/${GITHUB_REPOSITORY}:backend-test-${TARGET_SHA}"
+          image="${REGISTRY}/${GITHUB_REPOSITORY,,}:backend-test-${TARGET_SHA}"
           digest=""
           for attempt in 1 2 3; do
             digest="$(docker buildx imagetools inspect "${image}" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)"


### PR DESCRIPTION
## Summary
- normalize the immutable backend-test GHCR image name before publishing
- retain the lowercase-name contract in the backend test workflow check

## Validation
- `bash .github/scripts/test-backend-test-contract.sh`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `python3 .github/scripts/check_quality_gates_contract.py --repo-root . --declaration .github/quality-gates.json --metadata-script .github/scripts/metadata_gate.py --profile final`

Resolves the CI Main publish failure that blocked the stable patch release after #882.