### PR TITLE
fix(release): unblock latest stable publication

### DIFF
--- a/.github/scripts/release_snapshot.py
+++ b/.github/scripts/release_snapshot.py
@@ -130,7 +130,7 @@ def parse_args() -> argparse.Namespace:
 
     next_pending = subparsers.add_parser(
         "next-pending",
-        help="Find the oldest unreleased snapshot on the first-parent path up to a given main commit.",
+        help="Find the newest unreleased snapshot on the first-parent path up to a given main commit.",
     )
     next_pending.add_argument("--notes-ref", default=DEFAULT_NOTES_REF)
     next_pending.add_argument("--main-ref", required=True)
@@ -595,10 +595,23 @@ def pending_release_targets(
     *,
     is_release_eligible: Callable[[str], Literal["eligible", "ineligible", "unknown"]] | None = None,
 ) -> list[str]:
-    pending: list[str] = []
-    for commit in first_parent_commits(upper_bound_sha):
-        snapshot = read_snapshot(notes_ref, commit)
+    commits = first_parent_commits(upper_bound_sha)
+    snapshots = [(commit, read_snapshot(notes_ref, commit)) for commit in commits]
+    newest_published_stable_index: int | None = None
+
+    for index, (_, snapshot) in enumerate(snapshots):
         if not snapshot or not snapshot.get("release_enabled"):
+            continue
+        if snapshot.get("release_channel") != "stable":
+            continue
+        if release_tag_points_to_target(snapshot):
+            newest_published_stable_index = index
+
+    pending: list[str] = []
+    for index, (commit, snapshot) in enumerate(snapshots):
+        if not snapshot or not snapshot.get("release_enabled"):
+            continue
+        if newest_published_stable_index is not None and index < newest_published_stable_index:
             continue
         if release_tag_points_to_target(snapshot):
             continue
@@ -1037,7 +1050,7 @@ def export_next_pending(args: argparse.Namespace) -> int:
         upper_bound,
         is_release_eligible=eligibility_check,
     )
-    export_key_values({"target_sha": pending[0] if pending else ""}, args.github_output)
+    export_key_values({"target_sha": pending[-1] if pending else ""}, args.github_output)
     return 0
 
 

--- a/.github/scripts/test-release-snapshot.sh
+++ b/.github/scripts/test-release-snapshot.sh
@@ -680,11 +680,35 @@ with tempfile.TemporaryDirectory(prefix="release-snapshot-") as tmp:
                 )
             )
             assert exit_code == 0
-            assert github_output.read_text().strip() == f"target_sha={sha2}"
+            assert github_output.read_text().strip() == f"target_sha={sha3}"
         finally:
             module.ci_main_run_is_release_eligible = original_ci_main_eligibility
             module.fetch_notes_ref = original_fetch_notes_ref
             module.fetch_tags = original_fetch_tags
+
+        superseding_snapshot = dict(snapshot3)
+        superseding_snapshot.update(
+            {
+                "channel_label": "channel:stable",
+                "release_channel": "stable",
+                "release_prerelease": False,
+                "app_effective_version": "0.2.1",
+                "release_tag": "v0.2.1",
+                "tags_csv": "ghcr.io/ivanli-cn/codex-vibe-monitor:v0.2.1",
+            }
+        )
+        run(
+            "notes",
+            f"--ref={module.DEFAULT_NOTES_REF}",
+            "add",
+            "-f",
+            "-m",
+            json.dumps(superseding_snapshot),
+            sha3,
+            cwd=repo,
+        )
+        run("tag", "v0.2.1", sha3, cwd=repo)
+        assert module.pending_release_targets(module.DEFAULT_NOTES_REF, sha3) == []
 
         run("tag", "v0.2.0", sha2, cwd=repo)
         assert module.release_tag_points_to_target(snapshot2) is True

--- a/docs/specs/8239m-release-latest-published-stable/HISTORY.md
+++ b/docs/specs/8239m-release-latest-published-stable/HISTORY.md
@@ -8,6 +8,7 @@
 ## Key Decisions
 
 - No separate historical decision record was present before this migration.
+- Release queue 以最新 pending snapshot 为发布候选；较新 stable tag 已证明发布后，其祖先路径上的旧 snapshot 视为被覆盖。这保证 release backlog 不会阻塞当前应用修复，同时保留 immutable snapshot 与 Git tag 的发布事实。
 
 ## Migrated Change History
 

--- a/docs/specs/8239m-release-latest-published-stable/IMPLEMENTATION.md
+++ b/docs/specs/8239m-release-latest-published-stable/IMPLEMENTATION.md
@@ -24,4 +24,5 @@
 - [x] M1: 拆分 immutable tags 与 publish-time tags 责任边界
 - [x] M2: 让 `latest` 只受更高已发布 stable 影响
 - [x] M3: README 与脚本级回归测试对齐新语义
-- [ ] M4: fast-track 推进到 PR / CI / review 收敛
+- [x] M4: release queue 选择最新 pending snapshot，并在较新 stable 发布后跳过已覆盖祖先项。
+- [ ] M5: fast-track 推进到 PR / CI / review 收敛

--- a/docs/specs/8239m-release-latest-published-stable/SPEC.md
+++ b/docs/specs/8239m-release-latest-published-stable/SPEC.md
@@ -1,54 +1,51 @@
 # Release `latest` 仅指向最新已发布 stable（#8239m）
 
-## 背景 / 问题陈述
+## Context and Scope
 
 - 当前 release snapshot 在写入 git notes 时，会把 stable 的 `tags_csv` 预写成 `vX.Y.Z + latest`。
 - 真正发布时，`Release` workflow 又会调用 `release_snapshot.py export --resolve-publication-tags` 重新计算 tags。
 - 现有重算逻辑把“主干后面存在更高 stable snapshot”直接等同于“存在更高已发布 stable”，导致手动 backfill、rerun 旧 stable 或 stable backlog 场景下，`latest` 可能被未发布的 pending stable 提前压掉。
-
-## 目标 / 非目标
 
 ### Goals
 
 - 明确并落地唯一语义：`latest` 只指向最新已发布 stable。
 - pending stable snapshot 不能压掉当前已发布 stable 的 `latest`。
 - stable 新 snapshot 的 immutable `tags_csv` 只保存版本 tag；`latest` 只在发布阶段动态解析。
+- release queue 必须优先选择最新的可发布 snapshot，避免较早的积压项阻塞当前应用修复。
+- 一旦较新的 stable snapshot 已发布，位于其祖先路径的未发布 snapshot 必须视为已覆盖，不得再次进入 release queue。
 - README、脚本帮助文案与回归测试统一到同一规则。
 
-### Non-goals
+### Out of Scope
 
-- 不调整 semver bump、release queue、手动 backfill 入口或 PR label 规则。
+- 不调整 semver bump、手动 backfill 入口或 PR label 规则。
 - 不引入 registry API / GitHub Release API 作为新的发布状态来源。
 - 不迁移历史 release snapshot note schema。
 
-## 范围（Scope）
-
-### In scope
+### In Scope
 
 - `.github/scripts/release_snapshot.py`：重构 immutable tags 与 publish-time tags 的职责边界。
 - `.github/scripts/test-release-snapshot.sh`：补齐 pending stable、旧 stable rerun/backfill、rc 不更新 latest 的回归。
 - `README.md`：更新 stable / rc 与 `latest` 的准确语义。
 
-### Out of scope
-
-- `.github/workflows/release.yml` 的工作流拓扑与权限模型。
-- 应用运行时代码、HTTP API、数据库或前端界面。
-
-## 需求（Requirements）
+## Requirements
 
 ### MUST
 
-- stable snapshot 写入 notes 时，`tags_csv` 只能包含不可变版本 tag。
-- `publication_tags()` 追加 `latest` 时，只能根据“是否存在更高已发布 stable”判定；未发布 snapshot 不得参与压制。
-- `release_tag_points_to_target()` 继续作为“该 snapshot 是否已发布”的权威信号。
-- 历史 snapshot 即使仍带 `latest`，在 `export --resolve-publication-tags` 时也必须按新规则重新计算，避免旧 note 影响结果。
+- REQ-001: stable snapshot 写入 notes 时，`tags_csv` 只能包含不可变版本 tag。
+- REQ-002: `publication_tags()` 追加 `latest` 时，只能根据“是否存在更高已发布 stable”判定；未发布 snapshot 不得参与压制。
+- REQ-003: `release_tag_points_to_target()` 继续作为“该 snapshot 是否已发布”的权威信号。
+- REQ-004: 历史 snapshot 即使仍带 `latest`，在 `export --resolve-publication-tags` 时也必须按新规则重新计算，避免旧 note 影响结果。
+- REQ-005: `next-pending` 必须选择未被明确判定为 CI Main 失败的最新 pending snapshot；较早的 unknown 状态不得阻塞较新的可发布 snapshot。
+- REQ-006: 若较新的 stable snapshot 已由其 immutable Git tag 证明发布，release queue 必须跳过该 stable target 之前的所有 snapshot。
 
 ### SHOULD
 
 - helper 命名直接体现 immutable tags 与 publish-time tags 的分工，避免再次出现双重真相源。
 - README 明确写出：`rc` 永不更新 `latest`；stable 仅在不存在更高已发布 stable 时更新 `latest`。
 
-## 验收标准（Acceptance Criteria）
+## Verification
+
+- VER-001 covers: REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006. `test-release-snapshot.sh` 验证 immutable tag、`latest`、最新 pending 选择和已覆盖祖先跳过语义。
 
 - Given 某个 stable 已发布，且主干后面只有更高但未发布的 stable snapshot
   When 对该已发布 stable 运行 `publication_tags()`
@@ -62,13 +59,23 @@
 - Given 新写入的 stable snapshot
   When 查看 immutable note 中的 `tags_csv`
   Then 只包含 `${image}:vX.Y.Z`。
+- Given 较早的 pending snapshot 的 CI 状态尚未索引，且较新的 pending snapshot 可发布
+  When 解析 `next-pending`
+  Then 选择较新的 snapshot，不被旧 snapshot 阻塞。
+- Given 较新的 stable snapshot 已发布
+  When 解析其祖先路径上的 pending snapshot
+  Then release queue 跳过这些已覆盖项。
 
-## 风险 / 假设（Risks / Assumptions）
+## Constraints
 
 - 风险：历史 note 仍可能保存 `latest`，所以 release workflow 必须继续通过 `--resolve-publication-tags` 动态重算。
 - 假设：当前 workflow 的发布顺序保持“manifest push/verify -> git tag -> GitHub Release”，因此 `release_tag_points_to_target()` 足以代表“已发布 stable”。
 
-## 参考（References）
+## Related ADRs
+
+- [ADR 0007: CI-contained representative-scale validation](../../adr/0007-ci-contained-representative-scale-validation.md)
+
+## References
 
 - `.github/scripts/release_snapshot.py`
 - `.github/scripts/test-release-snapshot.sh`


### PR DESCRIPTION
## Summary
- Select the newest CI-eligible pending release snapshot instead of blocking on older backlog.
- Treat ancestor snapshots as superseded once a newer stable tag proves publication.
- Preserve immutable snapshots and tags while allowing the latest Summary fix to release normally.

## Recovery
After this type:skip PR merges, the Release workflow selects the already merged Summary target and publishes v2.69.8. No manual tag, deployment, restart, or rollback is required.

## Validation
- bash .github/scripts/test-release-snapshot.sh
- bash .github/scripts/test-backend-test-contract.sh
- spec_contract_check.py for docs/specs/8239m-release-latest-published-stable/SPEC.md
- spec_drift_check.sh for the release specification
- GitHub CI will run the complete quality-gates contract; the shared testbox credential-safe source snapshot intentionally excludes workflow token placeholders and cannot execute that workflow-inspection test.

Delivery role: direct
Spec: docs/specs/8239m-release-latest-published-stable/SPEC.md
Spec Disposition: updated and synchronized
Solutions: -
Project Docs: -
<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->