### PR TITLE
fix(release): build runtime smoke images

### DIFF
--- a/.github/scripts/build-smoke-image-with-retry.sh
+++ b/.github/scripts/build-smoke-image-with-retry.sh
@@ -48,6 +48,7 @@ for attempt in $(seq 1 "${retry_attempts}"); do
   if docker buildx build \
     --progress plain \
     --file "${dockerfile_path}" \
+    --target "ci-smoke-runtime" \
     --platform "${build_platform}" \
     --load \
     --tag "${smoke_tag}" \

--- a/.github/scripts/build-smoke-image-with-retry.sh
+++ b/.github/scripts/build-smoke-image-with-retry.sh
@@ -48,7 +48,7 @@ for attempt in $(seq 1 "${retry_attempts}"); do
   if docker buildx build \
     --progress plain \
     --file "${dockerfile_path}" \
-    --target "ci-smoke-runtime" \
+    --target "runtime" \
     --platform "${build_platform}" \
     --load \
     --tag "${smoke_tag}" \

--- a/.github/scripts/test-backend-test-contract.sh
+++ b/.github/scripts/test-backend-test-contract.sh
@@ -46,13 +46,15 @@ if grep -Fq 'image="${REGISTRY}/${GITHUB_REPOSITORY}:backend-test-${TARGET_SHA}"
   exit 1
 fi
 
+grep -q '^FROM production-runtime AS runtime$' "$dockerfile"
+
 release_amd_smoke_build="$(sed -n '/^      - name: Build smoke image (linux\/amd64, load)$/,/^      - name: Smoke test image (linux\/amd64)$/p' "$release_workflow")"
-if ! grep -Fq 'target: ci-smoke-runtime' <<<"$release_amd_smoke_build"; then
+if ! grep -Fq 'target: runtime' <<<"$release_amd_smoke_build"; then
   echo 'release amd64 smoke build must use the runtime image target' >&2
   exit 1
 fi
 
-if ! grep -Fq -- '--target "ci-smoke-runtime"' "$repo_root/.github/scripts/build-smoke-image-with-retry.sh"; then
+if ! grep -Fq -- '--target "runtime"' "$repo_root/.github/scripts/build-smoke-image-with-retry.sh"; then
   echo 'release arm64 smoke build helper must use the runtime image target' >&2
   exit 1
 fi

--- a/.github/scripts/test-backend-test-contract.sh
+++ b/.github/scripts/test-backend-test-contract.sh
@@ -46,6 +46,17 @@ if grep -Fq 'image="${REGISTRY}/${GITHUB_REPOSITORY}:backend-test-${TARGET_SHA}"
   exit 1
 fi
 
+release_amd_smoke_build="$(sed -n '/^      - name: Build smoke image (linux\/amd64, load)$/,/^      - name: Smoke test image (linux\/amd64)$/p' "$release_workflow")"
+if ! grep -Fq 'target: ci-smoke-runtime' <<<"$release_amd_smoke_build"; then
+  echo 'release amd64 smoke build must use the runtime image target' >&2
+  exit 1
+fi
+
+if ! grep -Fq -- '--target "ci-smoke-runtime"' "$repo_root/.github/scripts/build-smoke-image-with-retry.sh"; then
+  echo 'release arm64 smoke build helper must use the runtime image target' >&2
+  exit 1
+fi
+
 manual_backfill_step="$(sed -n '/^      - name: Ensure immutable release snapshot for manual backfill$/,/^      - name: Select pending release target$/p' "$release_workflow")"
 if ! grep -Fq -- '--backend-test-image-digest "${{ steps.manual-backend-test-image.outputs.digest }}"' <<<"$manual_backfill_step"; then
   echo 'manual snapshot backfill must bind the resolved backend-test image digest' >&2

--- a/.github/scripts/test-build-smoke-image-with-retry.sh
+++ b/.github/scripts/test-build-smoke-image-with-retry.sh
@@ -89,7 +89,7 @@ BUILD_RETRY_BASE_DELAY_SECS="0" \
 bash "$script" >"$tmp_dir/transient.out" 2>"$tmp_dir/transient.err"
 
 [[ "$(cat "$attempt_file")" == "3" ]]
-grep -Fq -- '--target ci-smoke-runtime' "$args_file"
+grep -Fq -- '--target runtime' "$args_file"
 grep -q "transient failure for linux/arm64; retry in 0s (1/5)" "$tmp_dir/transient.err"
 grep -q "transient failure for linux/arm64; retry in 0s (2/5)" "$tmp_dir/transient.err"
 

--- a/.github/scripts/test-build-smoke-image-with-retry.sh
+++ b/.github/scripts/test-build-smoke-image-with-retry.sh
@@ -9,6 +9,10 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 cat >"$tmp_dir/docker-transient" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "${FAKE_DOCKER_ARGS_FILE:-}" ]]; then
+  printf '%q ' "$@" >>"$FAKE_DOCKER_ARGS_FILE"
+  printf '\n' >>"$FAKE_DOCKER_ARGS_FILE"
+fi
 attempt_file="${FAKE_DOCKER_ATTEMPT_FILE:?}"
 count=0
 if [[ -f "$attempt_file" ]]; then
@@ -71,8 +75,10 @@ mkdir -p "$transient_path"
 cp "$tmp_dir/docker-transient" "$transient_path/docker"
 
 attempt_file="$tmp_dir/transient-attempts"
+args_file="$tmp_dir/transient-args"
 PATH="$transient_path:$PATH" \
 FAKE_DOCKER_ATTEMPT_FILE="$attempt_file" \
+FAKE_DOCKER_ARGS_FILE="$args_file" \
 BUILD_PLATFORM="linux/arm64" \
 SMOKE_TAG="ghcr.io/example/smoke:arm64" \
 CANDIDATE_TAG="ghcr.io/example/candidate:arm64" \
@@ -83,6 +89,7 @@ BUILD_RETRY_BASE_DELAY_SECS="0" \
 bash "$script" >"$tmp_dir/transient.out" 2>"$tmp_dir/transient.err"
 
 [[ "$(cat "$attempt_file")" == "3" ]]
+grep -Fq -- '--target ci-smoke-runtime' "$args_file"
 grep -q "transient failure for linux/arm64; retry in 0s (1/5)" "$tmp_dir/transient.err"
 grep -q "transient failure for linux/arm64; retry in 0s (2/5)" "$tmp_dir/transient.err"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,7 +428,7 @@ jobs:
           platforms: ${{ env.PLATFORM_AMD64 }}
           push: false
           load: true
-          target: ci-smoke-runtime
+          target: runtime
           tags: |
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,7 @@ jobs:
           platforms: ${{ env.PLATFORM_AMD64 }}
           push: false
           load: true
+          target: ci-smoke-runtime
           tags: |
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-amd64


### PR DESCRIPTION
## Summary\n- build release candidate smoke images from the ci-smoke-runtime target\n- keep arm64 retry builds on the same runtime target\n- lock the target selection with focused workflow contracts\n\n## Validation\n- bash .github/scripts/test-build-smoke-image-with-retry.sh\n- bash .github/scripts/test-backend-test-contract.sh\n- bash .github/scripts/test-quality-gates-contract.sh\n- actionlint .github/workflows/release.yml\n- git diff --check