### PR TITLE
perf(ci): parallelize main candidates and release promotion

### DIFF
--- a/.github/quality-gates.json
+++ b/.github/quality-gates.json
@@ -122,6 +122,18 @@
       ],
       "auxiliary_jobs": [
         "Backend Test Archive Producer",
+        "Candidate Image Metadata",
+        "Build + Smoke + Push Candidate (linux/amd64)",
+        "Build + Smoke + Push Candidate (linux/arm64)",
+        "Backend Tests (Stateful SQLite shard 1/2)",
+        "Backend Tests (Stateful SQLite shard 2/2)"
+      ]
+    }
+  ],
+  "expected_auxiliary_workflows": [
+    {
+      "workflow": "Backend Test Image",
+      "jobs": [
         "Publish Backend Test Image"
       ]
     }
@@ -132,6 +144,8 @@
       "jobs": [
         "CI Main Gate",
         "Release Meta (snapshot + tags)",
+        "Validate Candidate Images",
+        "Candidate Promotion Policy",
         "Build + Smoke + Push Candidate (linux/amd64)",
         "Build + Smoke + Push Candidate (linux/arm64)",
         "Release Publish (manifest + tag + GitHub Release)"

--- a/.github/scripts/build-smoke-image-with-retry.sh
+++ b/.github/scripts/build-smoke-image-with-retry.sh
@@ -5,6 +5,7 @@ build_platform="${BUILD_PLATFORM:-}"
 smoke_tag="${SMOKE_TAG:-}"
 candidate_tag="${CANDIDATE_TAG:-}"
 app_effective_version="${APP_EFFECTIVE_VERSION:-}"
+app_git_revision="${APP_GIT_REVISION:-}"
 cache_ref="${CACHE_REF:-}"
 build_context="${BUILD_CONTEXT:-.}"
 dockerfile_path="${DOCKERFILE_PATH:-./Dockerfile}"
@@ -44,6 +45,10 @@ is_transient_failure() {
 
 for attempt in $(seq 1 "${retry_attempts}"); do
   err_file="$(mktemp)"
+  build_args=("--build-arg" "APP_EFFECTIVE_VERSION=${app_effective_version}")
+  if [[ -n "${app_git_revision}" ]]; then
+    build_args+=("--build-arg" "APP_GIT_REVISION=${app_git_revision}")
+  fi
 
   if docker buildx build \
     --progress plain \
@@ -53,7 +58,7 @@ for attempt in $(seq 1 "${retry_attempts}"); do
     --load \
     --tag "${smoke_tag}" \
     --tag "${candidate_tag}" \
-    --build-arg "APP_EFFECTIVE_VERSION=${app_effective_version}" \
+    "${build_args[@]}" \
     --cache-from "type=registry,ref=${cache_ref}" \
     --cache-to "type=registry,ref=${cache_ref},mode=max" \
     "${build_context}" 2>"${err_file}"; then

--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -32,6 +32,7 @@ class ContractModel:
     expected_pr_auxiliary_workflows: dict[str, tuple[str, ...]]
     expected_main_workflows: dict[str, tuple[str, ...]]
     expected_main_auxiliary_workflows: dict[str, tuple[str, ...]]
+    expected_auxiliary_workflows: dict[str, tuple[str, ...]]
     expected_release_workflows: dict[str, tuple[str, ...]]
     label_check_name: str
 
@@ -381,6 +382,11 @@ def validate_quality_gates(payload: dict[str, Any]) -> ContractModel:
 
     expected_pr_workflows, expected_pr_auxiliary_workflows = parse_expected_workflows(payload, "expected_pr_workflows")
     expected_main_workflows, expected_main_auxiliary_workflows = parse_expected_workflows(payload, "expected_main_workflows")
+    expected_auxiliary_workflows, expected_auxiliary_auxiliary_workflows = parse_expected_workflows(payload, "expected_auxiliary_workflows")
+    require(
+        not any(expected_auxiliary_auxiliary_workflows.values()),
+        "quality-gates.json: auxiliary workflows must not declare auxiliary jobs",
+    )
     expected_release_workflows, expected_release_auxiliary_workflows = parse_expected_workflows(payload, "expected_release_workflows")
     require(
         not any(expected_release_auxiliary_workflows.values()),
@@ -419,6 +425,7 @@ def validate_quality_gates(payload: dict[str, Any]) -> ContractModel:
         expected_pr_auxiliary_workflows=expected_pr_auxiliary_workflows,
         expected_main_workflows=expected_main_workflows,
         expected_main_auxiliary_workflows=expected_main_auxiliary_workflows,
+        expected_auxiliary_workflows=expected_auxiliary_workflows,
         expected_release_workflows=expected_release_workflows,
         label_check_name=label_required[0],
     )
@@ -770,7 +777,7 @@ def validate_ci_main(path: Path, contract: ContractModel) -> None:
             == "${{ steps.build-backend-test-archive.outcome == 'success' && steps.cargo-test-cache.outputs.cache-hit != 'true' }}",
             "ci-main.yml.jobs.backend-test-archive: target cache must save only after a successful archive build",
         )
-        for backend_job_id in ("backend-tests-lightweight", "backend-tests-stateful-sqlite", "backend-tests-archive-file-io"):
+        for backend_job_id in ("backend-tests-lightweight", "backend-tests-archive-file-io"):
             require(
                 job_config(workflow, backend_job_id, "ci-main.yml").get("needs") == "backend-test-archive",
                 f"ci-main.yml.jobs.{backend_job_id}.needs must use the archive producer",
@@ -780,22 +787,54 @@ def validate_ci_main(path: Path, contract: ContractModel) -> None:
                 "always()",
                 f"ci-main.yml.jobs.{backend_job_id}",
             )
-        if "Publish Backend Test Image" in auxiliary_jobs:
-            image_job = job_config(workflow, "backend-test-image", "ci-main.yml")
-            require(image_job.get("name") == "Publish Backend Test Image", "ci-main.yml backend-test-image job name drifted")
-            require(
-                image_job.get("needs") == [
-                    "backend-tests-lightweight",
-                    "backend-tests-stateful-sqlite",
-                    "backend-tests-archive-file-io",
-                ],
-                "ci-main.yml backend-test-image needs drifted",
-            )
-            image_permissions = require_mapping(image_job.get("permissions"), "ci-main.yml.jobs.backend-test-image.permissions")
-            require(image_permissions.get("packages") == "write", "ci-main.yml backend-test-image must publish with packages: write")
-            image_build = step_config(image_job, "Build and publish immutable backend-test image (linux/amd64)", "ci-main.yml.jobs.backend-test-image")
-            require(image_build.get("id") == "build-backend-test-image", "ci-main.yml backend-test-image step id drifted")
-            require(image_build.get("with", {}).get("target") == "backend-test" and image_build.get("with", {}).get("push") is True, "ci-main.yml backend-test-image must push the backend-test target")
+        for shard_id, partition in (
+            ("backend-tests-stateful-sqlite-shard-1", "hash:1/2"),
+            ("backend-tests-stateful-sqlite-shard-2", "hash:2/2"),
+        ):
+            shard_job = job_config(workflow, shard_id, "ci-main.yml")
+            require(shard_job.get("needs") == "backend-test-archive", f"ci-main.yml.jobs.{shard_id}.needs must use the archive producer")
+            require_exact_if(shard_job, "always()", f"ci-main.yml.jobs.{shard_id}")
+            shard_run = str(step_config(shard_job, "Run stateful SQLite backend profile", f"ci-main.yml.jobs.{shard_id}").get("run", ""))
+            require(f"--partition {partition}" in shard_run, f"ci-main.yml.jobs.{shard_id} must run partition {partition}")
+        aggregate_job = job_config(workflow, "backend-tests-stateful-sqlite", "ci-main.yml")
+        require(
+            aggregate_job.get("needs") == ["backend-tests-stateful-sqlite-shard-1", "backend-tests-stateful-sqlite-shard-2"],
+            "ci-main.yml.jobs.backend-tests-stateful-sqlite.needs must aggregate both shards",
+        )
+        require_exact_if(aggregate_job, "always()", "ci-main.yml.jobs.backend-tests-stateful-sqlite")
+        aggregate_run = str(step_config(aggregate_job, "Require both Stateful SQLite shards", "ci-main.yml.jobs.backend-tests-stateful-sqlite").get("run", ""))
+        require("SHARD_ONE_RESULT" in aggregate_run and "SHARD_TWO_RESULT" in aggregate_run, "ci-main.yml Stateful SQLite aggregate must inspect both shard results")
+
+        candidate_meta = job_config(workflow, "candidate-meta", "ci-main.yml")
+        require(candidate_meta.get("name") == "Candidate Image Metadata", "ci-main.yml candidate metadata job name drifted")
+        require_no_if(candidate_meta, "ci-main.yml.jobs.candidate-meta")
+        candidate_ensure = step_config(candidate_meta, "Ensure immutable release snapshot", "ci-main.yml.jobs.candidate-meta")
+        candidate_ensure_run = str(candidate_ensure.get("run", ""))
+        require("--target-only" in candidate_ensure_run, "ci-main.yml candidate metadata must freeze only the current SHA")
+        candidate_exports = step_config(candidate_meta, "Export candidate metadata", "ci-main.yml.jobs.candidate-meta")
+        candidate_exports_run = str(candidate_exports.get("run", ""))
+        require("target_sha_short" in candidate_exports_run and "app_effective_version" in candidate_exports_run, "ci-main.yml candidate metadata outputs drifted")
+        for candidate_id, platform in (("candidate-amd64", "amd64"), ("candidate-arm64", "arm64")):
+            candidate_job = job_config(workflow, candidate_id, "ci-main.yml")
+            require(candidate_job.get("if") == "${{ needs.candidate-meta.outputs.release_enabled == 'true' }}", f"ci-main.yml.jobs.{candidate_id}.if drifted")
+            require(candidate_job.get("needs") == "candidate-meta", f"ci-main.yml.jobs.{candidate_id}.needs drifted")
+            checkout = checkout_step(candidate_job, "Checkout target SHA", f"ci-main.yml.jobs.{candidate_id}")
+            require(checkout.get("ref") == "${{ needs.candidate-meta.outputs.target_sha }}", f"ci-main.yml.jobs.{candidate_id} checkout ref drifted")
+            build_name = f"Build candidate image (linux/{platform})"
+            build = step_config(candidate_job, build_name, f"ci-main.yml.jobs.{candidate_id}")
+            if build.get("uses") == "docker/build-push-action@v7":
+                build_with = require_mapping(build.get("with"), f"ci-main.yml.jobs.{candidate_id}.steps[{build_name!r}].with")
+                require(build_with.get("target") == "runtime", f"ci-main.yml.jobs.{candidate_id} must build runtime target")
+                build_args = str(build_with.get("build-args", ""))
+                require("APP_EFFECTIVE_VERSION=" in build_args and "APP_GIT_REVISION=" in build_args, f"ci-main.yml.jobs.{candidate_id} OCI build args drifted")
+            else:
+                build_env = require_mapping(build.get("env"), f"ci-main.yml.jobs.{candidate_id}.steps[{build_name!r}].env")
+                require(build_env.get("APP_EFFECTIVE_VERSION") == "${{ needs.candidate-meta.outputs.app_effective_version }}", f"ci-main.yml.jobs.{candidate_id} version plumbing drifted")
+                require(build_env.get("APP_GIT_REVISION") == "${{ needs.candidate-meta.outputs.target_sha }}", f"ci-main.yml.jobs.{candidate_id} revision plumbing drifted")
+                require("build-smoke-image-with-retry.sh" in str(build.get("run", "")), f"ci-main.yml.jobs.{candidate_id} must use the retry helper")
+            smoke = step_config(candidate_job, f"Smoke test image (linux/{platform})", f"ci-main.yml.jobs.{candidate_id}")
+            require("SMOKE_TAG" in require_mapping(smoke.get("env"), f"ci-main.yml.jobs.{candidate_id}.smoke.env"), f"ci-main.yml.jobs.{candidate_id} smoke tag missing")
+
     release_snapshot_permissions = require_mapping(
         release_snapshot.get("permissions"), "ci-main.yml.jobs.release-snapshot.permissions"
     )
@@ -833,6 +872,33 @@ def validate_ci_main(path: Path, contract: ContractModel) -> None:
     )
 
 
+def validate_backend_test_image(path: Path, contract: ContractModel) -> None:
+    workflow = load_yaml(path)
+    workflow_name = workflow.get("name")
+    require(isinstance(workflow_name, str) and workflow_name, "backend-test-image.yml: workflow name must stay non-empty")
+    expected_jobs = set(contract.expected_auxiliary_workflows.get(workflow_name, ()))
+    require(expected_jobs, f"backend-test-image.yml: workflow {workflow_name!r} must be declared in expected_auxiliary_workflows")
+    require_exact_named_jobs(workflow, expected_jobs, "backend-test-image.yml")
+
+    workflow_run = event_config(workflow, "workflow_run", "backend-test-image.yml")
+    assert_event_types(workflow_run, {"completed"}, "backend-test-image.yml.on.workflow_run")
+    assert_event_branches(workflow_run, {"main"}, "backend-test-image.yml.on.workflow_run")
+    require(workflow_run.get("workflows") == ["CI Main"], "backend-test-image.yml.on.workflow_run.workflows drifted")
+    permissions = require_mapping(workflow.get("permissions"), "backend-test-image.yml.permissions")
+    require(permissions.get("contents") == "read", "backend-test-image.yml.permissions.contents must stay read")
+
+    job = named_job_config(workflow, "backend-test-image", expected_jobs, "backend-test-image.yml")
+    require_exact_if(job, "${{ github.event.workflow_run.conclusion == 'success' }}", "backend-test-image.yml.jobs.backend-test-image")
+    job_permissions = require_mapping(job.get("permissions"), "backend-test-image.yml.jobs.backend-test-image.permissions")
+    require(job_permissions.get("packages") == "write", "backend-test-image.yml backend-test-image must publish with packages: write")
+    checkout = checkout_step(job, "Checkout CI Main head", "backend-test-image.yml.jobs.backend-test-image")
+    require(checkout.get("ref") == "${{ github.event.workflow_run.head_sha }}", "backend-test-image.yml checkout must use workflow_run.head_sha")
+    build = step_config(job, "Build and publish immutable backend-test image (linux/amd64)", "backend-test-image.yml.jobs.backend-test-image")
+    build_with = require_mapping(build.get("with"), "backend-test-image.yml backend-test build")
+    require(build_with.get("target") == "backend-test" and build_with.get("push") is True, "backend-test-image.yml must publish the backend-test target")
+    tags = str(build_with.get("tags", ""))
+    require("backend-test-${{ github.event.workflow_run.head_sha }}" in tags, "backend-test-image.yml tag must use workflow_run.head_sha")
+    require("backend-test-${{ github.sha }}" not in tags, "backend-test-image.yml must not tag from its own workflow SHA")
 def validate_label_gate(path: Path, contract: ContractModel) -> None:
     workflow = load_yaml(path)
     workflow_name = workflow.get("name")
@@ -1129,9 +1195,42 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     candidate_run = str(candidate_step.get("run", ""))
     require("candidate_suffix=${TARGET_SHA:0:12}" in candidate_run, "release.yml.jobs.release-meta: candidate suffix drifted")
 
+    candidate_availability = named_job_config(workflow, "candidate-availability", expected_jobs, "release.yml")
+    require(
+        candidate_availability.get("needs") == ["release-meta"],
+        "release.yml.jobs.candidate-availability.needs drifted",
+    )
+    require(
+        candidate_availability.get("if")
+        == "${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}",
+        "release.yml.jobs.candidate-availability.if drifted",
+    )
+    availability_run = str(step_config(candidate_availability, "Verify candidate SHA, version, and platforms", "release.yml.jobs.candidate-availability").get("run", ""))
+    require("docker pull --platform" in availability_run, "release.yml candidate availability must pull both candidate platforms")
+    require("org.opencontainers.image.revision" in availability_run and "org.opencontainers.image.version" in availability_run, "release.yml candidate availability must verify OCI metadata")
+    require("available=${available}" in availability_run, "release.yml candidate availability output drifted")
+
+    candidate_policy = named_job_config(workflow, "candidate-policy", expected_jobs, "release.yml")
+    require(
+        candidate_policy.get("needs") == ["release-meta", "candidate-availability"],
+        "release.yml.jobs.candidate-policy.needs drifted",
+    )
+    require(
+        candidate_policy.get("if")
+        == "${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}",
+        "release.yml.jobs.candidate-policy.if drifted",
+    )
+    policy_run = str(step_config(candidate_policy, "Enforce automatic candidate requirement", "release.yml.jobs.candidate-policy").get("run", ""))
+    require("github.event_name" in policy_run and "Automatic Release requires complete" in policy_run, "release.yml candidate policy must fail closed for automatic runs")
+    require("Manual Release will use the fallback build" in policy_run, "release.yml candidate policy must document manual fallback")
+
     docker_amd = named_job_config(workflow, "docker-amd64", expected_jobs, "release.yml")
-    require(docker_amd.get("needs") == ["release-meta"], "release.yml.jobs.docker-amd64.needs drifted")
-    require(docker_amd.get("if") == "needs.release-meta.outputs.release_enabled == 'true'", "release.yml.jobs.docker-amd64.if drifted")
+    require(docker_amd.get("needs") == ["release-meta", "candidate-availability"], "release.yml.jobs.docker-amd64.needs drifted")
+    require(
+        docker_amd.get("if")
+        == "${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}",
+        "release.yml.jobs.docker-amd64.if drifted",
+    )
     amd_checkout = checkout_step(docker_amd, "Checkout code", "release.yml.jobs.docker-amd64")
     require(amd_checkout.get("ref") == "${{ needs.release-meta.outputs.target_sha }}", "release.yml.jobs.docker-amd64 checkout ref drifted")
     amd_smoke_step = step_config(docker_amd, "Smoke test image (linux/amd64)", "release.yml.jobs.docker-amd64")
@@ -1142,6 +1241,15 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     )
 
     docker_arm = named_job_config(workflow, "docker-arm64", expected_jobs, "release.yml")
+    require(
+        docker_arm.get("needs") == ["release-meta", "candidate-availability"],
+        "release.yml.jobs.docker-arm64.needs drifted",
+    )
+    require(
+        docker_arm.get("if")
+        == "${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}",
+        "release.yml.jobs.docker-arm64.if drifted",
+    )
     arm_checkout = checkout_step(docker_arm, "Checkout code", "release.yml.jobs.docker-arm64")
     require(arm_checkout.get("ref") == "${{ needs.release-meta.outputs.target_sha }}", "release.yml.jobs.docker-arm64 checkout ref drifted")
     require(arm_checkout.get("path") == "target", "release.yml.jobs.docker-arm64 checkout path drifted")
@@ -1173,6 +1281,14 @@ def validate_release(path: Path, contract: ContractModel) -> None:
         arm_build_env.get("CACHE_REF") == "${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64",
         "release.yml.jobs.docker-arm64: arm64 smoke build cache ref drifted",
     )
+    require(
+        arm_build_env.get("APP_EFFECTIVE_VERSION") == "${{ needs.release-meta.outputs.app_effective_version }}",
+        "release.yml.jobs.docker-arm64: arm64 smoke build version plumbing drifted",
+    )
+    require(
+        arm_build_env.get("APP_GIT_REVISION") == "${{ needs.release-meta.outputs.target_sha }}",
+        "release.yml.jobs.docker-arm64: arm64 smoke build revision plumbing drifted",
+    )
     arm_build_run = str(arm_build_step.get("run", ""))
     require(
         "./.github/scripts/build-smoke-image-with-retry.sh" in arm_build_run,
@@ -1187,7 +1303,16 @@ def validate_release(path: Path, contract: ContractModel) -> None:
     )
 
     publish = named_job_config(workflow, "release-publish", expected_jobs, "release.yml")
-    require(publish.get("needs") == ["release-meta", "docker-amd64", "docker-arm64"], "release.yml.jobs.release-publish.needs drifted")
+    require(
+        publish.get("needs")
+        == ["release-meta", "candidate-availability", "candidate-policy", "docker-amd64", "docker-arm64"],
+        "release.yml.jobs.release-publish.needs drifted",
+    )
+    require(
+        publish.get("if")
+        == "${{ always() && needs.release-meta.outputs.release_enabled == 'true' && needs.candidate-policy.result == 'success' && (needs.candidate-availability.outputs.available == 'true' || (github.event_name == 'workflow_dispatch' && needs.docker-amd64.result == 'success' && needs.docker-arm64.result == 'success')) }}",
+        "release.yml.jobs.release-publish.if drifted",
+    )
     publish_permissions = require_mapping(publish.get("permissions"), "release.yml.jobs.release-publish.permissions")
     require(publish_permissions.get("actions") == "write", "release.yml.jobs.release-publish.permissions.actions must stay write")
     require(publish_permissions.get("contents") == "write", "release.yml.jobs.release-publish.permissions.contents must stay write")
@@ -1379,6 +1504,7 @@ def main() -> int:
         require(profile == "final", "quality-gates-contract: bootstrap profile is no longer supported by this repository")
         validate_ci_pr(repo_root / ".github" / "workflows" / "ci-pr.yml", contract)
         validate_ci_main(repo_root / ".github" / "workflows" / "ci-main.yml", contract)
+        validate_backend_test_image(repo_root / ".github" / "workflows" / "backend-test-image.yml", contract)
         validate_release(repo_root / ".github" / "workflows" / "release.yml", contract)
         validate_release_snapshot_pr(repo_root / ".github" / "workflows" / "release-snapshot-pr.yml")
         validate_label_gate(repo_root / ".github" / "workflows" / "label-gate.yml", contract)

--- a/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/ci-main.yml
@@ -21,6 +21,182 @@ env:
   RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
 
 jobs:
+  candidate-meta:
+    name: Candidate Image Metadata
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      pull-requests: read
+    timeout-minutes: 10
+    outputs:
+      release_enabled: ${{ steps.snapshot.outputs.release_enabled }}
+      target_sha: ${{ steps.snapshot.outputs.target_sha }}
+      image_name: ${{ steps.snapshot.outputs.image_name_lower }}
+      app_effective_version: ${{ steps.snapshot.outputs.app_effective_version }}
+      candidate_suffix: ${{ steps.snapshot.outputs.target_sha_short }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure immutable release snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${GITHUB_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --target-only \
+            --output "$RUNNER_TEMP/release-snapshot.json"
+
+      - name: Export candidate metadata
+        id: snapshot
+        env:
+          SNAPSHOT_PATH: ${{ runner.temp }}/release-snapshot.json
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["SNAPSHOT_PATH"]).read_text())
+          target_sha = payload["target_sha"]
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as output:
+              output.write(f"release_enabled={str(payload['release_enabled']).lower()}\n")
+              output.write(f"target_sha={target_sha}\n")
+              output.write(f"target_sha_short={target_sha[:12]}\n")
+              output.write(f"image_name_lower={payload['image_name_lower']}\n")
+              output.write(f"app_effective_version={payload.get('app_effective_version', '')}\n")
+          PY
+
+  candidate-amd64:
+    name: Build + Smoke + Push Candidate (linux/amd64)
+    needs: candidate-meta
+    if: ${{ needs.candidate-meta.outputs.release_enabled == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 35
+    steps:
+      - name: Checkout target SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build candidate image (linux/amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+            ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+          build-args: |
+            APP_EFFECTIVE_VERSION=${{ needs.candidate-meta.outputs.app_effective_version }}
+            APP_GIT_REVISION=${{ needs.candidate-meta.outputs.target_sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-amd64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-amd64,mode=max
+
+      - name: Smoke test image (linux/amd64)
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-amd64-${{ needs.candidate-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: linux/amd64
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/amd64)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+        run: docker push "$IMAGE_REF"
+
+  candidate-arm64:
+    name: Build + Smoke + Push Candidate (linux/arm64)
+    needs: candidate-meta
+    if: ${{ needs.candidate-meta.outputs.release_enabled == 'true' }}
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 35
+    steps:
+      - name: Checkout target SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-helpers
+
+      - name: Install workflow helper scripts
+        shell: bash
+        run: install -m 755 workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh ./.github/scripts/build-smoke-image-with-retry.sh
+
+      - name: Build candidate image (linux/arm64)
+        shell: bash
+        env:
+          BUILD_PLATFORM: linux/arm64
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          APP_EFFECTIVE_VERSION: ${{ needs.candidate-meta.outputs.app_effective_version }}
+          APP_GIT_REVISION: ${{ needs.candidate-meta.outputs.target_sha }}
+          CACHE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-arm64
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
+
+      - name: Smoke test image (linux/arm64)
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ needs.candidate-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: linux/arm64
+          SMOKE_TIMEOUT_SECS: "120"
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/arm64)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+        run: docker push "$IMAGE_REF"
+
   lint:
     name: Lint & Format Check
     runs-on: ubuntu-24.04
@@ -28,8 +204,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Verify Rust system dependencies
         run: |
@@ -44,20 +218,38 @@ jobs:
           components: rustfmt, clippy
 
       - name: Restore legacy Cargo workspace cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+
+      - name: Restore Cargo registry
+        id: cargo-registry-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-registry-
 
       - name: Cargo fmt check
         run: cargo fmt --all -- --check
 
       - name: Cargo clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Save Cargo registry
+        if: ${{ always() && steps.cargo-registry-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
 
   repository-tooling-checks:
     name: Repository Tooling Checks
@@ -103,6 +295,8 @@ jobs:
             .github/scripts/release_snapshot.py \
             .github/scripts/verify_manifest_platforms.py
           bash -n .github/scripts/build-smoke-image-with-retry.sh
+          bash -n .github/scripts/run-backend-tests.sh
+          bash -n .github/scripts/test-representative-scale-contract.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -156,6 +350,8 @@ jobs:
           bash .github/scripts/test-build-smoke-image-with-retry.sh
           bash .github/scripts/test-release-snapshot.sh
           bash .github/scripts/test-live-quality-gates.sh
+          bash .github/scripts/test-backend-test-contract.sh
+          bash .github/scripts/test-representative-scale-contract.sh
 
       - name: Front-end lint
         run: bun run lint:web
@@ -236,10 +432,40 @@ jobs:
         working-directory: web
         run: bun run storybook:build -- --quiet
 
-      - name: Build docs and demo sites
+      - name: Compute DOCS_BASE
+        shell: bash
         run: |
-          cd docs-site && bun run build
-          cd ../web && bun run demo:build
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY##*/}"
+          if [[ "${repo}" == "${owner}.github.io" ]]; then
+            echo "DOCS_BASE=/" >> "$GITHUB_ENV"
+          else
+            echo "DOCS_BASE=/${repo}/" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build docs site
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docs-site
+          DOCS_BASE="${DOCS_BASE}" bun run build
+
+      - name: Build Web Demo static site
+        working-directory: web
+        run: VITE_DEPLOY_BASE="${DOCS_BASE}demo/" bun run demo:build
+
+      - name: Assemble public docs site smoke check
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/assemble-pages-site.sh docs-site/doc_build web/storybook-static web/demo-dist .tmp/pages-site
+          test -f .tmp/pages-site/index.html
+          test -f .tmp/pages-site/storybook/index.html
+          test -f .tmp/pages-site/demo/index.html
+          test -f .tmp/pages-site/demo/mockServiceWorker.js
+          test -f .tmp/pages-site/storybook.html
+          grep -q "${DOCS_BASE}storybook.html" .tmp/pages-site/index.html
 
   records-overlay-e2e:
     name: Records Overlay E2E
@@ -280,9 +506,45 @@ jobs:
           cat /tmp/codex-vibe-monitor-vite.log || true
           exit 1
 
-      - name: Run records overlay Playwright regression
+      - name: Start mock-only Web Demo server
         working-directory: web
-        run: bun run test:e2e -- records-filter-overlay.spec.ts
+        run: |
+          bun run demo:dev -- --host 127.0.0.1 --port 60083 > /tmp/codex-vibe-monitor-demo.log 2>&1 &
+          echo $! > /tmp/codex-vibe-monitor-demo.pid
+
+      - name: Wait for Web Demo readiness
+        run: |
+          for _ in {1..60}; do
+            if curl -fsS http://127.0.0.1:60083/ >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Web Demo server failed to start within 60 seconds."
+          cat /tmp/codex-vibe-monitor-demo.log || true
+          exit 1
+
+      - name: Run records overlay and Web Demo Playwright regression
+        working-directory: web
+        shell: bash
+        run: |
+          set -euo pipefail
+          records_status=0
+          demo_status=0
+          dashboard_status=0
+          PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-records \
+            bun run test:e2e -- --workers=1 --output=test-results/records-overlay records-filter-overlay.spec.ts &
+          records_pid=$!
+          E2E_BASE_URL=http://127.0.0.1:60083 PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-demo \
+            bun run test:e2e -- --workers=1 --output=test-results/demo-runtime demo-runtime.spec.ts &
+          demo_pid=$!
+          PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-dashboard \
+            bun run test:e2e -- --workers=1 --output=test-results/dashboard-working-conversations dashboard-working-conversations-layout.spec.ts &
+          dashboard_pid=$!
+          wait "$records_pid" || records_status=$?
+          wait "$demo_pid" || demo_status=$?
+          wait "$dashboard_pid" || dashboard_status=$?
+          exit $(( records_status || demo_status || dashboard_status ))
 
       - name: Upload Playwright diagnostics
         if: failure()
@@ -290,7 +552,9 @@ jobs:
         with:
           name: records-overlay-playwright-report
           path: |
-            web/playwright-report
+            web/playwright-report-records
+            web/playwright-report-demo
+            web/playwright-report-dashboard
             web/test-results
           if-no-files-found: ignore
 
@@ -300,18 +564,80 @@ jobs:
           if [ -f /tmp/codex-vibe-monitor-vite.pid ]; then
             kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
           fi
+          if [ -f /tmp/codex-vibe-monitor-demo.pid ]; then
+            kill "$(cat /tmp/codex-vibe-monitor-demo.pid)" || true
+          fi
 
   backend-test-archive:
     name: Backend Test Archive Producer
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Verify Rust system dependencies
+        run: |
+          command -v pkg-config
+          test -r /usr/include/sqlite3.h
+          command -v unzip
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Restore Cargo registry
+        id: cargo-registry-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Restore Cargo test artifacts
+        id: cargo-test-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-test-v3-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'src/**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-v3-${{ hashFiles('Cargo.lock') }}-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Build backend test archive
         id: build-backend-test-archive
         run: cargo nextest archive --locked --all-features --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
 
+      - name: Upload backend test archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}/backend-tests.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
+
+      - name: Save Cargo registry
+        if: ${{ always() && steps.cargo-registry-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
       - name: Save Cargo test artifacts
         if: ${{ steps.build-backend-test-archive.outcome == 'success' && steps.cargo-test-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-test-v3-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'src/**/*.rs') }}
 
   backend-tests-lightweight:
     needs: backend-test-archive
@@ -331,27 +657,22 @@ jobs:
         with:
           toolchain: 1.96.0
 
-      - name: Cache cargo directories
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Run lightweight backend profile
-        run: bash .github/scripts/run-backend-tests.sh --profile lightweight
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
 
-  backend-tests-stateful-sqlite:
+      - name: Run lightweight backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile lightweight --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite-shard-1:
     needs: backend-test-archive
     if: always()
-    name: Backend Tests (Stateful SQLite)
+    name: Backend Tests (Stateful SQLite shard 1/2)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -366,22 +687,67 @@ jobs:
         with:
           toolchain: 1.96.0
 
-      - name: Cache cargo directories
-        uses: actions/cache@v5
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
+
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite --partition hash:1/2 --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite-shard-2:
+    needs: backend-test-archive
+    if: always()
+    name: Backend Tests (Stateful SQLite shard 2/2)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
+
       - name: Run stateful SQLite backend profile
-        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite --partition hash:2/2 --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
+    needs:
+      - backend-tests-stateful-sqlite-shard-1
+      - backend-tests-stateful-sqlite-shard-2
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require both Stateful SQLite shards
+        env:
+          SHARD_ONE_RESULT: ${{ needs.backend-tests-stateful-sqlite-shard-1.result }}
+          SHARD_TWO_RESULT: ${{ needs.backend-tests-stateful-sqlite-shard-2.result }}
+        run: |
+          set -euo pipefail
+          echo "Stateful SQLite shard 1/2: ${SHARD_ONE_RESULT}"
+          echo "Stateful SQLite shard 2/2: ${SHARD_TWO_RESULT}"
+          test "${SHARD_ONE_RESULT}" = success
+          test "${SHARD_TWO_RESULT}" = success
 
   backend-tests-archive-file-io:
     needs: backend-test-archive
@@ -401,22 +767,17 @@ jobs:
         with:
           toolchain: 1.96.0
 
-      - name: Cache cargo directories
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
+
       - name: Run archive / file I/O backend profile
-        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io
+        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
 
   release-snapshot:
     name: Release Snapshot

--- a/.github/scripts/fixtures/quality-gates-contract/quality-gates.json
+++ b/.github/scripts/fixtures/quality-gates-contract/quality-gates.json
@@ -118,7 +118,20 @@
         "Release Snapshot"
       ],
       "auxiliary_jobs": [
-        "Backend Test Archive Producer"
+        "Backend Test Archive Producer",
+        "Candidate Image Metadata",
+        "Build + Smoke + Push Candidate (linux/amd64)",
+        "Build + Smoke + Push Candidate (linux/arm64)",
+        "Backend Tests (Stateful SQLite shard 1/2)",
+        "Backend Tests (Stateful SQLite shard 2/2)"
+      ]
+    }
+  ],
+  "expected_auxiliary_workflows": [
+    {
+      "workflow": "Backend Test Image",
+      "jobs": [
+        "Publish Backend Test Image"
       ]
     }
   ],
@@ -128,6 +141,8 @@
       "jobs": [
         "CI Main Gate",
         "Release Meta (snapshot + tags)",
+        "Validate Candidate Images",
+        "Candidate Promotion Policy",
         "Build + Smoke + Push Candidate (linux/amd64)",
         "Build + Smoke + Push Candidate (linux/arm64)",
         "Release Publish (manifest + tag + GitHub Release)"

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -234,6 +234,24 @@ jobs:
             --github-token "${GITHUB_TOKEN}" \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Recover selected release snapshot
+        if: github.event_name != 'workflow_dispatch' && steps.pending-target.outputs.target_sha != ''
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ steps.pending-target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${TARGET_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --target-only \
+            --skip-publish \
+            --output "$RUNNER_TEMP/release-snapshot.json"
+
       - name: Load immutable release snapshot
         if: steps.pending-target.outputs.target_sha != ''
         id: snapshot
@@ -277,11 +295,90 @@ jobs:
             fi
           done
 
+  candidate-availability:
+    name: Validate Candidate Images
+    runs-on: ubuntu-24.04
+    needs: [release-meta]
+    if: ${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 15
+    outputs:
+      available: ${{ steps.verify.outputs.available }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify candidate SHA, version, and platforms
+        id: verify
+        shell: bash
+        env:
+          IMAGE_NAME_LOWER: ${{ needs.release-meta.outputs.image_name_lower }}
+          CANDIDATE_SUFFIX: ${{ needs.release-meta.outputs.candidate_suffix }}
+          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${IMAGE_NAME_LOWER}"
+          available=true
+          for platform in amd64 arm64; do
+            ref="${image}:candidate-${CANDIDATE_SUFFIX}-${platform}"
+            echo "[candidate] ${ref}"
+            if ! docker pull --platform "linux/${platform}" "${ref}"; then
+              echo "[candidate] missing image: ${ref}" >&2
+              available=false
+              continue
+            fi
+
+            revision="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${ref}" || true)"
+            version="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' "${ref}" || true)"
+            if [[ "${revision}" != "${TARGET_SHA}" ]]; then
+              echo "[candidate] revision mismatch for ${ref}: expected ${TARGET_SHA}, got ${revision:-<missing>}" >&2
+              available=false
+            fi
+            if [[ "${version}" != "${APP_EFFECTIVE_VERSION}" ]]; then
+              echo "[candidate] version mismatch for ${ref}: expected ${APP_EFFECTIVE_VERSION}, got ${version:-<missing>}" >&2
+              available=false
+            fi
+          done
+
+          echo "available=${available}" >> "$GITHUB_OUTPUT"
+
+  candidate-policy:
+    name: Candidate Promotion Policy
+    runs-on: ubuntu-24.04
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}
+    timeout-minutes: 5
+    steps:
+      - name: Enforce automatic candidate requirement
+        env:
+          AVAILABLE: ${{ needs.candidate-availability.outputs.available }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ] && [ "${AVAILABLE}" != "true" ]; then
+            echo "Automatic Release requires complete SHA/version-matched amd64 and arm64 candidates." >&2
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${AVAILABLE}" != "true" ]; then
+            echo "Manual Release will use the fallback build because candidates are unavailable or mismatched."
+          else
+            echo "Candidate images are complete and eligible for promotion."
+          fi
+
   docker-amd64:
     name: Build + Smoke + Push Candidate (linux/amd64)
     runs-on: ubuntu-24.04
-    needs: [release-meta]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}
     permissions:
       contents: read
       packages: write
@@ -310,11 +407,13 @@ jobs:
           platforms: ${{ env.PLATFORM_AMD64 }}
           push: false
           load: true
+          target: runtime
           tags: |
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
           build-args: |
             APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
+            APP_GIT_REVISION=${{ needs.release-meta.outputs.target_sha }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64,mode=max
 
@@ -341,8 +440,8 @@ jobs:
   docker-arm64:
     name: Build + Smoke + Push Candidate (linux/arm64)
     runs-on: ubuntu-24.04-arm
-    needs: [release-meta]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}
     permissions:
       contents: read
       packages: write
@@ -386,6 +485,7 @@ jobs:
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          APP_GIT_REVISION: ${{ needs.release-meta.outputs.target_sha }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
         run: ./.github/scripts/build-smoke-image-with-retry.sh
 
@@ -414,8 +514,8 @@ jobs:
   release-publish:
     name: Release Publish (manifest + tag + GitHub Release)
     runs-on: ubuntu-24.04
-    needs: [release-meta, docker-amd64, docker-arm64]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability, candidate-policy, docker-amd64, docker-arm64]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && needs.candidate-policy.result == 'success' && (needs.candidate-availability.outputs.available == 'true' || (github.event_name == 'workflow_dispatch' && needs.docker-amd64.result == 'success' && needs.docker-arm64.result == 'success')) }}
     permissions:
       actions: write
       contents: write

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/ci-main.yml
@@ -21,6 +21,182 @@ env:
   RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
 
 jobs:
+  candidate-meta:
+    name: Candidate Image Metadata
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      pull-requests: read
+    timeout-minutes: 10
+    outputs:
+      release_enabled: ${{ steps.snapshot.outputs.release_enabled }}
+      target_sha: ${{ steps.snapshot.outputs.target_sha }}
+      image_name: ${{ steps.snapshot.outputs.image_name_lower }}
+      app_effective_version: ${{ steps.snapshot.outputs.app_effective_version }}
+      candidate_suffix: ${{ steps.snapshot.outputs.target_sha_short }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure immutable release snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${GITHUB_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --target-only \
+            --output "$RUNNER_TEMP/release-snapshot.json"
+
+      - name: Export candidate metadata
+        id: snapshot
+        env:
+          SNAPSHOT_PATH: ${{ runner.temp }}/release-snapshot.json
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["SNAPSHOT_PATH"]).read_text())
+          target_sha = payload["target_sha"]
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as output:
+              output.write(f"release_enabled={str(payload['release_enabled']).lower()}\n")
+              output.write(f"target_sha={target_sha}\n")
+              output.write(f"target_sha_short={target_sha[:12]}\n")
+              output.write(f"image_name_lower={payload['image_name_lower']}\n")
+              output.write(f"app_effective_version={payload.get('app_effective_version', '')}\n")
+          PY
+
+  candidate-amd64:
+    name: Build + Smoke + Push Candidate (linux/amd64)
+    needs: candidate-meta
+    if: ${{ needs.candidate-meta.outputs.release_enabled == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 35
+    steps:
+      - name: Checkout target SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build candidate image (linux/amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+            ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+          build-args: |
+            APP_EFFECTIVE_VERSION=${{ needs.candidate-meta.outputs.app_effective_version }}
+            APP_GIT_REVISION=${{ needs.candidate-meta.outputs.target_sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-amd64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-amd64,mode=max
+
+      - name: Smoke test image (linux/amd64)
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-amd64-${{ needs.candidate-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: linux/amd64
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/amd64)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+        run: docker push "$IMAGE_REF"
+
+  candidate-arm64:
+    name: Build + Smoke + Push Candidate (linux/arm64)
+    needs: candidate-meta
+    if: ${{ needs.candidate-meta.outputs.release_enabled == 'true' }}
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 35
+    steps:
+      - name: Checkout target SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-helpers
+
+      - name: Install workflow helper scripts
+        shell: bash
+        run: install -m 755 workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh ./.github/scripts/build-smoke-image-with-retry.sh
+
+      - name: Build candidate image (linux/arm64)
+        shell: bash
+        env:
+          BUILD_PLATFORM: linux/arm64
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          APP_EFFECTIVE_VERSION: ${{ needs.candidate-meta.outputs.app_effective_version }}
+          APP_GIT_REVISION: ${{ needs.candidate-meta.outputs.target_sha }}
+          CACHE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-arm64
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
+
+      - name: Smoke test image (linux/arm64)
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ needs.candidate-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: linux/arm64
+          SMOKE_TIMEOUT_SECS: "120"
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/arm64)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+        run: docker push "$IMAGE_REF"
+
   lint:
     name: Lint & Format Check
     runs-on: ubuntu-24.04
@@ -28,8 +204,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Verify Rust system dependencies
         run: |
@@ -44,20 +218,38 @@ jobs:
           components: rustfmt, clippy
 
       - name: Restore legacy Cargo workspace cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+
+      - name: Restore Cargo registry
+        id: cargo-registry-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-registry-
 
       - name: Cargo fmt check
         run: cargo fmt --all -- --check
 
       - name: Cargo clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Save Cargo registry
+        if: ${{ always() && steps.cargo-registry-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
 
   repository-tooling-checks:
     name: Repository Tooling Checks
@@ -82,6 +274,15 @@ jobs:
         working-directory: web
         run: bun install --frozen-lockfile
 
+      - name: Type-check Web Demo sources
+        run: bun run typecheck:web
+
+      - name: Install docs-site dependencies
+        run: bun install --cwd docs-site --frozen-lockfile
+
+      - name: Git hook contract smoke
+        run: bash scripts/test-git-hooks-contract.sh
+
       - name: Bun-first guard
         run: bun run check:bun-first
 
@@ -94,6 +295,8 @@ jobs:
             .github/scripts/release_snapshot.py \
             .github/scripts/verify_manifest_platforms.py
           bash -n .github/scripts/build-smoke-image-with-retry.sh
+          bash -n .github/scripts/run-backend-tests.sh
+          bash -n .github/scripts/test-representative-scale-contract.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -147,6 +350,8 @@ jobs:
           bash .github/scripts/test-build-smoke-image-with-retry.sh
           bash .github/scripts/test-release-snapshot.sh
           bash .github/scripts/test-live-quality-gates.sh
+          bash .github/scripts/test-backend-test-contract.sh
+          bash .github/scripts/test-representative-scale-contract.sh
 
       - name: Front-end lint
         run: bun run lint:web
@@ -227,10 +432,40 @@ jobs:
         working-directory: web
         run: bun run storybook:build -- --quiet
 
-      - name: Build docs and demo sites
+      - name: Compute DOCS_BASE
+        shell: bash
         run: |
-          cd docs-site && bun run build
-          cd ../web && bun run demo:build
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY##*/}"
+          if [[ "${repo}" == "${owner}.github.io" ]]; then
+            echo "DOCS_BASE=/" >> "$GITHUB_ENV"
+          else
+            echo "DOCS_BASE=/${repo}/" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build docs site
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docs-site
+          DOCS_BASE="${DOCS_BASE}" bun run build
+
+      - name: Build Web Demo static site
+        working-directory: web
+        run: VITE_DEPLOY_BASE="${DOCS_BASE}demo/" bun run demo:build
+
+      - name: Assemble public docs site smoke check
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash ./.github/scripts/assemble-pages-site.sh docs-site/doc_build web/storybook-static web/demo-dist .tmp/pages-site
+          test -f .tmp/pages-site/index.html
+          test -f .tmp/pages-site/storybook/index.html
+          test -f .tmp/pages-site/demo/index.html
+          test -f .tmp/pages-site/demo/mockServiceWorker.js
+          test -f .tmp/pages-site/storybook.html
+          grep -q "${DOCS_BASE}storybook.html" .tmp/pages-site/index.html
 
   records-overlay-e2e:
     name: Records Overlay E2E
@@ -271,9 +506,45 @@ jobs:
           cat /tmp/codex-vibe-monitor-vite.log || true
           exit 1
 
-      - name: Run records overlay Playwright regression
+      - name: Start mock-only Web Demo server
         working-directory: web
-        run: bun run test:e2e -- records-filter-overlay.spec.ts
+        run: |
+          bun run demo:dev -- --host 127.0.0.1 --port 60083 > /tmp/codex-vibe-monitor-demo.log 2>&1 &
+          echo $! > /tmp/codex-vibe-monitor-demo.pid
+
+      - name: Wait for Web Demo readiness
+        run: |
+          for _ in {1..60}; do
+            if curl -fsS http://127.0.0.1:60083/ >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Web Demo server failed to start within 60 seconds."
+          cat /tmp/codex-vibe-monitor-demo.log || true
+          exit 1
+
+      - name: Run records overlay and Web Demo Playwright regression
+        working-directory: web
+        shell: bash
+        run: |
+          set -euo pipefail
+          records_status=0
+          demo_status=0
+          dashboard_status=0
+          PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-records \
+            bun run test:e2e -- --workers=1 --output=test-results/records-overlay records-filter-overlay.spec.ts &
+          records_pid=$!
+          E2E_BASE_URL=http://127.0.0.1:60083 PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-demo \
+            bun run test:e2e -- --workers=1 --output=test-results/demo-runtime demo-runtime.spec.ts &
+          demo_pid=$!
+          PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-dashboard \
+            bun run test:e2e -- --workers=1 --output=test-results/dashboard-working-conversations dashboard-working-conversations-layout.spec.ts &
+          dashboard_pid=$!
+          wait "$records_pid" || records_status=$?
+          wait "$demo_pid" || demo_status=$?
+          wait "$dashboard_pid" || dashboard_status=$?
+          exit $(( records_status || demo_status || dashboard_status ))
 
       - name: Upload Playwright diagnostics
         if: failure()
@@ -281,7 +552,9 @@ jobs:
         with:
           name: records-overlay-playwright-report
           path: |
-            web/playwright-report
+            web/playwright-report-records
+            web/playwright-report-demo
+            web/playwright-report-dashboard
             web/test-results
           if-no-files-found: ignore
 
@@ -291,18 +564,80 @@ jobs:
           if [ -f /tmp/codex-vibe-monitor-vite.pid ]; then
             kill "$(cat /tmp/codex-vibe-monitor-vite.pid)" || true
           fi
+          if [ -f /tmp/codex-vibe-monitor-demo.pid ]; then
+            kill "$(cat /tmp/codex-vibe-monitor-demo.pid)" || true
+          fi
 
   backend-test-archive:
     name: Backend Test Archive Producer
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Verify Rust system dependencies
+        run: |
+          command -v pkg-config
+          test -r /usr/include/sqlite3.h
+          command -v unzip
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Restore Cargo registry
+        id: cargo-registry-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Restore Cargo test artifacts
+        id: cargo-test-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-test-v3-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'src/**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-v3-${{ hashFiles('Cargo.lock') }}-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Build backend test archive
         id: build-backend-test-archive
         run: cargo nextest archive --locked --all-features --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
 
+      - name: Upload backend test archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}/backend-tests.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
+
+      - name: Save Cargo registry
+        if: ${{ always() && steps.cargo-registry-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
       - name: Save Cargo test artifacts
         if: ${{ steps.build-backend-test-archive.outcome == 'success' && steps.cargo-test-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-test-v3-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'src/**/*.rs') }}
 
   backend-tests-lightweight:
     needs: backend-test-archive
@@ -322,27 +657,22 @@ jobs:
         with:
           toolchain: 1.96.0
 
-      - name: Cache cargo directories
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Run lightweight backend profile
-        run: bash .github/scripts/run-backend-tests.sh --profile lightweight
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
 
-  backend-tests-stateful-sqlite:
+      - name: Run lightweight backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile lightweight --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite-shard-1:
     needs: backend-test-archive
     if: always()
-    name: Backend Tests (Stateful SQLite)
+    name: Backend Tests (Stateful SQLite shard 1/2)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -357,22 +687,67 @@ jobs:
         with:
           toolchain: 1.96.0
 
-      - name: Cache cargo directories
-        uses: actions/cache@v5
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
+
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite --partition hash:1/2 --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite-shard-2:
+    needs: backend-test-archive
+    if: always()
+    name: Backend Tests (Stateful SQLite shard 2/2)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
+
       - name: Run stateful SQLite backend profile
-        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite --partition hash:2/2 --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
+    needs:
+      - backend-tests-stateful-sqlite-shard-1
+      - backend-tests-stateful-sqlite-shard-2
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require both Stateful SQLite shards
+        env:
+          SHARD_ONE_RESULT: ${{ needs.backend-tests-stateful-sqlite-shard-1.result }}
+          SHARD_TWO_RESULT: ${{ needs.backend-tests-stateful-sqlite-shard-2.result }}
+        run: |
+          set -euo pipefail
+          echo "Stateful SQLite shard 1/2: ${SHARD_ONE_RESULT}"
+          echo "Stateful SQLite shard 2/2: ${SHARD_TWO_RESULT}"
+          test "${SHARD_ONE_RESULT}" = success
+          test "${SHARD_TWO_RESULT}" = success
 
   backend-tests-archive-file-io:
     needs: backend-test-archive
@@ -392,22 +767,17 @@ jobs:
         with:
           toolchain: 1.96.0
 
-      - name: Cache cargo directories
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
+
       - name: Run archive / file I/O backend profile
-        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io
+        run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
 
   release-snapshot:
     name: Release Snapshot

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -234,6 +234,24 @@ jobs:
             --github-token "${GITHUB_TOKEN}" \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Recover selected release snapshot
+        if: github.event_name != 'workflow_dispatch' && steps.pending-target.outputs.target_sha != ''
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ steps.pending-target.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${TARGET_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --target-only \
+            --skip-publish \
+            --output "$RUNNER_TEMP/release-snapshot.json"
+
       - name: Load immutable release snapshot
         if: steps.pending-target.outputs.target_sha != ''
         id: snapshot
@@ -277,11 +295,90 @@ jobs:
             fi
           done
 
+  candidate-availability:
+    name: Validate Candidate Images
+    runs-on: ubuntu-24.04
+    needs: [release-meta]
+    if: ${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 15
+    outputs:
+      available: ${{ steps.verify.outputs.available }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify candidate SHA, version, and platforms
+        id: verify
+        shell: bash
+        env:
+          IMAGE_NAME_LOWER: ${{ needs.release-meta.outputs.image_name_lower }}
+          CANDIDATE_SUFFIX: ${{ needs.release-meta.outputs.candidate_suffix }}
+          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${IMAGE_NAME_LOWER}"
+          available=true
+          for platform in amd64 arm64; do
+            ref="${image}:candidate-${CANDIDATE_SUFFIX}-${platform}"
+            echo "[candidate] ${ref}"
+            if ! docker pull --platform "linux/${platform}" "${ref}"; then
+              echo "[candidate] missing image: ${ref}" >&2
+              available=false
+              continue
+            fi
+
+            revision="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${ref}" || true)"
+            version="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' "${ref}" || true)"
+            if [[ "${revision}" != "${TARGET_SHA}" ]]; then
+              echo "[candidate] revision mismatch for ${ref}: expected ${TARGET_SHA}, got ${revision:-<missing>}" >&2
+              available=false
+            fi
+            if [[ "${version}" != "${APP_EFFECTIVE_VERSION}" ]]; then
+              echo "[candidate] version mismatch for ${ref}: expected ${APP_EFFECTIVE_VERSION}, got ${version:-<missing>}" >&2
+              available=false
+            fi
+          done
+
+          echo "available=${available}" >> "$GITHUB_OUTPUT"
+
+  candidate-policy:
+    name: Candidate Promotion Policy
+    runs-on: ubuntu-24.04
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}
+    timeout-minutes: 5
+    steps:
+      - name: Enforce automatic candidate requirement
+        env:
+          AVAILABLE: ${{ needs.candidate-availability.outputs.available }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ] && [ "${AVAILABLE}" != "true" ]; then
+            echo "Automatic Release requires complete SHA/version-matched amd64 and arm64 candidates." >&2
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${AVAILABLE}" != "true" ]; then
+            echo "Manual Release will use the fallback build because candidates are unavailable or mismatched."
+          else
+            echo "Candidate images are complete and eligible for promotion."
+          fi
+
   docker-amd64:
     name: Build + Smoke + Push Candidate (linux/amd64)
     runs-on: ubuntu-24.04
-    needs: [release-meta]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}
     permissions:
       contents: read
       packages: write
@@ -310,11 +407,13 @@ jobs:
           platforms: ${{ env.PLATFORM_AMD64 }}
           push: false
           load: true
+          target: runtime
           tags: |
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
           build-args: |
             APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
+            APP_GIT_REVISION=${{ needs.release-meta.outputs.target_sha }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64,mode=max
 
@@ -341,8 +440,8 @@ jobs:
   docker-arm64:
     name: Build + Smoke + Push Candidate (linux/arm64)
     runs-on: ubuntu-24.04-arm
-    needs: [release-meta]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}
     permissions:
       contents: read
       packages: write
@@ -386,6 +485,7 @@ jobs:
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          APP_GIT_REVISION: ${{ needs.release-meta.outputs.target_sha }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
         run: ./.github/scripts/build-smoke-image-with-retry.sh
 
@@ -414,8 +514,8 @@ jobs:
   release-publish:
     name: Release Publish (manifest + tag + GitHub Release)
     runs-on: ubuntu-24.04
-    needs: [release-meta, docker-amd64, docker-arm64]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability, candidate-policy, docker-amd64, docker-arm64]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && needs.candidate-policy.result == 'success' && (needs.candidate-availability.outputs.available == 'true' || (github.event_name == 'workflow_dispatch' && needs.docker-amd64.result == 'success' && needs.docker-arm64.result == 'success')) }}
     permissions:
       actions: write
       contents: write

--- a/.github/scripts/run-backend-tests.sh
+++ b/.github/scripts/run-backend-tests.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: run-backend-tests.sh [--profile lightweight|stateful-sqlite|archive-file-io] [--archive-file PATH] [--test-filter EXPR]
+Usage: run-backend-tests.sh [--profile lightweight|stateful-sqlite|archive-file-io] [--archive-file PATH] [--test-filter EXPR] [--partition hash:N/M]
 
 Profiles:
   lightweight
@@ -17,12 +17,16 @@ instead of building test binaries in this invocation.
 
 When --test-filter is set, replace the profile's default nextest filter while
 retaining the profile's schema-template and workspace contract.
+
+When --partition is set, pass one deterministic cargo-nextest hash partition to
+the selected profile. The value must be hash:N/M with 1 <= N <= M.
 EOF
 }
 
 profile="all"
 archive_file=""
 test_filter_override=""
+partition=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --profile)
@@ -52,6 +56,15 @@ while [[ $# -gt 0 ]]; do
       test_filter_override="$2"
       shift 2
       ;;
+    --partition)
+      if [[ $# -lt 2 ]]; then
+        echo "::error::--partition requires a value." >&2
+        usage >&2
+        exit 64
+      fi
+      partition="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -63,6 +76,21 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+partition_args=()
+if [[ -n "$partition" ]]; then
+  if [[ ! "$partition" =~ ^hash:([0-9]+)/([0-9]+)$ ]]; then
+    echo "::error::--partition must use hash:N/M." >&2
+    exit 64
+  fi
+  partition_index="${BASH_REMATCH[1]}"
+  partition_count="${BASH_REMATCH[2]}"
+  if (( partition_index < 1 || partition_count < 1 || partition_index > partition_count )); then
+    echo "::error::--partition requires 1 <= N <= M." >&2
+    exit 64
+  fi
+  partition_args=(--partition "$partition")
+fi
 
 backend_test_workspace="${BACKEND_TEST_WORKSPACE:-/tmp/codex-vibe-monitor-backend-test}"
 if [[ "$backend_test_workspace" != /tmp/* || "$backend_test_workspace" == *..* ]]; then
@@ -180,15 +208,15 @@ run_profile() {
   if [[ -n "$test_threads" ]]; then
     echo "backend_test_profile_test_threads_${selected_profile//-/_}=$test_threads"
     if [[ -n "$archive_file" ]]; then
-      cargo nextest run --archive-file "$archive_file" --no-fail-fast --test-threads "$test_threads" -E "$filter_expr"
+      cargo nextest run --archive-file "$archive_file" --no-fail-fast --test-threads "$test_threads" "${partition_args[@]}" -E "$filter_expr"
     else
-      cargo nextest run --locked --all-features --no-fail-fast --test-threads "$test_threads" -E "$filter_expr"
+      cargo nextest run --locked --all-features --no-fail-fast --test-threads "$test_threads" "${partition_args[@]}" -E "$filter_expr"
     fi
   else
     if [[ -n "$archive_file" ]]; then
-      cargo nextest run --archive-file "$archive_file" --no-fail-fast -E "$filter_expr"
+      cargo nextest run --archive-file "$archive_file" --no-fail-fast "${partition_args[@]}" -E "$filter_expr"
     else
-      cargo nextest run --locked --all-features --no-fail-fast -E "$filter_expr"
+      cargo nextest run --locked --all-features --no-fail-fast "${partition_args[@]}" -E "$filter_expr"
     fi
   fi
   if [[ "$selected_profile" == "stateful-sqlite" ]]; then

--- a/.github/scripts/test-backend-test-contract.sh
+++ b/.github/scripts/test-backend-test-contract.sh
@@ -7,6 +7,8 @@ runner="$repo_root/.github/scripts/run-backend-tests.sh"
 compose_file="$repo_root/compose.backend-test.yml"
 ci_main_workflow="$repo_root/.github/workflows/ci-main.yml"
 release_workflow="$repo_root/.github/workflows/release.yml"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
 
 grep -q '^FROM rust:1.96.0-bookworm AS backend-test$' "$dockerfile"
 grep -q '^  backend-test:$' "$compose_file"
@@ -22,6 +24,56 @@ grep -q '^    entrypoint: \[\]$' "$compose_file"
 grep -q '^    command: \["sleep", "infinity"\]$' "$compose_file"
 grep -q '^    user: "65534:65534"$' "$compose_file"
 grep -q '^      CARGO_HOME: /tmp/codex-vibe-monitor-backend-test/cargo-home$' "$compose_file"
+
+web_builder_section="$(sed -n '/^FROM oven\/bun:.* AS web-builder$/,/^# Stage 2:/p' "$dockerfile")"
+web_arg_line="$(grep -n '^ARG APP_EFFECTIVE_VERSION$' <<<"$web_builder_section" | cut -d: -f1)"
+web_workdir_line="$(grep -n '^WORKDIR /app/web$' <<<"$web_builder_section" | cut -d: -f1)"
+if (( web_arg_line < web_workdir_line )); then
+  echo 'web builder must not declare APP_EFFECTIVE_VERSION before dependency installation' >&2
+  exit 1
+fi
+web_copy_line="$(grep -n '^COPY web/ \.\/$' <<<"$web_builder_section" | cut -d: -f1)"
+if (( web_arg_line != web_copy_line + 1 )); then
+  echo 'web builder must declare APP_EFFECTIVE_VERSION immediately before version-dependent build steps' >&2
+  exit 1
+fi
+
+rust_builder_section="$(sed -n '/^FROM rust:.* AS rust-builder$/,/^# Stage 3:/p' "$dockerfile")"
+rust_arg_line="$(grep -n '^ARG APP_EFFECTIVE_VERSION$' <<<"$rust_builder_section" | cut -d: -f1)"
+rust_workdir_line="$(grep -n '^WORKDIR /app$' <<<"$rust_builder_section" | cut -d: -f1)"
+if (( rust_arg_line < rust_workdir_line )); then
+  echo 'rust builder must not declare APP_EFFECTIVE_VERSION before dependency installation' >&2
+  exit 1
+fi
+rust_copy_line="$(grep -n '^COPY src \.\/src$' <<<"$rust_builder_section" | cut -d: -f1)"
+if (( rust_arg_line != rust_copy_line + 1 )); then
+  echo 'rust builder must declare APP_EFFECTIVE_VERSION immediately before source build steps' >&2
+  exit 1
+fi
+grep -q 'org.opencontainers.image.revision=${APP_GIT_REVISION}' "$dockerfile"
+
+set +e
+invalid_partition_output="$(PATH=/usr/bin:/bin bash "$runner" --profile stateful-sqlite --partition hash:3/2 2>&1)"
+invalid_partition_rc=$?
+set -e
+[[ "$invalid_partition_rc" == 64 ]]
+grep -q -- '--partition requires 1 <= N <= M' <<<"$invalid_partition_output"
+
+partition_bin="$tmp_dir/partition-bin"
+mkdir -p "$partition_bin"
+cat >"$partition_bin/cargo-nextest" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat >"$partition_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "$@"
+printf '\n'
+EOF
+chmod +x "$partition_bin/cargo-nextest" "$partition_bin/cargo"
+partition_output="$(PATH="$partition_bin:/usr/bin:/bin" BACKEND_TEST_WORKSPACE="$tmp_dir/partition-workspace" bash "$runner" --profile stateful-sqlite --partition hash:1/2 2>&1)"
+grep -q -- '--partition hash:1/2' <<<"$partition_output"
 
 if ! grep -Fq 'id: backend-test-image-name' "$ci_main_workflow"; then
   echo 'expected CI Main to normalize the backend-test GHCR image name' >&2

--- a/.github/scripts/test-backend-test-contract.sh
+++ b/.github/scripts/test-backend-test-contract.sh
@@ -6,9 +6,11 @@ dockerfile="$repo_root/Dockerfile"
 runner="$repo_root/.github/scripts/run-backend-tests.sh"
 compose_file="$repo_root/compose.backend-test.yml"
 ci_main_workflow="$repo_root/.github/workflows/ci-main.yml"
+backend_test_image_workflow="$repo_root/.github/workflows/backend-test-image.yml"
 release_workflow="$repo_root/.github/workflows/release.yml"
 tmp_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_dir}"' EXIT
+partition_workspace="/tmp/codex-vibe-monitor-backend-test-contract-${PPID}"
+trap 'rm -rf "${tmp_dir}" "${partition_workspace}"' EXIT
 
 grep -q '^FROM rust:1.96.0-bookworm AS backend-test$' "$dockerfile"
 grep -q '^  backend-test:$' "$compose_file"
@@ -72,26 +74,36 @@ printf '%q ' "$@"
 printf '\n'
 EOF
 chmod +x "$partition_bin/cargo-nextest" "$partition_bin/cargo"
-partition_output="$(PATH="$partition_bin:/usr/bin:/bin" BACKEND_TEST_WORKSPACE="$tmp_dir/partition-workspace" bash "$runner" --profile stateful-sqlite --partition hash:1/2 2>&1)"
+partition_output="$(PATH="$partition_bin:/usr/bin:/bin" BACKEND_TEST_WORKSPACE="$partition_workspace" bash "$runner" --profile stateful-sqlite --partition hash:1/2 2>&1)"
 grep -q -- '--partition hash:1/2' <<<"$partition_output"
 
-if ! grep -Fq 'id: backend-test-image-name' "$ci_main_workflow"; then
-  echo 'expected CI Main to normalize the backend-test GHCR image name' >&2
+if grep -Fq '^  backend-test-image:' "$ci_main_workflow"; then
+  echo 'backend-test image must be outside the CI Main completion path' >&2
   exit 1
 fi
 
-if ! grep -Fq 'image_name=${GITHUB_REPOSITORY,,}' "$ci_main_workflow"; then
-  echo 'expected CI Main backend-test image name to use Bash lowercase normalization' >&2
+if ! grep -Fq 'workflow_run:' "$backend_test_image_workflow" || ! grep -Fq 'github.event.workflow_run.conclusion == '\''success'\''' "$backend_test_image_workflow"; then
+  echo 'backend-test image workflow must run only after successful CI Main' >&2
   exit 1
 fi
 
-if ! grep -Fq 'tags: ${{ env.REGISTRY }}/${{ steps.backend-test-image-name.outputs.image_name }}:backend-test-${{ github.sha }}' "$ci_main_workflow"; then
-  echo 'expected CI Main backend-test image tag to use the normalized image name' >&2
+if ! grep -Fq 'image_name=${GITHUB_REPOSITORY,,}' "$backend_test_image_workflow"; then
+  echo 'backend-test image name must use Bash lowercase normalization' >&2
   exit 1
 fi
 
-if grep -Fq 'tags: ${{ env.REGISTRY }}/${{ github.repository }}:backend-test-${{ github.sha }}' "$ci_main_workflow"; then
-  echo 'CI Main must not publish the backend-test image with an unnormalized repository name' >&2
+if ! grep -Fq 'backend-test-${{ github.event.workflow_run.head_sha }}' "$backend_test_image_workflow"; then
+  echo 'backend-test image tag must use the CI Main workflow_run head SHA' >&2
+  exit 1
+fi
+
+if grep -Fq 'backend-test-${{ github.sha }}' "$backend_test_image_workflow"; then
+  echo 'backend-test image must not use the independent workflow SHA' >&2
+  exit 1
+fi
+
+if [[ "$(grep -Fc -- '--partition hash:1/2' "$ci_main_workflow")" != 1 || "$(grep -Fc -- '--partition hash:2/2' "$ci_main_workflow")" != 1 ]]; then
+  echo 'CI Main must run exactly one Stateful SQLite job for each hash partition' >&2
   exit 1
 fi
 

--- a/.github/scripts/test-build-smoke-image-with-retry.sh
+++ b/.github/scripts/test-build-smoke-image-with-retry.sh
@@ -83,6 +83,7 @@ BUILD_PLATFORM="linux/arm64" \
 SMOKE_TAG="ghcr.io/example/smoke:arm64" \
 CANDIDATE_TAG="ghcr.io/example/candidate:arm64" \
 APP_EFFECTIVE_VERSION="test-version" \
+APP_GIT_REVISION="0123456789abcdef0123456789abcdef01234567" \
 CACHE_REF="ghcr.io/example/buildcache:arm64" \
 BUILD_RETRY_ATTEMPTS="5" \
 BUILD_RETRY_BASE_DELAY_SECS="0" \
@@ -90,6 +91,7 @@ bash "$script" >"$tmp_dir/transient.out" 2>"$tmp_dir/transient.err"
 
 [[ "$(cat "$attempt_file")" == "3" ]]
 grep -Fq -- '--target runtime' "$args_file"
+grep -Fq -- '--build-arg APP_GIT_REVISION=0123456789abcdef0123456789abcdef01234567' "$args_file"
 grep -q "transient failure for linux/arm64; retry in 0s (1/5)" "$tmp_dir/transient.err"
 grep -q "transient failure for linux/arm64; retry in 0s (2/5)" "$tmp_dir/transient.err"
 

--- a/.github/workflows/backend-test-image.yml
+++ b/.github/workflows/backend-test-image.yml
@@ -1,0 +1,60 @@
+name: Backend Test Image
+
+on:
+  workflow_run:
+    workflows:
+      - CI Main
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  backend-test-image:
+    name: Publish Backend Test Image
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 35
+    steps:
+      - name: Checkout CI Main head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize backend-test image name
+        id: backend-test-image-name
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "image_name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish immutable backend-test image (linux/amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: backend-test
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.backend-test-image-name.outputs.image_name }}:backend-test-${{ github.event.workflow_run.head_sha }}
+          build-args: |
+            APP_GIT_REVISION=${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -21,6 +21,182 @@ env:
   RELEASE_SNAPSHOT_NOTES_REF: refs/notes/release-snapshots
 
 jobs:
+  candidate-meta:
+    name: Candidate Image Metadata
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+      issues: read
+      pull-requests: read
+    timeout-minutes: 10
+    outputs:
+      release_enabled: ${{ steps.snapshot.outputs.release_enabled }}
+      target_sha: ${{ steps.snapshot.outputs.target_sha }}
+      image_name: ${{ steps.snapshot.outputs.image_name_lower }}
+      app_effective_version: ${{ steps.snapshot.outputs.app_effective_version }}
+      candidate_suffix: ${{ steps.snapshot.outputs.target_sha_short }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity for release notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure immutable release snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_snapshot.py ensure \
+            --target-sha "${GITHUB_SHA}" \
+            --github-repository "${GITHUB_REPOSITORY}" \
+            --github-token "${GITHUB_TOKEN}" \
+            --notes-ref "${RELEASE_SNAPSHOT_NOTES_REF}" \
+            --registry "${REGISTRY}" \
+            --target-only \
+            --output "$RUNNER_TEMP/release-snapshot.json"
+
+      - name: Export candidate metadata
+        id: snapshot
+        env:
+          SNAPSHOT_PATH: ${{ runner.temp }}/release-snapshot.json
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["SNAPSHOT_PATH"]).read_text())
+          target_sha = payload["target_sha"]
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as output:
+              output.write(f"release_enabled={str(payload['release_enabled']).lower()}\n")
+              output.write(f"target_sha={target_sha}\n")
+              output.write(f"target_sha_short={target_sha[:12]}\n")
+              output.write(f"image_name_lower={payload['image_name_lower']}\n")
+              output.write(f"app_effective_version={payload.get('app_effective_version', '')}\n")
+          PY
+
+  candidate-amd64:
+    name: Build + Smoke + Push Candidate (linux/amd64)
+    needs: candidate-meta
+    if: ${{ needs.candidate-meta.outputs.release_enabled == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 35
+    steps:
+      - name: Checkout target SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build candidate image (linux/amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+            ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+          build-args: |
+            APP_EFFECTIVE_VERSION=${{ needs.candidate-meta.outputs.app_effective_version }}
+            APP_GIT_REVISION=${{ needs.candidate-meta.outputs.target_sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-amd64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-amd64,mode=max
+
+      - name: Smoke test image (linux/amd64)
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-amd64-${{ needs.candidate-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: linux/amd64
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/amd64)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-amd64
+        run: docker push "$IMAGE_REF"
+
+  candidate-arm64:
+    name: Build + Smoke + Push Candidate (linux/arm64)
+    needs: candidate-meta
+    if: ${{ needs.candidate-meta.outputs.release_enabled == 'true' }}
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 35
+    steps:
+      - name: Checkout target SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.candidate-meta.outputs.target_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: workflow-helpers
+
+      - name: Install workflow helper scripts
+        shell: bash
+        run: install -m 755 workflow-helpers/.github/scripts/build-smoke-image-with-retry.sh ./.github/scripts/build-smoke-image-with-retry.sh
+
+      - name: Build candidate image (linux/arm64)
+        shell: bash
+        env:
+          BUILD_PLATFORM: linux/arm64
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          APP_EFFECTIVE_VERSION: ${{ needs.candidate-meta.outputs.app_effective_version }}
+          APP_GIT_REVISION: ${{ needs.candidate-meta.outputs.target_sha }}
+          CACHE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:buildcache-arm64
+        run: ./.github/scripts/build-smoke-image-with-retry.sh
+
+      - name: Smoke test image (linux/arm64)
+        env:
+          SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:smoke-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+          SMOKE_CONTAINER_NAME: smoke-codex-vibe-monitor-arm64-${{ needs.candidate-meta.outputs.candidate_suffix }}
+          SMOKE_PLATFORM: linux/arm64
+          SMOKE_TIMEOUT_SECS: "120"
+        run: ./.github/scripts/smoke-test-image.sh "$SMOKE_TAG"
+
+      - name: Push candidate image (linux/arm64)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ needs.candidate-meta.outputs.image_name }}:candidate-${{ needs.candidate-meta.outputs.candidate_suffix }}-arm64
+        run: docker push "$IMAGE_REF"
+
   lint:
     name: Lint & Format Check
     runs-on: ubuntu-24.04
@@ -493,10 +669,10 @@ jobs:
       - name: Run lightweight backend profile
         run: bash .github/scripts/run-backend-tests.sh --profile lightweight --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
 
-  backend-tests-stateful-sqlite:
+  backend-tests-stateful-sqlite-shard-1:
     needs: backend-test-archive
     if: always()
-    name: Backend Tests (Stateful SQLite)
+    name: Backend Tests (Stateful SQLite shard 1/2)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -521,7 +697,57 @@ jobs:
           path: ${{ runner.temp }}
 
       - name: Run stateful SQLite backend profile
-        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite --partition hash:1/2 --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite-shard-2:
+    needs: backend-test-archive
+    if: always()
+    name: Backend Tests (Stateful SQLite shard 2/2)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Download backend test archive
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-test-archive-${{ github.run_id }}
+          path: ${{ runner.temp }}
+
+      - name: Run stateful SQLite backend profile
+        run: bash .github/scripts/run-backend-tests.sh --profile stateful-sqlite --partition hash:2/2 --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
+
+  backend-tests-stateful-sqlite:
+    name: Backend Tests (Stateful SQLite)
+    needs:
+      - backend-tests-stateful-sqlite-shard-1
+      - backend-tests-stateful-sqlite-shard-2
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require both Stateful SQLite shards
+        env:
+          SHARD_ONE_RESULT: ${{ needs.backend-tests-stateful-sqlite-shard-1.result }}
+          SHARD_TWO_RESULT: ${{ needs.backend-tests-stateful-sqlite-shard-2.result }}
+        run: |
+          set -euo pipefail
+          echo "Stateful SQLite shard 1/2: ${SHARD_ONE_RESULT}"
+          echo "Stateful SQLite shard 2/2: ${SHARD_TWO_RESULT}"
+          test "${SHARD_ONE_RESULT}" = success
+          test "${SHARD_TWO_RESULT}" = success
 
   backend-tests-archive-file-io:
     needs: backend-test-archive
@@ -552,51 +778,6 @@ jobs:
 
       - name: Run archive / file I/O backend profile
         run: bash .github/scripts/run-backend-tests.sh --profile archive-file-io --archive-file "$RUNNER_TEMP/backend-tests.tar.zst"
-
-  backend-test-image:
-    name: Publish Backend Test Image
-    runs-on: ubuntu-24.04
-    needs:
-      - backend-tests-lightweight
-      - backend-tests-stateful-sqlite
-      - backend-tests-archive-file-io
-    permissions:
-      contents: read
-      packages: write
-    timeout-minutes: 35
-    outputs:
-      digest: ${{ steps.build-backend-test-image.outputs.digest }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Normalize backend-test image name
-        id: backend-test-image-name
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "image_name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and publish immutable backend-test image (linux/amd64)
-        id: build-backend-test-image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          target: backend-test
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ steps.backend-test-image-name.outputs.image_name }}:backend-test-${{ github.sha }}
 
   release-snapshot:
     name: Release Snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,11 +295,90 @@ jobs:
             fi
           done
 
+  candidate-availability:
+    name: Validate Candidate Images
+    runs-on: ubuntu-24.04
+    needs: [release-meta]
+    if: ${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 15
+    outputs:
+      available: ${{ steps.verify.outputs.available }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify candidate SHA, version, and platforms
+        id: verify
+        shell: bash
+        env:
+          IMAGE_NAME_LOWER: ${{ needs.release-meta.outputs.image_name_lower }}
+          CANDIDATE_SUFFIX: ${{ needs.release-meta.outputs.candidate_suffix }}
+          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${IMAGE_NAME_LOWER}"
+          available=true
+          for platform in amd64 arm64; do
+            ref="${image}:candidate-${CANDIDATE_SUFFIX}-${platform}"
+            echo "[candidate] ${ref}"
+            if ! docker pull --platform "linux/${platform}" "${ref}"; then
+              echo "[candidate] missing image: ${ref}" >&2
+              available=false
+              continue
+            fi
+
+            revision="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${ref}" || true)"
+            version="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' "${ref}" || true)"
+            if [[ "${revision}" != "${TARGET_SHA}" ]]; then
+              echo "[candidate] revision mismatch for ${ref}: expected ${TARGET_SHA}, got ${revision:-<missing>}" >&2
+              available=false
+            fi
+            if [[ "${version}" != "${APP_EFFECTIVE_VERSION}" ]]; then
+              echo "[candidate] version mismatch for ${ref}: expected ${APP_EFFECTIVE_VERSION}, got ${version:-<missing>}" >&2
+              available=false
+            fi
+          done
+
+          echo "available=${available}" >> "$GITHUB_OUTPUT"
+
+  candidate-policy:
+    name: Candidate Promotion Policy
+    runs-on: ubuntu-24.04
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.result == 'success' && needs.release-meta.outputs.release_enabled == 'true' }}
+    timeout-minutes: 5
+    steps:
+      - name: Enforce automatic candidate requirement
+        env:
+          AVAILABLE: ${{ needs.candidate-availability.outputs.available }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ] && [ "${AVAILABLE}" != "true" ]; then
+            echo "Automatic Release requires complete SHA/version-matched amd64 and arm64 candidates." >&2
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${AVAILABLE}" != "true" ]; then
+            echo "Manual Release will use the fallback build because candidates are unavailable or mismatched."
+          else
+            echo "Candidate images are complete and eligible for promotion."
+          fi
+
   docker-amd64:
     name: Build + Smoke + Push Candidate (linux/amd64)
     runs-on: ubuntu-24.04
-    needs: [release-meta]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}
     permissions:
       contents: read
       packages: write
@@ -334,6 +413,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-amd64
           build-args: |
             APP_EFFECTIVE_VERSION=${{ needs.release-meta.outputs.app_effective_version }}
+            APP_GIT_REVISION=${{ needs.release-meta.outputs.target_sha }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-amd64,mode=max
 
@@ -360,8 +440,8 @@ jobs:
   docker-arm64:
     name: Build + Smoke + Push Candidate (linux/arm64)
     runs-on: ubuntu-24.04-arm
-    needs: [release-meta]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && github.event_name == 'workflow_dispatch' && needs.candidate-availability.outputs.available != 'true' }}
     permissions:
       contents: read
       packages: write
@@ -405,6 +485,7 @@ jobs:
           SMOKE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:smoke-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           CANDIDATE_TAG: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:candidate-${{ needs.release-meta.outputs.candidate_suffix }}-arm64
           APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          APP_GIT_REVISION: ${{ needs.release-meta.outputs.target_sha }}
           CACHE_REF: ${{ env.REGISTRY }}/${{ needs.release-meta.outputs.image_name_lower }}:buildcache-arm64
         run: ./.github/scripts/build-smoke-image-with-retry.sh
 
@@ -433,8 +514,8 @@ jobs:
   release-publish:
     name: Release Publish (manifest + tag + GitHub Release)
     runs-on: ubuntu-24.04
-    needs: [release-meta, docker-amd64, docker-arm64]
-    if: needs.release-meta.outputs.release_enabled == 'true'
+    needs: [release-meta, candidate-availability, candidate-policy, docker-amd64, docker-arm64]
+    if: ${{ always() && needs.release-meta.outputs.release_enabled == 'true' && needs.candidate-policy.result == 'success' && (needs.candidate-availability.outputs.available == 'true' || (github.event_name == 'workflow_dispatch' && needs.docker-amd64.result == 'success' && needs.docker-arm64.result == 'success')) }}
     permissions:
       actions: write
       contents: write

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -473,6 +473,18 @@ _Avoid_: PR 正文转抄, 流程元数据拼接
 与主线提交绑定的不可变自动发布决策记录，保存版本意图与发布计算所需字段；手工覆盖字段只存在于本次 workflow 的临时快照，不写入该记录。
 _Avoid_: Release 正文, 手工覆盖审计, 公开变更说明
 
+**候选镜像**:
+由一个主线提交按目标架构构建、完成本地 smoke 后写入 GHCR 的不可变 SHA 镜像；它不是版本 tag、`latest`、manifest、Git tag、GitHub Release 或部署来源。
+_Avoid_: 临时发布, 预发布版本, 正式镜像
+
+**正式提升**:
+在同一提交的 CI Main 全部成功后，将其已 smoke 验证的候选镜像创建为正式多架构 manifest，并依次完成 tag 与 GitHub Release 的发布操作。
+_Avoid_: 候选构建, 镜像重建, 提前发布
+
+**Stateful SQLite 测试分片**:
+完整 Stateful SQLite profile 的一个确定性、互不重叠的 nextest 子集；所有分片的并集才构成完整 profile，任一分片失败都会使同一个 required check 失败。
+_Avoid_: 可选测试, 新的 required check, 不完整 profile
+
 **PR 发布评论**:
 附在源 PR 上的版本交付追溯记录；它独立于 GitHub Release 页面。
 _Avoid_: Release 正文, 发布说明

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Stage 1: build the web assets
 FROM oven/bun:1.3.14-alpine AS web-builder
-ARG APP_EFFECTIVE_VERSION
 WORKDIR /app/web
 
 COPY web/package.json web/bun.lock ./
 RUN bun install --frozen-lockfile
 
 COPY web/ ./
+ARG APP_EFFECTIVE_VERSION
 ENV VITE_APP_VERSION=${APP_EFFECTIVE_VERSION}
 RUN bun run build
 
@@ -14,7 +14,6 @@ RUN bun run build
 # IMPORTANT: runtime image is Debian bookworm (glibc 2.36). Pin the Rust build stage to bookworm too,
 # otherwise the rust:<version> default base may drift and produce a binary requiring newer GLIBC.
 FROM rust:1.96.0-bookworm AS rust-builder
-ARG APP_EFFECTIVE_VERSION
 WORKDIR /app
 
 RUN apt-get update \
@@ -29,6 +28,7 @@ RUN mkdir -p src \
 
 # Copy app sources and build the real binary.
 COPY src ./src
+ARG APP_EFFECTIVE_VERSION
 ENV APP_EFFECTIVE_VERSION=${APP_EFFECTIVE_VERSION}
 RUN find src -type f -name '*.rs' -exec touch {} + \
     && rm -f target/release/codex-vibe-monitor \
@@ -77,6 +77,7 @@ COPY scripts/search-raw /usr/local/bin/search-raw
 # Stage 5: production runtime image
 FROM runtime-base AS production-runtime
 ARG APP_EFFECTIVE_VERSION
+ARG APP_GIT_REVISION
 ARG FRONTEND_EFFECTIVE_VERSION
 
 COPY --from=rust-builder /app/target/release/codex-vibe-monitor /usr/local/bin/codex-vibe-monitor
@@ -92,7 +93,8 @@ ENV DATABASE_PATH=/srv/app/data/codex_vibe_monitor.db \
     MALLOC_ARENA_MAX=8 \
     APP_EFFECTIVE_VERSION=${APP_EFFECTIVE_VERSION}
 
-LABEL org.opencontainers.image.version=${APP_EFFECTIVE_VERSION}
+LABEL org.opencontainers.image.version=${APP_EFFECTIVE_VERSION} \
+      org.opencontainers.image.revision=${APP_GIT_REVISION}
 
 VOLUME ["/srv/app/data"]
 EXPOSE 8080
@@ -107,8 +109,6 @@ CMD ["codex-vibe-monitor"]
 # 24.04; matching its glibc here avoids executing a host-built debug binary against
 # the older production runtime.
 FROM ubuntu:24.04 AS ci-smoke-runtime
-ARG APP_EFFECTIVE_VERSION
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl gzip libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*
@@ -123,6 +123,7 @@ COPY .ci-smoke/web ./web
 
 RUN chmod 0755 /usr/local/bin/search-raw /usr/local/bin/codex-vibe-monitor
 
+ARG APP_EFFECTIVE_VERSION
 ENV DATABASE_PATH=/srv/app/data/codex_vibe_monitor.db \
     HTTP_BIND=0.0.0.0:8080 \
     STATIC_DIR=/srv/app/web \

--- a/docs/adr/0013-overlap-main-ci-with-candidate-image-builds.md
+++ b/docs/adr/0013-overlap-main-ci-with-candidate-image-builds.md
@@ -1,0 +1,31 @@
+# ADR 0013: Overlap main CI with candidate image builds
+
+## Status
+
+Accepted
+
+Automatic publication currently waits for all of `CI Main`, then repeats the two native image builds, smoke checks, and cache export in `Release`. Historical successful runs therefore have a median merge-to-publication time of 20 minutes 35 seconds, with no observed run meeting the 10-minute objective. The workflow will instead build an immutable, smoke-verified candidate image for each releasable main SHA while CI runs, then make `Release` promote those exact candidates only after the matching CI Main run succeeds. This preserves the release boundary while turning the two long stages from serial work into overlapping work.
+
+## Decision
+
+- A **candidate image** is an architecture-specific, SHA-derived GHCR tag that has completed local smoke. It is not a version tag, `latest`, a multi-architecture manifest, a Git tag, a GitHub Release, or a deployment source. `CI Main` may push `candidate-<sha12>-amd64` and `candidate-<sha12>-arm64` only for a release-enabled snapshot.
+- A new early CI metadata job reads the immutable merged-PR snapshot for the exact main SHA. If the merge-event snapshot has not arrived yet, it idempotently creates the same target-only snapshot before exporting the version and candidate suffix. Both candidate builders check out that target SHA, build, smoke, and push their architecture tag. A candidate build or smoke failure fails CI Main and cannot be promoted.
+- `Release` continues to serialize with `release-main`, select the existing queued target, validate both candidate tags, create the version manifests, verify platforms, and create the Git tag and GitHub Release. It must not rebuild a missing candidate for an automatic main release. This keeps ordered release semantics while leaving only promotion on the post-CI critical path.
+- `workflow_dispatch` remains compatible with historical main commits. When both exact candidate tags exist it promotes them; when either is absent it may use the existing synchronized build-and-smoke path as a manual-backfill fallback. That fallback is intentionally outside the automatic merge-to-publication SLO.
+- The Dockerfile declares `APP_EFFECTIVE_VERSION` only immediately before the version-dependent web and Rust application builds, not before dependency installation or the dummy Rust dependency build. A release version changes every publication; declaring it earlier invalidates otherwise reusable dependency layers.
+- Stateful SQLite validation is split into two deterministic `cargo nextest` hash partitions (`hash:1/2` and `hash:2/2`) after the shared archive producer. Each keeps the established six test threads and a private schema template. Their aggregate remains the sole owner-facing `Backend Tests (Stateful SQLite)` required check; it fails unless both shards succeed. Thus every test remains mandatory without adding a branch-protection check or increasing per-test concurrency.
+- The `backend-test` image moves to a separate success-only `workflow_run` workflow for CI Main. It checks out and tags the CI run's exact head SHA, remains auxiliary to branch protection and Release, and never supplies a release image digest.
+
+## Consequences
+
+- The automatic critical path becomes `max(CI quality gates, candidate build and smoke) + manifest/tag/Release promotion`, rather than `CI Main + candidate build and smoke + promotion`.
+- The acceptance metric is the elapsed time from automatic CI Main creation for an eligible main SHA to completion of that SHA's GitHub Release creation. Across the most recent ten eligible automatic releases, P95 must be at most 10 minutes and the operating target for P50 is at most 7 minutes. Candidate cache-hit evidence and each Stateful shard duration are retained with that measurement so a regression identifies its owner.
+- Workflow contracts, fixtures, and branch-protection declarations must retain the three existing backend check names. The new shard jobs and candidate jobs are implementation detail, not new required checks.
+- Candidate retention and deletion are deliberately not automated by this decision. Any GHCR cleanup requires a separately approved retention policy and an exact, recoverable target definition.
+
+## Considered Options
+
+- Keep image builds in Release: rejected because it guarantees the observed serial critical path and cannot meet the objective through minor cache tuning alone.
+- Publish version tags before CI completes: rejected because a failing quality gate could leave a user-visible release that was never fully validated.
+- Add two Stateful shard checks directly to branch protection: rejected because it changes the external required-check contract; an aggregate check preserves that interface while retaining complete coverage.
+- Rebuild missing automatic candidates in Release: rejected because it silently restores the slow path and weakens the guarantee that promotion uses CI-smoked artifacts.

--- a/docs/specs/8239m-release-latest-published-stable/SPEC.md
+++ b/docs/specs/8239m-release-latest-published-stable/SPEC.md
@@ -74,6 +74,7 @@
 ## Related ADRs
 
 - [ADR 0007: CI-contained representative-scale validation](../../adr/0007-ci-contained-representative-scale-validation.md)
+- [ADR 0013: Overlap main CI with candidate image builds](../../adr/0013-overlap-main-ci-with-candidate-image-builds.md)
 
 ## References
 

--- a/docs/specs/m7q2r-manual-release-override/SPEC.md
+++ b/docs/specs/m7q2r-manual-release-override/SPEC.md
@@ -1,5 +1,9 @@
 # 受控手动发版覆盖（#m7q2r）
 
+## Related ADRs
+
+- [ADR 0013: Overlap main CI with candidate image builds](../../adr/0013-overlap-main-ci-with-candidate-image-builds.md)
+
 ## 背景 / 问题陈述
 
 现有 `Release` workflow 的 `workflow_dispatch(commit_sha)` 只能重放已冻结的 release snapshot。若目标 commit 的原始 PR release intent 是 `type:skip` 或 `type:docs`，手动 backfill 仍会导出 `release_enabled=false`，无法对已经进入 `main` 且通过质量门禁的 commit 做维护者显式发版。

--- a/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/IMPLEMENTATION.md
@@ -26,8 +26,10 @@
   - `--profile lightweight`
   - `--profile stateful-sqlite`
   - `--profile archive-file-io`
+  - `--partition hash:N/M`（仅用于受校验的 Stateful SQLite 分片）
 - PR2 已将不属于 `src/tests/**` / `src/upstream_accounts/tests/**` 的 136 个内联 backend unit tests 并回 `lightweight` profile，避免 profile split 造成 coverage 回归。
 - PR2 已把 owner-facing backend required checks 更新为三个 job，并同步 `.github/quality-gates.json`、contract fixtures、release snapshot 自测与 live quality-gates fixtures。
+- 当前主线将 Stateful SQLite 完整集合并行分为 `hash:1/2` 与 `hash:2/2`，由单一 `Backend Tests (Stateful SQLite)` 聚合 required check 收口；成功 CI Main 后的 `backend-test` 镜像发布独立为 `workflow_run`，不再阻塞 CI Main 完成。
 - PR2 发现 `CI PR` 仅对 `base=main` 触发，导致 stacked PR 无服务端 checks；现已将 `CI PR` 的 `pull_request` 触发范围放开到所有 PR base，同时保留 `Label Gate` / `Review Policy` 与 live rules 对齐检查只对 `main` 生效。
 - PR #576 已合并为 `main@405dfe7b8d4e44b33c25836528c936a9a6341704` 并发布为 `v2.21.1`；`CI Main` run `29072008929` 的三路 backend job 都通过。
 - 该 CI Main 的 backend job wall time 为：

--- a/docs/specs/q7yt7-backend-test-resource-profiles/SPEC.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/SPEC.md
@@ -5,6 +5,7 @@
 ## Related ADRs
 
 - [ADR 0007: CI-contained representative-scale validation](../../adr/0007-ci-contained-representative-scale-validation.md)
+- [ADR 0013: Overlap main CI with candidate image builds](../../adr/0013-overlap-main-ci-with-candidate-image-builds.md)
 
 ## 背景 / 问题陈述
 

--- a/docs/specs/q7yt7-backend-test-resource-profiles/SPEC.md
+++ b/docs/specs/q7yt7-backend-test-resource-profiles/SPEC.md
@@ -124,6 +124,13 @@
 - Candidate PRs MUST build the target from the current commit. A trusted main
   workflow may publish the immutable test image, but Release does not consume
   its digest as validation evidence.
+- `CI Main` MAY execute the complete `stateful-sqlite` profile as deterministic
+  `hash:1/2` and `hash:2/2` shards. A single `Backend Tests (Stateful SQLite)`
+  aggregate required check MUST fail when either shard fails, while preserving
+  the profile filter set and six test threads.
+- The immutable `backend-test` image MUST be published by a success-only
+  `workflow_run` after `CI Main` and tagged with that run's `head_sha`; it MUST
+  not extend the CI Main completion path or provide Release evidence.
 - Affected PRs MUST run the deterministic Representative-Scale Acceptance
   fixture. It MUST cover the old aggregate source admission boundary, paged
   archive proof, and staged all-time checkpoint without reducing the existing


### PR DESCRIPTION
## Summary
- Build and smoke-test immutable amd64/arm64 candidate images in CI Main while quality gates run.
- Make Release validate SHA/version-matched candidates and promote them without automatic rebuilds; retain manual fallback builds.
- Split Stateful SQLite into two hash partitions behind the existing aggregate required check.
- Move the backend-test image publication to a success-only workflow_run keyed by CI Main head_sha.
- Move Docker version arguments after dependency layers and preserve OCI revision/version metadata.

## Validation
- `bash .github/scripts/test-quality-gates-contract.sh`
- `bash .github/scripts/test-backend-test-contract.sh`
- `bash .github/scripts/test-build-smoke-image-with-retry.sh`
- `bash .github/scripts/test-release-snapshot.sh`
- `actionlint .github/workflows/ci-main.yml .github/workflows/release.yml .github/workflows/backend-test-image.yml`
- `bun run lint:docs`
- `python3 -m py_compile .github/scripts/release_snapshot.py .github/scripts/check_quality_gates_contract.py`
- `git diff --check`

## Release impact
This is workflow/tooling-only and is labeled `type:skip`; no product version or formal release is created by this PR.
