### PR TITLE
fix(release): verify publication surfaces

### DIFF
--- a/.github/scripts/test-release-publication-verification.sh
+++ b/.github/scripts/test-release-publication-verification.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+release_workflow="$repo_root/.github/workflows/release.yml"
+grep -q -- "- name: Verify published release surfaces" "$release_workflow"
+grep -q "verify_release_publication.py" "$release_workflow"
+
+python3 - "$repo_root/.github/scripts/verify_release_publication.py" <<'PY'
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("verify_release_publication", script_path)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+spec.loader.exec_module(module)
+
+target_sha = "a" * 40
+release_tag = "v2.71.8"
+app_effective_version = "2.71.8"
+refs = {
+    "ghcr.io/ivanli-cn/codex-vibe-monitor:v2.71.8",
+    "ghcr.io/ivanli-cn/codex-vibe-monitor:latest",
+}
+manifest = {
+    "schemaVersion": 2,
+    "manifests": [
+        {"platform": {"os": "linux", "architecture": "amd64"}},
+        {"platform": {"os": "linux", "architecture": "arm64"}},
+    ],
+}
+release = {
+    "tag_name": release_tag,
+    "draft": False,
+    "prerelease": False,
+    "html_url": "https://github.com/example/example/releases/tag/v2.71.8",
+}
+
+image_manifests = {reference: manifest for reference in refs}
+image_labels = {
+    (reference, platform): {
+        "org.opencontainers.image.revision": target_sha,
+        "org.opencontainers.image.version": app_effective_version,
+    }
+    for reference in refs
+    for platform in module.REQUIRED_PLATFORMS
+}
+
+assert module.verify_publication(
+    release_payload=release,
+    tag_target_sha=target_sha,
+    release_tag=release_tag,
+    target_sha=target_sha,
+    release_prerelease=False,
+    image_manifests=image_manifests,
+    image_labels=image_labels,
+    expected_image_refs=refs,
+    app_effective_version=app_effective_version,
+) == []
+
+first_ref = next(iter(refs))
+
+def assert_failure(**overrides: object) -> None:
+    values = {
+        "release_payload": release,
+        "tag_target_sha": target_sha,
+        "release_tag": release_tag,
+        "target_sha": target_sha,
+        "release_prerelease": False,
+        "image_manifests": image_manifests,
+        "image_labels": image_labels,
+        "expected_image_refs": refs,
+        "app_effective_version": app_effective_version,
+    }
+    values.update(overrides)
+    assert module.verify_publication(**values), overrides
+
+assert_failure(tag_target_sha="b" * 40)
+assert_failure(release_payload={**release, "draft": True})
+assert_failure(release_payload={**release, "tag_name": "v2.71.7"})
+assert_failure(image_manifests={first_ref: manifest}, expected_image_refs=refs)
+assert_failure(
+    image_manifests={first_ref: {"manifests": [{"platform": {"os": "linux", "architecture": "amd64"}}]},
+        **{reference: manifest for reference in refs if reference != first_ref}},
+    expected_image_refs=refs,
+)
+assert_failure(
+    image_labels={
+        **image_labels,
+        (first_ref, "linux/amd64"): {
+            "org.opencontainers.image.revision": "b" * 40,
+            "org.opencontainers.image.version": app_effective_version,
+        },
+    }
+)
+assert_failure(image_labels={key: value for key, value in image_labels.items() if key[1] != "linux/arm64"})
+
+with tempfile.TemporaryDirectory(prefix="release-publication-verification-") as tmp:
+    root = Path(tmp)
+    release_file = root / "release.json"
+    release_file.write_text(json.dumps(release), encoding="utf-8")
+    manifest_file = root / "manifest.json"
+    manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+    assert module.parse_image_proof(f"{first_ref}|{manifest_file}")[0] in refs
+    labels_file = root / "labels.json"
+    labels_file.write_text(json.dumps(next(iter(image_labels.values()))), encoding="utf-8")
+    assert module.parse_image_label_proof(f"{first_ref}|linux/amd64|{labels_file}")[:2] == (first_ref, "linux/amd64")
+
+    cli_args = [
+        "verify_release_publication.py",
+        "--release-json",
+        str(release_file),
+        "--tag-target-sha",
+        target_sha,
+        "--release-tag",
+        release_tag,
+        "--target-sha",
+        target_sha,
+        "--app-effective-version",
+        app_effective_version,
+        "--tags-csv",
+        ",".join(sorted(refs)),
+    ]
+    for reference in sorted(refs):
+        cli_args.extend(("--manifest-proof", f"{reference}|{manifest_file}"))
+    for reference, platform in sorted(image_labels):
+        cli_args.extend(("--image-label-proof", f"{reference}|{platform}|{labels_file}"))
+
+    original_argv = sys.argv
+    sys.argv = cli_args
+    try:
+        assert module.main() == 0
+    finally:
+        sys.argv = original_argv
+
+print("test-release-publication-verification: all checks passed")
+PY

--- a/.github/scripts/verify_release_publication.py
+++ b/.github/scripts/verify_release_publication.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate that every release surface points at the intended immutable build."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_PLATFORMS = frozenset(("linux/amd64", "linux/arm64"))
+REVISION_LABEL = "org.opencontainers.image.revision"
+VERSION_LABEL = "org.opencontainers.image.version"
+
+
+class PublicationError(ValueError):
+    """Raised when a published release surface is incomplete or mismatched."""
+
+
+def _require(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def verify_release_metadata(
+    payload: dict[str, Any],
+    *,
+    release_tag: str,
+    target_sha: str,
+    release_prerelease: bool,
+) -> list[str]:
+    errors: list[str] = []
+    _require(payload.get("tag_name") == release_tag, "GitHub Release tag_name does not match release_tag", errors)
+    _require(payload.get("draft") is False, "GitHub Release must be published and not a draft", errors)
+    _require(
+        payload.get("prerelease") is release_prerelease,
+        "GitHub Release prerelease state does not match release snapshot",
+        errors,
+    )
+    _require(bool(payload.get("html_url")), "GitHub Release is missing html_url", errors)
+    _require(bool(target_sha) and len(target_sha) == 40, "target_sha must be a full commit SHA", errors)
+    return errors
+
+
+def verify_tag_target(actual_sha: str, *, target_sha: str) -> list[str]:
+    if actual_sha != target_sha:
+        return ["Git tag does not resolve to target_sha"]
+    return []
+
+
+def verify_manifest(manifest: dict[str, Any], *, reference: str) -> list[str]:
+    platforms = {
+        f"{platform.get('os')}/{platform.get('architecture')}"
+        for item in manifest.get("manifests", [])
+        for platform in (item.get("platform") or {},)
+        if platform.get("os") and platform.get("architecture")
+    }
+    missing = sorted(REQUIRED_PLATFORMS - platforms)
+    if missing:
+        return [f"{reference} is missing required platforms: {', '.join(missing)}"]
+    return []
+
+
+def verify_image_labels(
+    labels: dict[str, Any],
+    *,
+    reference: str,
+    platform: str,
+    target_sha: str,
+    app_effective_version: str,
+) -> list[str]:
+    errors: list[str] = []
+    _require(
+        labels.get(REVISION_LABEL) == target_sha,
+        f"{reference} ({platform}) revision label does not match target_sha",
+        errors,
+    )
+    _require(
+        labels.get(VERSION_LABEL) == app_effective_version,
+        f"{reference} ({platform}) version label does not match app_effective_version",
+        errors,
+    )
+    return errors
+
+
+def parse_image_proof(value: str) -> tuple[str, Path]:
+    reference, separator, path = value.partition("|")
+    if not separator or not reference or not path:
+        raise PublicationError("image proof must use REFERENCE|JSON_PATH")
+    return reference, Path(path)
+
+
+def parse_image_label_proof(value: str) -> tuple[str, str, Path]:
+    reference, separator, remainder = value.partition("|")
+    platform, separator, path = remainder.partition("|")
+    if not separator or not reference or not platform or not path:
+        raise PublicationError("image label proof must use REFERENCE|PLATFORM|JSON_PATH")
+    return reference, platform, Path(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise PublicationError(f"{path} must contain a JSON object")
+    return value
+
+
+def verify_publication(
+    *,
+    release_payload: dict[str, Any],
+    tag_target_sha: str,
+    release_tag: str,
+    target_sha: str,
+    release_prerelease: bool,
+    image_manifests: dict[str, dict[str, Any]],
+    image_labels: dict[tuple[str, str], dict[str, Any]],
+    expected_image_refs: set[str],
+    app_effective_version: str,
+) -> list[str]:
+    errors = verify_release_metadata(
+        release_payload,
+        release_tag=release_tag,
+        target_sha=target_sha,
+        release_prerelease=release_prerelease,
+    )
+    errors.extend(verify_tag_target(tag_target_sha, target_sha=target_sha))
+
+    actual_refs = set(image_manifests)
+    _require(actual_refs == expected_image_refs, "published image tags do not match the release snapshot", errors)
+    for reference, manifest in image_manifests.items():
+        errors.extend(verify_manifest(manifest, reference=reference))
+
+    expected_label_keys = {(reference, platform) for reference in expected_image_refs for platform in REQUIRED_PLATFORMS}
+    actual_label_keys = set(image_labels)
+    _require(actual_label_keys == expected_label_keys, "published image label proofs are incomplete", errors)
+    for (reference, platform), labels in image_labels.items():
+        if reference not in expected_image_refs or platform not in REQUIRED_PLATFORMS:
+            continue
+        errors.extend(
+            verify_image_labels(
+                labels,
+                reference=reference,
+                platform=platform,
+                target_sha=target_sha,
+                app_effective_version=app_effective_version,
+            )
+        )
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-json", required=True, type=Path)
+    parser.add_argument("--tag-target-sha", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--target-sha", required=True)
+    parser.add_argument("--app-effective-version", required=True)
+    parser.add_argument("--release-prerelease", action="store_true")
+    parser.add_argument("--tags-csv", required=True)
+    parser.add_argument("--manifest-proof", action="append", default=[])
+    parser.add_argument("--image-label-proof", action="append", default=[])
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifests = dict(parse_image_proof(value) for value in args.manifest_proof)
+        image_manifests = {reference: load_json(path) for reference, path in manifests.items()}
+        label_proofs = {
+            (reference, platform): path for reference, platform, path in map(parse_image_label_proof, args.image_label_proof)
+        }
+        image_labels = {key: load_json(path) for key, path in label_proofs.items()}
+        expected_refs = {tag.strip() for tag in args.tags_csv.split(",") if tag.strip()}
+        errors = verify_publication(
+            release_payload=load_json(args.release_json),
+            tag_target_sha=args.tag_target_sha,
+            release_tag=args.release_tag,
+            target_sha=args.target_sha,
+            release_prerelease=args.release_prerelease,
+            image_manifests=image_manifests,
+            image_labels=image_labels,
+            expected_image_refs=expected_refs,
+            app_effective_version=args.app_effective_version,
+        )
+    except (OSError, json.JSONDecodeError, PublicationError) as exc:
+        print(f"release publication verification failed: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        for error in errors:
+            print(f"release publication verification failed: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "release publication verified: "
+        f"tag={args.release_tag} images={len(image_manifests)} "
+        f"platforms={','.join(sorted(REQUIRED_PLATFORMS))}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -293,10 +293,12 @@ jobs:
             .github/scripts/check_live_quality_gates.py \
             .github/scripts/check_quality_gates_contract.py \
             .github/scripts/release_snapshot.py \
-            .github/scripts/verify_manifest_platforms.py
+            .github/scripts/verify_manifest_platforms.py \
+            .github/scripts/verify_release_publication.py
           bash -n .github/scripts/build-smoke-image-with-retry.sh
           bash -n .github/scripts/run-backend-tests.sh
           bash -n .github/scripts/test-representative-scale-contract.sh
+          bash -n .github/scripts/test-release-publication-verification.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -352,6 +354,7 @@ jobs:
           bash .github/scripts/test-live-quality-gates.sh
           bash .github/scripts/test-backend-test-contract.sh
           bash .github/scripts/test-representative-scale-contract.sh
+          bash .github/scripts/test-release-publication-verification.sh
 
       - name: Front-end lint
         run: bun run lint:web

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -130,10 +130,12 @@ jobs:
             .github/scripts/check_live_quality_gates.py \
             .github/scripts/check_quality_gates_contract.py \
             .github/scripts/release_snapshot.py \
-            .github/scripts/verify_manifest_platforms.py
+            .github/scripts/verify_manifest_platforms.py \
+            .github/scripts/verify_release_publication.py
           bash -n .github/scripts/build-smoke-image-with-retry.sh
           bash -n .github/scripts/run-backend-tests.sh
           bash -n .github/scripts/test-representative-scale-contract.sh
+          bash -n .github/scripts/test-release-publication-verification.sh
 
       - name: Resolve trusted quality-gates sources
         id: trusted-quality-gates
@@ -258,6 +260,7 @@ jobs:
           bash .github/scripts/test-live-quality-gates.sh
           bash .github/scripts/test-backend-test-contract.sh
           bash .github/scripts/test-representative-scale-contract.sh
+          bash .github/scripts/test-release-publication-verification.sh
 
       - name: Front-end lint
         run: bun run lint:web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -669,6 +669,129 @@ jobs:
 
             core.notice(`Created GitHub Release for tag ${tag}`)
 
+      - name: Verify published release surfaces
+        uses: actions/github-script@v9
+        env:
+          RELEASE_JSON: ${{ runner.temp }}/release-publication.json
+          TAG_TARGET_SHA_FILE: ${{ runner.temp }}/release-tag-target-sha.txt
+          RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
+          RELEASE_PRERELEASE: ${{ needs.release-meta.outputs.release_prerelease }}
+          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
+        with:
+          script: |
+            const fs = require('fs')
+            const { owner, repo } = context.repo
+            const tag = process.env.RELEASE_TAG
+            const expectedPrerelease = process.env.RELEASE_PRERELEASE === 'true'
+            const expectedSha = process.env.TARGET_SHA
+
+            if (!tag || !expectedSha) {
+              core.setFailed('Release verification is missing tag or target SHA')
+              return
+            }
+
+            const release = await github.rest.repos.getReleaseByTag({ owner, repo, tag })
+            if (release.data.tag_name !== tag || release.data.draft || release.data.prerelease !== expectedPrerelease) {
+              core.setFailed(`Published GitHub Release metadata does not match ${tag}`)
+              return
+            }
+            if (!release.data.html_url || !release.data.published_at) {
+              core.setFailed(`GitHub Release ${tag} is missing publication metadata`)
+              return
+            }
+
+            let object = (await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` })).data.object
+            for (let depth = 0; object.type === 'tag' && depth < 4; depth += 1) {
+              object = (await github.rest.git.getTag({ owner, repo, tag_sha: object.sha })).data.object
+            }
+            if (object.type !== 'commit' || object.sha !== expectedSha) {
+              core.setFailed(`Git tag ${tag} does not resolve to ${expectedSha}`)
+              return
+            }
+
+            fs.writeFileSync(process.env.RELEASE_JSON, JSON.stringify(release.data))
+            fs.writeFileSync(process.env.TAG_TARGET_SHA_FILE, `${object.sha}\n`)
+            core.notice(`Verified GitHub Release ${tag} and tag target ${object.sha}`)
+
+      - name: Verify final release image manifests
+        shell: bash
+        env:
+          RELEASE_JSON: ${{ runner.temp }}/release-publication.json
+          TAG_TARGET_SHA_FILE: ${{ runner.temp }}/release-tag-target-sha.txt
+          RELEASE_TAG: ${{ needs.release-meta.outputs.release_tag }}
+          RELEASE_PRERELEASE: ${{ needs.release-meta.outputs.release_prerelease }}
+          TARGET_SHA: ${{ needs.release-meta.outputs.target_sha }}
+          APP_EFFECTIVE_VERSION: ${{ needs.release-meta.outputs.app_effective_version }}
+          TAGS_CSV: ${{ needs.release-meta.outputs.tags_csv }}
+        run: |
+          set -euo pipefail
+          if [ ! -s "${RELEASE_JSON}" ] || [ ! -s "${TAG_TARGET_SHA_FILE}" ]; then
+            echo "Release metadata verification did not produce its proof files." >&2
+            exit 1
+          fi
+
+          manifest_args=()
+          image_label_args=()
+          index=0
+          IFS=',' read -r -a tags <<< "${TAGS_CSV}"
+          for tag in "${tags[@]}"; do
+            [[ -z "${tag}" ]] && continue
+            manifest_file="${RUNNER_TEMP}/release-manifest-${index}.json"
+            verified=false
+            for attempt in 1 2 3 4 5; do
+              if docker buildx imagetools inspect "${tag}" --raw >"${manifest_file}" 2>"${RUNNER_TEMP}/release-manifest-${index}.err"; then
+                verified=true
+                break
+              fi
+              if [ "${attempt}" -eq 5 ]; then
+                echo "Final release image manifest is unavailable: ${tag}" >&2
+                exit 1
+              fi
+              sleep "$((attempt * 3))"
+            done
+            if [ "${verified}" != true ]; then
+              echo "Final release image manifest verification failed: ${tag}" >&2
+              exit 1
+            fi
+            if ! RAW_JSON="$(<"${manifest_file}")" REQUIRED_PLATFORMS="${PLATFORMS}" \
+              python3 ./.github/scripts/verify_manifest_platforms.py "${tag}" >/dev/null; then
+              echo "Final release image platform proof failed: ${tag}" >&2
+              exit 1
+            fi
+            manifest_args+=(--manifest-proof "${tag}|${manifest_file}")
+            IFS=',' read -r -a platforms <<< "${PLATFORMS}"
+            for platform in "${platforms[@]}"; do
+              label_file="${RUNNER_TEMP}/release-label-${index}.json"
+              if ! docker pull --platform "${platform}" "${tag}" \
+                >"${RUNNER_TEMP}/release-pull-${index}.log" \
+                2>"${RUNNER_TEMP}/release-pull-${index}.err"; then
+                echo "Final release image is unavailable for ${tag} (${platform})" >&2
+                exit 1
+              fi
+              if ! docker image inspect --format '{{json .Config.Labels}}' "${tag}" >"${label_file}"; then
+                echo "Final release image labels are unavailable for ${tag} (${platform})" >&2
+                exit 1
+              fi
+              image_label_args+=(--image-label-proof "${tag}|${platform}|${label_file}")
+              index=$((index + 1))
+            done
+          done
+
+          prerelease_args=()
+          if [ "${RELEASE_PRERELEASE}" = true ]; then
+            prerelease_args+=(--release-prerelease)
+          fi
+          python3 ./.github/scripts/verify_release_publication.py \
+            --release-json "${RELEASE_JSON}" \
+            --tag-target-sha "$(<"${TAG_TARGET_SHA_FILE}")" \
+            --release-tag "${RELEASE_TAG}" \
+            --target-sha "${TARGET_SHA}" \
+            --app-effective-version "${APP_EFFECTIVE_VERSION}" \
+            "${prerelease_args[@]}" \
+            --tags-csv "${TAGS_CSV}" \
+            "${manifest_args[@]}" \
+            "${image_label_args[@]}"
+
       - name: Resolve next pending release target
         if: github.event_name != 'workflow_dispatch'
         id: next-pending


### PR DESCRIPTION
## Summary
- Verify the GitHub Release metadata and tag target after publication.
- Verify every final image tag has both linux/amd64 and linux/arm64 manifests.
- Pull each final platform image and verify OCI revision/version labels match the release target.
- Add deterministic script coverage to CI Main and CI PR.

## Validation
- `bun run lint:docs`
- `actionlint .github/workflows/release.yml`
- `bash .github/scripts/test-release-publication-verification.sh`
- `bash .github/scripts/test-quality-gates-contract.sh`

No production deployment or configuration change is included.