### PR TITLE
fix(release): backfill missing snapshot digest

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -1015,6 +1015,28 @@ def ensure_snapshot(args: argparse.Namespace) -> int:
         if existing is not None:
             requested_digest = getattr(args, "backend_test_image_digest", "")
             existing_digest = existing.get("backend_test_image_digest", "")
+            if requested_digest and not existing_digest:
+                # Legacy snapshots predate trusted backend-test digest binding. Only an
+                # absent digest may be augmented; conflicting non-empty values stay immutable.
+                existing = dict(existing)
+                existing["backend_test_image_digest"] = requested_digest
+                existing = validate_snapshot(existing, expected_sha=target_sha)
+                with tempfile.TemporaryDirectory(prefix="release-snapshot-notes-") as tmp:
+                    temp_note = Path(tmp) / "snapshot.json"
+                    write_json(temp_note, existing)
+                    git("notes", f"--ref={args.notes_ref}", "add", "-f", "-F", str(temp_note), target_sha)
+
+                write_json(output_path, existing)
+                if getattr(args, "skip_publish", False):
+                    return 0
+
+                push = git("push", "origin", args.notes_ref, check=False)
+                if push.returncode == 0:
+                    return 0
+                if attempt == args.max_attempts:
+                    detail = push.stderr.strip() or push.stdout.strip() or "git push origin notes ref failed"
+                    raise SnapshotError(f"Failed to publish release snapshot after {attempt} attempts: {detail}")
+                continue
             if requested_digest and existing_digest != requested_digest:
                 raise SnapshotError(
                     f"Release snapshot backend-test image digest mismatch for {target_sha}: "

--- a/.github/scripts/test-backend-test-contract.sh
+++ b/.github/scripts/test-backend-test-contract.sh
@@ -46,6 +46,25 @@ if grep -Fq 'image="${REGISTRY}/${GITHUB_REPOSITORY}:backend-test-${TARGET_SHA}"
   exit 1
 fi
 
+manual_backfill_step="$(sed -n '/^      - name: Ensure immutable release snapshot for manual backfill$/,/^      - name: Select pending release target$/p' "$release_workflow")"
+if ! grep -Fq -- '--backend-test-image-digest "${{ steps.manual-backend-test-image.outputs.digest }}"' <<<"$manual_backfill_step"; then
+  echo 'manual snapshot backfill must bind the resolved backend-test image digest' >&2
+  exit 1
+fi
+
+pending_recovery_steps="$(sed -n '/^      - name: Set up Docker Buildx for pending release digest lookup$/,/^      - name: Load immutable release snapshot$/p' "$release_workflow")"
+for required in \
+  "if: github.event_name != 'workflow_dispatch' && steps.pending-target.outputs.target_sha != ''" \
+  'image="${REGISTRY}/${GITHUB_REPOSITORY,,}:backend-test-${TARGET_SHA}"' \
+  'python3 .github/scripts/release_snapshot.py ensure' \
+  '--backend-test-image-digest "${BACKEND_TEST_IMAGE_DIGEST}"' \
+  '--skip-publish'; do
+  if ! grep -Fq -- "$required" <<<"$pending_recovery_steps"; then
+    echo "automatic pending-release snapshot recovery is missing: $required" >&2
+    exit 1
+  fi
+done
+
 github_repository_fixture='IvanLi-CN/Codex-Vibe-Monitor'
 target_sha_fixture='deadbeef'
 manual_image="ghcr.io/$(printf '%s' "$github_repository_fixture" | tr '[:upper:]' '[:lower:]'):backend-test-${target_sha_fixture}"

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -74,6 +74,107 @@ def make_pr(number: int, title: str, head_sha: str, labels: list[str]) -> dict[s
     }
 
 
+with tempfile.TemporaryDirectory(prefix="release-snapshot-digest-backfill-") as tmp:
+    repo = Path(tmp)
+    run("init", cwd=repo)
+    run("config", "user.name", "Test User", cwd=repo)
+    run("config", "user.email", "test@example.com", cwd=repo)
+    run("checkout", "-b", "main", cwd=repo)
+    (repo / "Cargo.toml").write_text('[package]\nname = "demo"\nversion = "0.1.0"\n')
+    (repo / "README.md").write_text("target\n")
+    run("add", "Cargo.toml", "README.md", cwd=repo)
+    run("commit", "-m", "target", cwd=repo)
+    target_sha = run("rev-parse", "HEAD", cwd=repo)
+    legacy_snapshot = {
+        "schema_version": module.SNAPSHOT_SCHEMA_VERSION,
+        "target_sha": target_sha,
+        "pr_number": 900,
+        "pr_title": "Legacy snapshot without backend-test digest",
+        "registry": "ghcr.io",
+        "pr_head_sha": target_sha,
+        "type_label": "type:patch",
+        "channel_label": "channel:stable",
+        "release_bump": "patch",
+        "release_channel": "stable",
+        "release_enabled": True,
+        "release_prerelease": False,
+        "image_name_lower": "ivanli-cn/codex-vibe-monitor",
+        "base_stable_version": "0.1.0",
+        "next_stable_version": "0.1.1",
+        "app_effective_version": "0.1.1",
+        "release_tag": "v0.1.1",
+        "tags_csv": "ghcr.io/ivanli-cn/codex-vibe-monitor:v0.1.1",
+        "notes_ref": module.DEFAULT_NOTES_REF,
+        "snapshot_source": "ci-main",
+        "created_at": "2026-03-15T00:00:00Z",
+    }
+    run(
+        "notes",
+        f"--ref={module.DEFAULT_NOTES_REF}",
+        "add",
+        "-f",
+        "-m",
+        json.dumps(legacy_snapshot),
+        target_sha,
+        cwd=repo,
+    )
+
+    original_cwd = Path.cwd()
+    original_git = module.git
+    digest = "sha256:" + "b" * 64
+    output_path = repo / "backfilled-snapshot.json"
+    os.chdir(repo)
+    try:
+        def fake_git(*args: str, **kwargs: object):
+            if args == ("push", "origin", module.DEFAULT_NOTES_REF):
+                return subprocess.CompletedProcess(["git", *args], 0, "", "")
+            return original_git(*args, **kwargs)
+
+        module.git = fake_git
+        exit_code = module.ensure_snapshot(
+            argparse.Namespace(
+                target_sha=target_sha,
+                github_repository="IvanLi-CN/codex-vibe-monitor",
+                github_token="token",
+                notes_ref=module.DEFAULT_NOTES_REF,
+                registry="ghcr.io",
+                api_root="https://api.github.com",
+                output=str(output_path),
+                max_attempts=1,
+                target_only=True,
+                backend_test_image_digest=digest,
+            )
+        )
+        assert exit_code == 0
+        stored = module.read_snapshot(module.DEFAULT_NOTES_REF, target_sha)
+        assert stored is not None
+        assert stored["backend_test_image_digest"] == digest
+        assert json.loads(output_path.read_text())["backend_test_image_digest"] == digest
+
+        try:
+            module.ensure_snapshot(
+                argparse.Namespace(
+                    target_sha=target_sha,
+                    github_repository="IvanLi-CN/codex-vibe-monitor",
+                    github_token="token",
+                    notes_ref=module.DEFAULT_NOTES_REF,
+                    registry="ghcr.io",
+                    api_root="https://api.github.com",
+                    output=str(repo / "conflicting-snapshot.json"),
+                    max_attempts=1,
+                    target_only=True,
+                    backend_test_image_digest="sha256:" + "c" * 64,
+                )
+            )
+        except module.SnapshotError as exc:
+            assert "digest mismatch" in str(exc)
+        else:
+            raise AssertionError("non-empty backend-test digest conflicts must fail")
+    finally:
+        module.git = original_git
+        os.chdir(original_cwd)
+
+
 original_urlopen = module.request.urlopen
 original_sleep = module.time.sleep
 try:

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -125,8 +125,11 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-digest-backfill-") as 
     output_path = repo / "backfilled-snapshot.json"
     os.chdir(repo)
     try:
+        push_calls: list[tuple[str, ...]] = []
+
         def fake_git(*args: str, **kwargs: object):
             if args == ("push", "origin", module.DEFAULT_NOTES_REF):
+                push_calls.append(args)
                 return subprocess.CompletedProcess(["git", *args], 0, "", "")
             return original_git(*args, **kwargs)
 
@@ -143,9 +146,11 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-digest-backfill-") as 
                 max_attempts=1,
                 target_only=True,
                 backend_test_image_digest=digest,
+                skip_publish=True,
             )
         )
         assert exit_code == 0
+        assert not push_calls
         stored = module.read_snapshot(module.DEFAULT_NOTES_REF, target_sha)
         assert stored is not None
         assert stored["backend_test_image_digest"] == digest

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -175,6 +175,34 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-digest-backfill-") as 
             assert "digest mismatch" in str(exc)
         else:
             raise AssertionError("non-empty backend-test digest conflicts must fail")
+
+        # Simulate the subsequent workflow fetch restoring the legacy remote note.
+        run(
+            "notes",
+            f"--ref={module.DEFAULT_NOTES_REF}",
+            "add",
+            "-f",
+            "-m",
+            json.dumps(legacy_snapshot),
+            target_sha,
+            cwd=repo,
+        )
+        restored = module.read_snapshot(module.DEFAULT_NOTES_REF, target_sha)
+        assert restored is not None
+        assert not restored.get("backend_test_image_digest")
+
+        export_output = repo / "exported-snapshot.txt"
+        assert module.export_existing_snapshot(
+            argparse.Namespace(
+                target_sha=target_sha,
+                notes_ref=module.DEFAULT_NOTES_REF,
+                snapshot_file=str(output_path),
+                resolve_publication_tags=False,
+                main_ref="",
+                github_output=str(export_output),
+            )
+        ) == 0
+        assert f"backend_test_image_digest={digest}" in export_output.read_text()
     finally:
         module.git = original_git
         os.chdir(original_cwd)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
           set -euo pipefail
           image="${REGISTRY}/${GITHUB_REPOSITORY,,}:backend-test-${TARGET_SHA}"
           digest=""
-          for attempt in 1 2 3; do
+          for _ in 1 2 3; do
             digest="$(docker buildx imagetools inspect "${image}" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)"
             if [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
               break
@@ -264,6 +264,7 @@ jobs:
             --registry "${REGISTRY}" \
             --snapshot-source manual-backfill \
             --target-only \
+            --backend-test-image-digest "${{ steps.manual-backend-test-image.outputs.digest }}" \
             --skip-publish \
             --output "$RUNNER_TEMP/release-snapshot.json"
 
@@ -295,6 +296,61 @@ jobs:
             --github-repository "${GITHUB_REPOSITORY}" \
             --github-token "${GITHUB_TOKEN}" \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx for pending release digest lookup
+        if: github.event_name != 'workflow_dispatch' && steps.pending-target.outputs.target_sha != ''
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR for pending release digest lookup
+        if: github.event_name != 'workflow_dispatch' && steps.pending-target.outputs.target_sha != ''
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve trusted backend-test image digest for pending release
+        if: github.event_name != 'workflow_dispatch' && steps.pending-target.outputs.target_sha != ''
+        id: pending-backend-test-image
+        shell: bash
+        env:
+          TARGET_SHA: ${{ steps.pending-target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${GITHUB_REPOSITORY,,}:backend-test-${TARGET_SHA}"
+          digest=""
+          for _ in 1 2 3; do
+            digest="$(docker buildx imagetools inspect "${image}" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)"
+            if [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              break
+            fi
+            sleep 2
+          done
+          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Missing immutable backend-test image digest for ${image}." >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >>"${GITHUB_OUTPUT}"
+
+      - name: Recover selected release snapshot
+        if: github.event_name != 'workflow_dispatch' && steps.pending-target.outputs.target_sha != ''
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ steps.pending-target.outputs.target_sha }}
+          BACKEND_TEST_IMAGE_DIGEST: ${{ steps.pending-backend-test-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${TARGET_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --target-only \
+            --backend-test-image-digest "${BACKEND_TEST_IMAGE_DIGEST}" \
+            --skip-publish \
+            --output "$RUNNER_TEMP/release-snapshot.json"
 
       - name: Load immutable release snapshot
         if: steps.pending-target.outputs.target_sha != ''


### PR DESCRIPTION
## Summary
- allow a legacy release snapshot to be augmented only when its backend-test image digest is absent
- preserve hard failure for any non-empty digest conflict
- cover the compatibility path with an isolated Git-notes regression

## Validation
- `bash .github/scripts/test-release-snapshot.sh`
- `python3 -m py_compile .github/scripts/release_snapshot.py`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `git diff --check`

Restores the normal stable release chain after the pre-digest snapshot created for the Summary fix.