### PR TITLE
fix(summary): supervise historical coverage recovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -164,6 +164,15 @@ the committed terminal tail that `RollingDelta` can reconstruct without
 re-reading historical archive pages.
 _Avoid_: archive coverage fence, request-time cursor, raw-source replay
 
+**Historical Summary Coverage Recovery Supervisor**:
+The single off-request owner for AllTime checkpoint pages and Legacy Summary
+Snapshot V2 backfill. It prioritizes pages intersecting the current 30-day
+horizon, commits each verified cursor/proof before yielding, and resumes after
+pressure, restart, or a generation fence change. It never calls the generic
+Projection builder for unfinished history; recent exact selections remain
+published while an unproven historical scope is selection-local unavailable.
+_Avoid_: startup full rebuild, request-time archive recovery, partial history
+
 **Legacy Summary Coverage Recovery**:
 The low-priority supervisor that seek-pages completed legacy invocation archives
 into verified Summary Archive Snapshot V2 pages. Its cursor and per-manifest

--- a/docs/adr/0011-prompt-cache-in-flight-phase-index.md
+++ b/docs/adr/0011-prompt-cache-in-flight-phase-index.md
@@ -1,4 +1,4 @@
-# ADR 0010: Prompt Cache In-Flight Phase Index
+# ADR 0011: Prompt Cache In-Flight Phase Index
 
 Status: Accepted
 

--- a/docs/adr/0012-historical-summary-coverage-supervisor.md
+++ b/docs/adr/0012-historical-summary-coverage-supervisor.md
@@ -1,0 +1,66 @@
+# ADR 0012: Historical Summary Coverage Recovery Supervisor
+
+Status: Accepted
+
+## Context
+
+Summary's recent selections must remain exact and memory-only while historical
+archive coverage converges under a bounded maintenance budget. A single refresh
+owner previously mixed rolling publication with all-time manifest proof, raw
+archive hydration, and legacy Snapshot recovery. A slow or missing archive could
+therefore repeat broad work, delay publication, or make an unrelated recent
+selection unavailable.
+
+The repository already has durable all-time and Snapshot V2 cursors. The missing
+boundary is runtime ownership: those cursors need one scheduler that can advance
+one verified page, yield to pressure and restart from committed progress without
+calling the generic Summary Projection builder.
+
+## Decision
+
+Introduce `SummaryCoverageRecoverySupervisor` as the only maintenance owner for
+historical Summary recovery. It coordinates two bounded workers:
+
+- All-time raw replacement and manifest/rollup proof advances use the existing
+  generation-fenced all-time checkpoint. Each verified page commits its cursor,
+  accumulator, and proof before the next page is considered.
+- Legacy archive recovery uses the existing seek-paged Snapshot V2 backfill. It
+  prioritizes candidates intersecting the current 30-day horizon, verifies
+  manifest SHA, row count, coverage, page order, and semantic decoding, and only
+  then records V2 authority. Missing or invalid sources become a finite
+  unavailable outcome; a pressure or SQLite lock defer leaves the uncommitted
+  cursor unchanged.
+
+The regular Summary refresh path publishes and renews the exact rolling
+Projection independently. It never calls the generic all-time build for an
+unfinished checkpoint and never opens paged raw archive sources. Once a
+checkpoint scope is exact-ready, the supervisor atomically merges its totals
+and the bounded live-tail overlay into the published Projection. A changed
+coverage fence retries the bounded supervisor pass; it does not revoke an
+already exact recent Projection.
+
+HTTP and Summary SSE continue to read only the immutable hub Projection and its
+availability overlay. A selection intersecting an unproven temporal, account,
+or current-rank boundary remains `unavailable`; disjoint exact selections stay
+available. The supervisor emits only stage, scope, count, cursor, proof, and
+duration telemetry and never places source payload in logs or responses.
+
+## Alternatives considered
+
+- Keep all-time and Snapshot recovery inside the generic Projection builder:
+  rejected because one slow archive can block or repeatedly rebuild unrelated
+  recent selections.
+- Run Snapshot backfill only from startup rollup maintenance: rejected because
+  startup ownership couples low-priority archive I/O to rollup scheduling and
+  does not provide one recovery owner or 30-day prioritization.
+- Reconstruct historical totals in the HTTP handler: rejected because it breaks
+  the Projection-only and zero request-time I/O contract.
+
+## Consequences
+
+Historical recovery has one observable owner, bounded page commits, and durable
+restart progress. Recent Summary availability no longer depends on all-time
+archive latency. The supervisor adds maintenance scheduling and a finalization
+merge, and all-time exactness may remain unavailable until its proof pages and
+Snapshot V2 authority complete. This is intentional fail-closed behavior: no
+partial or approximate totals are published.

--- a/docs/specs/dashboard-hot-topic-projection/SPEC.md
+++ b/docs/specs/dashboard-hot-topic-projection/SPEC.md
@@ -4,7 +4,7 @@
 
 ## Related ADRs
 
-- [ADR 0010: Prompt Cache In-Flight Phase Index](../../adr/0010-prompt-cache-in-flight-phase-index.md)
+- [ADR 0011: Prompt Cache In-Flight Phase Index](../../adr/0011-prompt-cache-in-flight-phase-index.md)
 
 ## Context and Scope
 

--- a/docs/specs/runtime-read-model-pressure-recovery/HISTORY.md
+++ b/docs/specs/runtime-read-model-pressure-recovery/HISTORY.md
@@ -45,3 +45,8 @@
 - All-time checkpoint freshness is keyed to scope-local manifest, rollup, replay
   and Snapshot proof versions. Committed terminal tail changes remain a bounded
   overlay and no longer cancel or restart historical raw recovery.
+- Historical Summary recovery now has one bounded Supervisor owner. AllTime
+  checkpoint pages and Legacy Snapshot V2 backfill yield independently, prefer
+  the current 30-day horizon, and commit proof before advancing their cursors;
+  unfinished history no longer re-enters generic Projection hydration or
+  blocks exact recent selections.

--- a/docs/specs/runtime-read-model-pressure-recovery/IMPLEMENTATION.md
+++ b/docs/specs/runtime-read-model-pressure-recovery/IMPLEMENTATION.md
@@ -28,6 +28,13 @@
   archive SHA and materializes bounded V2 pages. Missing, unreadable or
   mismatched authority is recorded as a finite unavailable outcome and remains
   retryable; a budget boundary leaves the cursor at the last committed page.
+- `SummaryCoverageRecoverySupervisor` is now the sole runtime owner for
+  unfinished AllTime checkpoint pages and Legacy Snapshot V2 backfill. It
+  advances one generation-fenced proof page, gives 30-day-intersecting Snapshot
+  candidates priority, and finalizes only after exact proof. The regular Summary
+  refresh path no longer invokes the generic AllTime builder or paged raw
+  hydration; pressure, restart, and SQLite lock defer preserve the last
+  committed cursor while recent Projection selections stay available.
 - HTTP and Summary SSE compose the immutable base and journal from hub memory.
   A current selection that would require rank replacement, or a time/account
   range intersecting a `DeltaGapProof`, is unavailable rather than approximate.

--- a/docs/specs/runtime-read-model-pressure-recovery/SPEC.md
+++ b/docs/specs/runtime-read-model-pressure-recovery/SPEC.md
@@ -11,6 +11,7 @@
 - [ADR 0008: Bounded incremental Summary projection recovery](../../adr/0008-bounded-incremental-summary-projection-recovery.md)
 - [ADR 0009: Durable Summary source-change and archive-snapshot recovery](../../adr/0009-durable-summary-source-change-and-archive-snapshot-recovery.md)
 - [ADR 0010: Summary coverage fence and Snapshot authority](../../adr/0010-summary-coverage-fence-and-snapshot-authority.md)
+- [ADR 0012: Historical Summary Coverage Recovery Supervisor](../../adr/0012-historical-summary-coverage-supervisor.md)
 - [ADR 0007: CI-contained representative-scale validation](../../adr/0007-ci-contained-representative-scale-validation.md)
 
 ## 背景 / 问题陈述

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -10608,141 +10608,155 @@ pub(crate) async fn refresh_summary_snapshots(state: &AppState) -> Result<()> {
     if !state.subscription_hub.has_summary_all_time_owner().await {
         return Ok(());
     }
-    if summary_projection_all_time_staged_recovery_required(&state.pool).await? {
-        let checkpoint = tokio::time::timeout(
-            SUMMARY_PROJECTION_BUILD_DEADLINE,
-            advance_summary_all_time_projection_checkpoint(state),
-        )
-        .await
-        .map_err(|_| {
-            anyhow!(
-                "summary all-time staged checkpoint exceeded {SUMMARY_PROJECTION_BUILD_DEADLINE:?}"
-            )
-        });
-        let checkpoint = match checkpoint {
-            Ok(Ok(checkpoint)) => checkpoint,
-            Ok(Err(error))
-                if error
-                    .downcast_ref::<SummaryProjectionAllTimeGenerationChanged>()
-                    .is_some() =>
-            {
-                debug!(
-                    "summary all-time staged checkpoint observed a generation change; rebuilding rolling projection"
-                );
-                refresh_summary_snapshots_with_mode(
-                    state,
-                    SummaryProjectionBuildMode::RollingDelta,
-                )
-                .await?;
-                return Ok(());
-            }
-            Ok(Err(error)) => {
-                warn!(error = ?error, "summary all-time staged checkpoint deferred; keeping fresh rolling projection");
-                return Ok(());
-            }
-            Err(error) => return Err(error),
-        };
-        if checkpoint.global_ready() || checkpoint.account_ready() {
-            let publication = tokio::time::timeout(
-                SUMMARY_PROJECTION_BUILD_DEADLINE,
-                publish_summary_all_time_projection_checkpoint(state, checkpoint),
-            )
-            .await
-            .map_err(|_| {
-                anyhow!(
-                    "summary all-time staged finalization exceeded {SUMMARY_PROJECTION_BUILD_DEADLINE:?}"
-                )
-            });
-            match publication {
-                Ok(Ok(())) => {}
-                Ok(Err(error))
-                    if error
-                        .downcast_ref::<SummaryProjectionAllTimeGenerationChanged>()
-                        .is_some() =>
-                {
-                    debug!(
-                        "summary all-time staged finalization observed a generation change; rebuilding rolling projection"
-                    );
-                    refresh_summary_snapshots_with_mode(
-                        state,
-                        SummaryProjectionBuildMode::RollingDelta,
-                    )
-                    .await?;
-                }
-                Ok(Err(error)) => {
-                    warn!(error = ?error, "summary all-time staged finalization deferred; keeping fresh rolling projection");
-                }
-                Err(error) => return Err(error),
-            }
-        } else {
-            // A proof page can establish that one or more immutable archives need raw
-            // replacement, but the checkpoint itself only advances compact proof cursors. Run
-            // that replacement on the AllTime reconciliation path: it is the sole background
-            // owner of paged raw archive hydration, and a deferred attempt leaves the already
-            // published rolling projection intact.
-            if let Err(error) =
-                refresh_summary_snapshots_with_mode(state, SummaryProjectionBuildMode::AllTime)
-                    .await
-            {
-                if error
-                    .downcast_ref::<SummaryProjectionAllTimeGenerationChanged>()
-                    .is_some()
-                {
-                    debug!(
-                        "summary all-time paged raw recovery observed a generation change; rebuilding rolling projection"
-                    );
-                    refresh_summary_snapshots_with_mode(
-                        state,
-                        SummaryProjectionBuildMode::RollingDelta,
-                    )
-                    .await?;
-                } else {
-                    warn!(error = ?error, "summary all-time paged raw recovery deferred; keeping fresh rolling projection");
-                }
-            }
-        }
-        return Ok(());
-    }
-    let coverage = tokio::time::timeout(
-        SUMMARY_PROJECTION_BUILD_DEADLINE,
-        advance_summary_all_time_coverage_checkpoint(&state.pool),
-    )
-    .await
-    .map_err(|_| {
-        anyhow!(
-            "summary all-time coverage checkpoint exceeded {SUMMARY_PROJECTION_BUILD_DEADLINE:?}"
-        )
-    })?;
-    let coverage = match coverage {
-        Ok(coverage) => coverage,
-        Err(error) => {
-            warn!(error = ?error, "summary all-time coverage checkpoint deferred; keeping fresh rolling projection");
-            return Ok(());
-        }
-    };
-    if !coverage.is_complete() {
-        debug!(
-            "summary all-time coverage checkpoint remains incomplete; keeping fresh rolling projection"
-        );
-        return Ok(());
-    }
-    if let Err(error) =
-        refresh_summary_snapshots_with_mode(state, SummaryProjectionBuildMode::AllTime).await
-    {
+    if let Err(error) = SummaryCoverageRecoverySupervisor::run(state).await {
         if error
             .downcast_ref::<SummaryProjectionAllTimeGenerationChanged>()
             .is_some()
         {
             debug!(
-                "summary all-time reconciliation cancelled after a generation change; rebuilding rolling projection"
+                "summary historical coverage recovery observed a generation change; keeping rolling projection"
             );
-            refresh_summary_snapshots_with_mode(state, SummaryProjectionBuildMode::RollingDelta)
-                .await?;
         } else {
-            warn!(error = ?error, "summary all-time reconciliation deferred; keeping fresh rolling projection");
+            warn!(error = ?error, "summary historical coverage recovery deferred; keeping fresh rolling projection");
         }
     }
     Ok(())
+}
+
+/// Owns historical Summary recovery independently from the availability-critical rolling
+/// projection. Every pass advances at most one bounded proof/checkpoint page, then gives the
+/// Snapshot V2 backfill a chance to recover the next missing authority. The generic projection
+/// builder is intentionally never used here: archive raw hydration belongs to this supervisor.
+pub(crate) struct SummaryCoverageRecoverySupervisor;
+
+impl SummaryCoverageRecoverySupervisor {
+    pub(crate) async fn run(state: &AppState) -> Result<()> {
+        let recovery = async {
+            for attempt in 0..2 {
+                match Self::run_once(state).await {
+                    Err(error)
+                        if error
+                            .downcast_ref::<SummaryProjectionAllTimeGenerationChanged>()
+                            .is_some()
+                            && attempt == 0 =>
+                    {
+                        // V2 proof publication advances the coverage fence. Refresh only the
+                        // bounded RollingDelta metadata before retrying finalization; never
+                        // fall back to the generic AllTime builder.
+                        refresh_summary_snapshots_with_deadline(
+                            state,
+                            SummaryProjectionBuildMode::RollingDelta,
+                            Some(SUMMARY_PROJECTION_BUILD_DEADLINE),
+                            true,
+                        )
+                        .await?;
+                    }
+                    result => return result,
+                }
+            }
+            Ok(())
+        };
+        tokio::pin!(recovery);
+        let mut renew = tokio::time::interval(SUMMARY_SNAPSHOT_MAX_STALE / 3);
+        loop {
+            tokio::select! {
+                result = &mut recovery => return result,
+                _ = renew.tick() => {
+                    if let Err(error) = renew_summary_projection_freshness_if_generation_matches(state).await {
+                        debug!(error = ?error, "summary historical coverage freshness renewal deferred");
+                    }
+                }
+            }
+        }
+    }
+
+    async fn run_once(state: &AppState) -> Result<()> {
+        let started_at = Instant::now();
+        let checkpoint = tokio::time::timeout(
+            SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE,
+            advance_summary_all_time_projection_checkpoint(state),
+        )
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "summary historical coverage checkpoint exceeded {SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE:?}"
+            )
+        })??;
+
+        if checkpoint.global_ready() || checkpoint.account_ready() {
+            let global_ready = checkpoint.global_ready();
+            let account_ready = checkpoint.account_ready();
+            #[cfg(test)]
+            pause_summary_projection_test_interleave(
+                &state.pool,
+                SummaryProjectionBuildMode::AllTime,
+                SummaryProjectionTestInterleaveStage::BeforeProjectionPublication,
+            )
+            .await?;
+            tokio::time::timeout(
+                SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE,
+                publish_summary_all_time_projection_checkpoint(state, checkpoint),
+            )
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "summary historical coverage finalization exceeded {SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE:?}"
+                )
+            })??;
+            info!(
+                stage = "historical_coverage_projection_publish",
+                elapsed_ms = started_at.elapsed().as_millis() as u64,
+                global_ready,
+                account_ready,
+                "summary historical coverage projection published"
+            );
+            if global_ready {
+                return Ok(());
+            }
+        }
+
+        let backfill = backfill_summary_archive_snapshots_v2_window(
+            &state.pool,
+            SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE.min(Duration::from_secs(2)),
+        )
+        .await?;
+        info!(
+            stage = "historical_coverage_snapshot_backfill",
+            elapsed_ms = started_at.elapsed().as_millis() as u64,
+            candidate_count = backfill.candidate_count,
+            scanned_archive_batches = backfill.scanned_archive_batches,
+            materialized_archive_batches = backfill.materialized_archive_batches,
+            unavailable_archive_batches = backfill.unavailable_archive_batches,
+            hit_budget = backfill.hit_budget,
+            "summary historical coverage recovery page completed"
+        );
+
+        // A successful V2 page may have completed the proof needed by the checkpoint. Continue
+        // bounded state-machine steps in this maintenance pass so small histories become
+        // publishable immediately; the deadline still prevents a large history from monopolizing
+        // the supervisor and every step commits its cursor independently.
+        for _ in 0..64 {
+            if started_at.elapsed() >= SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE {
+                break;
+            }
+            let checkpoint = advance_summary_all_time_projection_checkpoint(state).await?;
+            if checkpoint.global_ready() || checkpoint.account_ready() {
+                let global_ready = checkpoint.global_ready();
+                #[cfg(test)]
+                pause_summary_projection_test_interleave(
+                    &state.pool,
+                    SummaryProjectionBuildMode::AllTime,
+                    SummaryProjectionTestInterleaveStage::BeforeProjectionPublication,
+                )
+                .await?;
+                publish_summary_all_time_projection_checkpoint(state, checkpoint).await?;
+                if global_ready {
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 async fn renew_summary_projection_freshness_if_generation_matches(
@@ -10927,6 +10941,9 @@ pub(crate) async fn refresh_summary_snapshots_with_mode(
     state: &AppState,
     mode: SummaryProjectionBuildMode,
 ) -> Result<()> {
+    if matches!(mode, SummaryProjectionBuildMode::AllTime) {
+        return SummaryCoverageRecoverySupervisor::run(state).await;
+    }
     if matches!(mode, SummaryProjectionBuildMode::RollingDelta) {
         let started = Instant::now();
         if state
@@ -10981,11 +10998,15 @@ pub(crate) async fn refresh_summary_snapshots_with_mode(
         .await;
     }
     let deadline = match mode {
-        SummaryProjectionBuildMode::HistoricalLiveCoverage
-        | SummaryProjectionBuildMode::AllTime => SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE,
+        SummaryProjectionBuildMode::HistoricalLiveCoverage => {
+            SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE
+        }
         SummaryProjectionBuildMode::Bootstrap
         | SummaryProjectionBuildMode::RollingDelta
         | SummaryProjectionBuildMode::Rolling => SUMMARY_PROJECTION_BUILD_DEADLINE,
+        SummaryProjectionBuildMode::AllTime => {
+            unreachable!("AllTime is owned by coverage supervisor")
+        }
     };
     refresh_summary_snapshots_with_deadline(state, mode, Some(deadline), true).await
 }
@@ -11696,9 +11717,24 @@ async fn summary_all_time_coverage_page_is_exact(
         .map(|archive| archive.file_path().to_string())
         .collect::<Vec<_>>();
     let replay_coverage = load_summary_projection_archive_replay_coverage(pool, &paths).await?;
-    let account_ids_by_file = load_summary_projection_archive_manifest_account_sets(pool, &paths)
-        .await
-        .context("summary all-time coverage account manifest proof hydration failed")?;
+    // Account manifest admission is an independent proof.  A high-cardinality account
+    // manifest must only make account-scoped all-time unavailable; global replay/rollup proof
+    // can still advance over the same immutable archive page.
+    let account_manifest_overflow =
+        match load_summary_projection_archive_manifest_account_sets(pool, &paths).await {
+            Ok(account_ids_by_file) => Some(account_ids_by_file),
+            Err(error)
+                if error.to_string().starts_with(
+                    "summary projection archive account manifest exceeded bounded row budget",
+                ) =>
+            {
+                None
+            }
+            Err(error) => {
+                return Err(error
+                    .context("summary all-time coverage account manifest proof hydration failed"));
+            }
+        };
     let mut global_complete = true;
     let mut account_complete = true;
     for archive in &page.archives {
@@ -11706,9 +11742,15 @@ async fn summary_all_time_coverage_page_is_exact(
             .get(archive.file_path())
             .copied()
             .unwrap_or_default();
-        let account_ids = account_ids_by_file
-            .get(archive.file_path())
-            .expect("coverage proof account manifest includes every archive path");
+        let account_ids = account_manifest_overflow
+            .as_ref()
+            .and_then(|account_ids_by_file| account_ids_by_file.get(archive.file_path()));
+        // A verified Snapshot V2 page set is a complete normalized Summary source. It can
+        // replace both compact rollup and account-manifest proof when the raw archive is gone,
+        // allowing the historical supervisor to advance without reopening the source file.
+        if summary_archive_snapshot_path_has_proof(pool, archive.file_path()).await? {
+            continue;
+        }
         let (archive_global_complete, archive_account_complete) =
             if let Some(range) = summary_projection_archive_coverage_range(archive) {
                 let rollup_range = (
@@ -11720,20 +11762,26 @@ async fn summary_all_time_coverage_page_is_exact(
                     load_summary_projection_rollup_totals_in_range(pool, Some(rollup_range))
                         .await
                         .context("summary all-time coverage rollup key proof hydration failed")?;
-                summary_projection_all_time_manifest_scope_coverage(
-                    archive,
-                    replay,
-                    page.account_manifest_refreshed_paths
-                        .contains(archive.file_path()),
-                    account_ids,
-                    &hourly_rollup_totals,
-                )?
+                let (global_complete, mut account_complete) =
+                    summary_projection_all_time_manifest_scope_coverage(
+                        archive,
+                        replay,
+                        page.account_manifest_refreshed_paths
+                            .contains(archive.file_path()),
+                        account_ids.unwrap_or(&HashSet::new()),
+                        &hourly_rollup_totals,
+                    )?;
+                if account_ids.is_none() {
+                    account_complete = false;
+                }
+                (global_complete, account_complete)
             } else {
                 // Legacy manifests have no finite range. A replay marker is still required, but
                 // there are no concrete bucket keys to validate in this bounded proof page.
                 (
                     archive.has_materialized_historical_rollups() && replay.overall,
                     archive.has_materialized_historical_rollups()
+                        && account_ids.is_some()
                         && page
                             .account_manifest_refreshed_paths
                             .contains(archive.file_path())
@@ -11748,6 +11796,25 @@ async fn summary_all_time_coverage_page_is_exact(
         }
     }
     Ok((global_complete, account_complete))
+}
+
+async fn summary_archive_snapshot_path_has_proof(
+    pool: &Pool<Sqlite>,
+    file_path: &str,
+) -> Result<bool> {
+    let Some((archive_batch_id, manifest_sha256)) = sqlx::query_as::<_, (i64, String)>(
+        "SELECT id, sha256 FROM archive_batches
+         WHERE dataset = 'codex_invocations' AND status = 'completed' AND file_path = ?1
+         ORDER BY id DESC LIMIT 1",
+    )
+    .bind(file_path)
+    .fetch_optional(pool)
+    .await
+    .context("summary Snapshot V2 manifest identity lookup failed")?
+    else {
+        return Ok(false);
+    };
+    summary_archive_snapshot_has_proof(pool, archive_batch_id, &manifest_sha256).await
 }
 
 async fn advance_summary_all_time_coverage_checkpoint_scope(
@@ -12440,7 +12507,13 @@ async fn advance_summary_all_time_projection_checkpoint(
         .await?
         .coverage_sources_match(generation_fence)
     {
-        return Err(SummaryProjectionAllTimeGenerationChanged.into());
+        // The rolling projection may predate a newly verified Snapshot V2 page. Its recent
+        // records remain exact; the finalizer can merge the historical totals and publish the
+        // current fence atomically below. A concurrent live fence change is still checked before
+        // the swap.
+        debug!(
+            "summary historical coverage finalization is merging into a projection with an older coverage fence"
+        );
     }
     Ok(checkpoint)
 }
@@ -12471,6 +12544,240 @@ async fn summary_all_time_projection_checkpoint_live_tail_count(
     Ok(())
 }
 
+fn summary_snapshot_v2_record_preview(
+    record: SummaryArchiveSnapshotV2Record,
+) -> UpstreamAccountInvocationPreviewRow {
+    UpstreamAccountInvocationPreviewRow {
+        upstream_account_id: record.upstream_account_id,
+        id: record.id,
+        invoke_id: record.invoke_id,
+        prompt_cache_key: None,
+        occurred_at: record.occurred_at,
+        conversation_created_at: None,
+        status: record.status,
+        live_phase: None,
+        failure_class: record.failure_class,
+        route_mode: None,
+        model: record.model,
+        request_model: None,
+        response_model: record.response_model,
+        total_tokens: record.total_tokens,
+        cost: record.cost,
+        cost_input: record.cost_input,
+        cost_cache_write: record.cost_cache_write,
+        cost_cache_read: record.cost_cache_read,
+        cost_output: record.cost_output,
+        cost_reasoning: record.cost_reasoning,
+        source: Some(record.source),
+        input_tokens: Some(record.input_tokens),
+        output_tokens: Some(record.output_tokens),
+        cache_input_tokens: Some(record.cache_input_tokens),
+        reasoning_tokens: Some(record.reasoning_tokens),
+        reasoning_effort: record.reasoning_effort,
+        error_message: record.error_message,
+        downstream_status_code: None,
+        downstream_error_message: None,
+        failure_kind: record.failure_kind,
+        is_actionable: Some(i64::from(record.is_actionable)),
+        proxy_display_name: None,
+        upstream_account_name: None,
+        upstream_account_plan_type: None,
+        response_content_encoding: None,
+        request_compression_algorithm: None,
+        transport: None,
+        requested_service_tier: None,
+        service_tier: None,
+        billing_service_tier: None,
+        t_req_read_ms: None,
+        t_req_parse_ms: None,
+        t_upstream_connect_ms: None,
+        t_upstream_ttfb_ms: None,
+        first_token_ms: None,
+        t_upstream_stream_ms: None,
+        t_resp_parse_ms: None,
+        t_persist_ms: None,
+        t_total_ms: None,
+        endpoint: None,
+        compaction_request_kind: None,
+        compaction_response_kind: None,
+        image_intent: None,
+    }
+}
+
+#[derive(Default)]
+struct SummaryV2ArchiveTotals {
+    global: StatsTotals,
+    accounts: HashMap<i64, StatsTotals>,
+    global_usage: UsageBreakdownAccumulator,
+    account_usage: HashMap<i64, UsageBreakdownAccumulator>,
+    global_by_bucket: HashMap<i64, StatsTotals>,
+    account_by_bucket: HashMap<(i64, i64), StatsTotals>,
+    global_usage_by_bucket: HashMap<i64, UsageBreakdownAccumulator>,
+    account_usage_by_bucket: HashMap<(i64, i64), UsageBreakdownAccumulator>,
+    replacement_buckets: HashSet<i64>,
+    materialized_buckets: HashSet<i64>,
+    materialized_months_without_coverage: HashSet<String>,
+}
+
+async fn load_summary_v2_archive_totals(pool: &Pool<Sqlite>) -> Result<SummaryV2ArchiveTotals> {
+    let archives = sqlx::query_as::<_, (i64, String, Option<String>, Option<String>, Option<String>, Option<String>)>(
+        "SELECT id, sha256, historical_rollups_materialized_at, coverage_start_at, coverage_end_at, month_key
+         FROM archive_batches
+         WHERE dataset = 'codex_invocations' AND status = 'completed'
+           AND COALESCE(summary_source_kind, 'unknown') <> 'live_mirror'",
+    )
+    .fetch_all(pool)
+    .await
+    .context("summary V2 archive totals manifest lookup failed")?;
+    let mut totals = SummaryV2ArchiveTotals::default();
+    for (
+        archive_batch_id,
+        manifest_sha256,
+        materialized_at,
+        coverage_start,
+        coverage_end,
+        month_key,
+    ) in archives
+    {
+        if materialized_at.is_some() {
+            if let (Some(start), Some(end)) = (
+                coverage_start
+                    .as_deref()
+                    .and_then(parse_snapshot_coverage_at),
+                coverage_end.as_deref().and_then(parse_snapshot_coverage_at),
+            ) {
+                let mut bucket = align_bucket_epoch(start.timestamp(), 3_600, 0);
+                let end_bucket = align_bucket_epoch(end.timestamp(), 3_600, 0);
+                let mut count = 0usize;
+                while bucket <= end_bucket && count < 4096 {
+                    totals.materialized_buckets.insert(bucket);
+                    bucket = bucket.saturating_add(3_600);
+                    count += 1;
+                }
+            } else if let Some(month_key) = month_key {
+                totals
+                    .materialized_months_without_coverage
+                    .insert(month_key);
+            }
+            continue;
+        }
+        if !summary_archive_snapshot_has_proof(pool, archive_batch_id, &manifest_sha256).await? {
+            continue;
+        }
+        // Materialized archives are already represented by the durable rollup checkpoint. V2
+        // pages are only an aggregate source for an unmaterialized archive whose stale or
+        // missing replay markers would otherwise leave the checkpoint without exact totals.
+        // Adding a materialized page set here would double count its rollup totals.
+        let pages = sqlx::query_scalar::<_, Vec<u8>>(
+            "SELECT payload FROM summary_archive_snapshot
+             WHERE archive_batch_id = ?1 AND manifest_sha256 = ?2 ORDER BY page_index ASC",
+        )
+        .bind(archive_batch_id)
+        .bind(&manifest_sha256)
+        .fetch_all(pool)
+        .await?;
+        for payload in pages {
+            let records = decode_summary_archive_snapshot_v2_payload(&payload)?;
+            let mut identity_query = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+                "SELECT id, invoke_id FROM codex_invocations WHERE id IN (",
+            );
+            {
+                let mut separated = identity_query.separated(", ");
+                for record in &records {
+                    separated.push_bind(record.id);
+                }
+            }
+            identity_query.push(") OR invoke_id IN (");
+            {
+                let mut separated = identity_query.separated(", ");
+                for record in &records {
+                    separated.push_bind(&record.invoke_id);
+                }
+            }
+            identity_query.push(")");
+            let live_identity = identity_query
+                .build_query_as::<(i64, String)>()
+                .fetch_all(pool)
+                .await?
+                .into_iter()
+                .collect::<HashSet<_>>();
+            for record in records {
+                if live_identity.contains(&(record.id, record.invoke_id.clone()))
+                    || live_identity
+                        .iter()
+                        .any(|(_, invoke_id)| invoke_id == &record.invoke_id)
+                {
+                    continue;
+                }
+                let preview = summary_snapshot_v2_record_preview(record);
+                let summary_record = SummaryProjectionRecord {
+                    occurred_at: parse_to_utc_datetime(&preview.occurred_at)
+                        .ok_or_else(|| anyhow!("V2 Snapshot record has invalid occurred_at"))?,
+                    global_rollup_covered: false,
+                    account_rollup_covered: false,
+                    usage_global_rollup_covered: false,
+                    usage_account_rollup_covered: false,
+                    is_persisted_live_record: false,
+                    is_archive_record: true,
+                    archive_has_materialized_rollups: false,
+                    account_archive_totals_fallback_included: false,
+                    row: preview.clone(),
+                };
+                let record_totals = summary_projection_all_time_record_totals(&summary_record);
+                let bucket = align_bucket_epoch(summary_record.occurred_at.timestamp(), 3_600, 0);
+                let archive_month = preview.occurred_at.get(..7).unwrap_or_default();
+                if !totals.materialized_buckets.contains(&bucket)
+                    && !totals
+                        .materialized_months_without_coverage
+                        .contains(archive_month)
+                {
+                    totals.replacement_buckets.insert(bucket);
+                }
+                totals.global = totals.global.add(record_totals);
+                let bucket_totals = totals.global_by_bucket.entry(bucket).or_default();
+                *bucket_totals = bucket_totals.add(record_totals);
+                totals
+                    .global_usage_by_bucket
+                    .entry(bucket)
+                    .or_default()
+                    .add_row(&preview);
+                if let Some(account_id) = preview.upstream_account_id.filter(|id| *id > 0) {
+                    let entry = totals.accounts.entry(account_id).or_default();
+                    *entry = entry.add(record_totals);
+                    let bucket_entry = totals
+                        .account_by_bucket
+                        .entry((bucket, account_id))
+                        .or_default();
+                    *bucket_entry = bucket_entry.add(record_totals);
+                    totals
+                        .account_usage
+                        .entry(account_id)
+                        .or_default()
+                        .add_row(&preview);
+                    totals
+                        .account_usage_by_bucket
+                        .entry((bucket, account_id))
+                        .or_default()
+                        .add_row(&preview);
+                }
+                totals.global_usage.add_row(&preview);
+            }
+        }
+    }
+    Ok(totals)
+}
+
+fn subtract_summary_totals(left: StatsTotals, right: StatsTotals) -> StatsTotals {
+    StatsTotals {
+        total_count: left.total_count.saturating_sub(right.total_count),
+        success_count: left.success_count.saturating_sub(right.success_count),
+        failure_count: left.failure_count.saturating_sub(right.failure_count),
+        total_tokens: left.total_tokens.saturating_sub(right.total_tokens),
+        total_cost: (left.total_cost - right.total_cost).max(0.0),
+        non_success_cost: (left.non_success_cost - right.non_success_cost).max(0.0),
+    }
+}
+
 async fn publish_summary_all_time_projection_checkpoint(
     state: &AppState,
     checkpoint: SummaryAllTimeProjectionCheckpointRow,
@@ -12479,12 +12786,6 @@ async fn publish_summary_all_time_projection_checkpoint(
         return Ok(());
     }
     let generation_fence = checkpoint.generation_fence();
-    if !load_summary_projection_generation_fence(state)
-        .await?
-        .coverage_sources_match(generation_fence)
-    {
-        return Err(SummaryProjectionAllTimeGenerationChanged.into());
-    }
     let projection = state
         .subscription_hub
         .summary_projection()
@@ -12492,12 +12793,6 @@ async fn publish_summary_all_time_projection_checkpoint(
         .ok_or_else(|| {
             anyhow!("summary all-time checkpoint requires a published rolling projection")
         })?;
-    if !projection
-        .generation_fence
-        .coverage_sources_match(generation_fence)
-    {
-        return Err(SummaryProjectionAllTimeGenerationChanged.into());
-    }
     let mut next = Arc::unwrap_or_clone(projection);
     let published_at = Instant::now();
     let mut account_ids = HashSet::new();
@@ -12507,32 +12802,100 @@ async fn publish_summary_all_time_projection_checkpoint(
     } else {
         HashMap::new()
     };
+    let snapshot_totals = load_summary_v2_archive_totals(&state.pool).await?;
+    let hourly_rollup_totals = if checkpoint.global_ready() || checkpoint.account_ready() {
+        load_summary_projection_rollup_totals(&state.pool).await?.0
+    } else {
+        HashMap::new()
+    };
     if checkpoint.global_ready() {
+        let live_high_watermark_id =
+            load_summary_projection_live_high_watermark(&state.pool).await?;
         summary_all_time_projection_checkpoint_live_tail_count(
             &state.pool,
             generation_fence.rollup_live_cursor,
-            generation_fence.live_high_watermark_id,
+            live_high_watermark_id,
             "global",
         )
         .await?;
-        let live_tail =
-            if generation_fence.live_high_watermark_id > generation_fence.rollup_live_cursor {
-                crate::stats::query_live_invocation_totals_after_id(
+        let live_tail = if live_high_watermark_id > generation_fence.rollup_live_cursor {
+            crate::stats::query_live_invocation_totals_after_id(
+                &state.pool,
+                InvocationSourceScope::All,
+                generation_fence.rollup_live_cursor,
+                live_high_watermark_id,
+            )
+            .await
+            .map_err(|error| {
+                anyhow!("summary all-time staged global live-tail hydration failed: {error:?}")
+            })?
+        } else {
+            StatsTotals::default()
+        };
+        let has_completed_archives = sqlx::query_scalar::<_, i64>(
+            "SELECT EXISTS(SELECT 1 FROM archive_batches WHERE dataset = 'codex_invocations' AND status = 'completed' AND COALESCE(summary_source_kind, 'unknown') <> 'live_mirror')",
+        )
+        .fetch_one(&state.pool)
+        .await
+        .context("summary all-time archive presence lookup failed")?
+            != 0;
+        if has_completed_archives
+            && generation_fence.live_high_watermark_id > generation_fence.rollup_live_cursor
+            && generation_fence.rollup_live_cursor == 0
+        {
+            // A compact historical baseline without a live cursor cannot prove whether any
+            // retained live rows are already represented. Keep all-time fail-closed until the
+            // background rollup/recovery owner establishes that boundary.
+            return Ok(());
+        }
+        let mut totals = if has_completed_archives {
+            checkpoint.global_totals().add(live_tail)
+        } else {
+            StatsTotals::from(
+                crate::stats::query_stats_row_through_id(
                     &state.pool,
                     InvocationSourceScope::All,
-                    generation_fence.rollup_live_cursor,
                     generation_fence.live_high_watermark_id,
                 )
                 .await
-                .map_err(|error| {
-                    anyhow!("summary all-time staged global live-tail hydration failed: {error:?}")
-                })?
-            } else {
-                StatsTotals::default()
-            };
-        let mut totals = checkpoint.global_totals().add(live_tail);
+                .context("summary all-time live-only finalization failed")?,
+            )
+        };
+        let mut exact_replacement_buckets = snapshot_totals.replacement_buckets.clone();
+        for record in next.records.iter().chain(next.current_records.iter()) {
+            if summary_projection_all_time_uses_global_exact_record(
+                record,
+                generation_fence.rollup_live_cursor,
+            ) && record.archive_has_materialized_rollups
+            {
+                exact_replacement_buckets.insert(align_bucket_epoch(
+                    record.occurred_at.timestamp(),
+                    3_600,
+                    0,
+                ));
+            }
+        }
+        for bucket in &exact_replacement_buckets {
+            if let Some(rollup) = hourly_rollup_totals.get(&(*bucket, None)) {
+                totals = subtract_summary_totals(totals, *rollup);
+            }
+        }
+        for snapshot in snapshot_totals.global_by_bucket.values() {
+            // V2 pages belong to unmaterialized archives and therefore add history that is not
+            // present in the compact checkpoint. Replacement buckets were subtracted above so
+            // their page totals are also added back exactly once; a sibling sharing a materialized
+            // bucket still contributes its own rows without replacing that sibling's rollup.
+            totals = totals.add(*snapshot);
+        }
         let mut exact_record_ids = HashSet::new();
         for record in next.records.iter().chain(next.current_records.iter()) {
+            let bucket = align_bucket_epoch(record.occurred_at.timestamp(), 3_600, 0);
+            if record.is_persisted_live_record
+                && record.row.id <= generation_fence.rollup_live_cursor
+                && hourly_rollup_totals.contains_key(&(bucket, None))
+            {
+                continue;
+            }
             if !exact_record_ids.insert(record.row.invoke_id.as_str())
                 || !summary_projection_all_time_uses_global_exact_record(
                     record,
@@ -12545,12 +12908,26 @@ async fn publish_summary_all_time_projection_checkpoint(
         }
         let mut usage = UsageBreakdownAccumulator::default();
         for (key, value) in &hourly_rollup_usage {
+            if key.1.is_none() && exact_replacement_buckets.contains(&key.0) {
+                continue;
+            }
             if key.1.is_none() {
                 usage.merge_response(value);
             }
         }
+        for snapshot in snapshot_totals.global_usage_by_bucket.values() {
+            usage.merge_response(&snapshot.clone().into_response());
+        }
         let mut response = totals.into_response();
-        response.usage_breakdown = Some(usage.into_response());
+        let usage_response = usage.into_response();
+        if usage_response.cache_read_tokens > 0
+            || usage_response.cache_write_tokens > 0
+            || usage_response.output_tokens > 0
+            || usage_response.costs.is_some()
+            || !usage_response.models.is_empty()
+        {
+            response.usage_breakdown = Some(usage_response);
+        }
         response.non_success_cost = Some(totals.non_success_cost);
         response.maintenance = next.maintenance.clone();
         let in_progress = next
@@ -12577,9 +12954,8 @@ async fn publish_summary_all_time_projection_checkpoint(
             .collect();
     }
 
-    if checkpoint.account_ready()
-        && let Some(account_rollup_live_cursor) = generation_fence.account_rollup_live_cursor
-    {
+    if checkpoint.account_ready() {
+        let account_rollup_live_cursor = generation_fence.account_rollup_live_cursor.unwrap_or(0);
         summary_all_time_projection_checkpoint_live_tail_count(
             &state.pool,
             account_rollup_live_cursor,
@@ -12587,6 +12963,20 @@ async fn publish_summary_all_time_projection_checkpoint(
             "account",
         )
         .await?;
+        let mut account_replacement_buckets = snapshot_totals.replacement_buckets.clone();
+        for record in next.records.iter().chain(next.current_records.iter()) {
+            if summary_projection_all_time_uses_account_exact_record(
+                record,
+                generation_fence.account_rollup_live_cursor,
+            ) && record.archive_has_materialized_rollups
+            {
+                account_replacement_buckets.insert(align_bucket_epoch(
+                    record.occurred_at.timestamp(),
+                    3_600,
+                    0,
+                ));
+            }
+        }
         let mut account_totals = sqlx::query_as::<_, SummaryAllTimeCheckpointAccountTotalsRow>(
             "SELECT upstream_account_id, total_count, success_count, failure_count, total_tokens, \
                     total_cost, non_success_cost \
@@ -12599,6 +12989,17 @@ async fn publish_summary_all_time_projection_checkpoint(
         .into_iter()
         .map(|row| (row.upstream_account_id, row.totals()))
         .collect::<HashMap<_, _>>();
+        if !account_replacement_buckets.is_empty() {
+            account_totals = load_summary_projection_account_rollup_totals(
+                &state.pool,
+                &account_replacement_buckets,
+            )
+            .await?;
+        }
+        for (account_id, snapshot) in &snapshot_totals.accounts {
+            let entry = account_totals.entry(*account_id).or_default();
+            *entry = entry.add(*snapshot);
+        }
         if generation_fence.live_high_watermark_id > account_rollup_live_cursor {
             for (account_id, totals) in load_summary_projection_live_tail_account_totals(
                 &state.pool,
@@ -12613,6 +13014,13 @@ async fn publish_summary_all_time_projection_checkpoint(
         }
         let mut exact_record_ids = HashSet::new();
         for record in next.records.iter().chain(next.current_records.iter()) {
+            let bucket = align_bucket_epoch(record.occurred_at.timestamp(), 3_600, 0);
+            if record.is_persisted_live_record
+                && record.row.id <= account_rollup_live_cursor
+                && hourly_rollup_totals.contains_key(&(bucket, record.row.upstream_account_id))
+            {
+                continue;
+            }
             if !exact_record_ids.insert(record.row.invoke_id.as_str())
                 || !summary_projection_all_time_uses_account_exact_record(
                     record,
@@ -12637,12 +13045,28 @@ async fn publish_summary_all_time_projection_checkpoint(
         for (account_id, totals) in account_totals {
             let mut usage = UsageBreakdownAccumulator::default();
             for (key, value) in &hourly_rollup_usage {
-                if key.1 == Some(account_id) {
+                if key.1 == Some(account_id) && !account_replacement_buckets.contains(&key.0) {
                     usage.merge_response(value);
                 }
             }
+            for bucket in &snapshot_totals.replacement_buckets {
+                if let Some(snapshot) = snapshot_totals
+                    .account_usage_by_bucket
+                    .get(&(*bucket, account_id))
+                {
+                    usage.merge_response(&snapshot.clone().into_response());
+                }
+            }
             let mut response = totals.into_response();
-            response.usage_breakdown = Some(usage.into_response());
+            let usage_response = usage.into_response();
+            if usage_response.cache_read_tokens > 0
+                || usage_response.cache_write_tokens > 0
+                || usage_response.output_tokens > 0
+                || usage_response.costs.is_some()
+                || !usage_response.models.is_empty()
+            {
+                response.usage_breakdown = Some(usage_response);
+            }
             response.non_success_cost = Some(totals.non_success_cost);
             response.maintenance = next.maintenance.clone();
             let in_progress = next
@@ -12668,7 +13092,10 @@ async fn publish_summary_all_time_projection_checkpoint(
             .extend(account_ids.iter().copied());
         next.known_account_ids.extend(account_ids.iter().copied());
         next.all_time_account_manifest_admission_blocked_at = None;
-    } else if checkpoint.account_unavailable != 0 {
+    } else if checkpoint.account_unavailable != 0 || checkpoint.account_manifest_complete == 0 {
+        // An account scope without a complete manifest/rollup proof is not an empty account;
+        // retain a local unavailable marker so unknown or affected account selections fail closed
+        // while the independent global projection remains exact.
         next.all_time_account_manifest_admission_blocked_at = Some(published_at);
     }
 
@@ -33471,7 +33898,7 @@ mod request_compression_query_tests {
         .await
         .expect("create finalization interleave gate");
         let interleave = install_summary_projection_test_interleave_at(
-            SummaryProjectionTestInterleaveStage::AfterAllTimeArchiveDiscovery,
+            SummaryProjectionTestInterleaveStage::BeforeProjectionPublication,
         );
         let state_for_finalization = state.clone();
         let finalization = tokio::spawn(async move {
@@ -33555,7 +33982,7 @@ mod request_compression_query_tests {
         .await
         .expect("create finalization interleave gate");
         let interleave = install_summary_projection_test_interleave_at(
-            SummaryProjectionTestInterleaveStage::AfterAllTimeArchiveDiscovery,
+            SummaryProjectionTestInterleaveStage::BeforeProjectionPublication,
         );
         let refresh_state = state.clone();
         let refresh =
@@ -33586,6 +34013,7 @@ mod request_compression_query_tests {
             .subscription_hub
             .acknowledge_replayed_summary_delta(delta)
             .await;
+        interleave.resume_build();
 
         let result = tokio::time::timeout(
             SUMMARY_PROJECTION_ALL_TIME_FINALIZATION_DEADLINE + Duration::from_secs(2),
@@ -34346,7 +34774,7 @@ mod request_compression_query_tests {
     }
 
     #[tokio::test]
-    async fn summary_projection_staged_recovery_reaches_paged_raw_hydration() {
+    async fn summary_projection_staged_recovery_defers_paged_raw_to_supervisor() {
         let state = crate::tests::test_state_with_openai_base(
             url::Url::parse("http://127.0.0.1:9").expect("valid test URL"),
         )
@@ -34400,18 +34828,94 @@ mod request_compression_query_tests {
                 async move { refresh_summary_snapshots(state_for_recovery.as_ref()).await },
             );
         tokio::pin!(recovery);
+        tokio::time::timeout(Duration::from_secs(5), &mut recovery)
+            .await
+            .expect("staged coverage supervisor should not wait on generic raw hydration")
+            .expect("join staged coverage recovery")
+            .expect("defer unavailable raw source without withdrawing rolling projection");
+        clear_summary_projection_test_interleave();
+        assert_eq!(
+            interleave.build_attempts(),
+            0,
+            "staged coverage recovery must defer paged raw hydration to its own page worker",
+        );
+        state.pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn summary_all_time_recovery_never_enters_live_exact_admission() {
+        let state = crate::tests::test_state_with_openai_base(
+            url::Url::parse("http://127.0.0.1:9").expect("valid test URL"),
+        )
+        .await;
+        let archive_bucket_start = Utc
+            .timestamp_opt(
+                align_bucket_epoch((Utc::now() - ChronoDuration::days(3)).timestamp(), 3_600, 0),
+                0,
+            )
+            .single()
+            .expect("valid recovery archive bucket");
+        let coverage_start = crate::stats::db_occurred_at_lower_bound(archive_bucket_start);
+        let coverage_end =
+            crate::db_occurred_at_upper_bound(archive_bucket_start + ChronoDuration::hours(1));
+        for index in 0..=SUMMARY_PROJECTION_MAX_ARCHIVE_BATCHES {
+            sqlx::query(
+                "INSERT INTO archive_batches \
+                 (dataset, month_key, file_path, sha256, row_count, status, coverage_start_at, coverage_end_at, \
+                  historical_rollups_materialized_at) \
+                 VALUES ('codex_invocations', '2026-08', ?1, ?2, 1, 'completed', ?3, ?4, datetime('now'))",
+            )
+            .bind(format!("/definitely/missing/summary-recovery-{index}.sqlite.gz"))
+            .bind(format!("summary-recovery-{index}"))
+            .bind(&coverage_start)
+            .bind(&coverage_end)
+            .execute(&state.pool)
+            .await
+            .expect("seed recovery manifest");
+        }
+        hydrate_summary_snapshots(state.as_ref())
+            .await
+            .expect("publish rolling projection before all-time recovery");
+        sqlx::query(
+            "CREATE TABLE summary_projection_test_interleave_gate (id INTEGER PRIMARY KEY)",
+        )
+        .execute(&state.pool)
+        .await
+        .expect("create recovery interleave gate");
+        state
+            .subscription_hub
+            .note_summary_http_interest(true)
+            .await;
+        let interleave = install_summary_projection_test_interleave_at(
+            SummaryProjectionTestInterleaveStage::BeforePagedBoundaryArchiveHydration,
+        );
+        let state_for_recovery = state.clone();
+        let recovery =
+            tokio::spawn(
+                async move { refresh_summary_snapshots(state_for_recovery.as_ref()).await },
+            );
+        tokio::pin!(recovery);
         tokio::select! {
+            result = &mut recovery => {
+                clear_summary_projection_test_interleave();
+                result.expect("run summary coverage recovery").expect("recovery should not fail");
+            }
             _ = interleave.wait_for_writer() => {
                 interleave.resume_build();
                 let _ = recovery.await;
                 clear_summary_projection_test_interleave();
-            }
-            result = &mut recovery => {
-                clear_summary_projection_test_interleave();
-                result.expect("run staged all-time recovery").expect("defer unavailable raw source without withdrawing rolling projection");
-                panic!("staged all-time recovery must own paged raw archive hydration");
+                assert_eq!(
+                    interleave.build_attempts(),
+                    0,
+                    "AllTime recovery must not enter generic paged raw hydration",
+                );
             }
         }
+        assert_eq!(
+            interleave.build_attempts(),
+            0,
+            "AllTime recovery must not enter generic paged raw hydration",
+        );
         state.pool.close().await;
     }
 
@@ -34542,30 +35046,14 @@ mod request_compression_query_tests {
         let all_time_interleave = install_summary_projection_test_interleave_at(
             SummaryProjectionTestInterleaveStage::BeforePagedBoundaryArchiveHydration,
         );
-        let state_for_all_time = state.clone();
-        let all_time = tokio::spawn(async move {
-            refresh_summary_snapshots_with_mode(
-                state_for_all_time.as_ref(),
-                SummaryProjectionBuildMode::AllTime,
-            )
+        refresh_summary_snapshots_with_mode(state.as_ref(), SummaryProjectionBuildMode::AllTime)
             .await
-        });
-        tokio::pin!(all_time);
-        tokio::select! {
-            _ = all_time_interleave.wait_for_writer() => {
-                all_time_interleave.resume_build();
-                let _ = all_time.await;
-                clear_summary_projection_test_interleave();
-            }
-            _ = &mut all_time => {
-                clear_summary_projection_test_interleave();
-                panic!("all-time reconciliation must own paged boundary raw archive hydration");
-            }
-        }
+            .expect("coverage supervisor should defer missing raw archives");
+        clear_summary_projection_test_interleave();
         assert_eq!(
             all_time_interleave.build_attempts(),
-            1,
-            "only all-time reconciliation may enter the paged raw archive stage",
+            0,
+            "AllTime supervisor must not enter the generic paged raw projection builder",
         );
         state.pool.close().await;
 
@@ -34636,6 +35124,9 @@ mod request_compression_query_tests {
         .execute(&state.pool)
         .await
         .expect("create historical coverage interleave gate");
+        hydrate_summary_snapshots(state.as_ref())
+            .await
+            .expect("publish rolling projection before AllTime coverage recovery");
         let interleave = install_summary_projection_test_interleave_at(
             SummaryProjectionTestInterleaveStage::BeforeHistoricalLiveCoverage,
         );
@@ -34705,6 +35196,9 @@ mod request_compression_query_tests {
         .execute(&state.pool)
         .await
         .expect("create historical coverage interleave gate");
+        hydrate_summary_snapshots(state.as_ref())
+            .await
+            .expect("publish rolling projection before AllTime coverage recovery");
         let interleave = install_summary_projection_test_interleave_at(
             SummaryProjectionTestInterleaveStage::BeforeHistoricalLiveCoverage,
         );

--- a/src/api/slices/invocations_and_summary.rs
+++ b/src/api/slices/invocations_and_summary.rs
@@ -10657,7 +10657,13 @@ impl SummaryCoverageRecoverySupervisor {
             Ok(())
         };
         tokio::pin!(recovery);
-        let mut renew = tokio::time::interval(SUMMARY_SNAPSHOT_MAX_STALE / 3);
+        // Do not renew the lease on the interval's immediate first tick.  A just-published
+        // projection must still honor its recorded `refreshed_at`; the first keepalive is only
+        // needed after one cadence interval while a long historical page is in flight.
+        let mut renew = tokio::time::interval_at(
+            tokio::time::Instant::now() + SUMMARY_SNAPSHOT_MAX_STALE / 3,
+            SUMMARY_SNAPSHOT_MAX_STALE / 3,
+        );
         loop {
             tokio::select! {
                 result = &mut recovery => return result,
@@ -13012,12 +13018,24 @@ async fn publish_summary_all_time_projection_checkpoint(
                 *entry = entry.add(totals);
             }
         }
+        let account_live_tail_loaded =
+            generation_fence.live_high_watermark_id > account_rollup_live_cursor;
         let mut exact_record_ids = HashSet::new();
         for record in next.records.iter().chain(next.current_records.iter()) {
             let bucket = align_bucket_epoch(record.occurred_at.timestamp(), 3_600, 0);
             if record.is_persisted_live_record
                 && record.row.id <= account_rollup_live_cursor
                 && hourly_rollup_totals.contains_key(&(bucket, record.row.upstream_account_id))
+            {
+                continue;
+            }
+            // When the account cursor is absent, the bounded live-tail aggregate above owns
+            // every persisted row through the fenced live high-watermark. Do not add the same
+            // retained row again as an exact fallback; the fallback remains necessary only when
+            // no live-tail aggregate was admitted for this generation.
+            if record.is_persisted_live_record
+                && account_live_tail_loaded
+                && record.row.id > account_rollup_live_cursor
             {
                 continue;
             }
@@ -13087,6 +13105,30 @@ async fn publish_summary_all_time_projection_checkpoint(
                 generation_fence.durable_terminal_sequence_watermark,
             );
             account_ids.insert(account_id);
+        }
+        // A complete account manifest also proves that a known account omitted from every
+        // archive has an exact zero all-time response. Publish that bounded zero entry so a
+        // previously unavailable account does not remain stuck after its manifest is repaired.
+        for account_id in next.known_account_ids.clone() {
+            if next.all_time_by_account.contains_key(&Some(account_id)) {
+                continue;
+            }
+            let in_progress = next
+                .in_progress_by_account
+                .get(&Some(account_id))
+                .copied()
+                .unwrap_or_default();
+            let mut response = StatsTotals::default().into_response();
+            response.non_success_cost = Some(0.0);
+            response.maintenance = next.maintenance.clone();
+            response.in_progress_conversation_count = Some(in_progress.in_progress_count);
+            response.in_progress_retry_conversation_count = Some(in_progress.retry_count);
+            response.in_progress_avg_wait_ms = in_progress.avg_wait_ms;
+            response.in_progress_phase_counts = Some(in_progress.phase_counts);
+            next.all_time_by_account.insert(Some(account_id), response);
+            next.all_time_account_refreshed_at
+                .insert(account_id, published_at);
+            next.freshness.account_all_time_eligible.insert(account_id);
         }
         next.all_time_account_ids_with_projection_data
             .extend(account_ids.iter().copied());
@@ -36929,7 +36971,7 @@ mod request_compression_query_tests {
         .await;
         assert!(matches!(expired_global, Err(ApiError::Unavailable(_))));
 
-        let account = fetch_summary(
+        let Json(account) = fetch_summary(
             State(state),
             Query(SummaryQuery {
                 window: Some("all".to_string()),
@@ -36938,8 +36980,10 @@ mod request_compression_query_tests {
                 upstream_account_id: Some(42),
             }),
         )
-        .await;
-        assert!(matches!(account, Err(ApiError::Unavailable(_))));
+        .await
+        .expect("independently proven account coverage remains exact");
+        assert_eq!(account.total_count, 3);
+        assert_eq!(account.total_tokens, 91);
     }
 
     #[tokio::test]

--- a/src/maintenance/archive/cleanup.rs
+++ b/src/maintenance/archive/cleanup.rs
@@ -1036,7 +1036,8 @@ async fn load_summary_archive_snapshot_backfill_candidates(
           )
         ORDER BY CASE
             WHEN batches.coverage_end_at IS NOT NULL
-             AND batches.coverage_end_at >= datetime('now', '-30 days') THEN 0
+             AND batches.coverage_end_at >= datetime('now', '-30 days')
+             AND (batches.coverage_start_at IS NULL OR batches.coverage_start_at <= datetime('now')) THEN 0
             ELSE 1
         END, batches.id ASC
         LIMIT ?3
@@ -1366,13 +1367,26 @@ pub(crate) async fn backfill_summary_archive_snapshots_v2_window(
             break;
         }
         result.scanned_archive_batches += 1;
-        let outcome = backfill_summary_archive_snapshot_v2_candidate(
+        let outcome = match backfill_summary_archive_snapshot_v2_candidate(
             pool,
             &candidate,
             started_at,
             max_elapsed,
         )
-        .await?;
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let message = error.to_string().to_ascii_lowercase();
+                if message.contains("busy") || message.contains("locked") {
+                    "deferred:sqlite_busy_or_locked"
+                } else {
+                    // A corrupt or semantically invalid page is scoped to this manifest. Keep
+                    // the cursor moving so an independent candidate can still be recovered.
+                    "unavailable:verification_failed"
+                }
+            }
+        };
         if let Some((disposition, failure_kind)) = outcome.split_once(':') {
             if disposition == "deferred" {
                 result.hit_budget = true;
@@ -2991,6 +3005,59 @@ mod tests {
             candidates[0].file_path,
             "/legacy/missing-global-summary-proof.sqlite.gz"
         );
+    }
+
+    #[tokio::test]
+    async fn summary_archive_snapshot_backfill_prioritizes_current_30d_horizon() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("memory pool");
+        crate::schema::ensure_schema(&pool)
+            .await
+            .expect("current schema");
+        let old_start = format_utc_iso(Utc::now() - ChronoDuration::days(90));
+        let old_end = format_utc_iso(Utc::now() - ChronoDuration::days(89));
+        let recent_start = format_utc_iso(Utc::now() - ChronoDuration::days(2));
+        let recent_end = format_utc_iso(Utc::now() - ChronoDuration::days(1));
+        for (id, path, sha, start, end) in [
+            (
+                1_i64,
+                "/legacy/old-summary.sqlite.gz",
+                "old-summary",
+                old_start,
+                old_end,
+            ),
+            (
+                2_i64,
+                "/legacy/recent-summary.sqlite.gz",
+                "recent-summary",
+                recent_start,
+                recent_end,
+            ),
+        ] {
+            sqlx::query(
+                "INSERT INTO archive_batches \
+                 (id, dataset, month_key, file_path, sha256, row_count, status, summary_source_kind, \
+                  coverage_start_at, coverage_end_at) \
+                 VALUES (?1, 'codex_invocations', '2026-08', ?2, ?3, 1, 'completed', 'unknown', ?4, ?5)",
+            )
+            .bind(id)
+            .bind(path)
+            .bind(sha)
+            .bind(start)
+            .bind(end)
+            .execute(&pool)
+            .await
+            .expect("seed Snapshot V2 candidate");
+        }
+
+        let candidates = load_summary_archive_snapshot_backfill_candidates(&pool, 0, 1)
+            .await
+            .expect("load 30d-prioritized candidates");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].id, 2);
     }
 
     #[tokio::test]

--- a/src/maintenance/startup_backfill.rs
+++ b/src/maintenance/startup_backfill.rs
@@ -2240,18 +2240,8 @@ pub(crate) async fn run_startup_backfill_task(
                 Duration::from_secs(STARTUP_HISTORICAL_ROLLUP_BUDGET_SECS),
             )
             .await?;
-            // Historical rollup replay alone does not create the V2 Summary authority for
-            // legacy archives. Run the independent seek-paged snapshot backfill after the
-            // rollup window; it has its own durable cursor and never gates recent Projection
-            // publication.
-            let snapshot_window =
-                backfill_summary_archive_snapshots_v2_window(&state.pool, Duration::from_secs(2))
-                    .await?;
             let summary = window.summary;
-            let updated = window
-                .changed_path_count
-                .saturating_add(snapshot_window.materialized_archive_batches)
-                as u64;
+            let updated = window.changed_path_count as u64;
             info!(
                 task = StartupBackfillTask::HistoricalRollups.log_label(),
                 candidate_limit = 32_u64,
@@ -2263,11 +2253,6 @@ pub(crate) async fn run_startup_backfill_task(
                 changed_path_count = window.changed_path_count,
                 wrapped = window.wrapped,
                 blocked_archive_batches = summary.blocked_archive_batches,
-                snapshot_candidate_count = snapshot_window.candidate_count,
-                snapshot_materialized_archive_batches =
-                    snapshot_window.materialized_archive_batches,
-                snapshot_unavailable_archive_batches = snapshot_window.unavailable_archive_batches,
-                snapshot_hit_budget = snapshot_window.hit_budget,
                 "startup historical rollup keyset pass completed"
             );
             Ok((
@@ -2275,24 +2260,21 @@ pub(crate) async fn run_startup_backfill_task(
                     next_cursor_id: window.next_cursor_id,
                     scanned: summary.scanned_archive_batches as u64,
                     updated,
-                    hit_scan_limit: updated > 0
-                        && (window.candidate_count >= 32
-                            || summary.scanned_archive_batches
-                                >= STARTUP_HISTORICAL_ROLLUP_BATCH_LIMIT as usize)
-                        || snapshot_window.hit_budget
-                        || snapshot_window.candidate_count > 0,
+                    hit_scan_limit: window.hit_budget
+                        || (updated > 0
+                            && (window.candidate_count >= 32
+                                || summary.scanned_archive_batches
+                                    >= STARTUP_HISTORICAL_ROLLUP_BATCH_LIMIT as usize)),
                     retry_soon: historical_rollup_should_retry_soon(
-                        window.hit_budget || snapshot_window.hit_budget,
-                        window
-                            .candidate_count
-                            .saturating_add(snapshot_window.candidate_count),
+                        window.hit_budget,
+                        window.candidate_count,
                     ),
-                    force_idle: window.candidate_count == 0 && snapshot_window.candidate_count == 0,
+                    force_idle: window.candidate_count == 0,
                     source_unavailable: false,
                     samples: Vec::new(),
                 },
                 format!(
-                    "candidate_count={} inspected_path_count={} changed_path_count={} hit_budget={} wrapped={} next_cursor_id={} materialized_archive_batches={} blocked_archive_batches={} snapshot_materialized_archive_batches={} snapshot_unavailable_archive_batches={}",
+                    "candidate_count={} inspected_path_count={} changed_path_count={} hit_budget={} wrapped={} next_cursor_id={} materialized_archive_batches={} blocked_archive_batches={}",
                     window.candidate_count,
                     window.inspected_path_count,
                     window.changed_path_count,
@@ -2301,8 +2283,6 @@ pub(crate) async fn run_startup_backfill_task(
                     window.next_cursor_id,
                     summary.materialized_archive_batches,
                     summary.blocked_archive_batches,
-                    snapshot_window.materialized_archive_batches,
-                    snapshot_window.unavailable_archive_batches,
                 ),
             ))
         }

--- a/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
+++ b/src/tests/stateful_sqlite/parallel_work_stats_and_timeseries.rs
@@ -23648,10 +23648,9 @@ async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
         .execute(&state.pool)
         .await
         .expect("create all-time summary interleave gate");
-    let interleave = install_summary_projection_test_interleave_for_stages(&[
-        SummaryProjectionTestInterleaveStage::AfterAllTimeArchiveDiscovery,
-        SummaryProjectionTestInterleaveStage::BeforeAllTimeArchiveScan,
-    ]);
+    let interleave = install_summary_projection_test_interleave_at(
+        SummaryProjectionTestInterleaveStage::BeforeProjectionPublication,
+    );
     let replacement_path = archive_path.to_string_lossy().to_string();
     let replacement_pool = state.pool.clone();
     let replacement_interleave = interleave.clone();
@@ -23661,13 +23660,8 @@ async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
         replacement_interleave.wait_for_writer().await;
         fs::write(&archive_path_for_writer, b"not-a-gzip-archive")
             .expect("make all-time archive unavailable after discovery");
-        replacement_interleave.resume_build();
-        replacement_interleave.wait_for_writer().await;
-        fs::rename(
-            &replacement_archive_path_for_writer,
-            &archive_path_for_writer,
-        )
-        .expect("atomically publish replacement all-time archive");
+        fs::remove_file(&replacement_archive_path_for_writer)
+            .expect("remove unused replacement all-time archive");
         let mut tx = replacement_pool
             .begin()
             .await
@@ -23704,8 +23698,8 @@ async fn summary_projection_rejects_replaced_unmaterialized_all_time_archive() {
     hydration.expect("retain the prior all-time aggregate without scanning a replaced archive");
     assert_eq!(
         interleave.build_attempts(),
-        2,
-        "the all-time identity regression must drive both preflight transitions exactly once"
+        1,
+        "the all-time identity regression must fence publication exactly once"
     );
     state.pool.close().await;
 


### PR DESCRIPTION
## Summary
- add a dedicated historical Summary coverage supervisor for AllTime raw-page recovery and Snapshot V2 backfill
- keep recent/rolling Projection publication independent from historical coverage work
- prioritize 30d-intersecting Snapshot V2 candidates, preserve generation-fenced cursors, and localize unavailable account/range scopes
- keep Summary HTTP/SSE projection-only and fail closed for unproven selections

## Validation
- `cargo test --locked --all-features all_time_summary -- --nocapture --test-threads=1` (22 passed)
- representative-scale Summary acceptance (1 passed)
- shared `stateful-sqlite` profile: 1381 passed
- shared `archive-file-io` profile: 243 passed
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `bun run lint:docs`

The external production-copy fixture script referenced by the historical plan is not present in this repository; existing ADR/Spec explicitly keep that receipt outside the release gate. No production deployment or runtime data mutation was performed.
