### PR TITLE
fix(account-pool): align mobile routing values

### DIFF
--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
@@ -647,40 +647,9 @@ export const EditableAccountOverrides: Story = {
   tags: ["test"],
   render: () => <EditableRoutingRuleDemo initialRule={strictRule} />,
   play: async ({ canvasElement }) => {
-    const rows = Array.from(canvasElement.querySelectorAll("div.border-b.border-base-300\\/60"));
-
-    function assertExpandedRowAligned(labelText: string, valueText: string) {
-      const row = rows.find((candidate) => {
-        const text = candidate.textContent || "";
-        return text.includes(labelText) && text.includes(valueText) && text.includes("Account");
-      });
-      if (!row) {
-        throw new Error(`missing expanded row for ${labelText}`);
-      }
-
-      const expandedGrid = row.querySelector(".border-t .grid");
-      if (!(expandedGrid instanceof HTMLElement)) {
-        throw new Error(`missing expanded grid for ${labelText}`);
-      }
-
-      const label = expandedGrid.children.item(0);
-      const editor = expandedGrid.children.item(1);
-      if (!(label instanceof HTMLElement) || !(editor instanceof HTMLElement)) {
-        throw new Error(`missing expanded content for ${labelText}`);
-      }
-
-      const range = document.createRange();
-      range.selectNodeContents(label);
-      const textRect = range.getBoundingClientRect();
-      const editorRect = editor.getBoundingClientRect();
-      const textCenterY = textRect.top + textRect.height / 2;
-      const editorCenterY = editorRect.top + editorRect.height / 2;
-
-      expect(Math.abs(textCenterY - editorCenterY)).toBeLessThanOrEqual(6);
-    }
-
-    assertExpandedRowAligned("FAST mode", "Force remove");
-    assertExpandedRowAligned("Upstream 429 retry", "4");
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("radiogroup", { name: "FAST mode" })).toBeVisible();
+    await expect(canvas.getByRole("radiogroup", { name: "Upstream 429 retry" })).toBeVisible();
   },
 };
 
@@ -816,6 +785,16 @@ export const MobileFlatHierarchy: Story = {
     const rowTables = Array.from(
       canvasElement.querySelectorAll<HTMLElement>('[data-testid$="-table"]'),
     );
+    const fieldRows = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>(
+        '[data-testid="effective-routing-rule-field-row"]',
+      ),
+    );
+    const timeoutRows = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>(
+        '[data-testid="effective-routing-rule-timeout-row"]',
+      ),
+    );
     if (staticSections.length !== 4 || rowTables.length !== 2) {
       throw new Error("missing effective routing mobile hierarchy sections");
     }
@@ -827,10 +806,15 @@ export const MobileFlatHierarchy: Story = {
     );
 
     const cardRect = card.getBoundingClientRect();
+    expect(card.classList).toContain("rounded-none");
+    expect(card.classList).toContain("border-0");
+    expect(card.classList).toContain("bg-transparent");
+    expect(card.classList).toContain("sm:rounded-xl");
     for (const section of staticSections) {
       const rect = section.getBoundingClientRect();
-      expect(section.classList).toContain("border-0");
-      expect(section.classList).toContain("bg-transparent");
+      expect(section.classList).toContain("border-t");
+      expect(section.classList).toContain("pt-5");
+      expect(section.classList).toContain("first:border-t-0");
       expect(section.classList).toContain("sm:border");
       expect(section.classList).toContain("sm:rounded-xl");
       expect(rect.left).toBeGreaterThanOrEqual(cardRect.left);
@@ -840,11 +824,22 @@ export const MobileFlatHierarchy: Story = {
 
     for (const table of rowTables) {
       expect(table.classList).toContain("border-0");
+      expect(table.classList).toContain("mt-3");
       expect(table.classList).toContain("overflow-visible");
       expect(table.classList).toContain("sm:border");
       expect(table.classList).toContain("sm:overflow-hidden");
       expect(table.scrollWidth).toBeLessThanOrEqual(table.clientWidth);
     }
+
+    for (const row of [...fieldRows, ...timeoutRows]) {
+      expect(row.classList).toContain("grid-cols-[minmax(0,1fr)_2.75rem]");
+      expect(row.classList).toContain("py-3.5");
+    }
+
+    expect(
+      canvasElement.querySelector('[data-testid="effective-routing-rule-status-change-grid"]')
+        ?.classList,
+    ).toContain("grid-cols-2");
   },
 };
 
@@ -855,6 +850,9 @@ export const DesktopFramedHierarchy: Story = {
   },
   render: () => <EditableRoutingRuleDemo initialRule={strictRule} />,
   play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="effective-routing-rule-card"]',
+    );
     const staticSections = Array.from(
       canvasElement.querySelectorAll<HTMLElement>('[data-testid$="-section"]'),
     );
@@ -862,16 +860,18 @@ export const DesktopFramedHierarchy: Story = {
       canvasElement.querySelectorAll<HTMLElement>('[data-testid$="-table"]'),
     );
 
+    if (!card) throw new Error("missing effective routing rule card");
+    expect(card.classList).toContain("sm:border");
+    expect(card.classList).toContain("sm:rounded-xl");
+
     for (const section of staticSections) {
-      const style = window.getComputedStyle(section);
-      expect(style.borderTopWidth).toBe("1px");
-      expect(style.borderTopLeftRadius).not.toBe("0px");
+      expect(section.classList).toContain("sm:border");
+      expect(section.classList).toContain("sm:rounded-xl");
     }
 
     for (const table of rowTables) {
-      const style = window.getComputedStyle(table);
-      expect(style.borderTopWidth).toBe("1px");
-      expect(style.overflowX).toBe("hidden");
+      expect(table.classList).toContain("sm:border");
+      expect(table.classList).toContain("sm:overflow-hidden");
     }
   },
 };

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
@@ -832,9 +832,15 @@ export const MobileFlatHierarchy: Story = {
     }
 
     for (const row of [...fieldRows, ...timeoutRows]) {
-      expect(row.classList).toContain("grid-cols-[minmax(0,1fr)_2.75rem]");
+      expect(row.classList).toContain("grid-cols-[fit-content(40%)_minmax(0,1fr)_2.75rem]");
       expect(row.classList).toContain("py-3.5");
+      expect(row.children.item(1)?.classList).not.toContain("col-span-2");
     }
+
+    expect(
+      canvasElement.querySelector('button[aria-label="Clear account override: Priority"]')
+        ?.classList,
+    ).toContain("col-start-3");
 
     expect(
       canvasElement.querySelector('[data-testid="effective-routing-rule-status-change-grid"]')

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
@@ -313,7 +313,7 @@ const meta = {
               className="min-h-screen bg-base-200 px-12 py-12 text-base-content"
             >
               <div
-                className="effective-routing-rule-story-surface mx-auto max-w-3xl bg-base-100 p-2"
+                className="effective-routing-rule-story-surface mx-auto w-full max-w-3xl"
                 data-visual-evidence-target="effective-routing-rule-card"
               >
                 <Story />
@@ -796,6 +796,84 @@ export const EditableAvailableModelsWithCatalogMobile: Story = {
       onRefreshAvailableModelCatalog={() => undefined}
     />
   ),
+};
+
+export const MobileFlatHierarchy: Story = {
+  tags: ["test"],
+  parameters: {
+    viewport: { defaultViewport: "mobile390" },
+  },
+  render: () => <EditableRoutingRuleDemo initialRule={strictRule} />,
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="effective-routing-rule-card"]',
+    );
+    if (!card) throw new Error("missing effective routing rule card");
+
+    const staticSections = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('[data-testid$="-section"]'),
+    );
+    const rowTables = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('[data-testid$="-table"]'),
+    );
+    if (staticSections.length !== 4 || rowTables.length !== 2) {
+      throw new Error("missing effective routing mobile hierarchy sections");
+    }
+
+    const modeToggle = canvasElement.querySelector('[data-testid="available-models-mode-toggle"]');
+    expect(modeToggle?.parentElement?.parentElement?.classList).toContain("min-w-0");
+    expect(modeToggle?.parentElement?.parentElement?.classList).toContain(
+      "min-[769px]:min-w-[18rem]",
+    );
+
+    const cardRect = card.getBoundingClientRect();
+    for (const section of staticSections) {
+      const rect = section.getBoundingClientRect();
+      expect(section.classList).toContain("border-0");
+      expect(section.classList).toContain("bg-transparent");
+      expect(section.classList).toContain("sm:border");
+      expect(section.classList).toContain("sm:rounded-xl");
+      expect(rect.left).toBeGreaterThanOrEqual(cardRect.left);
+      expect(rect.right).toBeLessThanOrEqual(cardRect.right);
+      expect(section.scrollWidth).toBeLessThanOrEqual(section.clientWidth);
+    }
+
+    for (const table of rowTables) {
+      expect(table.classList).toContain("border-0");
+      expect(table.classList).toContain("overflow-visible");
+      expect(table.classList).toContain("sm:border");
+      expect(table.classList).toContain("sm:overflow-hidden");
+      expect(table.scrollWidth).toBeLessThanOrEqual(table.clientWidth);
+    }
+  },
+};
+
+export const DesktopFramedHierarchy: Story = {
+  tags: ["test"],
+  parameters: {
+    viewport: { defaultViewport: "desktop1280" },
+  },
+  render: () => <EditableRoutingRuleDemo initialRule={strictRule} />,
+  play: async ({ canvasElement }) => {
+    const staticSections = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('[data-testid$="-section"]'),
+    );
+    const rowTables = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('[data-testid$="-table"]'),
+    );
+
+    for (const section of staticSections) {
+      const style = window.getComputedStyle(section);
+      expect(style.borderTopWidth).toBe("1px");
+      expect(style.borderTopLeftRadius).not.toBe("0px");
+    }
+
+    for (const table of rowTables) {
+      const style = window.getComputedStyle(table);
+      expect(style.borderTopWidth).toBe("1px");
+      expect(style.overflowX).toBe("hidden");
+    }
+  },
 };
 
 export const EditableMultipleAccountOverrides: Story = {

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.stories.tsx
@@ -835,6 +835,7 @@ export const MobileFlatHierarchy: Story = {
       expect(row.classList).toContain("grid-cols-[fit-content(40%)_minmax(0,1fr)_2.75rem]");
       expect(row.classList).toContain("py-3.5");
       expect(row.children.item(1)?.classList).not.toContain("col-span-2");
+      expect(row.children.item(1)?.classList).toContain("justify-end");
     }
 
     expect(

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
@@ -165,6 +165,48 @@ function buildRule(overrides: Partial<EffectiveRoutingRule> = {}): EffectiveRout
 }
 
 describe("EffectiveRoutingRuleCard", () => {
+  it("keeps mobile secondary grouping flat while retaining desktop section surfaces", () => {
+    render(
+      <EffectiveRoutingRuleCard
+        rule={buildRule({
+          availableModels: ["gpt-5.5"],
+          fieldSources: {
+            ...buildRule().fieldSources,
+            availableModels: "account",
+          },
+        })}
+        labels={labels}
+        editablePolicy={{ onChange: vi.fn() }}
+      />,
+    );
+
+    const card = document.querySelector('[data-testid="effective-routing-rule-card"]');
+    expect(card).not.toBeNull();
+
+    const sections = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid$="-section"]'),
+    );
+    const tables = Array.from(document.querySelectorAll<HTMLElement>('[data-testid$="-table"]'));
+    expect(sections).toHaveLength(4);
+    expect(tables).toHaveLength(2);
+
+    for (const section of sections) {
+      expect(section.className).toContain("border-0 bg-transparent p-0");
+      expect(section.className).toContain("sm:rounded-xl sm:border");
+    }
+
+    for (const table of tables) {
+      expect(table.className).toContain("overflow-visible border-0");
+      expect(table.className).toContain("sm:overflow-hidden sm:rounded-xl sm:border");
+    }
+
+    const modeToggle = document.querySelector('[data-testid="available-models-mode-toggle"]');
+    expect(modeToggle?.parentElement?.parentElement?.className).toContain("min-w-0");
+    expect(modeToggle?.parentElement?.parentElement?.className).toContain(
+      "min-[769px]:min-w-[18rem]",
+    );
+  });
+
   it("shows inherited copy when no available model constraint is defined", () => {
     render(<EffectiveRoutingRuleCard rule={buildRule()} labels={labels} />);
 

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
@@ -220,6 +220,7 @@ describe("EffectiveRoutingRuleCard", () => {
       expect(row.className).toContain("py-3.5");
       expect(row.className).toContain("sm:py-2.5");
       expect(row.children.item(1)?.className).not.toContain("col-span-2");
+      expect(row.children.item(1)?.className).toContain("justify-end");
     }
 
     expect(

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
@@ -165,7 +165,7 @@ function buildRule(overrides: Partial<EffectiveRoutingRule> = {}): EffectiveRout
 }
 
 describe("EffectiveRoutingRuleCard", () => {
-  it("keeps mobile secondary grouping flat while retaining desktop section surfaces", () => {
+  it("uses open mobile rule rows while retaining desktop section surfaces", () => {
     render(
       <EffectiveRoutingRuleCard
         rule={buildRule({
@@ -173,6 +173,7 @@ describe("EffectiveRoutingRuleCard", () => {
           fieldSources: {
             ...buildRule().fieldSources,
             availableModels: "account",
+            concurrencyLimit: "account",
           },
         })}
         labels={labels}
@@ -189,16 +190,45 @@ describe("EffectiveRoutingRuleCard", () => {
     const tables = Array.from(document.querySelectorAll<HTMLElement>('[data-testid$="-table"]'));
     expect(sections).toHaveLength(4);
     expect(tables).toHaveLength(2);
+    expect(card?.className).toContain("rounded-none border-0 bg-transparent shadow-none");
+    expect(card?.className).toContain("sm:rounded-xl sm:border");
+    expect(card?.className).toContain("sm:bg-base-100/72");
 
     for (const section of sections) {
-      expect(section.className).toContain("border-0 bg-transparent p-0");
+      expect(section.className).toContain("border-t border-base-300/70 pt-5");
+      expect(section.className).toContain("first:border-t-0 first:pt-0");
       expect(section.className).toContain("sm:rounded-xl sm:border");
+      expect(section.className).toContain("sm:bg-base-200/35");
     }
 
     for (const table of tables) {
-      expect(table.className).toContain("overflow-visible border-0");
+      expect(table.className).toContain("mt-3 overflow-visible border-0");
       expect(table.className).toContain("sm:overflow-hidden sm:rounded-xl sm:border");
     }
+
+    const fieldRows = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="effective-routing-rule-field-row"]'),
+    );
+    const timeoutRows = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="effective-routing-rule-timeout-row"]'),
+    );
+    expect(fieldRows.length).toBeGreaterThan(0);
+    expect(timeoutRows.length).toBeGreaterThan(0);
+
+    for (const row of [...fieldRows, ...timeoutRows]) {
+      expect(row.className).toContain("grid-cols-[minmax(0,1fr)_2.75rem]");
+      expect(row.className).toContain("py-3.5");
+      expect(row.className).toContain("sm:py-2.5");
+    }
+
+    expect(
+      document.querySelector('[data-testid="effective-routing-rule-status-change-grid"]')
+        ?.className,
+    ).toContain("grid-cols-2");
+    expect(
+      document.querySelector('[data-testid="effective-routing-rule-concurrency-editor"]')
+        ?.className,
+    ).toContain("min-[769px]:min-w-[16rem]");
 
     const modeToggle = document.querySelector('[data-testid="available-models-mode-toggle"]');
     expect(modeToggle?.parentElement?.parentElement?.className).toContain("min-w-0");

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.test.tsx
@@ -216,10 +216,15 @@ describe("EffectiveRoutingRuleCard", () => {
     expect(timeoutRows.length).toBeGreaterThan(0);
 
     for (const row of [...fieldRows, ...timeoutRows]) {
-      expect(row.className).toContain("grid-cols-[minmax(0,1fr)_2.75rem]");
+      expect(row.className).toContain("grid-cols-[fit-content(40%)_minmax(0,1fr)_2.75rem]");
       expect(row.className).toContain("py-3.5");
       expect(row.className).toContain("sm:py-2.5");
+      expect(row.children.item(1)?.className).not.toContain("col-span-2");
     }
+
+    expect(
+      document.querySelector('button[aria-label="Edit account override: Priority"]')?.className,
+    ).toContain("col-start-3 row-start-1");
 
     expect(
       document.querySelector('[data-testid="effective-routing-rule-status-change-grid"]')

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
@@ -1307,7 +1307,7 @@ export function EffectiveRoutingRuleCard({
                 return (
                   <div key={row.label} className="border-b border-base-300/60 last:border-b-0">
                     <div
-                      className="grid grid-cols-[minmax(0,1fr)_2.75rem] items-start gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:items-center sm:gap-3 sm:px-3 sm:py-2.5"
+                      className="grid grid-cols-[fit-content(40%)_minmax(0,1fr)_2.75rem] items-center gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:gap-3 sm:px-3 sm:py-2.5"
                       data-testid="effective-routing-rule-field-row"
                     >
                       <span className="min-w-0 self-center font-semibold text-base-content/80">
@@ -1322,7 +1322,7 @@ export function EffectiveRoutingRuleCard({
                           }
                         />
                       </span>
-                      <div className="col-span-2 flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2 sm:contents">
                         {row.displayValueChips ? (
                           <ValueChipList
                             field={row.displayField}
@@ -1351,7 +1351,7 @@ export function EffectiveRoutingRuleCard({
                           size="icon"
                           variant={activeOverride || expanded ? "default" : "ghost"}
                           className={cn(
-                            "col-start-2 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
+                            "col-start-3 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
                             activeOverride || expanded
                               ? "text-primary-content"
                               : "text-base-content/65",
@@ -1440,13 +1440,13 @@ export function EffectiveRoutingRuleCard({
               {proxyBindingsVisible ? (
                 <div className="border-b border-base-300/60 last:border-b-0">
                   <div
-                    className="grid grid-cols-[minmax(0,1fr)_2.75rem] items-start gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:items-center sm:gap-3 sm:px-3 sm:py-2.5"
+                    className="grid grid-cols-[fit-content(40%)_minmax(0,1fr)_2.75rem] items-center gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:gap-3 sm:px-3 sm:py-2.5"
                     data-testid="effective-routing-rule-field-row"
                   >
                     <span className="min-w-0 self-center font-semibold text-base-content/80">
                       {labels.fieldProxyBindings ?? proxyBindings.labels.field}
                     </span>
-                    <div className="col-span-2 flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2 sm:contents">
                       <ProxyBindingChips
                         items={proxyBindings.items}
                         labels={proxyBindings.labels}
@@ -1464,7 +1464,7 @@ export function EffectiveRoutingRuleCard({
                       size="icon"
                       variant={proxyBindingsActiveOverride ? "default" : "ghost"}
                       className={cn(
-                        "col-start-2 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
+                        "col-start-3 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
                         proxyBindingsActiveOverride
                           ? "text-primary-content"
                           : "text-base-content/65",
@@ -1536,13 +1536,13 @@ export function EffectiveRoutingRuleCard({
               return (
                 <div key={row.key} className="border-b border-base-300/60 last:border-b-0">
                   <div
-                    className="grid grid-cols-[minmax(0,1fr)_2.75rem] items-start gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[minmax(0,1fr)_5rem_11rem_2rem] sm:items-center sm:gap-3 sm:px-3 sm:py-2.5"
+                    className="grid grid-cols-[fit-content(40%)_minmax(0,1fr)_2.75rem] items-center gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[minmax(0,1fr)_5rem_11rem_2rem] sm:gap-3 sm:px-3 sm:py-2.5"
                     data-testid="effective-routing-rule-timeout-row"
                   >
                     <span className="min-w-0 self-center font-semibold text-base-content/80">
                       {row.label}
                     </span>
-                    <div className="col-span-2 flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2 sm:contents">
                       <ValueChip field={row.field} value={row.value} labels={labels} />
                       <div className="min-w-0 flex flex-wrap items-center gap-2">
                         <span className="text-xs text-base-content/65">
@@ -1561,7 +1561,7 @@ export function EffectiveRoutingRuleCard({
                         size="icon"
                         variant={activeOverride || expanded ? "default" : "ghost"}
                         className={cn(
-                          "col-start-2 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
+                          "col-start-3 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
                           activeOverride || expanded
                             ? "text-primary-content"
                             : "text-base-content/65",

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
@@ -1272,18 +1272,25 @@ export function EffectiveRoutingRuleCard({
   };
 
   return (
-    <Card className="border-base-300/80 bg-base-100/72">
+    <Card className="border-base-300/80 bg-base-100/72" data-testid="effective-routing-rule-card">
       <CardHeader>
         <CardTitle>{labels.title}</CardTitle>
         <CardDescription>{labels.description}</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-3">
+      <CardContent className="space-y-6 sm:space-y-3">
         {visibleFieldRows.length > 0 || proxyBindingsVisible ? (
-          <div className="rounded-xl border border-base-300/70 bg-base-200/35 p-3">
-            <p className="metric-label">
+          <section
+            aria-labelledby="effective-routing-rule-field-source-heading"
+            className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+            data-testid="effective-routing-rule-field-source-section"
+          >
+            <p className="metric-label" id="effective-routing-rule-field-source-heading">
               {labels.sourceBreakdownTitle ?? "Field source breakdown"}
             </p>
-            <div className="mt-3 overflow-hidden rounded-xl border border-base-300/70">
+            <div
+              className="mt-2 overflow-visible border-0 sm:mt-3 sm:overflow-hidden sm:rounded-xl sm:border sm:border-base-300/70"
+              data-testid="effective-routing-rule-field-source-table"
+            >
               {visibleFieldRows.map((row) => {
                 const editable = row.field != null && editablePolicy != null;
                 const activeOverride = row.field != null && row.source === localOverrideSource;
@@ -1486,12 +1493,21 @@ export function EffectiveRoutingRuleCard({
                 </div>
               ) : null}
             </div>
-          </div>
+          </section>
         ) : null}
 
-        <div className="rounded-xl border border-base-300/70 bg-base-200/35 p-3">
-          <p className="metric-label">{labels.timeoutSectionTitle ?? "Request path timeouts"}</p>
-          <div className="mt-3 overflow-hidden rounded-xl border border-base-300/70">
+        <section
+          aria-labelledby="effective-routing-rule-timeout-heading"
+          className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+          data-testid="effective-routing-rule-timeout-section"
+        >
+          <p className="metric-label" id="effective-routing-rule-timeout-heading">
+            {labels.timeoutSectionTitle ?? "Request path timeouts"}
+          </p>
+          <div
+            className="mt-2 overflow-visible border-0 sm:mt-3 sm:overflow-hidden sm:rounded-xl sm:border sm:border-base-300/70"
+            data-testid="effective-routing-rule-timeout-table"
+          >
             {timeoutRows.map((row) => {
               const activeOverride = row.source === localOverrideSource;
               const expanded = expandedFields.includes(row.field);
@@ -1595,13 +1611,17 @@ export function EffectiveRoutingRuleCard({
               {labels.overrideSaving ?? "Saving..."}
             </p>
           ) : null}
-        </div>
+        </section>
 
         {showStatusChangeReasons ? (
-          <div className="rounded-xl border border-base-300/70 bg-base-200/35 p-3">
+          <section
+            aria-labelledby="effective-routing-rule-status-change-heading"
+            className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+            data-testid="effective-routing-rule-status-change-section"
+          >
             <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
               <div>
-                <p className="metric-label">
+                <p className="metric-label" id="effective-routing-rule-status-change-heading">
                   {labels.statusChangeReasonSectionTitle ?? "Status change trigger reasons"}
                 </p>
                 {labels.statusChangeReasonSectionHint ? (
@@ -1684,12 +1704,18 @@ export function EffectiveRoutingRuleCard({
                 {statusChangeReasonSectionError}
               </p>
             ) : null}
-          </div>
+          </section>
         ) : null}
 
         {showSourceTags ? (
-          <div className="rounded-xl border border-base-300/70 bg-base-200/35 p-3">
-            <p className="metric-label">{labels.sourceTags}</p>
+          <section
+            aria-labelledby="effective-routing-rule-source-tags-heading"
+            className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+            data-testid="effective-routing-rule-source-tags-section"
+          >
+            <p className="metric-label" id="effective-routing-rule-source-tags-heading">
+              {labels.sourceTags}
+            </p>
             <div className="mt-3 flex flex-wrap gap-2">
               {resolvedRule.sourceTagNames.length === 0 ? (
                 <span className="text-sm text-base-content/60">{labels.noTags}</span>
@@ -1701,7 +1727,7 @@ export function EffectiveRoutingRuleCard({
                 ))
               )}
             </div>
-          </div>
+          </section>
         ) : null}
       </CardContent>
     </Card>
@@ -1939,7 +1965,7 @@ function AvailableModelsEditor({
   const modeToggleLabel = `${currentModeLabel} -> ${nextModeLabel}`;
 
   return (
-    <div className="min-w-[18rem]">
+    <div className="min-w-0 min-[769px]:min-w-[18rem]">
       <div className="flex flex-col gap-2 min-[769px]:flex-row min-[769px]:items-center">
         <Button
           type="button"

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
@@ -1322,7 +1322,7 @@ export function EffectiveRoutingRuleCard({
                           }
                         />
                       </span>
-                      <div className="flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                      <div className="flex min-w-0 flex-wrap items-center justify-end gap-2 sm:contents">
                         {row.displayValueChips ? (
                           <ValueChipList
                             field={row.displayField}
@@ -1446,7 +1446,7 @@ export function EffectiveRoutingRuleCard({
                     <span className="min-w-0 self-center font-semibold text-base-content/80">
                       {labels.fieldProxyBindings ?? proxyBindings.labels.field}
                     </span>
-                    <div className="flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                    <div className="flex min-w-0 flex-wrap items-center justify-end gap-2 sm:contents">
                       <ProxyBindingChips
                         items={proxyBindings.items}
                         labels={proxyBindings.labels}
@@ -1542,7 +1542,7 @@ export function EffectiveRoutingRuleCard({
                     <span className="min-w-0 self-center font-semibold text-base-content/80">
                       {row.label}
                     </span>
-                    <div className="flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                    <div className="flex min-w-0 flex-wrap items-center justify-end gap-2 sm:contents">
                       <ValueChip field={row.field} value={row.value} labels={labels} />
                       <div className="min-w-0 flex flex-wrap items-center gap-2">
                         <span className="text-xs text-base-content/65">

--- a/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
+++ b/web/src/features/account-pool/EffectiveRoutingRuleCard.tsx
@@ -1272,23 +1272,30 @@ export function EffectiveRoutingRuleCard({
   };
 
   return (
-    <Card className="border-base-300/80 bg-base-100/72" data-testid="effective-routing-rule-card">
-      <CardHeader>
-        <CardTitle>{labels.title}</CardTitle>
-        <CardDescription>{labels.description}</CardDescription>
+    <Card
+      className="rounded-none border-0 bg-transparent shadow-none sm:rounded-xl sm:border sm:border-base-300/80 sm:bg-base-100/72 sm:shadow-[var(--surface-card-shadow)]"
+      data-testid="effective-routing-rule-card"
+    >
+      <CardHeader className="space-y-2 px-0 pb-4 pt-0 sm:space-y-1.5 sm:p-5">
+        <CardTitle className="text-base leading-6 sm:text-lg sm:leading-none">
+          {labels.title}
+        </CardTitle>
+        <CardDescription className="leading-5 sm:leading-normal">
+          {labels.description}
+        </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-6 sm:space-y-3">
+      <CardContent className="space-y-8 px-0 pb-0 sm:space-y-3 sm:px-5 sm:pb-5">
         {visibleFieldRows.length > 0 || proxyBindingsVisible ? (
           <section
             aria-labelledby="effective-routing-rule-field-source-heading"
-            className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+            className="border-t border-base-300/70 pt-5 first:border-t-0 first:pt-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
             data-testid="effective-routing-rule-field-source-section"
           >
             <p className="metric-label" id="effective-routing-rule-field-source-heading">
               {labels.sourceBreakdownTitle ?? "Field source breakdown"}
             </p>
             <div
-              className="mt-2 overflow-visible border-0 sm:mt-3 sm:overflow-hidden sm:rounded-xl sm:border sm:border-base-300/70"
+              className="mt-3 overflow-visible border-0 sm:overflow-hidden sm:rounded-xl sm:border sm:border-base-300/70"
               data-testid="effective-routing-rule-field-source-table"
             >
               {visibleFieldRows.map((row) => {
@@ -1299,8 +1306,11 @@ export function EffectiveRoutingRuleCard({
                 const busy = row.field != null && isBusy(row.field);
                 return (
                   <div key={row.label} className="border-b border-base-300/60 last:border-b-0">
-                    <div className="grid grid-cols-1 gap-1 px-3 py-2.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:items-center sm:gap-3">
-                      <span className="font-medium text-base-content/80">
+                    <div
+                      className="grid grid-cols-[minmax(0,1fr)_2.75rem] items-start gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:items-center sm:gap-3 sm:px-3 sm:py-2.5"
+                      data-testid="effective-routing-rule-field-row"
+                    >
+                      <span className="min-w-0 self-center font-semibold text-base-content/80">
                         <PolicyFieldLabel
                           label={row.label}
                           hint={
@@ -1312,31 +1322,36 @@ export function EffectiveRoutingRuleCard({
                           }
                         />
                       </span>
-                      {row.displayValueChips ? (
-                        <ValueChipList
-                          field={row.displayField}
-                          values={row.displayValueChips}
-                          labels={labels}
-                          variantOverride={row.displayValueVariant}
-                        />
-                      ) : (
-                        <ValueChip
-                          field={row.displayField}
-                          value={row.displayValue}
-                          labels={labels}
-                          variantOverride={row.displayValueVariant}
-                        />
-                      )}
-                      <Chip className="w-fit sm:justify-self-end" tone={sourceVariant(row.source)}>
-                        {sourceLabel(row.source, labels)}
-                      </Chip>
+                      <div className="col-span-2 flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                        {row.displayValueChips ? (
+                          <ValueChipList
+                            field={row.displayField}
+                            values={row.displayValueChips}
+                            labels={labels}
+                            variantOverride={row.displayValueVariant}
+                          />
+                        ) : (
+                          <ValueChip
+                            field={row.displayField}
+                            value={row.displayValue}
+                            labels={labels}
+                            variantOverride={row.displayValueVariant}
+                          />
+                        )}
+                        <Chip
+                          className="w-fit shrink-0 sm:justify-self-end"
+                          tone={sourceVariant(row.source)}
+                        >
+                          {sourceLabel(row.source, labels)}
+                        </Chip>
+                      </div>
                       {editable && row.field ? (
                         <Button
                           type="button"
                           size="icon"
                           variant={activeOverride || expanded ? "default" : "ghost"}
                           className={cn(
-                            "h-8 w-8 justify-self-start rounded-full sm:justify-self-end",
+                            "col-start-2 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
                             activeOverride || expanded
                               ? "text-primary-content"
                               : "text-base-content/65",
@@ -1359,11 +1374,11 @@ export function EffectiveRoutingRuleCard({
                           />
                         </Button>
                       ) : (
-                        <span aria-hidden />
+                        <span aria-hidden className="hidden sm:block" />
                       )}
                     </div>
                     {expanded && row.field ? (
-                      <div className="border-t border-base-300/50 bg-base-100/55 px-3 py-3">
+                      <div className="border-t border-base-300/50 bg-transparent px-0 py-4 sm:bg-base-100/55 sm:px-3 sm:py-3">
                         <div
                           className={cn(
                             "grid grid-cols-1 gap-y-2 sm:items-center sm:gap-x-3",
@@ -1424,27 +1439,32 @@ export function EffectiveRoutingRuleCard({
               })}
               {proxyBindingsVisible ? (
                 <div className="border-b border-base-300/60 last:border-b-0">
-                  <div className="grid grid-cols-1 gap-1 px-3 py-2.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:items-center sm:gap-3">
-                    <span className="font-medium text-base-content/80">
+                  <div
+                    className="grid grid-cols-[minmax(0,1fr)_2.75rem] items-start gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:items-center sm:gap-3 sm:px-3 sm:py-2.5"
+                    data-testid="effective-routing-rule-field-row"
+                  >
+                    <span className="min-w-0 self-center font-semibold text-base-content/80">
                       {labels.fieldProxyBindings ?? proxyBindings.labels.field}
                     </span>
-                    <ProxyBindingChips
-                      items={proxyBindings.items}
-                      labels={proxyBindings.labels}
-                      disabled={proxyBindings.busy || proxyBindings.disabled}
-                    />
-                    <Chip
-                      className="w-fit sm:justify-self-end"
-                      tone={sourceVariant(proxyBindingsSource)}
-                    >
-                      {sourceLabel(proxyBindingsSource, labels)}
-                    </Chip>
+                    <div className="col-span-2 flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                      <ProxyBindingChips
+                        items={proxyBindings.items}
+                        labels={proxyBindings.labels}
+                        disabled={proxyBindings.busy || proxyBindings.disabled}
+                      />
+                      <Chip
+                        className="w-fit shrink-0 sm:justify-self-end"
+                        tone={sourceVariant(proxyBindingsSource)}
+                      >
+                        {sourceLabel(proxyBindingsSource, labels)}
+                      </Chip>
+                    </div>
                     <Button
                       type="button"
                       size="icon"
                       variant={proxyBindingsActiveOverride ? "default" : "ghost"}
                       className={cn(
-                        "h-8 w-8 justify-self-start rounded-full sm:justify-self-end",
+                        "col-start-2 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
                         proxyBindingsActiveOverride
                           ? "text-primary-content"
                           : "text-base-content/65",
@@ -1468,7 +1488,7 @@ export function EffectiveRoutingRuleCard({
                     </Button>
                   </div>
                   {proxyBindingsExpanded ? (
-                    <div className="border-t border-base-300/50 bg-base-100/55 px-3 py-3">
+                    <div className="border-t border-base-300/50 bg-transparent px-0 py-4 sm:bg-base-100/55 sm:px-3 sm:py-3">
                       <div className="grid grid-cols-1 gap-y-3 sm:grid-cols-[9rem_minmax(0,1fr)_minmax(5rem,auto)_2rem] sm:items-start sm:gap-x-3">
                         <p className="text-sm font-semibold text-base-content">
                           {proxyBindings.labels.field}
@@ -1498,14 +1518,14 @@ export function EffectiveRoutingRuleCard({
 
         <section
           aria-labelledby="effective-routing-rule-timeout-heading"
-          className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+          className="border-t border-base-300/70 pt-5 first:border-t-0 first:pt-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
           data-testid="effective-routing-rule-timeout-section"
         >
           <p className="metric-label" id="effective-routing-rule-timeout-heading">
             {labels.timeoutSectionTitle ?? "Request path timeouts"}
           </p>
           <div
-            className="mt-2 overflow-visible border-0 sm:mt-3 sm:overflow-hidden sm:rounded-xl sm:border sm:border-base-300/70"
+            className="mt-3 overflow-visible border-0 sm:overflow-hidden sm:rounded-xl sm:border sm:border-base-300/70"
             data-testid="effective-routing-rule-timeout-table"
           >
             {timeoutRows.map((row) => {
@@ -1515,18 +1535,25 @@ export function EffectiveRoutingRuleCard({
               const error = editablePolicy?.errorByField?.[row.field] ?? null;
               return (
                 <div key={row.key} className="border-b border-base-300/60 last:border-b-0">
-                  <div className="grid grid-cols-1 gap-1 px-3 py-2.5 text-sm sm:grid-cols-[minmax(0,1fr)_5rem_11rem_2rem] sm:items-center sm:gap-3">
-                    <span className="min-w-0 font-medium text-base-content/80">{row.label}</span>
-                    <ValueChip field={row.field} value={row.value} labels={labels} />
-                    <div className="min-w-0 flex flex-wrap items-center gap-2">
-                      <span className="text-xs text-base-content/65">
-                        {activeOverride
-                          ? (labels.timeoutOverrideValue ?? "Account override")
-                          : (labels.timeoutInheritedValue ?? "Inherited")}
-                      </span>
-                      <Chip className="w-fit" tone={sourceVariant(row.source)}>
-                        {sourceLabel(row.source, labels)}
-                      </Chip>
+                  <div
+                    className="grid grid-cols-[minmax(0,1fr)_2.75rem] items-start gap-x-3 gap-y-2 py-3.5 text-sm sm:grid-cols-[minmax(0,1fr)_5rem_11rem_2rem] sm:items-center sm:gap-3 sm:px-3 sm:py-2.5"
+                    data-testid="effective-routing-rule-timeout-row"
+                  >
+                    <span className="min-w-0 self-center font-semibold text-base-content/80">
+                      {row.label}
+                    </span>
+                    <div className="col-span-2 flex min-w-0 flex-wrap items-center gap-2 sm:contents">
+                      <ValueChip field={row.field} value={row.value} labels={labels} />
+                      <div className="min-w-0 flex flex-wrap items-center gap-2">
+                        <span className="text-xs text-base-content/65">
+                          {activeOverride
+                            ? (labels.timeoutOverrideValue ?? "Account override")
+                            : (labels.timeoutInheritedValue ?? "Inherited")}
+                        </span>
+                        <Chip className="w-fit shrink-0" tone={sourceVariant(row.source)}>
+                          {sourceLabel(row.source, labels)}
+                        </Chip>
+                      </div>
                     </div>
                     {isEditable ? (
                       <Button
@@ -1534,7 +1561,7 @@ export function EffectiveRoutingRuleCard({
                         size="icon"
                         variant={activeOverride || expanded ? "default" : "ghost"}
                         className={cn(
-                          "h-8 w-8 justify-self-start rounded-full sm:justify-self-end",
+                          "col-start-2 row-start-1 h-11 w-11 justify-self-end rounded-full sm:col-auto sm:row-auto sm:h-8 sm:w-8 sm:justify-self-end",
                           activeOverride || expanded
                             ? "text-primary-content"
                             : "text-base-content/65",
@@ -1557,11 +1584,11 @@ export function EffectiveRoutingRuleCard({
                         />
                       </Button>
                     ) : (
-                      <span aria-hidden />
+                      <span aria-hidden className="hidden sm:block" />
                     )}
                   </div>
                   {expanded ? (
-                    <div className="border-t border-base-300/50 bg-base-100/55 px-3 py-3">
+                    <div className="border-t border-base-300/50 bg-transparent px-0 py-4 sm:bg-base-100/55 sm:px-3 sm:py-3">
                       <div className="grid grid-cols-1 gap-y-2 sm:grid-cols-[minmax(0,1fr)_5rem_11rem_2rem] sm:items-center sm:gap-x-3">
                         <p className="min-w-0 text-sm font-semibold text-base-content">
                           {row.label}
@@ -1616,7 +1643,7 @@ export function EffectiveRoutingRuleCard({
         {showStatusChangeReasons ? (
           <section
             aria-labelledby="effective-routing-rule-status-change-heading"
-            className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+            className="border-t border-base-300/70 pt-5 first:border-t-0 first:pt-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
             data-testid="effective-routing-rule-status-change-section"
           >
             <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -1635,7 +1662,7 @@ export function EffectiveRoutingRuleCard({
                   <Button
                     type="button"
                     variant="ghost"
-                    className="h-8 rounded-full border border-base-300/80 bg-base-100/92 px-3 text-xs font-semibold text-base-content/72 shadow-none hover:bg-base-100 hover:text-base-content"
+                    className="h-10 rounded-full border border-base-300/80 bg-base-100/92 px-3 text-xs font-semibold text-base-content/72 shadow-none hover:bg-base-100 hover:text-base-content sm:h-8"
                     disabled={statusChangeReasonResetBusy}
                     aria-label={
                       labels.statusChangeReasonResetAction ?? "Reset status change trigger reasons"
@@ -1663,7 +1690,10 @@ export function EffectiveRoutingRuleCard({
                 </Chip>
               </div>
             </div>
-            <div className="mt-3 grid gap-2 md:auto-rows-fr md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5">
+            <div
+              className="mt-3 grid grid-cols-2 gap-2 md:auto-rows-fr md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5"
+              data-testid="effective-routing-rule-status-change-grid"
+            >
               {statusChangeReasonRows.map((row) => {
                 const busy = isBusy(row.field);
                 const error = editablePolicy?.errorByField?.[row.field] ?? null;
@@ -1686,7 +1716,7 @@ export function EffectiveRoutingRuleCard({
                           })
                         }
                         ariaLabel={row.label}
-                        className="h-full min-h-[4rem] flex-1"
+                        className="h-full min-h-[5.25rem] flex-1 sm:min-h-[4rem]"
                       />
                     </div>
                     {busy ? (
@@ -1710,7 +1740,7 @@ export function EffectiveRoutingRuleCard({
         {showSourceTags ? (
           <section
             aria-labelledby="effective-routing-rule-source-tags-heading"
-            className="border-0 bg-transparent p-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
+            className="border-t border-base-300/70 pt-5 first:border-t-0 first:pt-0 sm:rounded-xl sm:border sm:border-base-300/70 sm:bg-base-200/35 sm:p-3"
             data-testid="effective-routing-rule-source-tags-section"
           >
             <p className="metric-label" id="effective-routing-rule-source-tags-heading">
@@ -1800,7 +1830,10 @@ function ConcurrencyInlineEditor({
   const sliderValue = apiConcurrencyLimitToSliderValue(value);
   const displayValue = formatConcurrencyLimitValue(value, unlimitedLabel);
   return (
-    <div className="min-w-[16rem] space-y-2">
+    <div
+      className="min-w-0 space-y-2 min-[769px]:min-w-[16rem]"
+      data-testid="effective-routing-rule-concurrency-editor"
+    >
       <div className="flex items-center justify-between gap-3">
         <span className="text-xs font-semibold uppercase tracking-[0.12em] text-base-content/55">
           {currentLabel}


### PR DESCRIPTION
## Summary
- Keep routing rule values on the same mobile row as each Label.
- Right-align value and source chips in the flexible middle column before the edit control.
- Preserve desktop card hierarchy and editable controls.

## Delivery role
Direct PR to `main`.

## Spec
- Spec: -
- Spec Disposition: no applicable Spec/PLAN files changed.

## Solutions
- Solutions: -

## Project Docs
- Project Docs: -

## Sync Results
- Spec sync: not applicable.
- Solutions sync: not applicable.
- Project Docs sync: not applicable.

## Validation
- `bun run typecheck:web`
- `bun run lint:web`
- `cd web && bun run test -- EffectiveRoutingRuleCard.test.tsx`
- `cd web && bun run test-storybook -- EffectiveRoutingRuleCard.stories.tsx`
- `cd web && bun run build`
- Web Demo verified at 390px and 1280px with no horizontal overflow or console errors; backend was not started.

## Visual Evidence

None
