### PR TITLE
fix(ci): remove source PR release comments

### DIFF
--- a/.github/scripts/check_quality_gates_contract.py
+++ b/.github/scripts/check_quality_gates_contract.py
@@ -1314,11 +1314,13 @@ def validate_release(path: Path, contract: ContractModel) -> None:
         "release.yml.jobs.release-publish.if drifted",
     )
     publish_permissions = require_mapping(publish.get("permissions"), "release.yml.jobs.release-publish.permissions")
+    require(
+        set(publish_permissions) == {"actions", "contents", "packages"},
+        "release.yml.jobs.release-publish.permissions must exclude source-PR comment permissions",
+    )
     require(publish_permissions.get("actions") == "write", "release.yml.jobs.release-publish.permissions.actions must stay write")
     require(publish_permissions.get("contents") == "write", "release.yml.jobs.release-publish.permissions.contents must stay write")
-    require(publish_permissions.get("issues") == "write", "release.yml.jobs.release-publish.permissions.issues must stay write")
     require(publish_permissions.get("packages") == "write", "release.yml.jobs.release-publish.permissions.packages must stay write")
-    require(publish_permissions.get("pull-requests") == "write", "release.yml.jobs.release-publish.permissions.pull-requests must stay write")
     publish_checkout = checkout_step(publish, "Checkout code", "release.yml.jobs.release-publish")
     require(publish_checkout.get("ref") == "${{ needs.release-meta.outputs.target_sha }}", "release.yml.jobs.release-publish checkout ref drifted")
     tag_step = step_config(publish, "Create and push git tag", "release.yml.jobs.release-publish")
@@ -1360,16 +1362,15 @@ def validate_release(path: Path, contract: ContractModel) -> None:
             forbidden_marker not in create_release_body,
             f"release.yml.jobs.release-publish: createRelease must not render {forbidden_marker!r}",
         )
-    comment_step = step_config(publish, "Upsert PR release version comment", "release.yml.jobs.release-publish")
-    comment_env = require_mapping(comment_step.get("env"), "release.yml.jobs.release-publish.steps['Upsert PR release version comment'].env")
-    require(comment_env.get("RELEASE_PR_NUMBER") == "${{ needs.release-meta.outputs.pr_number }}", "release.yml.jobs.release-publish: PR release comment must consume pr_number")
-    require(comment_env.get("RELEASE_TAG") == "${{ needs.release-meta.outputs.release_tag }}", "release.yml.jobs.release-publish: PR release comment must consume release_tag")
-    comment_script = str(comment_step.get("with", {}).get("script", ""))
-    require("codex-release-version-comment" in comment_script, "release.yml.jobs.release-publish: PR release comment marker drifted")
-    require("issues.listComments" in comment_script, "release.yml.jobs.release-publish: PR release comment must inspect existing comments")
-    require("issues.updateComment" in comment_script, "release.yml.jobs.release-publish: PR release comment must support updates")
-    require("github-actions[bot]" in comment_script, "release.yml.jobs.release-publish: PR release comment must only update github-actions[bot] comments")
-    require("leaving PR comment unchanged" in comment_script, "release.yml.jobs.release-publish: PR release comment must warn on foreign marker comments")
+    publish_steps = require_mapping(publish, "release.yml.jobs.release-publish").get("steps")
+    require(isinstance(publish_steps, list), "release.yml.jobs.release-publish.steps must be a list")
+    require(
+        not any(
+            isinstance(step, dict) and step.get("name") == "Upsert PR release version comment"
+            for step in publish_steps
+        ),
+        "release.yml.jobs.release-publish: source-PR release comment step must stay removed",
+    )
     next_step = step_config(publish, "Resolve next pending release target", "release.yml.jobs.release-publish")
     require(next_step.get("if") == "github.event_name != 'workflow_dispatch'", "release.yml.jobs.release-publish: next pending target gate drifted")
     next_env = require_mapping(next_step.get("env"), "release.yml.jobs.release-publish.steps['Resolve next pending release target'].env")

--- a/.github/scripts/fixtures/quality-gates-contract/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/release.yml
@@ -519,9 +519,7 @@ jobs:
     permissions:
       actions: write
       contents: write
-      issues: write
       packages: write
-      pull-requests: write
     timeout-minutes: 45
     steps:
       - name: Checkout code
@@ -670,94 +668,6 @@ jobs:
             })
 
             core.notice(`Created GitHub Release for tag ${tag}`)
-
-      - name: Upsert PR release version comment
-        uses: actions/github-script@v9
-        env:
-          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
-          RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
-          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
-          RELEASE_PR_NUMBER: ${{ needs.release-meta.outputs.pr_number }}
-          RELEASE_CHANNEL: ${{ needs.release-meta.outputs.release_channel }}
-        with:
-          script: |
-            const { owner, repo } = context.repo
-            const marker = '<!-- codex-release-version-comment -->'
-            const rawPrNumber = process.env.RELEASE_PR_NUMBER
-            const releaseTag = process.env.RELEASE_TAG
-            const appVersion = process.env.APP_EFFECTIVE_VERSION
-            const releaseChannel = process.env.RELEASE_CHANNEL || '(unknown)'
-            const targetSha = process.env.TARGET_SHA || '(unknown)'
-            const issueNumber = Number(rawPrNumber)
-
-            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-              core.notice('No PR number available for release comment; skipping.')
-              return
-            }
-            if (!releaseTag || !appVersion) {
-              core.notice('Missing release tag or app version; skipping PR release comment.')
-              return
-            }
-
-            const releaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${releaseTag}`
-            const body = [
-              marker,
-              `Released in [\`${releaseTag}\`](${releaseUrl})`,
-              `Version: \`${appVersion}\``,
-              `Channel: \`${releaseChannel}\``,
-              `Commit: \`${targetSha}\``,
-            ].join('\n')
-
-            try {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: issueNumber,
-                per_page: 100,
-              })
-              const foreignMarkerComment = comments.find(comment =>
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker) &&
-                (comment.user?.type !== 'Bot' || comment.user?.login !== 'github-actions[bot]')
-              )
-              if (foreignMarkerComment) {
-                core.warning(
-                  `Found marker comment ${foreignMarkerComment.id} owned by ${foreignMarkerComment.user?.login || 'unknown'}; leaving PR comment unchanged`
-                )
-                return
-              }
-              const existing = comments.find(comment =>
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker) &&
-                comment.user?.type === 'Bot' &&
-                comment.user?.login === 'github-actions[bot]'
-              )
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existing.id,
-                  body,
-                })
-                core.notice(`Updated PR #${issueNumber} release version comment for ${releaseTag}`)
-                return
-              }
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body,
-              })
-              core.notice(`Created PR #${issueNumber} release version comment for ${releaseTag}`)
-            } catch (error) {
-              const acceptedPermissions = error.response?.headers?.['x-accepted-github-permissions'] || '(not provided)'
-              const status = error.status || error.response?.status || '(unknown)'
-              core.warning(
-                `Failed to upsert PR release version comment: ${error.message} (status=${status}, accepted_permissions=${acceptedPermissions})`
-              )
-            }
 
       - name: Resolve next pending release target
         if: github.event_name != 'workflow_dispatch'

--- a/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
+++ b/.github/scripts/fixtures/quality-gates-contract/simplified/release.yml
@@ -519,9 +519,7 @@ jobs:
     permissions:
       actions: write
       contents: write
-      issues: write
       packages: write
-      pull-requests: write
     timeout-minutes: 45
     steps:
       - name: Checkout code
@@ -670,94 +668,6 @@ jobs:
             })
 
             core.notice(`Created GitHub Release for tag ${tag}`)
-
-      - name: Upsert PR release version comment
-        uses: actions/github-script@v9
-        env:
-          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
-          RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
-          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
-          RELEASE_PR_NUMBER: ${{ needs.release-meta.outputs.pr_number }}
-          RELEASE_CHANNEL: ${{ needs.release-meta.outputs.release_channel }}
-        with:
-          script: |
-            const { owner, repo } = context.repo
-            const marker = '<!-- codex-release-version-comment -->'
-            const rawPrNumber = process.env.RELEASE_PR_NUMBER
-            const releaseTag = process.env.RELEASE_TAG
-            const appVersion = process.env.APP_EFFECTIVE_VERSION
-            const releaseChannel = process.env.RELEASE_CHANNEL || '(unknown)'
-            const targetSha = process.env.TARGET_SHA || '(unknown)'
-            const issueNumber = Number(rawPrNumber)
-
-            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-              core.notice('No PR number available for release comment; skipping.')
-              return
-            }
-            if (!releaseTag || !appVersion) {
-              core.notice('Missing release tag or app version; skipping PR release comment.')
-              return
-            }
-
-            const releaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${releaseTag}`
-            const body = [
-              marker,
-              `Released in [\`${releaseTag}\`](${releaseUrl})`,
-              `Version: \`${appVersion}\``,
-              `Channel: \`${releaseChannel}\``,
-              `Commit: \`${targetSha}\``,
-            ].join('\n')
-
-            try {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: issueNumber,
-                per_page: 100,
-              })
-              const foreignMarkerComment = comments.find(comment =>
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker) &&
-                (comment.user?.type !== 'Bot' || comment.user?.login !== 'github-actions[bot]')
-              )
-              if (foreignMarkerComment) {
-                core.warning(
-                  `Found marker comment ${foreignMarkerComment.id} owned by ${foreignMarkerComment.user?.login || 'unknown'}; leaving PR comment unchanged`
-                )
-                return
-              }
-              const existing = comments.find(comment =>
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker) &&
-                comment.user?.type === 'Bot' &&
-                comment.user?.login === 'github-actions[bot]'
-              )
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existing.id,
-                  body,
-                })
-                core.notice(`Updated PR #${issueNumber} release version comment for ${releaseTag}`)
-                return
-              }
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body,
-              })
-              core.notice(`Created PR #${issueNumber} release version comment for ${releaseTag}`)
-            } catch (error) {
-              const acceptedPermissions = error.response?.headers?.['x-accepted-github-permissions'] || '(not provided)'
-              const status = error.status || error.response?.status || '(unknown)'
-              core.warning(
-                `Failed to upsert PR release version comment: ${error.message} (status=${status}, accepted_permissions=${acceptedPermissions})`
-              )
-            }
 
       - name: Resolve next pending release target
         if: github.event_name != 'workflow_dispatch'

--- a/.github/scripts/test-quality-gates-contract.sh
+++ b/.github/scripts/test-quality-gates-contract.sh
@@ -128,6 +128,53 @@ done
 
 python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$simplified_topology_repo" --profile final
 
+release_comment_permissions_repo="$tmp_dir/release-comment-permissions-repo"
+copy_repo_snapshot "$baseline_repo" "$release_comment_permissions_repo"
+python3 - <<'PY' "$release_comment_permissions_repo"
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/release.yml"
+text = path.read_text()
+needle = "      packages: write\n"
+replacement = "      issues: write\n      packages: write\n      pull-requests: write\n"
+if needle not in text:
+    raise SystemExit("failed to locate release-publish package permission")
+prefix, suffix = text.rsplit(needle, 1)
+path.write_text(prefix + replacement + suffix)
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$release_comment_permissions_repo" --profile final >/dev/null 2>"$tmp_dir/release-comment-permissions.log"; then
+  echo "expected source-PR comment permissions fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "permissions must exclude source-PR comment permissions" "$tmp_dir/release-comment-permissions.log"
+
+release_comment_step_repo="$tmp_dir/release-comment-step-repo"
+copy_repo_snapshot "$baseline_repo" "$release_comment_step_repo"
+python3 - <<'PY' "$release_comment_step_repo"
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+path = repo / ".github/workflows/release.yml"
+text = path.read_text()
+needle = "      - name: Resolve next pending release target\n"
+replacement = "      - name: Upsert PR release version comment\n        run: echo 'legacy source-PR comment'\n\n" + needle
+if needle not in text:
+    raise SystemExit("failed to locate release queue step")
+path.write_text(text.replace(needle, replacement, 1))
+PY
+
+if python3 "$repo_root/.github/scripts/check_quality_gates_contract.py" --repo-root "$release_comment_step_repo" --profile final >/dev/null 2>"$tmp_dir/release-comment-step.log"; then
+  echo "expected source-PR comment step fixture to fail" >&2
+  exit 1
+fi
+
+grep -q "source-PR release comment step must stay removed" "$tmp_dir/release-comment-step.log"
+
 release_notes_repo="$tmp_dir/release-notes-repo"
 copy_repo_snapshot "$baseline_repo" "$release_notes_repo"
 python3 - <<'PY' "$release_notes_repo"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,9 +519,7 @@ jobs:
     permissions:
       actions: write
       contents: write
-      issues: write
       packages: write
-      pull-requests: write
     timeout-minutes: 45
     steps:
       - name: Checkout code
@@ -670,94 +668,6 @@ jobs:
             })
 
             core.notice(`Created GitHub Release for tag ${tag}`)
-
-      - name: Upsert PR release version comment
-        uses: actions/github-script@v9
-        env:
-          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
-          RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
-          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
-          RELEASE_PR_NUMBER: ${{ needs.release-meta.outputs.pr_number }}
-          RELEASE_CHANNEL: ${{ needs.release-meta.outputs.release_channel }}
-        with:
-          script: |
-            const { owner, repo } = context.repo
-            const marker = '<!-- codex-release-version-comment -->'
-            const rawPrNumber = process.env.RELEASE_PR_NUMBER
-            const releaseTag = process.env.RELEASE_TAG
-            const appVersion = process.env.APP_EFFECTIVE_VERSION
-            const releaseChannel = process.env.RELEASE_CHANNEL || '(unknown)'
-            const targetSha = process.env.TARGET_SHA || '(unknown)'
-            const issueNumber = Number(rawPrNumber)
-
-            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-              core.notice('No PR number available for release comment; skipping.')
-              return
-            }
-            if (!releaseTag || !appVersion) {
-              core.notice('Missing release tag or app version; skipping PR release comment.')
-              return
-            }
-
-            const releaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${releaseTag}`
-            const body = [
-              marker,
-              `Released in [\`${releaseTag}\`](${releaseUrl})`,
-              `Version: \`${appVersion}\``,
-              `Channel: \`${releaseChannel}\``,
-              `Commit: \`${targetSha}\``,
-            ].join('\n')
-
-            try {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: issueNumber,
-                per_page: 100,
-              })
-              const foreignMarkerComment = comments.find(comment =>
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker) &&
-                (comment.user?.type !== 'Bot' || comment.user?.login !== 'github-actions[bot]')
-              )
-              if (foreignMarkerComment) {
-                core.warning(
-                  `Found marker comment ${foreignMarkerComment.id} owned by ${foreignMarkerComment.user?.login || 'unknown'}; leaving PR comment unchanged`
-                )
-                return
-              }
-              const existing = comments.find(comment =>
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker) &&
-                comment.user?.type === 'Bot' &&
-                comment.user?.login === 'github-actions[bot]'
-              )
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existing.id,
-                  body,
-                })
-                core.notice(`Updated PR #${issueNumber} release version comment for ${releaseTag}`)
-                return
-              }
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body,
-              })
-              core.notice(`Created PR #${issueNumber} release version comment for ${releaseTag}`)
-            } catch (error) {
-              const acceptedPermissions = error.response?.headers?.['x-accepted-github-permissions'] || '(not provided)'
-              const status = error.status || error.response?.status || '(unknown)'
-              core.warning(
-                `Failed to upsert PR release version comment: ${error.message} (status=${status}, accepted_permissions=${acceptedPermissions})`
-              )
-            }
 
       - name: Resolve next pending release target
         if: github.event_name != 'workflow_dispatch'

--- a/docs/archive/specs/q1m9k-release-pr-comment-permission/SPEC.md
+++ b/docs/archive/specs/q1m9k-release-pr-comment-permission/SPEC.md
@@ -1,69 +1,13 @@
-# Release PR 评论权限补齐（#q1m9k）
+# Release PR 评论权限补齐（已撤销）
 
 ## 状态
 
-- Status: 进行中
-- Created: 2026-03-17
-- Last: 2026-03-17
+- Status: 已撤销
 
-## 背景 / 问题陈述
+## 当前结论
 
-- `Release` workflow 已经执行到 `Upsert PR release version comment`，但线上真实 run 对 `PR #161` 返回 `Resource not accessible by integration`。
-- 同一个 job 内 tag、GitHub Release 与镜像发布均成功，说明故障集中在 PR 评论所需的权限声明。
+Release workflow 不再向来源 PR 写入发布结果，因此不再需要 `issues: write` 或 `pull-requests: write`。发布 job 仅保留创建 tag、GitHub Release、镜像发布和 release queue 调度所需的权限。
 
-## 目标 / 非目标
+成功发布由 release-owning agent 直接向 owner 报告。Release failure notification workflow 保持不变，发布失败仍按既有路径通知。
 
-### Goals
-
-- 补齐 release 评论步骤的 GitHub token 权限，使已完成的 release 能把版本评论写回对应 PR。
-- 用 contract / fixture 锁定新增权限，避免后续漂移。
-
-### Non-goals
-
-- 不改变 release 版本计算、tag / GitHub Release 创建或 release queue 串行逻辑。
-- 不把 PR 评论失败升级为发布失败。
-
-## 范围（Scope）
-
-### In scope
-
-- 更新 `.github/workflows/release.yml` 的 `release-publish.permissions`。
-- 更新 quality-gates contract 与 fixtures。
-
-### Out of scope
-
-- 重新设计评论正文。
-- 修改 branch protection 或仓库级 Actions policy。
-
-## 需求（Requirements）
-
-### MUST
-
-- `release-publish` 必须显式声明足够的 PR 评论权限。
-- contract checker 必须校验新增权限。
-- 本地 contract/self-test 必须通过。
-
-## 验收标准（Acceptance Criteria）
-
-- Given 一个 `type:{patch|minor|major}` 的 release
-  When `Release Publish` 执行 PR 评论步骤
-  Then workflow 不再因权限不足返回 `Resource not accessible by integration`。
-- Given 运行 `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final` 与 `bash .github/scripts/test-quality-gates-contract.sh`
-  When 本地校验执行
-  Then 二者都通过。
-
-## 质量门槛（Quality Gates）
-
-- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
-- `bash .github/scripts/test-quality-gates-contract.sh`
-
-## 里程碑（Milestones）
-
-- [ ] M1: 为 release-publish 补齐 PR 评论权限
-- [ ] M2: 更新 contract / fixture 并完成本地验证
-- [ ] M3: fast-flow 推进到 PR checks 收敛
-
-## 参考（References）
-
-- `.github/workflows/release.yml`
-- `docs/specs/sq8gw-release-pr-version-comment/SPEC.md`
+本文保留在归档目录中，仅作为已撤销方案的索引记录；历史评论权限问题不属于当前 workflow 合同。

--- a/docs/archive/specs/sq8gw-release-pr-version-comment/SPEC.md
+++ b/docs/archive/specs/sq8gw-release-pr-version-comment/SPEC.md
@@ -1,92 +1,13 @@
-# Release 工作流 PR 版本评论（#sq8gw）
+# Release 工作流 PR 版本评论（已撤销）
 
 ## 状态
 
-- Status: 进行中
-- Created: 2026-03-17
-- Last: 2026-03-17
+- Status: 已撤销
 
-## 背景 / 问题陈述
+## 当前结论
 
-- 现有 `Release` workflow 会创建 tag、GitHub Release 与多架构镜像，但 merged PR 本身不会收到“本次实际发布了哪个版本”的直接反馈。
-- 当 release queue 串行补发历史 main commit，或者维护者通过 `workflow_dispatch(commit_sha)` 做 backfill 时，PR 页面缺少一个稳定位置来确认最终发布版本号。
+Release workflow 不再在发布完成后向来源 PR 写入版本、状态或结果评论，也不再申请用于 PR 评论的 GitHub API 写权限。
 
-## 目标 / 非目标
+成功发布由负责该次 release 的 agent 直接向 owner 报告。Release 的 tag、GitHub Release、多架构镜像、发布队列和失败通知保持原有职责与行为。
 
-### Goals
-
-- 在 `Release Publish` 成功完成后，把本次发布的版本信息同步到对应 PR 评论区。
-- 评论内容至少包含 release tag、应用版本号与目标 commit，并链接到对应 GitHub Release。
-- 对 rerun / backfill 保持幂等：同一个 PR 只维护一条机器评论，后续发布更新该评论而不是重复刷屏。
-- 不影响现有 release queue、tag/Release 幂等与多架构发布流程。
-
-### Non-goals
-
-- 不修改 PR label 规则、版本分配规则或 release queue 调度逻辑。
-- 不为 `type:docs` / `type:skip` 增加额外评论。
-- 不新增应用运行时代码、数据库结构或前端行为。
-
-## 范围（Scope）
-
-### In scope
-
-- 更新 `.github/workflows/release.yml`，在 release 发布后 upsert PR 版本评论。
-- 为该评论步骤补齐最小权限与 quality-gates contract / fixture 自证。
-- 更新 spec 索引，记录这次 workflow 增量。
-
-### Out of scope
-
-- 变更 GitHub branch protection、仓库 rulesets 或标签管理策略。
-- 变更 GitHub Release body 模板。
-
-## 需求（Requirements）
-
-### MUST
-
-- 仅在 `release_enabled == true` 的发布路径上执行 PR 评论。
-- 评论必须基于 `release-meta` 从 immutable release snapshot 导出的输出（`pr_number`、`release_tag`、`app_effective_version`、`target_sha`），不得重新推导版本或重新查询 PR 标签。
-- 评论必须带固定 marker，便于后续 rerun / backfill 更新同一条评论。
-- 若目标 PR 不存在、`pr_number` 为空或评论 API 调用失败，workflow 应记录 notice / warning，但不能破坏已完成的发布结果或阻断后续 release queue。
-- `release-publish` 必须显式声明完成评论所需的最小权限。
-- `.github/scripts/check_quality_gates_contract.py` 与 fixtures 必须校验新权限和评论步骤，保证 contract 不漂移。
-
-### SHOULD
-
-- 评论正文简洁可扫描，直接给出 release tag、版本号、channel、commit 与 release 链接。
-- rerun / backfill 时覆盖旧评论内容，始终保持 PR 上的版本注释是最新一次成功发布结果。
-
-## 验收标准（Acceptance Criteria）
-
-- Given 一个正常的 stable / rc 发布
-  When `Release Publish` 完成
-  Then 对应 merged PR 下会出现一条带固定 marker 的评论，展示本次发布版本与 release 链接。
-- Given 同一个 commit 的 release workflow 被 rerun，或同一个 PR 对应的 backfill 重放
-  When 评论步骤再次执行
-  Then workflow 会更新已有机器评论，而不是新增第二条相同用途的评论。
-- Given 仓库执行 `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
-  When 校验 release workflow contract
-  Then 新增的评论权限与步骤约束会被验证并通过。
-
-## 非功能性验收 / 质量门槛（Quality Gates）
-
-### Quality checks
-
-- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --profile final`
-- `bash .github/scripts/test-quality-gates-contract.sh`
-
-## 实现里程碑（Milestones / Delivery checklist）
-
-- [x] M1: 为 release-publish 增加 PR 版本评论步骤与最小权限
-- [x] M2: 让评论步骤支持 marker-based upsert，兼容 rerun / backfill
-- [x] M3: 更新 contract checker 与 fixtures
-- [ ] M4: fast-flow 推进到 PR checks / review proof 收敛
-
-## 风险 / 假设（Risks / Assumptions）
-
-- 风险：GitHub comments API 短暂失败时，PR 版本评论可能缺席；本次选择 best-effort，不让评论失败回滚已完成发布。
-- 假设：发布 commit 的 PR 身份来自以 `merge_commit_sha` 为键冻结的 immutable release snapshot；即使 squash merge 后 GitHub commit 反查 PR 为空，`release-meta.outputs.pr_number` 仍由 snapshot 提供。
-
-## 参考（References）
-
-- `.github/workflows/release.yml`
-- `docs/specs/f6f6e-gh-actions-release-anti-cancel/SPEC.md`
+本文保留在归档目录中，仅作为已撤销方案的索引记录；其中的评论、marker、评论 API 和评论权限不属于当前 workflow 合同。


### PR DESCRIPTION
## Summary

- Remove the post-publish source-PR release version comment step and its GitHub comment API calls.
- Remove the release-publish `issues: write` and `pull-requests: write` permissions.
- Update release contract fixtures, checker tests, and archived specs to enforce the removal while preserving release failure notifications and queue behavior.

## Delivery role

Direct PR.

## Spec

- Spec: -
- Spec disposition: not_needed; the retired behavior is recorded in archived specs.

## Solutions

- None.

## Project Docs

- Archived release comment specs updated to record the current contract.

## Validation

- `python3 .github/scripts/check_quality_gates_contract.py --repo-root "$PWD" --declaration "$PWD/.github/quality-gates.json" --metadata-script "$PWD/.github/scripts/metadata_gate.py" --profile final`
- `bash .github/scripts/test-quality-gates-contract.sh`
- `git diff --check`
